### PR TITLE
Shift from File to Path class #107

### DIFF
--- a/src/functional/java/reposense/Entry.java
+++ b/src/functional/java/reposense/Entry.java
@@ -1,6 +1,7 @@
 package reposense;
 
 import java.io.IOException;
+import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -32,7 +33,7 @@ public class Entry {
     }
 
     @Test
-    public void test() throws Exception {
+    public void test() throws IOException, URISyntaxException {
         generateReport();
         String actualRelativeDir = getRelativeDir();
         Path actualFiles = Paths.get(getClass().getClassLoader().getResource("expected").toURI());
@@ -40,7 +41,7 @@ public class Entry {
         FileUtil.deleteDirectory(FT_TEMP_DIR);
     }
 
-    private void generateReport() throws Exception {
+    private void generateReport() throws URISyntaxException {
         Path configFilePath = Paths.get(getClass().getClassLoader().getResource("sample_full.csv").toURI());
         Calendar c = Calendar.getInstance();
         c.set(2017, 6, 1);

--- a/src/functional/java/reposense/Entry.java
+++ b/src/functional/java/reposense/Entry.java
@@ -1,12 +1,18 @@
 package reposense;
 
-import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 
 import reposense.dataobject.RepoConfiguration;
@@ -20,43 +26,50 @@ public class Entry {
     private static final String FT_TEMP_DIR = "ft_temp";
     private static final String EXPECTED_FOLDER = "expected";
 
+    @Before
+    public void setUp() throws IOException {
+        FileUtil.deleteDirectory(FT_TEMP_DIR);
+    }
+
     @Test
-    public void test() {
+    public void test() throws Exception {
         generateReport();
         String actualRelativeDir = getRelativeDir();
-        File actualFiles = new File(getClass().getClassLoader().getResource("expected").getFile());
+        Path actualFiles = Paths.get(getClass().getClassLoader().getResource("expected").toURI());
         verifyAllJson(actualFiles, actualRelativeDir);
         FileUtil.deleteDirectory(FT_TEMP_DIR);
     }
 
-    private void generateReport() {
-        File configFile = new File(getClass().getClassLoader().getResource("sample_full.csv").getFile());
+    private void generateReport() throws Exception {
+        Path configFilePath = Paths.get(getClass().getClassLoader().getResource("sample_full.csv").toURI());
         Calendar c = Calendar.getInstance();
         c.set(2017, 6, 1);
         Date fromDate = c.getTime();
         c.set(2017, 10, 30);
         Date toDate = c.getTime();
-        List<RepoConfiguration> configs = CsvConfigurationBuilder.buildConfigs(configFile, fromDate, toDate);
+        List<RepoConfiguration> configs = CsvConfigurationBuilder.buildConfigs(configFilePath, fromDate, toDate);
         RepoInfoFileGenerator.generateReposReport(configs, FT_TEMP_DIR);
     }
 
-    private void verifyAllJson(File expectedDirectory, String actualRelative) {
-        for (File file : expectedDirectory.listFiles()) {
-            if (file.isDirectory()) {
-                verifyAllJson(file, actualRelative);
-            } else {
-                if (!file.getName().endsWith(".json")) {
-                    continue;
+    private void verifyAllJson(Path expectedDirectory, String actualRelative) {
+        try (Stream<Path> pathStream = Files.list(expectedDirectory)) {
+            for (Path filePath : pathStream.collect(Collectors.toList())) {
+                if (Files.isDirectory(filePath)) {
+                    verifyAllJson(filePath, actualRelative);
                 }
-                String relativeDirectory = file.getAbsolutePath().split(EXPECTED_FOLDER)[1];
-                assertJson(file, relativeDirectory, actualRelative);
+                if (filePath.toString().endsWith(".json")) {
+                    String relativeDirectory = filePath.toAbsolutePath().toString().split(EXPECTED_FOLDER)[1];
+                    assertJson(filePath, relativeDirectory, actualRelative);
+                }
             }
+        } catch (IOException ioe) {
+            ioe.printStackTrace();
         }
     }
 
-    private void assertJson(File expectedJson, String expectedPosition, String actualRelative) {
-        File actualJson = new File(actualRelative + expectedPosition);
-        Assert.assertTrue(actualJson.exists());
+    private void assertJson(Path expectedJson, String expectedPosition, String actualRelative) {
+        Path actualJson = Paths.get(actualRelative, expectedPosition);
+        Assert.assertTrue(Files.exists(actualJson));
         try {
             Assert.assertTrue(TestUtil.compareFileContents(expectedJson, actualJson));
         } catch (IOException e) {
@@ -65,11 +78,16 @@ public class Entry {
     }
 
     private String getRelativeDir() {
-        for (File file : (new File(FT_TEMP_DIR)).listFiles()) {
-            if (file.getName().contains("DS_Store")) {
-                continue;
+        try (Stream<Path> pathStream = Files.list(Paths.get(FT_TEMP_DIR))) {
+            // filter out attribute file created in macOS
+            Optional<Path> optionalPath = pathStream
+                    .filter(filePath -> !filePath.toString().contains("DS_Store"))
+                    .findFirst();
+            if (optionalPath.isPresent()) {
+                return optionalPath.get().toString();
             }
-            return FT_TEMP_DIR + File.separator + file.getName();
+        } catch (IOException ioe) {
+            ioe.printStackTrace();
         }
         Assert.fail();
         return "";

--- a/src/main/java/reposense/analyzer/FileInfoGenerator.java
+++ b/src/main/java/reposense/analyzer/FileInfoGenerator.java
@@ -1,10 +1,10 @@
 package reposense.analyzer;
 
 import java.io.BufferedReader;
-import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.FileReader;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 
 import reposense.dataobject.FileInfo;
 import reposense.dataobject.LineInfo;
@@ -13,18 +13,16 @@ import reposense.dataobject.LineInfo;
 public class FileInfoGenerator {
     public static FileInfo generateFileInfo(String repoRoot, String relativePath) {
         FileInfo result = new FileInfo(relativePath);
-        File file = new File(repoRoot + '/' + relativePath);
-        try (BufferedReader br = new BufferedReader(new FileReader(file))) {
+        Path path = Paths.get(repoRoot, relativePath);
+        try (BufferedReader br = new BufferedReader(Files.newBufferedReader(path))) {
             String line;
             int lineNum = 1;
             while ((line = br.readLine()) != null) {
                 result.getLines().add(new LineInfo(lineNum, line));
                 lineNum += 1;
             }
-        } catch (FileNotFoundException e) {
-            e.printStackTrace();
-        } catch (IOException e) {
-            e.printStackTrace();
+        } catch (IOException ioe) {
+            ioe.printStackTrace();
         }
         return result;
     }

--- a/src/main/java/reposense/frontend/CliArguments.java
+++ b/src/main/java/reposense/frontend/CliArguments.java
@@ -1,6 +1,7 @@
 package reposense.frontend;
 
-import java.io.File;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Optional;
@@ -25,8 +26,8 @@ public class CliArguments {
 
     private static final String DEFAULT_FILE_ARG = ".";
 
-    private File configFile;
-    private File targetFile;
+    private Path configFilePath;
+    private Path targetFilePath;
     private Optional<Date> sinceDate;
     private Optional<Date> untilDate;
 
@@ -41,7 +42,7 @@ public class CliArguments {
     public CliArguments(String[] args) throws IllegalArgumentException {
         sinceDate = Optional.empty();
         untilDate = Optional.empty();
-        targetFile = new File(DEFAULT_FILE_ARG);
+        targetFilePath = Paths.get(DEFAULT_FILE_ARG);
 
         final HashMap<String, String> argumentMap = generateArgumentMap(args);
         checkAllMandatoryArgumentsPresent(argumentMap);
@@ -98,12 +99,12 @@ public class CliArguments {
 
         if (argumentMap.containsKey(CONFIG_FILE_ARG)) {
             final String configFilePath = argumentMap.get(CONFIG_FILE_ARG);
-            configFile = new File(configFilePath);
+            this.configFilePath = Paths.get(configFilePath);
         }
 
         if (argumentMap.containsKey(TARGET_FILE_ARG)) {
             final String targetFilePath = argumentMap.get(TARGET_FILE_ARG);
-            targetFile = new File(targetFilePath);
+            this.targetFilePath = Paths.get(targetFilePath);
         }
 
         try {
@@ -121,16 +122,16 @@ public class CliArguments {
         }
     }
 
-    public File getConfigFile() {
-        return configFile;
+    public Path getConfigFilePath() {
+        return configFilePath;
     }
 
     public Optional<Date> getSinceDate() {
         return sinceDate;
     }
 
-    public File getTargetFile() {
-        return targetFile;
+    public Path getTargetFilePath() {
+        return targetFilePath;
     }
 
     public Optional<Date> getUntilDate() {

--- a/src/main/java/reposense/frontend/RepoSense.java
+++ b/src/main/java/reposense/frontend/RepoSense.java
@@ -1,6 +1,6 @@
 package reposense.frontend;
 
-import java.io.File;
+import java.nio.file.Path;
 import java.util.Date;
 import java.util.List;
 
@@ -18,13 +18,13 @@ public class RepoSense {
         try {
             CliArguments cliArguments = new CliArguments(args);
 
-            File configFile = cliArguments.getConfigFile();
-            File targetFile = cliArguments.getTargetFile();
+            Path configFile = cliArguments.getConfigFilePath();
+            Path targetFile = cliArguments.getTargetFilePath();
             Date fromDate = cliArguments.getSinceDate().orElse(null);
             Date toDate = cliArguments.getUntilDate().orElse(null);
 
             List<RepoConfiguration> configs = CsvConfigurationBuilder.buildConfigs(configFile, fromDate, toDate);
-            RepoInfoFileGenerator.generateReposReport(configs, targetFile.getAbsolutePath());
+            RepoInfoFileGenerator.generateReposReport(configs, targetFile.toAbsolutePath().toString());
         } catch (IllegalArgumentException ex) {
             System.out.print(ex.getMessage());
             showHelpMessage();

--- a/src/main/java/reposense/git/GitCloner.java
+++ b/src/main/java/reposense/git/GitCloner.java
@@ -1,15 +1,16 @@
 package reposense.git;
 
+import java.io.IOException;
+
 import reposense.system.CommandRunner;
 import reposense.util.FileUtil;
 
 
 public class GitCloner {
     public static void downloadRepo(String organization, String repoName, String branchName) throws GitClonerException {
-        FileUtil.deleteDirectory(FileUtil.getRepoDirectory(organization, repoName));
-
-
         try {
+            FileUtil.deleteDirectory(FileUtil.getRepoDirectory(organization, repoName));
+
             System.out.println("cloning " + organization + "/" + repoName + "...");
             CommandRunner.cloneRepo(organization, repoName);
             System.out.println("cloning done!");
@@ -19,6 +20,8 @@ public class GitCloner {
             throw new GitClonerException(e);
             //Due to an unsolved bug on Windows Git, for some repository, Git Clone will return an error even
             // though the repo is cloned properly.
+        } catch (IOException ioe) {
+            throw new GitClonerException(ioe);
         }
 
         try {

--- a/src/main/java/reposense/report/RepoInfoFileGenerator.java
+++ b/src/main/java/reposense/report/RepoInfoFileGenerator.java
@@ -28,7 +28,11 @@ import reposense.util.FileUtil;
 
 public class RepoInfoFileGenerator {
 
-    public static void generateReposReport(List<RepoConfiguration> repoConfigs, String targetFileLocation) {
+    /**
+     * Generates the repo report in a new folder inside {@code targetFileLocation}, using the configs in
+     * {@code repoConfigs}, and returns the name of the folder generated.
+     */
+    public static String generateReposReport(List<RepoConfiguration> repoConfigs, String targetFileLocation) {
         String reportName = generateReportName();
         HashSet<Author> suspiciousAuthors = new HashSet<>();
 
@@ -63,6 +67,7 @@ public class RepoInfoFileGenerator {
         }
         FileUtil.writeJsonFile(repoConfigs, getSummaryResultPath(reportName, targetFileLocation));
 
+        return reportName;
     }
 
     private static void generateIndividualRepoReport(RepoConfiguration repoConfig, List<FileInfo> fileInfos,

--- a/src/main/java/reposense/report/RepoInfoFileGenerator.java
+++ b/src/main/java/reposense/report/RepoInfoFileGenerator.java
@@ -10,6 +10,8 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import java.util.zip.ZipInputStream;
 
 import reposense.analyzer.ContentAnalyzer;
@@ -78,7 +80,7 @@ public class RepoInfoFileGenerator {
                 Constants.STATIC_INDIVIDUAL_REPORT_TEMPLATE_ADDRESS);
 
         try {
-            Files.copy(templateLocation, repoReportDirectory);
+            copyDirectoryFiles(templateLocation, repoReportDirectory);
             FileUtil.writeJsonFile(fileInfos, getIndividualAuthorshipPath(repoReportDirectory.toString()));
             FileUtil.writeJsonFile(summary, getIndividualCommitsPath(repoReportDirectory.toString()));
             System.out.println("report for " + repoReportName + " Generated!");
@@ -91,6 +93,19 @@ public class RepoInfoFileGenerator {
         String location = targetFileLocation + File.separator + reportName;
         InputStream is = RepoSense.class.getResourceAsStream(Constants.TEMPLATE_ZIP_ADDRESS);
         FileUtil.unzip(new ZipInputStream(is), location);
+    }
+
+    /**
+     * Copies all the files inside {@code src} directory to {@code dest} directory.
+     * Creates the {@code dest} directory if it does not exist.
+     */
+    private static void copyDirectoryFiles(Path src, Path dest) throws IOException {
+        Files.createDirectories(dest);
+        try (Stream<Path> pathStream = Files.list(src)) {
+            for (Path filePath: pathStream.collect(Collectors.toList())) {
+                Files.copy(filePath, dest.resolve(src.relativize(filePath)));
+            }
+        }
     }
 
     private static String getIndividualAuthorshipPath(String repoReportDirectory) {

--- a/src/main/java/reposense/system/CommandRunner.java
+++ b/src/main/java/reposense/system/CommandRunner.java
@@ -1,7 +1,9 @@
 package reposense.system;
 
-import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Date;
 
 import reposense.util.Constants;
@@ -12,7 +14,7 @@ public class CommandRunner {
     private static boolean isWindows = isWindows();
 
     public static String gitLog(String root, Date fromDate, Date toDate) {
-        File rootFile = new File(root);
+        Path rootPath = Paths.get(root);
         String command = "git log --no-merges ";
         if (fromDate != null) {
             command += " --since=\"" + Constants.GIT_LOG_DATE_FORMAT.format(fromDate) + "\" ";
@@ -21,47 +23,45 @@ public class CommandRunner {
             command += " --until=\"" + Constants.GIT_LOG_DATE_FORMAT.format(toDate) + "\" ";
         }
         command += " --pretty=format:\"%h|%aN|%ad|%s\" --date=iso --shortstat -- \"*.java\" -- \"*.adoc\"";
-        return runCommand(rootFile, command);
+        return runCommand(rootPath, command);
     }
 
     public static void checkOut(String root, String hash) {
-        File rootFile = new File(root);
-        runCommand(rootFile, "git checkout " + hash);
+        Path rootPath = Paths.get(root);
+        runCommand(rootPath, "git checkout " + hash);
     }
 
     public static String blameRaw(String root, String fileDirectory) {
-        File rootFile = new File(root);
-        return runCommand(rootFile, "git blame " + addQuote(fileDirectory) + " -w -C -C -M --line-porcelain");
+        Path rootPath = Paths.get(root);
+        return runCommand(rootPath, "git blame " + addQuote(fileDirectory) + " -w -C -C -M --line-porcelain");
     }
 
     public static String checkStyleRaw(String absoluteDirectory) {
-        File rootFile = new File(".");
+        Path rootPath = Paths.get(absoluteDirectory);
         return runCommand(
-                rootFile,
+                rootPath,
                 "java -jar checkstyle-7.7-all.jar -c /google_checks.xml -f xml " + absoluteDirectory
         );
     }
 
-    public static String cloneRepo(String org, String repoName) {
-        File rootFile = new File(Constants.REPOS_ADDRESS + "/" + org);
-        if (!rootFile.exists()) {
-            rootFile.mkdirs();
-        }
-        return runCommand(rootFile, "git clone " + Constants.GITHUB_URL_ROOT + org + "/" + repoName);
+    public static String cloneRepo(String org, String repoName) throws IOException {
+        Path rootPath = Paths.get(Constants.REPOS_ADDRESS, org);
+        Files.createDirectories(rootPath);
+        return runCommand(rootPath, "git clone " + Constants.GITHUB_URL_ROOT + org + "/" + repoName);
     }
 
 
 
-    private static String runCommand(File directory, String command) {
+    private static String runCommand(Path path, String command) {
         ProcessBuilder pb = null;
         if (isWindows) {
             pb = new ProcessBuilder()
                     .command(new String[]{"CMD", "/c", command})
-                    .directory(directory);
+                    .directory(path.toFile());
         } else {
             pb = new ProcessBuilder()
                     .command(new String[]{"bash", "-c", command})
-                    .directory(directory);
+                    .directory(path.toFile());
         }
         Process p = null;
         try {
@@ -87,7 +87,7 @@ public class CommandRunner {
         } else {
             String errorMessage = "Error returned from command ";
             errorMessage += command + "on path ";
-            errorMessage += directory.getPath() + " :\n" + errorGobbler.getValue();
+            errorMessage += path.toString() + " :\n" + errorGobbler.getValue();
             throw new RuntimeException(errorMessage);
         }
     }

--- a/src/main/java/reposense/system/CsvConfigurationBuilder.java
+++ b/src/main/java/reposense/system/CsvConfigurationBuilder.java
@@ -1,9 +1,9 @@
 package reposense.system;
 
 import java.io.BufferedReader;
-import java.io.File;
-import java.io.FileReader;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -15,7 +15,7 @@ import reposense.util.Constants;
 
 public class CsvConfigurationBuilder {
 
-    public static List<RepoConfiguration> buildConfigs(File configFile, Date fromDate, Date toDate) {
+    public static List<RepoConfiguration> buildConfigs(Path configFile, Date fromDate, Date toDate) {
         List<RepoConfiguration> configs = parseConfig(configFile);
         for (RepoConfiguration config : configs) {
             config.setToDate(toDate);
@@ -24,10 +24,10 @@ public class CsvConfigurationBuilder {
         return configs;
     }
 
-    private static List<RepoConfiguration> parseConfig(File csvFile) {
+    private static List<RepoConfiguration> parseConfig(Path csvFile) {
         String line;
         List<RepoConfiguration> configs = new ArrayList<>();
-        try (BufferedReader br = new BufferedReader(new FileReader(csvFile))) {
+        try (BufferedReader br = new BufferedReader(Files.newBufferedReader(csvFile))) {
             br.readLine(); //skip title line
             while ((line = br.readLine()) != null) {
                 // use comma as separator

--- a/src/main/java/reposense/util/FileUtil.java
+++ b/src/main/java/reposense/util/FileUtil.java
@@ -1,13 +1,14 @@
 package reposense.util;
 
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.PrintWriter;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Comparator;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
@@ -24,11 +25,9 @@ public class FileUtil {
                 .create();
         String result = gson.toJson(object);
 
-        try {
-            PrintWriter out = new PrintWriter(path);
+        try (PrintWriter out = new PrintWriter(path)) {
             out.print(result);
             out.print("\n");
-            out.close();
         } catch (FileNotFoundException e) {
             e.printStackTrace();
         }
@@ -38,136 +37,53 @@ public class FileUtil {
         return Constants.REPOS_ADDRESS + File.separator + org + File.separator + repoName + File.separator;
     }
 
-    public static void deleteDirectory(String root) {
-
-        File directory = new File(root);
-
-        //make sure directory exists
-        if (directory.exists()) {
-            delete(directory);
+    public static void deleteDirectory(String root) throws IOException {
+        Path rootPath = Paths.get(root);
+        if (Files.exists(rootPath)) {
+            Files.walk(rootPath)
+                    .sorted(Comparator.reverseOrder())
+                    .forEach(FileUtil::deleteFile);
         }
     }
 
-    private static void delete(File file) {
-
-        if (file.isDirectory()) {
-            //directory is empty, then delete it
-            if (file.list().length == 0) {
-                file.delete();
-            } else {
-
-                //list all the directory contents
-                String[] files = file.list();
-
-                for (String temp : files) {
-                    //construct the file structure
-                    File fileDelete = new File(file, temp);
-                    //recursive delete
-                    delete(fileDelete);
-                }
-
-                //check the directory again, if empty then delete it
-                if (file.list().length == 0) {
-                    file.delete();
-                }
-            }
-
-        } else {
-            //if file, then delete it
-            file.delete();
-        }
-    }
-
-    public static void copyFiles(File src, File dest) {
-
-        if (src.isDirectory()) {
-
-            //if directory not exists, create it
-            if (!dest.exists()) {
-                dest.mkdir();
-                System.out.println("Directory copied from "
-                        + src + "  to " + dest);
-            }
-
-            //list all the directory contents
-            String[] files = src.list();
-
-            for (String file : files) {
-                //construct the src and dest file structure
-                File srcFile = new File(src, file);
-                File destFile = new File(dest, file);
-                //recursive copy
-                copyFiles(srcFile, destFile);
-            }
-
-        } else {
-            //if file, then copy it
-            //Use bytes stream to support all file types
-            copyFile(src, dest);
-            //System.out.println("File copied from " + src + " to " + dest);
-        }
-    }
-
-    public static void copyFile(File src, File dest) {
-        InputStream in = null;
+    private static void deleteFile(Path filePath) {
         try {
-            in = new FileInputStream(src);
-            OutputStream out = new FileOutputStream(dest);
-
-            byte[] buffer = new byte[1024];
-
-            int length;
-            //copy the file content in bytes
-            while ((length = in.read(buffer)) > 0) {
-                out.write(buffer, 0, length);
-            }
-
-            in.close();
-            out.close();
-        } catch (FileNotFoundException e) {
-            e.printStackTrace();
-        } catch (IOException e) {
-            e.printStackTrace();
+            // .git files created when cloning repo are `readonly`, so we need to set it to false in order to delete it
+            Files.setAttribute(filePath, "dos:readonly", false);
+            Files.delete(filePath);
+        } catch (IOException ioe) {
+            System.out.println("Error in deleting file " + filePath.toString());
         }
     }
 
     public static void unzip(ZipInputStream zipInput, String destinationFolder) {
-        File directory = new File(destinationFolder);
-
-        // if the output directory doesn't exist, create it
-        if (!directory.exists()) {
-            directory.mkdirs();
-        }
+        Path directory = Paths.get(destinationFolder);
 
         // buffer for read and write data to file
         byte[] buffer = new byte[2048];
 
         try {
+            Files.createDirectories(directory);
             ZipEntry entry = zipInput.getNextEntry();
 
             while (entry != null) {
                 String entryName = entry.getName();
-                File file = new File(destinationFolder + File.separator + entryName);
+                Path path = Paths.get(destinationFolder, entryName);
                 // create the directories of the zip directory
                 if (entry.isDirectory()) {
-                    File newDir = new File(file.getAbsolutePath());
-                    if (!newDir.exists()) {
-                        boolean success = newDir.mkdirs();
-                        if (success == false) {
-                            System.out.println("Problem creating Folder");
-                        }
-                    }
+                    Path newDir = Paths.get(path.toAbsolutePath().toString());
+                    Files.createDirectories(newDir);
                 } else {
-                    if (!file.getParentFile().exists()) {
-                        file.getParentFile().mkdirs();
+                    if (!Files.exists(path.getParent())) {
+                        Files.createDirectories(path.getParent());
                     }
-                    FileOutputStream fOutput = new FileOutputStream(file);
+                    OutputStream output = Files.newOutputStream(path);
                     int count = 0;
                     while ((count = zipInput.read(buffer)) > 0) {
                         // write 'count' bytes to the file output stream
-                        fOutput.write(buffer, 0, count);
+                        output.write(buffer, 0, count);
                     }
-                    fOutput.close();
+                    output.close();
                 }
                 // close ZipEntry and take the next one
                 zipInput.closeEntry();

--- a/src/test/java/reposense/analyzer/FileAnalyzerTest.java
+++ b/src/test/java/reposense/analyzer/FileAnalyzerTest.java
@@ -1,6 +1,7 @@
 package reposense.analyzer;
 
-import java.io.File;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.List;
 
 import org.junit.Assert;
@@ -21,18 +22,13 @@ public class FileAnalyzerTest extends GitTestTemplate {
         GitChecker.checkout(config.getRepoRoot(), TestConstants.TEST_COMMIT_HASH);
         List<FileInfo> files = FileAnalyzer.analyzeAllFiles(config);
         Assert.assertEquals(files.size(), 4);
-        Assert.assertTrue(isFileExistence("annotationTest.java", files));
-        Assert.assertTrue(isFileExistence("blameTest.java", files));
-        Assert.assertTrue(isFileExistence("newPos" + File.separator + "movedFile.java", files));
-        Assert.assertFalse(isFileExistence("inMasterBranch.java", files)); //empty file
+        Assert.assertTrue(isFileExistence(Paths.get("annotationTest.java"), files));
+        Assert.assertTrue(isFileExistence(Paths.get("blameTest.java"), files));
+        Assert.assertTrue(isFileExistence(Paths.get("newPos/movedFile.java"), files));
+        Assert.assertFalse(isFileExistence(Paths.get("inMasterBranch.java"), files)); //empty file
     }
 
-    private boolean isFileExistence(String filePath, List<FileInfo> files) {
-        for (FileInfo file : files) {
-            if (file.getPath().equals(filePath)) {
-                return true;
-            }
-        }
-        return false;
+    private boolean isFileExistence(Path filePath, List<FileInfo> files) {
+        return files.stream().anyMatch(file -> Paths.get(file.getPath()).equals(filePath));
     }
 }

--- a/src/test/java/reposense/git/GitCheckerTest.java
+++ b/src/test/java/reposense/git/GitCheckerTest.java
@@ -1,6 +1,8 @@
 package reposense.git;
 
-import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -13,15 +15,15 @@ public class GitCheckerTest extends GitTestTemplate {
     @Test
     public void checkoutBranchTest() {
         GitChecker.checkoutBranch(TestConstants.LOCAL_TEST_REPO_ADDRESS, "test");
-        File branchFile = new File(TestConstants.LOCAL_TEST_REPO_ADDRESS + File.separator + "inTestBranch.java");
-        Assert.assertTrue(branchFile.exists());
+        Path branchFile = Paths.get(TestConstants.LOCAL_TEST_REPO_ADDRESS, "inTestBranch.java");
+        Assert.assertTrue(Files.exists(branchFile));
     }
 
     @Test
     public void checkoutHashTest() {
         GitChecker.checkout(TestConstants.LOCAL_TEST_REPO_ADDRESS, TestConstants.FIRST_COMMIT_HASH);
-        File newFile = new File(TestConstants.LOCAL_TEST_REPO_ADDRESS + File.separator + "newFile.java");
-        Assert.assertFalse(newFile.exists());
+        Path newFile = Paths.get(TestConstants.LOCAL_TEST_REPO_ADDRESS, "newFile.java");
+        Assert.assertFalse(Files.exists(newFile));
     }
 
 }

--- a/src/test/java/reposense/system/CommandRunnerTest.java
+++ b/src/test/java/reposense/system/CommandRunnerTest.java
@@ -1,6 +1,8 @@
 package reposense.system;
 
-import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Calendar;
 
 import org.junit.Assert;
@@ -14,16 +16,15 @@ public class CommandRunnerTest extends GitTestTemplate {
 
     @Test
     public void cloneTest() {
-        File dir = new File(TestConstants.LOCAL_TEST_REPO_ADDRESS);
-        Assert.assertTrue(dir.exists());
+        Path dir = Paths.get(TestConstants.LOCAL_TEST_REPO_ADDRESS);
+        Assert.assertTrue(Files.exists(dir));
     }
 
     @Test
     public void checkoutTest() {
         CommandRunner.checkOut(TestConstants.LOCAL_TEST_REPO_ADDRESS, "test");
-        File branchFile = new File(TestConstants.LOCAL_TEST_REPO_ADDRESS
-                + File.separator + "inTestBranch.java");
-        Assert.assertTrue(branchFile.exists());
+        Path branchFile = Paths.get(TestConstants.LOCAL_TEST_REPO_ADDRESS, "inTestBranch.java");
+        Assert.assertTrue(Files.exists(branchFile));
     }
 
     @Test

--- a/src/test/java/reposense/template/GitTestTemplate.java
+++ b/src/test/java/reposense/template/GitTestTemplate.java
@@ -3,6 +3,8 @@ package reposense.template;
 import static reposense.util.TestConstants.TEST_ORG;
 import static reposense.util.TestConstants.TEST_REPO;
 
+import java.io.IOException;
+
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -17,7 +19,6 @@ import reposense.dataobject.RepoConfiguration;
 import reposense.git.GitBlamer;
 import reposense.git.GitCloner;
 import reposense.git.GitClonerException;
-
 import reposense.system.CommandRunner;
 import reposense.util.Constants;
 import reposense.util.FileUtil;
@@ -34,13 +35,13 @@ public class GitTestTemplate {
     }
 
     @BeforeClass
-    public static void beforeClass() throws GitClonerException {
+    public static void beforeClass() throws GitClonerException, IOException {
         deleteRepos();
         GitCloner.downloadRepo(TEST_ORG, TEST_REPO, "master");
     }
 
     @AfterClass
-    public static void afterClass() {
+    public static void afterClass() throws IOException {
         deleteRepos();
     }
 
@@ -49,7 +50,7 @@ public class GitTestTemplate {
         CommandRunner.checkOut(TestConstants.LOCAL_TEST_REPO_ADDRESS, "master");
     }
 
-    private static void deleteRepos() {
+    private static void deleteRepos() throws IOException {
         FileUtil.deleteDirectory(Constants.REPOS_ADDRESS);
     }
 

--- a/src/test/java/reposense/util/TestUtil.java
+++ b/src/test/java/reposense/util/TestUtil.java
@@ -1,8 +1,8 @@
 package reposense.util;
 
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.Path;
 
 public class TestUtil {
 
@@ -19,7 +19,7 @@ public class TestUtil {
      * Also prints out error message if the lines count are different,
      * else prints out the first line of content difference (if any).
      */
-    public static boolean compareFileContents(File expected, File actual) throws IOException {
+    public static boolean compareFileContents(Path expected, Path actual) throws IOException {
         return compareFileContents(expected, actual, 1);
     }
 
@@ -28,14 +28,14 @@ public class TestUtil {
      * Also prints out error message if the lines count are different,
      * else prints out maximum {@code maxTraceCounts} lines of content difference (if any).
      */
-    public static boolean compareFileContents(File expected, File actual, int maxTraceCounts) throws IOException {
+    public static boolean compareFileContents(Path expected, Path actual, int maxTraceCounts) throws IOException {
         int traceCounts = 0;
 
         System.out.println(String.format(MESSAGE_COMPARING_FILES, expected, actual));
 
-        String[] expectedContent = new String(Files.readAllBytes(expected.toPath()))
+        String[] expectedContent = new String(Files.readAllBytes(expected))
                 .replace("\r", "").split("\n");
-        String[] actualContent = new String(Files.readAllBytes(actual.toPath()))
+        String[] actualContent = new String(Files.readAllBytes(actual))
                 .replace("\r", "").split("\n");
 
         for (int i = 0; i < Math.min(expectedContent.length, actualContent.length); i++) {


### PR DESCRIPTION
Fixes #107 
```
java.nio.file.Path is able to do everything java.io.File can and generally in a better way. 
This is supported by the document posted on the website
https://docs.oracle.com/javase/tutorial/essential/io/legacy.html.

Let's move towards to using Path as a replacement to File whenever we can for better
exception handling and OS invariant coding.
```