### PR TITLE
TestUtil: add file content comparison method

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,5 +61,6 @@ task functional(type: Test) {
   classpath = sourceSets.functional.runtimeClasspath
   testLogging {
     events "passed", "skipped", "failed"
+    showStandardStreams = true
   }
 }

--- a/src/functional/java/reposense/Entry.java
+++ b/src/functional/java/reposense/Entry.java
@@ -2,7 +2,6 @@ package reposense;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.Files;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
@@ -14,6 +13,7 @@ import reposense.dataobject.RepoConfiguration;
 import reposense.report.RepoInfoFileGenerator;
 import reposense.system.CsvConfigurationBuilder;
 import reposense.util.FileUtil;
+import reposense.util.TestUtil;
 
 
 public class Entry {
@@ -57,19 +57,11 @@ public class Entry {
     private void assertJson(File expectedJson, String expectedPosition, String actualRelative) {
         File actual = new File(actualRelative + expectedPosition);
         Assert.assertTrue(actual.exists());
-        verifyContent(expectedJson, actual);
-    }
-
-    private void verifyContent(File expected, File actual) {
-        String expectedContent = "";
-        String actualContent = "";
         try {
-            expectedContent = new String(Files.readAllBytes(expected.toPath()));
-            actualContent = new String(Files.readAllBytes(actual.toPath()));
+            Assert.assertTrue(TestUtil.compareFileContents(expectedJson, actual));
         } catch (IOException e) {
-            Assert.fail();
+            Assert.fail(e.getMessage());
         }
-        Assert.assertEquals(expectedContent, actualContent);
     }
 
     private String getRelativeDir() {

--- a/src/functional/java/reposense/Entry.java
+++ b/src/functional/java/reposense/Entry.java
@@ -55,10 +55,10 @@ public class Entry {
     }
 
     private void assertJson(File expectedJson, String expectedPosition, String actualRelative) {
-        File actual = new File(actualRelative + expectedPosition);
-        Assert.assertTrue(actual.exists());
+        File actualJson = new File(actualRelative + expectedPosition);
+        Assert.assertTrue(actualJson.exists());
         try {
-            Assert.assertTrue(TestUtil.compareFileContents(expectedJson, actual));
+            Assert.assertTrue(TestUtil.compareFileContents(expectedJson, actualJson));
         } catch (IOException e) {
             Assert.fail(e.getMessage());
         }

--- a/src/test/java/reposense/util/TestUtil.java
+++ b/src/test/java/reposense/util/TestUtil.java
@@ -1,0 +1,58 @@
+package reposense.util;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+
+public class TestUtil {
+
+    private static final String MESSAGE_COMPARING_FILES = "Comparing files %s & %s\n";
+
+    private static final String MESSAGE_LINE_CONTENT_DIFFERENT = "Content different at line number %d:\n"
+            + "<< %s\n"
+            + ">> %s\n";
+
+    private static final String MESSAGE_LINES_LENGTH_DIFFERENT = "The files' lines count do not match.";
+
+    /**
+     * Returns true if the files' contents are the same, and false otherwise.
+     * Also prints out error message if the lines count are different,
+     * else prints out the first line of content difference (if any).
+     */
+    public static boolean compareFileContents(File expected, File actual) throws IOException {
+        return compareFileContents(expected, actual, 1);
+    }
+
+    /**
+     * Returns true if the files' contents are the same, and false otherwise.
+     * Also prints out error message if the lines count are different,
+     * else prints out maximum {@code maxTraceCounts} lines of content difference (if any).
+     */
+    public static boolean compareFileContents(File expected, File actual, int maxTraceCounts) throws IOException {
+        int traceCounts = 0;
+
+        System.out.println(String.format(MESSAGE_COMPARING_FILES, expected, actual));
+
+        String[] expectedContent = new String(Files.readAllBytes(expected.toPath()))
+                .replace("\r", "").split("\n");
+        String[] actualContent = new String(Files.readAllBytes(actual.toPath()))
+                .replace("\r", "").split("\n");
+
+        for (int i = 0; i < Math.min(expectedContent.length, actualContent.length); i++) {
+            if (!expectedContent[i].equals(actualContent[i])) {
+                System.out.println(
+                        String.format(MESSAGE_LINE_CONTENT_DIFFERENT, i + 1, expectedContent[i], actualContent[i]));
+                if (++traceCounts >= maxTraceCounts) {
+                    break;
+                }
+            }
+        }
+        if (expectedContent.length != actualContent.length) {
+            System.out.println(MESSAGE_LINES_LENGTH_DIFFERENT);
+            return false;
+        } else if (traceCounts >= maxTraceCounts) {
+            return false;
+        }
+        return true;
+    }
+}

--- a/src/test/java/reposense/util/TestUtil.java
+++ b/src/test/java/reposense/util/TestUtil.java
@@ -15,7 +15,7 @@ public class TestUtil {
     private static final String MESSAGE_LINES_LENGTH_DIFFERENT = "The files' lines count do not match.";
 
     /**
-     * Returns true if the files' contents are the same, and false otherwise.
+     * Returns true if the files' contents are the same.
      * Also prints out error message if the lines count are different,
      * else prints out the first line of content difference (if any).
      */
@@ -24,7 +24,7 @@ public class TestUtil {
     }
 
     /**
-     * Returns true if the files' contents are the same, and false otherwise.
+     * Returns true if the files' contents are the same.
      * Also prints out error message if the lines count are different,
      * else prints out maximum {@code maxTraceCounts} lines of content difference (if any).
      */


### PR DESCRIPTION
Proposed message:

```
Unlike diff tools, Assert.assertEquals does not provide useful 
information when the content in 2 File objects are not the same. 

This makes troubleshooting difficult. As without a clear indication, 
it is hard to trace the errors.

Let's implement the functionality of printing line differences by 
adding the method TestUtil#compareFileContents. 
```