### PR TITLE
updated template to fake merge separated reports

### DIFF
--- a/template/index.html
+++ b/template/index.html
@@ -5,7 +5,6 @@
     <link rel="stylesheet" href="https://code.jquery.com/ui/1.12.1/themes/base/jquery-ui.css">
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
     <link rel="stylesheet" href="static/css/style.css">
-    <script type="text/javascript" src="summary.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/datejs/1.0/date.min.js"></script>
 
     <script src="https://code.jquery.com/jquery-1.12.4.js"></script>
@@ -14,87 +13,93 @@
     <script type="text/javascript" src="static/scripts/utils.js"></script>
     <script type="text/javascript" src="static/scripts/summaryVueMethods.js"></script>
     <script>
-        var totalContributionLimit = getTotalContributionLimit();
-        var hexcolors = ["#E69F00", "#56B4E9", "#009E73", "#F0E442", "#0072B2", "#D55E00", "#CC79A7"];
-        var rgbacolors = ["rgba(230,159,0,0.6)", "rgba(86,180,233,0.6)", "rgba(0,158,115,0.6)", "rgba(240,228,66,0.6)", "rgba(0,114,178,0.6)", "rgba(213,94,0,0.6)", "rgba(204,121,167,0.6)"];
+        var app, totalContributionLimit;
+        var hexcolors, rgbacolor;
+        var sliceScaleLimitMap, minDateRange, maxDateRange;
 
