### PR TITLE
Fix failing ArgParser unit tests on Windows systems

### DIFF
--- a/src/test/java/reposense/parser/ArgsParserTest.java
+++ b/src/test/java/reposense/parser/ArgsParserTest.java
@@ -21,10 +21,10 @@ import reposense.util.TestUtil;
 public class ArgsParserTest {
 
     private static final Path PROJECT_DIRECTORY = Paths.get(System.getProperty("user.dir"));
-    private static final Path CONFIG_FILE_ABSOLUTE = Paths.get(new File(ArgsParserTest.class.getClassLoader()
-            .getResource("output/parser_test.csv").getPath()).getPath());
-    private static final Path OUTPUT_DIRECTORY_ABSOLUTE = Paths.get(new File(ArgsParserTest.class.getClassLoader()
-            .getResource("output").getPath()).getPath());
+    private static final Path CONFIG_FILE_ABSOLUTE = new File(ArgsParserTest.class.getClassLoader()
+            .getResource("output/parser_test.csv").getFile()).toPath();
+    private static final Path OUTPUT_DIRECTORY_ABSOLUTE = new File(ArgsParserTest.class.getClassLoader()
+            .getResource("output").getFile()).toPath();
     private static final Path CONFIG_FILE_RELATIVE = PROJECT_DIRECTORY.relativize(CONFIG_FILE_ABSOLUTE);
     private static final Path OUTPUT_DIRECTORY_RELATIVE = PROJECT_DIRECTORY.relativize(OUTPUT_DIRECTORY_ABSOLUTE);
     private static final String DEFAULT_MANDATORY_ARGS = "-config " + CONFIG_FILE_ABSOLUTE + " ";

--- a/src/test/java/reposense/parser/ArgsParserTest.java
+++ b/src/test/java/reposense/parser/ArgsParserTest.java
@@ -2,6 +2,7 @@ package reposense.parser;
 
 import static org.apache.tools.ant.types.Commandline.translateCommandline;
 
+import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -20,10 +21,10 @@ import reposense.util.TestUtil;
 public class ArgsParserTest {
 
     private static final Path PROJECT_DIRECTORY = Paths.get(System.getProperty("user.dir"));
-    private static final Path CONFIG_FILE_ABSOLUTE = Paths.get(ArgsParserTest.class.getClassLoader()
-            .getResource("output/parser_test.csv").getPath());
-    private static final Path OUTPUT_DIRECTORY_ABSOLUTE = Paths.get(ArgsParserTest.class.getClassLoader()
-            .getResource("output").getPath());
+    private static final Path CONFIG_FILE_ABSOLUTE = Paths.get(new File(ArgsParserTest.class.getClassLoader()
+            .getResource("output/parser_test.csv").getPath()).getPath());
+    private static final Path OUTPUT_DIRECTORY_ABSOLUTE = Paths.get(new File(ArgsParserTest.class.getClassLoader()
+            .getResource("output").getPath()).getPath());
     private static final Path CONFIG_FILE_RELATIVE = PROJECT_DIRECTORY.relativize(CONFIG_FILE_ABSOLUTE);
     private static final Path OUTPUT_DIRECTORY_RELATIVE = PROJECT_DIRECTORY.relativize(OUTPUT_DIRECTORY_ABSOLUTE);
     private static final String DEFAULT_MANDATORY_ARGS = "-config " + CONFIG_FILE_ABSOLUTE + " ";


### PR DESCRIPTION
Proposal Message:
```
ArgsParser unit tests use ClassLoader#getResource(String) to get the path to
a resource file/directory.

According to this SO post[1], ClassLoader#getResource(String) adds an extra
leading slash before a path on Windows systems, which may cause the path
we get to be invalid, resulting in all ArgsParser's unit tests to fail.

Let's update ArgsParserTest to use File(String).toPath() to prevent
the extra leading slash in Windows system.

[1]: Leading slash before disk name in Windows:
https://stackoverflow.com/questions/15662820/getresource-puts-a-leading-before-the-disk-name-using-java-1-7-windows-7
```