### PR TITLE
Align ramp chart by date using padding

### DIFF
--- a/template/index.html
+++ b/template/index.html
@@ -138,7 +138,7 @@
                         <div class="author_block" v-bind:id="authorRepo.author" style="width:100%;margin-left:2%">
                             <h5 class="author_name_tag" v-bind:displayName="authorRepo.displayName" v-bind:author="authorRepo.author" v-bind:authorDisplayName="authorRepo.authorDisplayName">{{i+1}}. {{authorRepo.organization}}/{{authorRepo.repo}}/{{authorRepo.authorDisplayName}}</h5>
                             <div class="spectrum">
-                                <template v-for="(element, index) in rangeFilter(authorRepo[intervalType],minDate,maxDate)">
+                                <template v-for="(element, index) in rangeFilter(authorRepo[intervalType],intervalType,minDate,maxDate)">
                                 <div class="slice" v-bind:style="getSliceStyle(index,element,intervalType,minDate,maxDate)" v-bind:title="getSliceTitle(element,intervalType)" v-bind:onclick="getSliceGithubLink(element,authorRepo)"></div>
                                 </template>
             </div>

--- a/template/static/scripts/summaryVueMethods.js
+++ b/template/static/scripts/summaryVueMethods.js
@@ -5,10 +5,19 @@ vueMethods = {
     updateMaxDate: function(date) {
         this.maxDate = date;
     },
-    rangeFilter: function(contributions, minDate, maxDate) {
+    rangeFilter: function(contributions, intervalType, minDate, maxDate) {
         var resultContribution = [];
         var minDateParsed = Date.parse(minDate);
         var maxDateParsed = Date.parse(maxDate);
+        
+        var startingDate = Date.parse(contributions[0]["fromDate"]);
+        var paddingCount = getIntervalCount(intervalType, minDate, startingDate);
+        if(minDateParsed < startingDate){
+            for(var i=0; i<paddingCount; i++){
+                resultContribution.push({ insertions:0 });
+            }
+        } 
+
         for (contribution of contributions) {
             var currentFromDate = Date.parse(contribution["fromDate"]);
             var currentToDate = Date.parse(contribution["toDate"]);
@@ -16,11 +25,12 @@ vueMethods = {
                 resultContribution.push(contribution);
             }
         }
+
         return resultContribution;
     },
     getSliceStyle: function(index, value, intervalType, minDate, maxDate) {
         var sliceScaleLimit = sliceScaleLimitMap[intervalType];
-        var spacing = 93 / getIntervalCount(intervalType, minDate, maxDate);
+        var spacing = 100 / getIntervalCount(intervalType, minDate, maxDate);
         var contribution = value['insertions'];
         var width;
         if (contribution == 0) {

--- a/template/static/scripts/summaryVueMethods.js
+++ b/template/static/scripts/summaryVueMethods.js
@@ -9,15 +9,13 @@ vueMethods = {
         var resultContribution = [];
         var minDateParsed = Date.parse(minDate);
         var maxDateParsed = Date.parse(maxDate);
-        
         var startingDate = Date.parse(contributions[0]["fromDate"]);
         var paddingCount = getIntervalCount(intervalType, minDate, startingDate);
         if(minDateParsed < startingDate){
             for(var i=0; i<paddingCount; i++){
                 resultContribution.push({ insertions:0 });
             }
-        } 
-
+        }
         for (contribution of contributions) {
             var currentFromDate = Date.parse(contribution["fromDate"]);
             var currentToDate = Date.parse(contribution["toDate"]);

--- a/template/static/scripts/utils.js
+++ b/template/static/scripts/utils.js
@@ -172,6 +172,7 @@ function getMinDate() {
             var authorContribution = summaryJson[i]["authorDailyIntervalContributions"];
             var currentRawDate = authorContribution[Object.keys(authorContribution)[0]][0]["fromDate"];
             var currentDate = Date.parse(currentRawDate);
+
             if (result) {
                 if (result.compareTo(currentDate) > 0) {
                     result = currentDate;
@@ -183,7 +184,9 @@ function getMinDate() {
         if (result==null){
             result = Date.today();
         }
-        return result.toString("M/d/yy");    }
+
+        return result.toString("M/d/yy");    
+    }
 }
 
 function getMaxDate() {
@@ -192,16 +195,19 @@ function getMaxDate() {
         //the fromDate has been set
         return Date.parse(rawDate).toString("M/d/yy");
     } else {
-        //find the min Date among all intervals
+        //find the max Date among all intervals
         var result;
+
         for (var i in summaryJson) {
             var authorContributions = summaryJson[i]["authorDailyIntervalContributions"];
             if (Object.keys(authorContributions).length == 0) continue;
+
             var authorIntervals = authorContributions[Object.keys(authorContributions)[0]];
             if (authorIntervals.length == 0) continue;
 
             var currentRawDate = authorIntervals[authorIntervals.length - 1]["toDate"];
             var currentDate = Date.parse(currentRawDate);
+
             if (result) {
                 if (result.compareTo(currentDate) < 0) {
                     result = currentDate;

--- a/template/static/scripts/utils.js
+++ b/template/static/scripts/utils.js
@@ -185,7 +185,7 @@ function getMinDate() {
             result = Date.today();
         }
 
-        return result.toString("M/d/yy");    
+        return result.toString("M/d/yy");
     }
 }
 


### PR DESCRIPTION
template: add padding to front of ramp slices. also make slices fill …

```
Ever since the splitting of the results, repositories which starts from 
different dates have problem aligning themselves.

Let's pad the ramp slices array with empty results to align all the 
different repositories together.
```