-        var sliceScaleLimitMap = getScaleLimitMap();
-        var minDateRange = getMinDate();
-        var maxDateRange = getMaxDate();
-        Vue.component('date-picker', {
-            template: '<input size="8"/>',
-            props: ['defaultDate'],
-            mounted: function() {
-                var self = this;
-                var minDateParsed = Date.parse(minDateRange);
-                var maxDateParsed = Date.parse(maxDateRange);
-                $(this.$el).datepicker({
-                    minDate: minDateParsed,
-                    maxDate: maxDateParsed,
-                    dateFormat: "mm/dd/y",
-                    onSelect: function(date) {
-                        self.$emit('update-date', date);
-                    }
-                });
-            },
-            beforeDestroy: function() {
-                $(this.$el).datepicker('hide').datepicker('destroy');
-            }
-        });
-        $(document).ready(function() {
-            var app = new Vue({
-                el: '#vue-app',
-                data: {
-                    summary: summaryJson,
-                    sortElement: getQueryVariable("sortElement","finalContribution"),
-                    sortOrder: getQueryVariable("sortOrder","high2low"),
-                    searchTerm: getQueryVariable("searchTerm",""),
-                    intervalType: getQueryVariable("intervalType","authorDailyIntervalContributions"),
-                    isGroupByRepo: (getQueryVariable("isGroupByRepo","true")=="true"),
-                    minDate: minDateRange,
-                    maxDate: maxDateRange,
-                },
-                methods: vueMethods
-            });
-            $(".author_name_tag").click(function() {
-                displayName = $(this).attr("displayName");
-                author = $(this).attr("author");
-                authorDisplayName = $(this).attr("authorDisplayName");
-                url = displayName + "/" + "index.html?author=" + author+"&authorDisplayName=" +authorDisplayName;
-                $(".author_block").removeClass("highlighted_block");
-                $("#" + author).addClass("highlighted_block");
-                $(".progress-chart-box").animate({
-                    width: "30%"
-                }, 300);
-                $(".code-review-box").animate({
-                    width: "70%"
-                }, 300, function() {
-                    $(".report-frame").attr('src', url);
-                });
-            });
-            $(".hide_button").click(function() {
-                $(".report-frame").attr('src', 'about:blank')
-                $(".author_block").removeClass("highlighted_block");
-                setTimeout((function() {
-                    $(".progress-chart-box").animate({
-                        width: "100%"
-                    }, 300);
-                    $(".code-review-box").animate({
-                        width: "0%"
-                    }, 300);
+        var initialize = function(){
+          totalContributionLimit = getTotalContributionLimit();
+          hexcolors = ["#E69F00", "#56B4E9", "#009E73", "#F0E442", "#0072B2", "#D55E00", "#CC79A7"];
+          rgbacolors = ["rgba(230,159,0,0.6)", "rgba(86,180,233,0.6)", "rgba(0,158,115,0.6)", "rgba(240,228,66,0.6)", "rgba(0,114,178,0.6)", "rgba(213,94,0,0.6)", "rgba(204,121,167,0.6)"];
 
-                }), 200);
+          sliceScaleLimitMap = getScaleLimitMap();
+          minDateRange = getMinDate();
+          maxDateRange = getMaxDate();
+          Vue.component('date-picker', {
+              template: '<input size="8"/>',
+              props: ['defaultDate'],
+              mounted: function() {
+                  var self = this;
+                  var minDateParsed = Date.parse(minDateRange);
+                  var maxDateParsed = Date.parse(maxDateRange);
+                  $(this.$el).datepicker({
+                      minDate: minDateParsed,
+                      maxDate: maxDateParsed,
+                      dateFormat: "mm/dd/y",
+                      onSelect: function(date) {
+                          self.$emit('update-date', date);
+                      }
+                  });
+              },
+              beforeDestroy: function() {
+                  $(this.$el).datepicker('hide').datepicker('destroy');
+              }
+          });
 
 
-            })
-        });
-        $(function() {
-            $(document).tooltip();
-            $("#minDatePicker").val(minDateRange);
-            $("#maxDatePicker").val(maxDateRange);
+          app = new Vue({
+              el: '#vue-app',
+              data: {
+                  summary: summaryJson,
+                  sortElement: getQueryVariable("sortElement","finalContribution"),
+                  sortOrder: getQueryVariable("sortOrder","high2low"),
+                  searchTerm: getQueryVariable("searchTerm",""),
+                  intervalType: getQueryVariable("intervalType","authorDailyIntervalContributions"),
+                  isGroupByRepo: (getQueryVariable("isGroupByRepo","true")=="true"),
+                  minDate: minDateRange,
+                  maxDate: maxDateRange,
+              },
+              methods: vueMethods
+          });
+          $(".author_name_tag").click(function() {
+              displayName = $(this).attr("displayName");
+              author = $(this).attr("author");
+              authorDisplayName = $(this).attr("authorDisplayName");
+              url = displayName + "/" + "index.html?author=" + author+"&authorDisplayName=" +authorDisplayName;
+              $(".author_block").removeClass("highlighted_block");
+              $("#" + author).addClass("highlighted_block");
+              $(".progress-chart-box").animate({
+                  width: "30%"
+              }, 300);
+              $(".code-review-box").animate({
+                  width: "70%"
+              }, 300, function() {
+                  $(".report-frame").attr('src', url);
+              });
+          });
 
-        });
+          $(".hide_button").click(function() {
+              $(".report-frame").attr('src', 'about:blank')
+              $(".author_block").removeClass("highlighted_block");
+              setTimeout((function() {
+                  $(".progress-chart-box").animate({
+                      width: "100%"
+                  }, 300);
+                  $(".code-review-box").animate({
+                      width: "0%"
+                  }, 300);
+
+              }), 200);
+          });
+
+          $(function() {
+              $(document).tooltip();
+              $("#minDatePicker").val(minDateRange);
+              $("#maxDatePicker").val(maxDateRange);
+          });
+        };
     </script>
+    <script type="text/javascript" src="summary.js"></script>
 </head>
 
 <body class="main-app">

--- a/template/repo_report/index.html
+++ b/template/repo_report/index.html
@@ -1,116 +1,119 @@
 <html>
-	<head>
-		<link rel="stylesheet" href="../static/css/collapse.css">
-		<link rel="stylesheet" href="../static/css/highlight-tomorrow.css">
-				<link rel="stylesheet" href="../static/css/style.css">
+  <head>
+    <link rel="stylesheet" href="../static/css/collapse.css">
+    <link rel="stylesheet" href="../static/css/highlight-tomorrow.css">
+        <link rel="stylesheet" href="../static/css/style.css">
 
