### PR TITLE
Fix main class could not be found

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
     id 'com.github.johnrengelman.shadow' version '2.0.3'
     id 'application'
 }
-mainClassName = "frontend.RepoSense"
+mainClassName = "reposense.frontend.RepoSense"
 
 repositories {
     mavenCentral()


### PR DESCRIPTION
The jar file built by gradle shadowjar plugin throws a could not find or load main class error.

This is due to the recent renaming of packages in the project and the mainClassName in gradle wasn't updated correspondingly.

Let's apply this fix in the build.gradle.