### PR TITLE
Gradle: replace build with shadowJar plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,9 +1,9 @@
 plugins {
     id 'java'
     id 'checkstyle'
+    id 'com.github.johnrengelman.shadow' version '2.0.3'
     id 'application'
 }
-
 mainClassName = "frontend.RepoSense"
 
 repositories {
@@ -26,10 +26,9 @@ dependencies {
     compile group: 'org.json', name: 'json', version: '20180130'
 }
 
-jar {
-    manifest {
-        attributes 'Main-Class': 'frontend.RepoSense'
-    }
+shadowJar {
+    archiveName = 'RepoSense.jar'
+    destinationDir = file("${buildDir}/jar/")
 }
 
 task myZip(type: Zip) {
@@ -38,9 +37,8 @@ task myZip(type: Zip) {
     destinationDir = file("src/main/resources")
 }
 
-tasks.build.dependsOn("myZip");
+tasks.shadowJar.dependsOn("myZip");
 tasks.run.dependsOn("myZip");
-
 
 configurations {
   functionalCompile.extendsFrom testCompile

--- a/docs/Build.md
+++ b/docs/Build.md
@@ -1,0 +1,11 @@
+# Build from Source
+
+This guide explains how to compile the executable Jar.
+
+1. Download our source code by
+   * using Git clone <br>
+     e.g. `git clone https://github.com/reposense/RepoSense.git` <br>
+   * or download and extract our [zip file](https://github.com/reposense/RepoSense/archive/master.zip).
+2. In the `RepoSense` directory, execute the below command in the terminal <br>
+   `gradlew shadowJar`
+3. The executable Jar file will be generated in the folder `build` > `jar` with the name `RepoSense.jar` upon successful build.

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -12,6 +12,7 @@
 
 ## How to Generate Dashboard
 1. Download the latest executable Jar on our [release](https://github.com/reposense/RepoSense/releases/latest).
+   * Alternatively, you can compile the executable Jar yourself by following our [build from source guide](Build.md).
 2. Execute it on the OS terminal. <br>
 Usage: `java -jar RepoSense.jar -config CSV_CONFIG_FILE_PATH [-output OUTPUT_DIRECTORY] [-since DD/MM/YYYY] [-until DD/MM/YYYY]`
 3. The dashboard can be in the folder designated in OUTPUT_DIRECTORY, or current working directory otherwise, as index.html.

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -5,16 +5,20 @@
 4. Profit!
 
 ## Dependencies
-1. Git
-2. Gradle
+1. **JDK `1.8.0_60`**  or later
+   * This app only works with Java 8 version.
+2. **Git** on the command line
+   * Ensure that you're able to use it on the OS terminal.
+
 ## How to Generate Dashboard
-```sh
-$ gradle clean build
+1. Download the latest executable Jar on our [release](https://github.com/reposense/RepoSense/releases/latest).
+2. Execute it on the OS terminal. <br>
+Usage: `java -jar RepoSense.jar -config CSV_CONFIG_FILE_PATH [-output OUTPUT_DIRECTORY] [-since DD/MM/YYYY] [-until DD/MM/YYYY]`
+3. The dashboard can be in the folder designated in OUTPUT_DIRECTORY, or current working directory otherwise, as index.html.
+
+Sample usage:
 ```
-Unzip the file in build/distributions/
-```
-$ cd build/distributions/RepoSense/bin
-$ ./RepoSense -config CSV_path.csv -output output_path/ -since 01/10/2017 -until 01/11/2017
+$ java -jar RepoSense.jar -config CSV_path.csv -output output_path/ -since 01/10/2017 -until 01/11/2017
 ```
 Argument List:
 - config: Mandatory. The path to the CSV config file.


### PR DESCRIPTION
Proposed commit message:

Gradle build compiles our source files and libraries used in the program into separate jar files, and delivers the entire package as a zip file.

It is rather inconvenient as user would have to extract from the zip file to use it and also have more unnecessary files to deal with. Additionally, if we package only our own class files into the JAR file, it will not work properly unless the user has all the other JAR files (i.e. third party libraries) our classes depend on.

Let's replace the gradle build with shadowJar plugin to package all dependencies into a single JAR file which enhance usability and portability.