-		<script type="text/javascript" src="result.js"></script>
-		<script src="https://code.jquery.com/jquery-1.12.4.js"></script>
-		<script src="../static/scripts/lib/jquery.collapsible.min.js"></script>
-		<script src="https://cdn.jsdelivr.net/npm/vue"></script>
-		<script src="../static/scripts/lib/highlight.pack.js"></script>
-		<script type="text/javascript" src="../static/scripts/utils.js"></script>
-		<script>
-		hljs.initHighlightingOnLoad();
-		var currentAuthor = getQueryVariable('author');
-		var currentAuthorDisplayName = getQueryVariable('authorDisplayName');
-		resultJson = sortByLineContributed(resultJson,currentAuthor);
-		$(document).ready(function() {
-			var app = new Vue({
-				el: '#vue-app',
-				data: {
-					currentAuthor : currentAuthor,
-					result : resultJson,
+    <script src="https://code.jquery.com/jquery-1.12.4.js"></script>
+    <script src="../static/scripts/lib/jquery.collapsible.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/vue"></script>
+    <script src="../static/scripts/lib/highlight.pack.js"></script>
+    <script type="text/javascript" src="../static/scripts/utils.js"></script>
+    <script>
+    // hljs.initHighlightingOnLoad();
+    var currentAuthor, currentAuthorDisplayName, app;
 
-				},
-				methods: {
-				getAuthorUrlQuery : function (author) {
-					return "?author=" + author
-				},
-				containAuthorLine : function(file, authorName){
-					for (i=0; i<file.lines.length;i++){
-						if (file.lines[i].author!= null && file.lines[i].author.gitId == authorName){
-							return true;
-						}
-					}
-					return false;
-				},
-				getAuthorClass : function(line, currentAuthor){
-					if (isNotAuthored(currentAuthor,line)){
-						return "unauthored";
-					}
-					return "";
-				},
-				isCollapseStart : function(lines,currentIndex,currentAuthor){
-					//console.log(currentIndex);
-					if (lines.length - currentIndex < 5){
-						//console.log("not enough");
-						// less than 10 lines left
-						return false;
-					}
-					if (currentIndex != 0 && isNotAuthored(currentAuthor,lines[currentIndex - 1])){
-						//console.log("not start");
-						return false;
-					}
-					for (var i=currentIndex;i<currentIndex+5;i++){
-						if (!isNotAuthored(currentAuthor,lines[i])){
-							//console.log("breaked");
-							return false;
-						}
-					}
-					return true;
-				},
-				isCollapseEnd : function(lines,currentIndex,currentAuthor){
-					if (currentIndex < 5){
-						return false;
-					}
-					if (currentIndex != lines.length - 1 && isNotAuthored(currentAuthor,lines[currentIndex + 1])){
-						return false;
-					}
-					for (var i=currentIndex;i>currentIndex-5;i--){
-						if (!isNotAuthored(currentAuthor,lines[i])){
-							return false;
-						}
-					}
-					return true;
-				},
+    var initialize = function(){
+      currentAuthor = getQueryVariable('author');
+      currentAuthorDisplayName = getQueryVariable('authorDisplayName');
+      resultJson = sortByLineContributed(resultJson,currentAuthor);
 
-				}
-			});
-			$(".collapseStart").each(function(){
-    			var $set = $(this).nextUntil("collapseEnd").andSelf();
-    			$set.wrapAll("<div class='collapse-container-small'></div>");
-    			var $innerSet = $(this).nextUntil("collapseEnd");
-    			$innerSet.wrapAll("<div></div>");
-			});
-			$( ".collapse-container" ).collapsible({animate: false});
-			$( ".collapse-container-small" ).collapsible("default-close",{animate: false});
+      app = new Vue({
+          el: '#vue-app',
+          data: {
+            currentAuthor : currentAuthor,
+            result : resultJson,
 
-		});
-		</script>
-	</head>
-	<body>
-		<div id="vue-app">
-			<div class="content-container">
-				<h3>current author:{{currentAuthorDisplayName==null?currentAuthor:currentAuthorDisplayName}}</h3>
-				<div class="collapse-container" >
-					<template v-for="file in result">
-					<template v-if="containAuthorLine(file, currentAuthor) || currentAuthor == null">
-					<h3>{{ file.path }} ( {{file.authorContributionMap[currentAuthor]}} lines)</h3>
-					<div>
+          },
+          methods: {
+          getAuthorUrlQuery : function (author) {
+            return "?author=" + author
+          },
+          containAuthorLine : function(file, authorName){
+            for (i=0; i<file.lines.length;i++){
+              if (file.lines[i].author!= null && file.lines[i].author.gitID == authorName){
+                return true;
+              }
+            }
+            return false;
+          },
+          getAuthorClass : function(line, currentAuthor){
+            if (isNotAuthored(currentAuthor,line)){
+              return "unauthored";
+            }
+            return "";
+          },
+          isCollapseStart : function(lines,currentIndex,currentAuthor){
+            //console.log(currentIndex);
+            if (lines.length - currentIndex < 5){
+              //console.log("not enough");
+              // less than 10 lines left
+              return false;
+            }
+            if (currentIndex != 0 && isNotAuthored(currentAuthor,lines[currentIndex - 1])){
+              //console.log("not start");
+              return false;
+            }
+            for (var i=currentIndex;i<currentIndex+5;i++){
+              if (!isNotAuthored(currentAuthor,lines[i])){
+                //console.log("breaked");
+                return false;
+              }
+            }
+            return true;
+          },
+          isCollapseEnd : function(lines,currentIndex,currentAuthor){
+            if (currentIndex < 5){
+              return false;
+            }
+            if (currentIndex != lines.length - 1 && isNotAuthored(currentAuthor,lines[currentIndex + 1])){
+              return false;
+            }
+            for (var i=currentIndex;i>currentIndex-5;i--){
+              if (!isNotAuthored(currentAuthor,lines[i])){
+                return false;
+              }
+            }
+            return true;
+          },
 
-						<template v-for="(line,index) in file.lines">
-							<h6 class="collapseStart"  v-if="isCollapseStart(file.lines,index,currentAuthor)">Untouched Code Chunk(Click to Expand)</h6>
-							<pre><code class="java" v-bind:class="getAuthorClass(line,currentAuthor)">{{line.content}}</code></pre>
-							<template v-if="isCollapseEnd(file.lines,index,currentAuthor)">
-  									<collapseEnd></collapseEnd>
-							</template>
-						</template>
-					</div>
-					</template>
-					</template>
-				</div>
-			</div>
-		</div>
-	</body>
+          }
+      });
+
+      $(".collapseStart").each(function(){
+          var $set = $(this).nextUntil("collapseEnd").andSelf();
+          $set.wrapAll("<div class='collapse-container-small'></div>");
+          var $innerSet = $(this).nextUntil("collapseEnd");
+          $innerSet.wrapAll("<div></div>");
+      });
+      $( ".collapse-container" ).collapsible({animate: false});
+      $( ".collapse-container-small" ).collapsible("default-close",{animate: false});
+    };
+    </script>
+    <script type="text/javascript" src="result.js"></script>
+  </head>
+  <body>
+    <div id="vue-app">
+      <div class="content-container">
+        <h3>current author:{{currentAuthorDisplayName==null?currentAuthor:currentAuthorDisplayName}}</h3>
+        <div class="collapse-container" >
+          <template v-for="file in result">
+          <template v-if="containAuthorLine(file, currentAuthor) || currentAuthor == null">
+          <h3>{{ file.path }} ( {{file.authorContributionMap[currentAuthor]}} lines)</h3>
+          <div>
+
+            <template v-for="(line,index) in file.lines">
+              <h6 class="collapseStart"  v-if="isCollapseStart(file.lines,index,currentAuthor)">Untouched Code Chunk(Click to Expand)</h6>
+              <pre><code class="java" v-bind:class="getAuthorClass(line,currentAuthor)">{{line.content}}</code></pre>
+              <template v-if="isCollapseEnd(file.lines,index,currentAuthor)">
+                    <collapseEnd></collapseEnd>
+              </template>
+            </template>
+          </div>
+          </template>
+          </template>
+        </div>
+      </div>
+    </div>
+  </body>
 </html>

--- a/template/static/scripts/utils.js
+++ b/template/static/scripts/utils.js
@@ -161,6 +161,8 @@ function isMatch(searchTerm, currentPhrase) {
 }
 
 function getMinDate() {
+    return "01/01/01";
+
     rawDate = summaryJson[Object.keys(summaryJson)[0]]["fromDate"];
     if (rawDate) {
         //the fromDate has been set
@@ -187,6 +189,8 @@ function getMinDate() {
 }
 
 function getMaxDate() {
+    return "01/01/99";
+
     rawDate = summaryJson[Object.keys(summaryJson)[0]]["toDate"];
     if (rawDate) {
         //the fromDate has been set


### PR DESCRIPTION
proposed message

```
We wanna generate the report for each repo iteratively to improve
performance.

Assume files converted into JSON formatted, rather than the initial JS
script which loads all the information into a pre-defined variable
name.

Assume folders reorganized to support the multiple reports format. This
potentially frees up the reporting capabilities of reposense, making it
possible for other developers to extend upon the generated results.

Template is updated to display the separated results through the means
of artifically merging them through dummy files like `summary.js` and
`report.js`.

Let's work on the template, it is temporary and work will commence on a 
seperated single file template to load the reports.
```