### PR TITLE
Remove RepoInfo's dependency on FileInfo #69

### DIFF
--- a/src/main/java/reposense/analyzer/ContentAnalyzer.java
+++ b/src/main/java/reposense/analyzer/ContentAnalyzer.java
@@ -44,8 +44,8 @@ public class ContentAnalyzer {
         return result;
     }
 
-    private static HashMap<Author, Integer> getAuthorMethodContributionCount(
-            ArrayList<FileInfo> files, List<Author> authors) {
+    public static HashMap<Author, Integer> getAuthorMethodContributionCount(
+            List<FileInfo> files, List<Author> authors) {
         HashMap<Author, Integer> result = new HashMap<Author, Integer>();
         for (Author author : authors) {
             result.put(author, 0);

--- a/src/main/java/reposense/analyzer/ContentAnalyzer.java
+++ b/src/main/java/reposense/analyzer/ContentAnalyzer.java
@@ -7,8 +7,6 @@ import java.util.List;
 import reposense.dataobject.Author;
 import reposense.dataobject.FileInfo;
 import reposense.dataobject.LineInfo;
-import reposense.dataobject.RepoConfiguration;
-import reposense.dataobject.RepoInfo;
 
 
 public class ContentAnalyzer {

--- a/src/main/java/reposense/analyzer/ContentAnalyzer.java
+++ b/src/main/java/reposense/analyzer/ContentAnalyzer.java
@@ -13,15 +13,6 @@ import reposense.dataobject.RepoInfo;
 
 public class ContentAnalyzer {
 
-    public static void aggregateFileInfos(RepoConfiguration config, RepoInfo repoInfo) {
-        ArrayList<FileInfo> result = FileAnalyzer.analyzeAllFiles(config);
-        repoInfo.setFileinfos(result);
-        //commitInfo.setAuthorIssueMap(getAuthorIssueCount(commitInfo.getFileinfos(),config.getAuthorList()));
-        repoInfo.setAuthorContributionMap(
-                getAuthorMethodContributionCount(repoInfo.getFileinfos(), config.getAuthorList()));
-
-    }
-
     private static HashMap<Author, Integer> getAuthorIssueCount(ArrayList<FileInfo> files, List<Author> authors) {
         HashMap<Author, Integer> result = new HashMap<Author, Integer>();
         for (FileInfo fileInfo : files) {

--- a/src/main/java/reposense/analyzer/RepoAnalyzer.java
+++ b/src/main/java/reposense/analyzer/RepoAnalyzer.java
@@ -5,7 +5,6 @@ import java.util.List;
 import reposense.dataobject.CommitInfo;
 import reposense.dataobject.FileInfo;
 import reposense.dataobject.RepoConfiguration;
-import reposense.dataobject.RepoInfo;
 import reposense.git.GitChecker;
 import reposense.git.GitLogger;
 

--- a/src/main/java/reposense/analyzer/RepoAnalyzer.java
+++ b/src/main/java/reposense/analyzer/RepoAnalyzer.java
@@ -1,5 +1,9 @@
 package reposense.analyzer;
 
+import java.util.List;
+
+import reposense.dataobject.CommitInfo;
+import reposense.dataobject.FileInfo;
 import reposense.dataobject.RepoConfiguration;
 import reposense.dataobject.RepoInfo;
 import reposense.git.GitChecker;
@@ -9,15 +13,14 @@ import reposense.git.GitLogger;
 public class RepoAnalyzer {
 
 
-    public static void analyzeCommits(RepoConfiguration config, RepoInfo repo) {
+    public static List<CommitInfo> analyzeCommits(RepoConfiguration config, RepoInfo repo) {
         GitChecker.checkoutBranch(config.getRepoRoot(), config.getBranch());
         System.out.println("analyzing commits for " + config.getOrganization() + "/" + config.getRepoName() + "...");
-        repo.setCommits(GitLogger.getCommits(config));
+        return GitLogger.getCommits(config);
     }
 
-    public static void analyzeAuthorship(RepoConfiguration config, RepoInfo repo) {
-        System.out.println("aggregating file info...");
-        ContentAnalyzer.aggregateFileInfos(config, repo);
-        System.out.println("done analyzing commits...");
+    public static List<FileInfo> analyzeAuthorship(RepoConfiguration config, RepoInfo repo) {
+        System.out.println("analyzing authorship...");
+        return FileAnalyzer.analyzeAllFiles(config);
     }
 }

--- a/src/main/java/reposense/analyzer/RepoAnalyzer.java
+++ b/src/main/java/reposense/analyzer/RepoAnalyzer.java
@@ -13,7 +13,9 @@ public class RepoAnalyzer {
         GitChecker.checkoutBranch(config.getRepoRoot(), config.getBranch());
         System.out.println("analyzing commits for " + config.getOrganization() + "/" + config.getRepoName() + "...");
         repo.setCommits(GitLogger.getCommits(config));
-        System.out.println("analyzing git log output...");
+    }
+
+    public static void analyzeAuthorship(RepoConfiguration config, RepoInfo repo) {
         System.out.println("aggregating file info...");
         ContentAnalyzer.aggregateFileInfos(config, repo);
         System.out.println("done analyzing commits...");

--- a/src/main/java/reposense/analyzer/RepoAnalyzer.java
+++ b/src/main/java/reposense/analyzer/RepoAnalyzer.java
@@ -13,13 +13,13 @@ import reposense.git.GitLogger;
 public class RepoAnalyzer {
 
 
-    public static List<CommitInfo> analyzeCommits(RepoConfiguration config, RepoInfo repo) {
+    public static List<CommitInfo> analyzeCommits(RepoConfiguration config) {
         GitChecker.checkoutBranch(config.getRepoRoot(), config.getBranch());
         System.out.println("analyzing commits for " + config.getOrganization() + "/" + config.getRepoName() + "...");
         return GitLogger.getCommits(config);
     }
 
-    public static List<FileInfo> analyzeAuthorship(RepoConfiguration config, RepoInfo repo) {
+    public static List<FileInfo> analyzeAuthorship(RepoConfiguration config) {
         System.out.println("analyzing authorship...");
         return FileAnalyzer.analyzeAllFiles(config);
     }

--- a/src/main/java/reposense/dataobject/RepoInfo.java
+++ b/src/main/java/reposense/dataobject/RepoInfo.java
@@ -13,7 +13,6 @@ public class RepoInfo {
     private List<CommitInfo> commits = new ArrayList<>();
     private String branch;
     private Map<Author, String> authorDisplayNameMap = new HashMap<>();
-    private List<FileInfo> fileinfos;
     private HashMap<Author, Integer> authorIssueMap;
     private HashMap<Author, Integer> authorContributionMap;
 
@@ -67,14 +66,6 @@ public class RepoInfo {
 
     public String getDirectoryName() {
         return organization + "_" + repoName;
-    }
-
-    public List<FileInfo> getFileinfos() {
-        return fileinfos;
-    }
-
-    public void setFileinfos(List<FileInfo> fileinfos) {
-        this.fileinfos = fileinfos;
     }
 
     public HashMap<Author, Integer> getAuthorIssueMap() {

--- a/src/main/java/reposense/dataobject/RepoInfo.java
+++ b/src/main/java/reposense/dataobject/RepoInfo.java
@@ -13,7 +13,7 @@ public class RepoInfo {
     private List<CommitInfo> commits = new ArrayList<>();
     private String branch;
     private Map<Author, String> authorDisplayNameMap = new HashMap<>();
-    private ArrayList<FileInfo> fileinfos;
+    private List<FileInfo> fileinfos;
     private HashMap<Author, Integer> authorIssueMap;
     private HashMap<Author, Integer> authorContributionMap;
 
@@ -69,11 +69,11 @@ public class RepoInfo {
         return organization + "_" + repoName;
     }
 
-    public ArrayList<FileInfo> getFileinfos() {
+    public List<FileInfo> getFileinfos() {
         return fileinfos;
     }
 
-    public void setFileinfos(ArrayList<FileInfo> fileinfos) {
+    public void setFileinfos(List<FileInfo> fileinfos) {
         this.fileinfos = fileinfos;
     }
 

--- a/src/main/java/reposense/report/RepoInfoFileGenerator.java
+++ b/src/main/java/reposense/report/RepoInfoFileGenerator.java
@@ -27,6 +27,7 @@ public class RepoInfoFileGenerator {
         String reportName = generateReportName();
         List<RepoInfo> repos = new ArrayList<>();
 
+        copyTemplate(reportName, targetFileLocation);
         for (RepoConfiguration config: repoConfigs) {
             try {
                 GitCloner.downloadRepo(config.getOrganization(), config.getRepoName(), config.getBranch());
@@ -42,7 +43,6 @@ public class RepoInfoFileGenerator {
             generateIndividualRepoReport(repoInfo, fileInfos, reportName, targetFileLocation);
             FileUtil.deleteDirectory(Constants.REPOS_ADDRESS);
         }
-        copyTemplate(reportName, targetFileLocation);
 
         Map<String, RepoContributionSummary> repoSummaries =
                 ContributionSummaryGenerator.analyzeContribution(repos, repoConfigs);

--- a/src/main/java/reposense/report/RepoInfoFileGenerator.java
+++ b/src/main/java/reposense/report/RepoInfoFileGenerator.java
@@ -35,8 +35,11 @@ public class RepoInfoFileGenerator {
                 continue;
             }
             RepoInfo repoInfo = analyzeRepo(config);
+            List<FileInfo> fileInfos = RepoAnalyzer.analyzeAuthorship(config);
+            repoInfo.setAuthorContributionMap(
+                    ContentAnalyzer.getAuthorMethodContributionCount(fileInfos, config.getAuthorList()));
             repos.add(repoInfo);
-            generateIndividualRepoReport(repoInfo, reportName, targetFileLocation);
+            generateIndividualRepoReport(repoInfo, fileInfos, reportName, targetFileLocation);
             FileUtil.deleteDirectory(Constants.REPOS_ADDRESS);
         }
         copyTemplate(reportName, targetFileLocation);
@@ -55,13 +58,12 @@ public class RepoInfoFileGenerator {
                 config.getAuthorDisplayNameMap()
         );
         repoinfo.setCommits(RepoAnalyzer.analyzeCommits(config));
-        repoinfo.setFileinfos(RepoAnalyzer.analyzeAuthorship(config));
-        repoinfo.setAuthorContributionMap(
-                ContentAnalyzer.getAuthorMethodContributionCount(repoinfo.getFileinfos(), config.getAuthorList()));
         return repoinfo;
     }
 
-    private static void generateIndividualRepoReport(RepoInfo repoinfo, String reportName, String targetFileLocation) {
+    private static void generateIndividualRepoReport(RepoInfo repoinfo, List<FileInfo> fileInfos,
+            String reportName, String targetFileLocation) {
+
         String repoReportName = repoinfo.getDirectoryName();
         String repoReportDirectory = targetFileLocation + "/" + reportName + "/" + repoReportName;
         new File(repoReportDirectory).mkdirs();
@@ -69,7 +71,6 @@ public class RepoInfoFileGenerator {
                 + reportName + File.separator
                 + Constants.STATIC_INDIVIDUAL_REPORT_TEMPLATE_ADDRESS;
         FileUtil.copyFiles(new File(templateLocation), new File(repoReportDirectory));
-        List<FileInfo> fileInfos = repoinfo.getFileinfos();
         FileUtil.writeJsonFile(fileInfos, getIndividualResultPath(repoReportDirectory), "resultJson");
         System.out.println("report for " + repoReportName + " Generated!");
     }

--- a/src/main/java/reposense/report/RepoInfoFileGenerator.java
+++ b/src/main/java/reposense/report/RepoInfoFileGenerator.java
@@ -54,8 +54,8 @@ public class RepoInfoFileGenerator {
                 config.getBranch(),
                 config.getAuthorDisplayNameMap()
         );
-        repoinfo.setCommits(RepoAnalyzer.analyzeCommits(config, repoinfo));
-        repoinfo.setFileinfos(RepoAnalyzer.analyzeAuthorship(config, repoinfo));
+        repoinfo.setCommits(RepoAnalyzer.analyzeCommits(config));
+        repoinfo.setFileinfos(RepoAnalyzer.analyzeAuthorship(config));
         repoinfo.setAuthorContributionMap(
                 ContentAnalyzer.getAuthorMethodContributionCount(repoinfo.getFileinfos(), config.getAuthorList()));
         return repoinfo;

--- a/src/main/java/reposense/report/RepoInfoFileGenerator.java
+++ b/src/main/java/reposense/report/RepoInfoFileGenerator.java
@@ -55,6 +55,7 @@ public class RepoInfoFileGenerator {
                     config.getAuthorDisplayNameMap()
             );
             RepoAnalyzer.analyzeCommits(config, repoinfo);
+            RepoAnalyzer.analyzeAuthorship(config, repoinfo);
             result.add(repoinfo);
         }
         FileUtil.deleteDirectory(Constants.REPOS_ADDRESS);


### PR DESCRIPTION
Part of #69 

Proposed message:

```
Separate the association between Commits and Authorship analysis is
necessary for us to match the proposed architecture in #69. 

Let's start by removing FileInfo from RepoInfo model.
```