### PR TITLE
Gradle: upgrade to version 4.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: java
 matrix:
   include:
-    - jdk: oraclejdk8
+    - jdk: oraclejdk9
 
 script: >-
     ./config/travis/run-checks.sh &&
@@ -10,7 +10,7 @@ script: >-
 addons:
   apt:
     packages:
-      - oracle-java8-installer
+      - oracle-java9-installer
 
 before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock

--- a/build.gradle
+++ b/build.gradle
@@ -19,11 +19,12 @@ test {
 }
 
 dependencies {
-    compile group: 'commons-collections', name: 'commons-collections', version: '3.2'
-    compile 'com.github.javaparser:javaparser-core:3.0.1'
-    compile 'com.google.code.gson:gson:2.6.2'
-    testCompile group: 'junit', name: 'junit', version: '4.12'
-    compile group: 'org.json', name: 'json', version: '20180130'
+    implementation  group: 'commons-collections', name: 'commons-collections', version: '3.2'
+    implementation  'com.github.javaparser:javaparser-core:3.0.1'
+    implementation  'com.google.code.gson:gson:2.6.2'
+    implementation  group: 'org.json', name: 'json', version: '20180130'
+
+    testImplementation group: 'junit', name: 'junit', version: '4.12'
 }
 
 shadowJar {
@@ -41,7 +42,7 @@ tasks.shadowJar.dependsOn("myZip");
 tasks.run.dependsOn("myZip");
 
 configurations {
-  functionalCompile.extendsFrom testCompile
+  functionalImplementation.extendsFrom testImplementation
   functionalRuntime.extendsFrom testRuntime
 }
 sourceSets {
@@ -56,7 +57,7 @@ sourceSets {
 }
 
 task functional(type: Test) {
-  testClassesDir = sourceSets.functional.output.classesDir
+  testClassesDirs = sourceSets.functional.output.classesDirs
   classpath = sourceSets.functional.runtimeClasspath
   testLogging {
     events "passed", "skipped", "failed"

--- a/docs/developer_guide.md
+++ b/docs/developer_guide.md
@@ -13,8 +13,7 @@ Thank you for contributing to RepoSense!
 
 ### Prerequisites
 
-1. **JDK `1.8.0_60`**  or later <br>
-> This app only works with Java 8 version. <br>
+1. **JDK `1.8.0_60`**  or later
 2. **Git** on the command line <br>
 > Ensure that you're able to use it on the OS terminal. <br>
 3. **IntelliJ** IDE [Optional]

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -6,7 +6,6 @@
 
 ## Dependencies
 1. **JDK `1.8.0_60`**  or later
-   * This app only works with Java 8 version.
 2. **Git** on the command line
    * Ensure that you're able to use it on the OS terminal.
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.7-all.zip


### PR DESCRIPTION
Fix #81. Seems easier than I thought... have nothing else to fix other than url 🤣 

Proposed message:
```
Gradle does not recognise Java 9 version.

This is likely due to gradle version being out-dated for too long.

Let's update gradle to latest version so that it is compatible with the newer version of Java.
```

Onhold till #68 is merged so that I can update the docs too.