### PR TITLE
Make Travis-CI test RepoSense on Mac OSX #143

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,21 @@
 language: java
 
 os:
+  - linux
   - osx
 
 matrix:
   include:
     - jdk: oraclejdk9
 
+script: >-
+    ./config/travis/run-checks.sh &&
+    travis_retry ./gradlew clean checkstyleMain checkstyleTest test functional
+
 addons:
   apt:
     packages:
       - oracle-java9-installer
-
-script: >-
-    ./config/travis/run-checks.sh &&
-    travis_retry ./gradlew clean checkstyleMain checkstyleTest test functional
 
 before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,6 @@ os:
   - linux
   - osx
 
-matrix:
-  include:
-    - jdk: oraclejdk9
-
 script: >-
     ./config/travis/run-checks.sh &&
     travis_retry ./gradlew clean checkstyleMain checkstyleTest test functional

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,13 @@
 language: java
 
-jdk:
-  - oraclejdk9
-  
 os:
   - linux
   - osx
+
+addons:
+  apt:
+    packages:
+      - oracle-java9-installer
 
 script: >-
     ./config/travis/run-checks.sh &&

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,13 +7,18 @@ matrix:
     - os: osx
 
 script: >-
-    ./config/travis/run-checks.sh && 
+    ./config/travis/run-checks.sh &&
     time travis_retry ./gradlew clean checkstyleMain checkstyleTest test functional
 
 addons:
   apt:
     packages:
       - oracle-java9-installer
+
+before_install:
+  # Ensure checkstyle runs in osx image
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew reinstall --with-pcre2 git; fi
 
 before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ matrix:
     - os: osx
 
 script: >-
-    ./config/travis/run-checks.sh &&
-    travis_retry ./gradlew clean checkstyleMain checkstyleTest test functional
+    ./config/travis/run-checks.sh && 
+    time travis_retry ./gradlew clean checkstyleMain checkstyleTest test functional
 
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,9 @@
 language: java
+
+os:
+  - linux
+  - osx
+
 matrix:
   include:
     - jdk: oraclejdk9

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: java
 
+jdk:
+  - oraclejdk9
+  
 os:
   - linux
   - osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,11 @@
 language: java
 
 os:
-  - linux
   - osx
+
+matrix:
+  include:
+    - jdk: oraclejdk9
 
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,11 +16,9 @@ addons:
       - oracle-java9-installer
 
 before_install:
-  # Ensure checkstyle runs in osx image
+  # pcre2 is needed for checkstyle to run in osx
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew reinstall --with-pcre2 git; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew tap caskroom/cask; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew cask install java; fi
 
 before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,18 +4,9 @@ os:
   - linux
   - osx
 
-matrix:
-  include:
-    - jdk: oraclejdk9
-
 script: >-
     ./config/travis/run-checks.sh &&
     travis_retry ./gradlew clean checkstyleMain checkstyleTest test functional
-
-addons:
-  apt:
-    packages:
-      - oracle-java9-installer
 
 before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,8 @@ before_install:
   # Ensure checkstyle runs in osx image
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew reinstall --with-pcre2 git; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew tap caskroom/cask; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew cask install java; fi
 
 before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,10 @@
 language: java
 
-os:
-  - linux
-  - osx
+matrix:
+  include:
+    - os: linux
+      jdk: oraclejdk9
+    - os: osx
 
 script: >-
     ./config/travis/run-checks.sh &&

--- a/build.gradle
+++ b/build.gradle
@@ -59,8 +59,6 @@ sourceSets {
 }
 
 task functional(type: Test) {
-  println(JavaVersion.current())
-
   testClassesDirs = sourceSets.functional.output.classesDirs
   classpath = sourceSets.functional.runtimeClasspath
   testLogging {

--- a/build.gradle
+++ b/build.gradle
@@ -59,6 +59,8 @@ sourceSets {
 }
 
 task functional(type: Test) {
+  println(JavaVersion.current())
+
   testClassesDirs = sourceSets.functional.output.classesDirs
   classpath = sourceSets.functional.runtimeClasspath
   testLogging {


### PR DESCRIPTION
Fixes #143 
```
As an Java application, RepoSense is able to execute on all OSes that
supports jar executable. It is important to ensure that our application
does not break on the supported OSes.

In addition to the linux execution environment, Travis also supports CI
on macOS. Furthermore, this multi-environment configuration allows
parallel execution according to Travis-CI documentation [1].

Let's enable a second build environment, macOS, on travis, so we can
ensure RepoSense runs correctly on all supported OSes.

[1] Testing Your Project on Multiple Operating Systems:
https://docs.travis-ci.com/user/multi-os/

```