### PR TITLE
Improve performance

### DIFF
--- a/docs/developer_guide.md
+++ b/docs/developer_guide.md
@@ -14,9 +14,10 @@ Thank you for contributing to RepoSense!
 ### Prerequisites
 
 1. **JDK `1.8.0_60`**  or later
-2. **Git** on the command line <br>
-> Ensure that you're able to use it on the OS terminal. <br>
-3. **IntelliJ** IDE [Optional]
+2. **Git** on the command line 
+3. **findstr** for Windows, **grep** for Linux on the command line
+   * Ensure that you're able to use these tools on the OS terminal.
+4. **IntelliJ** IDE [Optional]
 
 ### Setting up the project in your computer using IntelliJ
 1. Fork this repo, and clone the fork to your computer.

--- a/docs/developer_guide.md
+++ b/docs/developer_guide.md
@@ -15,7 +15,7 @@ Thank you for contributing to RepoSense!
 
 1. **JDK `1.8.0_60`**  or later
 2. **Git** on the command line 
-3. **findstr** for Windows, **grep** for Linux on the command line
+3. **findstr** for Windows, **grep** for macOS or Linux on the command line
    * Ensure that you're able to use these tools on the OS terminal.
 4. **IntelliJ** IDE [Optional]
 

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -7,7 +7,8 @@
 ## Dependencies
 1. **JDK `1.8.0_60`**  or later
 2. **Git** on the command line
-   * Ensure that you're able to use it on the OS terminal.
+3. **findstr** for Windows, **grep** for Linux on the command line
+   * Ensure that you're able to use these tools on the OS terminal.
 
 ## How to Generate Dashboard
 1. Download the latest executable Jar on our [release](https://github.com/reposense/RepoSense/releases/latest).

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -7,7 +7,7 @@
 ## Dependencies
 1. **JDK `1.8.0_60`**  or later
 2. **Git** on the command line
-3. **findstr** for Windows, **grep** for Linux on the command line
+3. **findstr** for Windows, **grep** for macOS or Linux on the command line
    * Ensure that you're able to use these tools on the OS terminal.
 
 ## How to Generate Dashboard

--- a/src/functional/java/reposense/Entry.java
+++ b/src/functional/java/reposense/Entry.java
@@ -68,7 +68,6 @@ public class Entry {
 
     private void assertJson(Path expectedJson, String expectedPosition, String actualRelative) {
         Path actualJson = Paths.get(actualRelative, expectedPosition);
-        System.out.println(actualRelative);
         Assert.assertTrue(Files.exists(actualJson));
         try {
             Assert.assertTrue(TestUtil.compareFileContents(expectedJson, actualJson));

--- a/src/main/java/reposense/git/GitBlamer.java
+++ b/src/main/java/reposense/git/GitBlamer.java
@@ -1,8 +1,5 @@
 package reposense.git;
 
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
 import reposense.dataobject.Author;
 import reposense.dataobject.FileInfo;
 import reposense.dataobject.RepoConfiguration;
@@ -11,24 +8,19 @@ import reposense.system.CommandRunner;
 
 public class GitBlamer {
 
-    private static final Pattern INSERTION_PATTERN = Pattern.compile("^author (.+)");
+    private static final int AUTHOR_NAME_OFFSET = "author ".length();
 
     public static void aggregateBlameInfo(FileInfo fileInfo, RepoConfiguration config) {
-        //System.out.println("blaming " + fileInfo.getPath());
         String raw = CommandRunner.blameRaw(config.getRepoRoot(), fileInfo.getPath());
         String[] rawLines = raw.split("\n");
         int lineCount = 0;
-        for (int i = 0; i < rawLines.length; i++) {
-            Matcher m = INSERTION_PATTERN.matcher(rawLines[i]);
-            if (m.find()) {
-                String authorRawName = m.group(1);
-                Author author = config.getAuthorAliasMap().get(authorRawName);
-                if (author == null) {
-                    author = new Author("-");
-                }
-                fileInfo.getLines().get(lineCount++).setAuthor(author);
+        for (String line: rawLines) {
+            String authorRawName = line.substring(AUTHOR_NAME_OFFSET);
+            Author author = config.getAuthorAliasMap().get(authorRawName);
+            if (author == null) {
+                author = new Author("-");
             }
+            fileInfo.getLines().get(lineCount++).setAuthor(author);
         }
-
     }
 }

--- a/src/main/java/reposense/system/CommandRunner.java
+++ b/src/main/java/reposense/system/CommandRunner.java
@@ -8,7 +8,6 @@ import java.util.Date;
 
 import reposense.util.Constants;
 
-
 public class CommandRunner {
 
     private static boolean isWindows = isWindows();
@@ -33,7 +32,15 @@ public class CommandRunner {
 
     public static String blameRaw(String root, String fileDirectory) {
         Path rootPath = Paths.get(root);
-        return runCommand(rootPath, "git blame " + addQuote(fileDirectory) + " -w -C -C -M --line-porcelain");
+        String blameCommand = "git blame " + addQuote(fileDirectory) + " -w -C -C -M --line-porcelain | ";
+
+        if (isWindows) {
+            blameCommand += "findstr /B /C:" + addQuote("author ");
+        } else {
+            blameCommand += "grep " + addQuote("^author .*");
+        }
+
+        return runCommand(rootPath, blameCommand);
     }
 
     public static String checkStyleRaw(String absoluteDirectory) {

--- a/src/main/java/reposense/util/FileUtil.java
+++ b/src/main/java/reposense/util/FileUtil.java
@@ -42,17 +42,7 @@ public class FileUtil {
         if (Files.exists(rootPath)) {
             Files.walk(rootPath)
                     .sorted(Comparator.reverseOrder())
-                    .forEach(FileUtil::deleteFile);
-        }
-    }
-
-    private static void deleteFile(Path filePath) {
-        try {
-            // .git files created when cloning repo are `readonly`, so we need to set it to false in order to delete it
-            Files.setAttribute(filePath, "dos:readonly", false);
-            Files.delete(filePath);
-        } catch (IOException ioe) {
-            System.out.println("Error in deleting file " + filePath.toString());
+                    .forEach(filePath -> filePath.toFile().delete());
         }
     }
 


### PR DESCRIPTION
Fixes #94.
Part of #84.
```
The analyzing of contribution for each file in the program is very slow 
due to several factors:
1. The `git blame` process produces a lot of unnecessary line information, 
causing a large amount of unnecessary time spent reading I/O. 
2. StreamGobbler uses String concatenation when reading from process InputStream,
which is polynomial in time based on the number of lines.

Let's improve performance of the program and functional test by:
1. Filter the `git blame` process output using `findstr` in Windows OS or `grep`
for other OS, thus having a smaller I/O to read.
2. Change StreamGobbler to read directly from InputStream instead of using
a BufferedReader, and use StringBuilder instead of String concatenation.
```