### PR TITLE
Clean up the logger output #139

### DIFF
--- a/src/main/java/reposense/system/CustomLogFormatter.java
+++ b/src/main/java/reposense/system/CustomLogFormatter.java
@@ -17,16 +17,8 @@ public class CustomLogFormatter extends SimpleFormatter {
     public synchronized String format(LogRecord record) {
         StringBuilder builder = new StringBuilder();
         builder.append(dateFormat.format(new Date(record.getMillis()))).append(" - ");
-
-        Throwable t = record.getThrown();
-
-        if (t != null) {
-            builder.append("An error has occurred");
-            builder.append("\n");
-        } else {
-            builder.append(formatMessage(record));
-            builder.append("\n");
-        }
+        builder.append(formatMessage(record));
+        builder.append("\n");
 
         return builder.toString();
     }

--- a/src/main/java/reposense/system/CustomLogFormatter.java
+++ b/src/main/java/reposense/system/CustomLogFormatter.java
@@ -1,7 +1,5 @@
 package reposense.system;
 
-import java.io.PrintWriter;
-import java.io.StringWriter;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Date;
@@ -13,22 +11,21 @@ import java.util.logging.SimpleFormatter;
  */
 public class CustomLogFormatter extends SimpleFormatter {
 
-    private static final DateFormat dateFormat = new SimpleDateFormat("dd/MM/yyyy hh:mm:ss");
+    private static final DateFormat dateFormat = new SimpleDateFormat("hh:mm:ss");
 
     @Override
     public synchronized String format(LogRecord record) {
         StringBuilder builder = new StringBuilder();
         builder.append(dateFormat.format(new Date(record.getMillis()))).append(" - ");
-        builder.append("[").append(record.getLevel()).append("] - ");
-        builder.append(formatMessage(record));
-        builder.append("\n");
 
         Throwable t = record.getThrown();
 
         if (t != null) {
-            StringWriter sw = new StringWriter();
-            t.printStackTrace(new PrintWriter(sw));
-            builder.append(sw);
+            builder.append("An error has occurred");
+            builder.append("\n");
+        } else {
+            builder.append(formatMessage(record));
+            builder.append("\n");
         }
 
         return builder.toString();


### PR DESCRIPTION
Fixes #139 

Proposed message:
```
Currently, the logger shows a lot of extra information in console which might 
not be useful for the user.

Let's configure the logger to only show the useful information to the user. 
```
