### PR TITLE
Add support for user-supplied file formats #56, #177

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -15,7 +15,7 @@
 1. Download the latest executable Jar on our [release](https://github.com/reposense/RepoSense/releases/latest).
    * Alternatively, you can compile the executable Jar yourself by following our [build from source guide](Build.md).
 1. Execute it on the OS terminal. <br>
-Usage: `java -jar RepoSense.jar -config CSV_CONFIG_FILE_PATH [-output OUTPUT_DIRECTORY] [-since DD/MM/YYYY] [-until DD/MM/YYYY] [-formats FORMAT]`
+Usage: `java -jar RepoSense.jar -config CSV_CONFIG_FILE_PATH [-output OUTPUT_DIRECTORY] [-since DD/MM/YYYY] [-until DD/MM/YYYY] [-formats FORMAT...]`
 1. The report will be generated in the designated OUTPUT_DIRECTORY, or current working directory otherwise.
 1. To visualize the report, open `index.html`.
 1. If the dashboard was not loaded automatically, upload the `archive.zip` (generated in the OUTPUT_DIRECTORY) manually to load the data.
@@ -40,7 +40,7 @@ The contribution calculation is based on the daily commits made within 00:00 to 
 ### Other option:
 1. Clone this repository (or [download as zip](https://github.com/reposense/RepoSense/archive/master.zip))
 1. Execute the following command on the OS terminal inside the project directory.<br>
-Usage: `gradlew run -Dargs="-config CSV_CONFIG_FILE_PATH [-output OUTPUT_DIRECTORY] [-since DD/MM/YYYY] [-until DD/MM/YYYY] [-formats FORMAT]"` <br>
+Usage: `gradlew run -Dargs="-config CSV_CONFIG_FILE_PATH [-output OUTPUT_DIRECTORY] [-since DD/MM/YYYY] [-until DD/MM/YYYY] [-formats FORMAT...]"` <br>
 
 Sample usage:
 ```

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -15,7 +15,7 @@
 1. Download the latest executable Jar on our [release](https://github.com/reposense/RepoSense/releases/latest).
    * Alternatively, you can compile the executable Jar yourself by following our [build from source guide](Build.md).
 1. Execute it on the OS terminal. <br>
-Usage: `java -jar RepoSense.jar -config CSV_CONFIG_FILE_PATH [-output OUTPUT_DIRECTORY] [-since DD/MM/YYYY] [-until DD/MM/YYYY] [-formats [FORMAT [FORMAT ...]]]`
+Usage: `java -jar RepoSense.jar -config CSV_CONFIG_FILE_PATH [-output OUTPUT_DIRECTORY] [-since DD/MM/YYYY] [-until DD/MM/YYYY] [-formats FORMAT]`
 1. The report will be generated in the designated OUTPUT_DIRECTORY, or current working directory otherwise.
 1. To visualize the report, open `index.html`.
 1. If the dashboard was not loaded automatically, upload the `archive.zip` (generated in the OUTPUT_DIRECTORY) manually to load the data.
@@ -40,7 +40,7 @@ The contribution calculation is based on the daily commits made within 00:00 to 
 ### Other option:
 1. Clone this repository (or [download as zip](https://github.com/reposense/RepoSense/archive/master.zip))
 1. Execute the following command on the OS terminal inside the project directory.<br>
-Usage: `gradlew run -Dargs="-config CSV_CONFIG_FILE_PATH [-output OUTPUT_DIRECTORY] [-since DD/MM/YYYY] [-until DD/MM/YYYY] [-formats [FORMAT [FORMAT ...]]]"` <br>
+Usage: `gradlew run -Dargs="-config CSV_CONFIG_FILE_PATH [-output OUTPUT_DIRECTORY] [-since DD/MM/YYYY] [-until DD/MM/YYYY] [-formats FORMAT]"` <br>
 
 Sample usage:
 ```

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -15,21 +15,22 @@
 1. Download the latest executable Jar on our [release](https://github.com/reposense/RepoSense/releases/latest).
    * Alternatively, you can compile the executable Jar yourself by following our [build from source guide](Build.md).
 1. Execute it on the OS terminal. <br>
-Usage: `java -jar RepoSense.jar -config CSV_CONFIG_FILE_PATH [-output OUTPUT_DIRECTORY] [-since DD/MM/YYYY] [-until DD/MM/YYYY]`
+Usage: `java -jar RepoSense.jar -config CSV_CONFIG_FILE_PATH [-output OUTPUT_DIRECTORY] [-since DD/MM/YYYY] [-until DD/MM/YYYY] [-formats [FORMAT [FORMAT ...]]]`
 1. The report will be generated in the designated OUTPUT_DIRECTORY, or current working directory otherwise.
 1. To visualize the report, open `index.html`.
 1. If the dashboard was not loaded automatically, upload the `archive.zip` (generated in the OUTPUT_DIRECTORY) manually to load the data.
 
 Sample usage:
 ```
-$ java -jar RepoSense.jar -config CSV_path.csv -output output_path/ -since 01/10/2017 -until 01/11/2017
+$ java -jar RepoSense.jar -config CSV_path.csv -output output_path/ -since 01/10/2017 -until 01/11/2017 -formats java adoc js
 ```
 
 Argument List:
 - config : Mandatory. The path to the CSV config file.
 - output : Optional. The path to the dashboard generated. If not provided, it will be generated in the current directory.
-- since : Optional. start date of analysis. Format: `DD/MM/YYYY`
-- until : Optional. end date of analysis. Format: `DD/MM/YYYY`
+- since : Optional. The start date of analysis. Format: `DD/MM/YYYY`
+- until : Optional. The end date of analysis. Format: `DD/MM/YYYY`
+- formats : Optional. The file formats to analyse. Formats: `alphanumerical file formats`. If not provided, the following file formats will be used. `adoc, cs, css, fxml, gradle, html, java, js, json, jsp, md, py, tag, xml`
 
 ```
 Note:
@@ -39,11 +40,11 @@ The contribution calculation is based on the daily commits made within 00:00 to 
 ### Other option:
 1. Clone this repository (or [download as zip](https://github.com/reposense/RepoSense/archive/master.zip))
 1. Execute the following command on the OS terminal inside the project directory.<br>
-Usage: `gradlew run -Dargs="-config CSV_CONFIG_FILE_PATH [-output OUTPUT_DIRECTORY] [-since DD/MM/YYYY] [-until DD/MM/YYYY]"` <br>
+Usage: `gradlew run -Dargs="-config CSV_CONFIG_FILE_PATH [-output OUTPUT_DIRECTORY] [-since DD/MM/YYYY] [-until DD/MM/YYYY] [-formats [FORMAT [FORMAT ...]]]"` <br>
 
 Sample usage:
 ```
-$ gradlew run -Dargs="-config CSV_path.csv -output output_path/ -since 01/10/2017 -until 01/11/2017"
+$ gradlew run -Dargs="-config CSV_path.csv -output output_path/ -since 01/10/2017 -until 01/11/2017 -formats java adoc js"
 ```
 
 `-Dargs="..."` uses the same argument format as mentioned above.

--- a/src/functional/java/reposense/Entry.java
+++ b/src/functional/java/reposense/Entry.java
@@ -63,9 +63,8 @@ public class Entry {
 
         CliArguments cliArguments = ArgsParser.parse(translateCommandline(input));
         List<RepoConfiguration> configs = CsvParser.parse(cliArguments.getConfigFilePath());
-        RepoConfiguration.setFormatsToRepoConfigs(configs, TESTING_FILE_FORMATS);
         RepoConfiguration.setDatesToRepoConfigs(configs, cliArguments.getSinceDate(), cliArguments.getUntilDate());
-        RepoConfiguration.setFormatsToRepoConfigs(configs, Arrays.asList("java", "adoc"));
+        RepoConfiguration.setFormatsToRepoConfigs(configs, TESTING_FILE_FORMATS);
 
         ReportGenerator.generateReposReport(configs, FT_TEMP_DIR);
     }

--- a/src/functional/java/reposense/Entry.java
+++ b/src/functional/java/reposense/Entry.java
@@ -63,8 +63,8 @@ public class Entry {
 
         CliArguments cliArguments = ArgsParser.parse(translateCommandline(input));
         List<RepoConfiguration> configs = CsvParser.parse(cliArguments.getConfigFilePath());
-        RepoConfiguration.setDatesToRepoConfigs(configs, cliArguments.getSinceDate(), cliArguments.getUntilDate());
         RepoConfiguration.setFormatsToRepoConfigs(configs, TESTING_FILE_FORMATS);
+        RepoConfiguration.setDatesToRepoConfigs(configs, cliArguments.getSinceDate(), cliArguments.getUntilDate());
 
         ReportGenerator.generateReposReport(configs, FT_TEMP_DIR);
     }

--- a/src/functional/java/reposense/Entry.java
+++ b/src/functional/java/reposense/Entry.java
@@ -65,6 +65,7 @@ public class Entry {
         List<RepoConfiguration> configs = CsvParser.parse(cliArguments.getConfigFilePath());
         RepoConfiguration.setFormatsToRepoConfigs(configs, TESTING_FILE_FORMATS);
         RepoConfiguration.setDatesToRepoConfigs(configs, cliArguments.getSinceDate(), cliArguments.getUntilDate());
+        RepoConfiguration.setFormatsToRepoConfigs(configs, Arrays.asList("java", "adoc"));
 
         ReportGenerator.generateReposReport(configs, FT_TEMP_DIR);
     }

--- a/src/main/java/reposense/RepoSense.java
+++ b/src/main/java/reposense/RepoSense.java
@@ -1,7 +1,6 @@
 package reposense;
 
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -16,9 +15,6 @@ import reposense.system.LogsManager;
 import reposense.util.FileUtil;
 
 public class RepoSense {
-    public static final List<String> DEFAULT_FILE_FORMATS = Arrays.asList("java", "adoc", "js", "md", "css",
-            "html", "cs", "json", "xml", "py", "fxml", "tag", "jsp", "gradle");
-
     private static final Logger logger = LogsManager.getLogger(RepoSense.class);
 
     public static void main(String[] args) {
@@ -26,9 +22,8 @@ public class RepoSense {
             CliArguments cliArguments = ArgsParser.parse(args);
 
             List<RepoConfiguration> configs = CsvParser.parse(cliArguments.getConfigFilePath());
-            RepoConfiguration.setFormatsToRepoConfigs(configs, DEFAULT_FILE_FORMATS);
             RepoConfiguration.setDatesToRepoConfigs(configs, cliArguments.getSinceDate(), cliArguments.getUntilDate());
-
+            RepoConfiguration.setFormatsToRepoConfigs(configs, cliArguments.getFormats());
             ReportGenerator.generateReposReport(
                     configs, cliArguments.getOutputFilePath().toAbsolutePath().toString());
 

--- a/src/main/java/reposense/RepoSense.java
+++ b/src/main/java/reposense/RepoSense.java
@@ -22,8 +22,8 @@ public class RepoSense {
             CliArguments cliArguments = ArgsParser.parse(args);
 
             List<RepoConfiguration> configs = CsvParser.parse(cliArguments.getConfigFilePath());
-            RepoConfiguration.setDatesToRepoConfigs(configs, cliArguments.getSinceDate(), cliArguments.getUntilDate());
             RepoConfiguration.setFormatsToRepoConfigs(configs, cliArguments.getFormats());
+            RepoConfiguration.setDatesToRepoConfigs(configs, cliArguments.getSinceDate(), cliArguments.getUntilDate());
             ReportGenerator.generateReposReport(
                     configs, cliArguments.getOutputFilePath().toAbsolutePath().toString());
 

--- a/src/main/java/reposense/authorship/FileInfoExtractor.java
+++ b/src/main/java/reposense/authorship/FileInfoExtractor.java
@@ -59,7 +59,7 @@ public class FileInfoExtractor {
                     getAllFileInfo(config, filePath, fileInfos);
                 }
 
-                if (isFileFormatInsideWhiteList(relativePath, config.getFileFormats())) {
+                if (isFormatInsideWhiteList(relativePath, config.getFormats())) {
                     fileInfos.add(generateFileInfo(config.getRepoRoot(), relativePath.replace('\\', '/')));
                 }
             }
@@ -95,9 +95,9 @@ public class FileInfoExtractor {
     }
 
     /**
-     * Returns true if the {@code relativePath}'s file type is inside {@code fileFormatsWhiteList}.
+     * Returns true if the {@code relativePath}'s file type is inside {@code formatsWhiteList}.
      */
-    private static boolean isFileFormatInsideWhiteList(String relativePath, List<String> fileFormatsWhiteList) {
-        return fileFormatsWhiteList.stream().anyMatch(fileFormat -> relativePath.endsWith("." + fileFormat));
+    private static boolean isFormatInsideWhiteList(String relativePath, List<String> formatsWhiteList) {
+        return formatsWhiteList.stream().anyMatch(format -> relativePath.endsWith("." + format));
     }
 }

--- a/src/main/java/reposense/commits/CommitInfoExtractor.java
+++ b/src/main/java/reposense/commits/CommitInfoExtractor.java
@@ -33,7 +33,7 @@ public class CommitInfoExtractor {
      */
     private static String getGitLogResult(RepoConfiguration config) {
         return CommandRunner.gitLog(
-                config.getRepoRoot(), config.getSinceDate(), config.getUntilDate(), config.getFileFormats());
+                config.getRepoRoot(), config.getSinceDate(), config.getUntilDate(), config.getFormats());
     }
 
     /**

--- a/src/main/java/reposense/model/CliArguments.java
+++ b/src/main/java/reposense/model/CliArguments.java
@@ -16,7 +16,7 @@ public class CliArguments {
     private List<String> formats;
 
     public CliArguments(Path configFilePath, Path outputFilePath,
-                        Optional<Date> sinceDate, Optional<Date> untilDate, List<String> formats) {
+            Optional<Date> sinceDate, Optional<Date> untilDate, List<String> formats) {
         this.configFilePath = configFilePath;
         this.outputFilePath = outputFilePath;
         this.sinceDate = sinceDate;

--- a/src/main/java/reposense/model/CliArguments.java
+++ b/src/main/java/reposense/model/CliArguments.java
@@ -2,6 +2,7 @@ package reposense.model;
 
 import java.nio.file.Path;
 import java.util.Date;
+import java.util.List;
 import java.util.Optional;
 
 /**
@@ -12,12 +13,15 @@ public class CliArguments {
     private Path outputFilePath;
     private Optional<Date> sinceDate;
     private Optional<Date> untilDate;
+    private List<String> formats;
 
-    public CliArguments(Path configFilePath, Path outputFilePath, Optional<Date> sinceDate, Optional<Date> untilDate) {
+    public CliArguments(Path configFilePath, Path outputFilePath,
+                        Optional<Date> sinceDate, Optional<Date> untilDate, List<String> formats) {
         this.configFilePath = configFilePath;
         this.outputFilePath = outputFilePath;
         this.sinceDate = sinceDate;
         this.untilDate = untilDate;
+        this.formats = formats;
     }
 
     public Path getConfigFilePath() {
@@ -34,5 +38,9 @@ public class CliArguments {
 
     public Optional<Date> getUntilDate() {
         return untilDate;
+    }
+
+    public List<String> getFormats() {
+        return formats;
     }
 }

--- a/src/main/java/reposense/model/RepoConfiguration.java
+++ b/src/main/java/reposense/model/RepoConfiguration.java
@@ -19,9 +19,8 @@ public class RepoConfiguration {
     private Date sinceDate;
     private Date untilDate;
 
-    private transient List<String> formats;
     private transient boolean needCheckStyle = false;
-    private transient List<String> fileFormats;
+    private transient List<String> formats;
     private transient int commitNum = 1;
     private transient List<String> ignoreDirectoryList = new ArrayList<>();
     private transient List<Author> authorList = new ArrayList<>();
@@ -45,10 +44,10 @@ public class RepoConfiguration {
     }
 
     /**
-     * Sets all {@code RepoConfiguration} in {@code configs} to have {@code fileFormats} set.
+     * Sets all {@code RepoConfiguration} in {@code configs} to have {@code formats} set.
      */
-    public static void setFormatsToRepoConfigs(List<RepoConfiguration> configs, List<String> fileFormats) {
-        configs.forEach(config -> config.setFileFormats(fileFormats));
+    public static void setFormatsToRepoConfigs(List<RepoConfiguration> configs, List<String> formats) {
+        configs.forEach(config -> config.setFormats(formats));
     }
 
     @Override
@@ -174,12 +173,12 @@ public class RepoConfiguration {
         return displayName;
     }
 
-    public List<String> getFileFormats() {
-        return fileFormats;
+    public List<String> getFormats() {
+        return formats;
     }
 
-    public void setFileFormats(List<String> fileFormats) {
-        this.fileFormats = fileFormats;
+    public void setFormats(List<String> formats) {
+        this.formats = formats;
     }
 
     public void setAuthorDisplayName(Author author, String displayName) {

--- a/src/main/java/reposense/model/RepoConfiguration.java
+++ b/src/main/java/reposense/model/RepoConfiguration.java
@@ -19,6 +19,7 @@ public class RepoConfiguration {
     private Date sinceDate;
     private Date untilDate;
 
+    private transient List<String> formats;
     private transient boolean needCheckStyle = false;
     private transient List<String> fileFormats;
     private transient int commitNum = 1;

--- a/src/main/java/reposense/parser/AlphanumericArgumentType.java
+++ b/src/main/java/reposense/parser/AlphanumericArgumentType.java
@@ -1,0 +1,27 @@
+package reposense.parser;
+
+import java.util.regex.Pattern;
+
+import net.sourceforge.argparse4j.inf.Argument;
+import net.sourceforge.argparse4j.inf.ArgumentParser;
+import net.sourceforge.argparse4j.inf.ArgumentParserException;
+import net.sourceforge.argparse4j.inf.ArgumentType;
+
+/**
+ * Verifies a String is alphanumeric.
+ */
+public class AlphanumericArgumentType implements ArgumentType<String> {
+    private static final String PARSE_EXCEPTION_MESSAGE_NOT_IN_ALPLANUMERIC =
+            "Invalid format. It must be in alphanumeric.";
+    private static final Pattern ALPHANUMERIC_PATTERN = Pattern.compile("[A-Za-z0-9]+");
+
+    @Override
+    public String convert(ArgumentParser parser, Argument arg, String value) throws ArgumentParserException {
+        if (!ALPHANUMERIC_PATTERN.matcher(value).matches()) {
+            throw new ArgumentParserException(
+                    String.format(PARSE_EXCEPTION_MESSAGE_NOT_IN_ALPLANUMERIC, value), parser);
+        }
+
+        return value;
+    }
+}

--- a/src/main/java/reposense/parser/AlphanumericArgumentType.java
+++ b/src/main/java/reposense/parser/AlphanumericArgumentType.java
@@ -8,7 +8,7 @@ import net.sourceforge.argparse4j.inf.ArgumentParserException;
 import net.sourceforge.argparse4j.inf.ArgumentType;
 
 /**
- * Verifies a String is alphanumeric.
+ * This class represents a Alphanumeric Argument Type.
  */
 public class AlphanumericArgumentType implements ArgumentType<String> {
     private static final String PARSE_EXCEPTION_MESSAGE_NOT_IN_ALPLANUMERIC =

--- a/src/main/java/reposense/parser/AlphanumericArgumentType.java
+++ b/src/main/java/reposense/parser/AlphanumericArgumentType.java
@@ -8,7 +8,7 @@ import net.sourceforge.argparse4j.inf.ArgumentParserException;
 import net.sourceforge.argparse4j.inf.ArgumentType;
 
 /**
- * This class represents a Alphanumeric Argument Type.
+ * Represents an alphanumeric type String argument.
  */
 public class AlphanumericArgumentType implements ArgumentType<String> {
     private static final String PARSE_EXCEPTION_MESSAGE_NOT_IN_ALPLANUMERIC =

--- a/src/main/java/reposense/parser/ArgsParser.java
+++ b/src/main/java/reposense/parser/ArgsParser.java
@@ -70,8 +70,9 @@ public class ArgsParser {
                 .metavar("FORMAT")
                 .type(new AlphanumericArgumentType())
                 .setDefault(DEFAULT_FORMATS)
-                .help("The alphanumeric file formats to process. "
-                        + "If not provided, popular programming file formats will be used.");
+                .help("The alphanumeric file formats to process.\n"
+                        + "If not provided, default file formats will be used.\n"
+                        + "Please refer to userguide for more information.");
 
         return parser;
     }

--- a/src/main/java/reposense/parser/ArgsParser.java
+++ b/src/main/java/reposense/parser/ArgsParser.java
@@ -4,7 +4,10 @@ import java.io.File;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Date;
+import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import net.sourceforge.argparse4j.ArgumentParsers;
 import net.sourceforge.argparse4j.impl.Arguments;
@@ -24,6 +27,7 @@ public class ArgsParser {
             "RepoSense is a contribution analysis tool for Git repositories.";
     private static final String MESSAGE_SINCE_DATE_LATER_THAN_UNTIL_DATE =
             "\"Since Date\" cannot be later than \"Until Date\"";
+    private static final List<String> DEFAULT_FORMATS =  Stream.of("java", "adoc").collect(Collectors.toList());
 
     private static ArgumentParser getArgumentParser() {
         ArgumentParser parser = ArgumentParsers
@@ -61,6 +65,13 @@ public class ArgsParser {
                 .setDefault(Optional.empty())
                 .help("The date to stop filtering.");
 
+        parser.addArgument("-formats")
+                .nargs("*")
+                .metavar("FORMAT")
+                .setDefault(DEFAULT_FORMATS)
+                .help("The file formats to process. "
+                        + "If not provided, java and adoc will be used.");
+
         return parser;
     }
 
@@ -81,6 +92,9 @@ public class ArgsParser {
 
             Path configFilePath = configFile.toPath();
             Path outputFilePath = Paths.get(outputFile.toString(), DEFAULT_REPORT_NAME);
+
+            List<String> formats = results.get("formats");
+            System.out.println(formats);
 
             verifyDatesRangeIsCorrect(sinceDate, untilDate);
             return new CliArguments(configFilePath, outputFilePath, sinceDate, untilDate);

--- a/src/main/java/reposense/parser/ArgsParser.java
+++ b/src/main/java/reposense/parser/ArgsParser.java
@@ -3,11 +3,10 @@ package reposense.parser;
 import java.io.File;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import net.sourceforge.argparse4j.ArgumentParsers;
 import net.sourceforge.argparse4j.impl.Arguments;
@@ -22,12 +21,13 @@ import reposense.model.CliArguments;
  */
 public class ArgsParser {
     public static final String DEFAULT_REPORT_NAME = "reposense-report";
+    public static final List<String> DEFAULT_FORMATS = Arrays.asList(
+            "adoc", "cs", "css", "fxml", "gradle", "html", "java", "js", "json", "jsp", "md", "py", "tag", "xml");
     private static final String PROGRAM_USAGE = "java -jar RepoSense.jar";
     private static final String PROGRAM_DESCRIPTION =
             "RepoSense is a contribution analysis tool for Git repositories.";
     private static final String MESSAGE_SINCE_DATE_LATER_THAN_UNTIL_DATE =
             "\"Since Date\" cannot be later than \"Until Date\"";
-    private static final List<String> DEFAULT_FORMATS =  Stream.of("java", "adoc").collect(Collectors.toList());
 
     private static ArgumentParser getArgumentParser() {
         ArgumentParser parser = ArgumentParsers
@@ -68,9 +68,10 @@ public class ArgsParser {
         parser.addArgument("-formats")
                 .nargs("*")
                 .metavar("FORMAT")
+                .type(new AlphanumericArgumentType())
                 .setDefault(DEFAULT_FORMATS)
-                .help("The file formats to process. "
-                        + "If not provided, java and adoc will be used.");
+                .help("The alphanumeric file formats to process. "
+                        + "If not provided, popular programming file formats will be used.");
 
         return parser;
     }
@@ -94,10 +95,9 @@ public class ArgsParser {
             Path outputFilePath = Paths.get(outputFile.toString(), DEFAULT_REPORT_NAME);
 
             List<String> formats = results.get("formats");
-            System.out.println(formats);
 
             verifyDatesRangeIsCorrect(sinceDate, untilDate);
-            return new CliArguments(configFilePath, outputFilePath, sinceDate, untilDate);
+            return new CliArguments(configFilePath, outputFilePath, sinceDate, untilDate, formats);
         } catch (ArgumentParserException ape) {
             throw new ParseException(getArgumentParser().formatUsage() + ape.getMessage() + "\n");
         }

--- a/src/main/java/reposense/system/CommandRunner.java
+++ b/src/main/java/reposense/system/CommandRunner.java
@@ -24,7 +24,6 @@ public class CommandRunner {
         command += convertToGitDateRangeArgs(sinceDate, untilDate);
         command += " --pretty=format:\"%h|%aN|%ad|%s\" --date=iso --shortstat";
         command += convertToGitFileFormatsArgs(fileFormats);
-
         return runCommand(rootPath, command);
     }
 
@@ -158,7 +157,6 @@ public class CommandRunner {
      */
     private static String convertToGitFileFormatsArgs(List<String> fileFormats) {
         StringBuilder gitFileFormatsArgsBuilder = new StringBuilder();
-
         final String cmdFormat = " -- " + addQuote("*.%s");
         fileFormats.stream()
                 .map(format -> String.format(cmdFormat, format))

--- a/src/main/java/reposense/system/CommandRunner.java
+++ b/src/main/java/reposense/system/CommandRunner.java
@@ -17,13 +17,13 @@ public class CommandRunner {
 
     private static boolean isWindows = isWindows();
 
-    public static String gitLog(String root, Date sinceDate, Date untilDate, List<String> fileFormats) {
+    public static String gitLog(String root, Date sinceDate, Date untilDate, List<String> formats) {
         Path rootPath = Paths.get(root);
 
         String command = "git log --no-merges ";
         command += convertToGitDateRangeArgs(sinceDate, untilDate);
         command += " --pretty=format:\"%h|%aN|%ad|%s\" --date=iso --shortstat";
-        command += convertToGitFileFormatsArgs(fileFormats);
+        command += convertToGitFormatsArgs(formats);
         return runCommand(rootPath, command);
     }
 
@@ -155,13 +155,13 @@ public class CommandRunner {
     /**
      * Returns the {@code String} command to specify the file formats to analyze for `git` commands.
      */
-    private static String convertToGitFileFormatsArgs(List<String> fileFormats) {
-        StringBuilder gitFileFormatsArgsBuilder = new StringBuilder();
+    private static String convertToGitFormatsArgs(List<String> formats) {
+        StringBuilder gitFormatsArgsBuilder = new StringBuilder();
         final String cmdFormat = " -- " + addQuote("*.%s");
-        fileFormats.stream()
+        formats.stream()
                 .map(format -> String.format(cmdFormat, format))
-                .forEach(gitFileFormatsArgsBuilder::append);
+                .forEach(gitFormatsArgsBuilder::append);
 
-        return gitFileFormatsArgsBuilder.toString();
+        return gitFormatsArgsBuilder.toString();
     }
 }

--- a/src/test/java/reposense/parser/ArgsParserTest.java
+++ b/src/test/java/reposense/parser/ArgsParserTest.java
@@ -33,7 +33,7 @@ public class ArgsParserTest {
     @Test
     public void parse_allCorrectInputs_success() throws ParseException, IOException {
         String input = String.format("-config %s -output %s -since 01/07/2017 -until 30/11/2017 "
-                        + "-formats java adoc html css js", CONFIG_FILE_ABSOLUTE, OUTPUT_DIRECTORY_ABSOLUTE);
+                + "-formats java adoc html css js", CONFIG_FILE_ABSOLUTE, OUTPUT_DIRECTORY_ABSOLUTE);
         CliArguments cliArguments = ArgsParser.parse(translateCommandline(input));
         Assert.assertTrue(Files.isSameFile(CONFIG_FILE_ABSOLUTE, cliArguments.getConfigFilePath()));
         Assert.assertTrue(Files.isSameFile(Paths.get(OUTPUT_DIRECTORY_ABSOLUTE.toString(),
@@ -51,7 +51,7 @@ public class ArgsParserTest {
     @Test
     public void parse_withExtraWhitespaces_success() throws ParseException, IOException {
         String input = String.format("-config %s      -output   %s   -since 01/07/2017   -until    30/11/2017   "
-                        + "-formats     java   adoc     html css js ", CONFIG_FILE_ABSOLUTE, OUTPUT_DIRECTORY_ABSOLUTE);
+                + "-formats     java   adoc     html css js ", CONFIG_FILE_ABSOLUTE, OUTPUT_DIRECTORY_ABSOLUTE);
         CliArguments cliArguments = ArgsParser.parse(translateCommandline(input));
         Assert.assertTrue(Files.isSameFile(CONFIG_FILE_ABSOLUTE, cliArguments.getConfigFilePath()));
         Assert.assertTrue(Files.isSameFile(Paths.get(OUTPUT_DIRECTORY_ABSOLUTE.toString(),

--- a/src/test/java/reposense/system/CommandRunnerTest.java
+++ b/src/test/java/reposense/system/CommandRunnerTest.java
@@ -10,7 +10,6 @@ import java.util.Date;
 import org.junit.Assert;
 import org.junit.Test;
 
-import reposense.parser.ArgsParser;
 import reposense.template.GitTestTemplate;
 import reposense.util.TestConstants;
 import reposense.util.TestUtil;
@@ -32,15 +31,9 @@ public class CommandRunnerTest extends GitTestTemplate {
     }
 
     @Test
-<<<<<<< HEAD
-    public void logWithContentTest() {
-        String content = CommandRunner.gitLog(
-                TestConstants.LOCAL_TEST_REPO_ADDRESS, null, null, config.getFileFormats());
-=======
     public void log_existingFormats_hasContent() {
         String content =
-                CommandRunner.gitLog(TestConstants.LOCAL_TEST_REPO_ADDRESS, null, null, ArgsParser.DEFAULT_FORMATS);
->>>>>>> 8835b7d... Update tests to 3 point
+                CommandRunner.gitLog(TestConstants.LOCAL_TEST_REPO_ADDRESS, null, null, config.getFileFormats());
         Assert.assertFalse(content.isEmpty());
     }
 
@@ -54,7 +47,6 @@ public class CommandRunnerTest extends GitTestTemplate {
     @Test
     public void log_sinceDateInFuture_noContent() {
         Date date = TestUtil.getDate(2050, Calendar.JANUARY, 1);
-<<<<<<< HEAD
         String content = CommandRunner.gitLog(
                 TestConstants.LOCAL_TEST_REPO_ADDRESS, date, null, config.getFileFormats());
         Assert.assertTrue(content.isEmpty());
@@ -62,14 +54,6 @@ public class CommandRunnerTest extends GitTestTemplate {
         date = TestUtil.getDate(1950, Calendar.JANUARY, 1);
         content = CommandRunner.gitLog(
                 TestConstants.LOCAL_TEST_REPO_ADDRESS, null, date, config.getFileFormats());
-=======
-        String content =
-                CommandRunner.gitLog(TestConstants.LOCAL_TEST_REPO_ADDRESS, date, null, ArgsParser.DEFAULT_FORMATS);
-        Assert.assertTrue(content.isEmpty());
-
-        date = TestUtil.getDate(1950, Calendar.JANUARY, 1);
-        content = CommandRunner.gitLog(TestConstants.LOCAL_TEST_REPO_ADDRESS, null, date, ArgsParser.DEFAULT_FORMATS);
->>>>>>> 8835b7d... Update tests to 3 point
         Assert.assertTrue(content.isEmpty());
     }
 

--- a/src/test/java/reposense/system/CommandRunnerTest.java
+++ b/src/test/java/reposense/system/CommandRunnerTest.java
@@ -33,7 +33,7 @@ public class CommandRunnerTest extends GitTestTemplate {
     @Test
     public void log_existingFormats_hasContent() {
         String content =
-                CommandRunner.gitLog(TestConstants.LOCAL_TEST_REPO_ADDRESS, null, null, config.getFileFormats());
+                CommandRunner.gitLog(TestConstants.LOCAL_TEST_REPO_ADDRESS, null, null, config.getFormats());
         Assert.assertFalse(content.isEmpty());
     }
 
@@ -48,12 +48,12 @@ public class CommandRunnerTest extends GitTestTemplate {
     public void log_sinceDateInFuture_noContent() {
         Date date = TestUtil.getDate(2050, Calendar.JANUARY, 1);
         String content = CommandRunner.gitLog(
-                TestConstants.LOCAL_TEST_REPO_ADDRESS, date, null, config.getFileFormats());
+                TestConstants.LOCAL_TEST_REPO_ADDRESS, date, null, config.getFormats());
         Assert.assertTrue(content.isEmpty());
 
         date = TestUtil.getDate(1950, Calendar.JANUARY, 1);
         content = CommandRunner.gitLog(
-                TestConstants.LOCAL_TEST_REPO_ADDRESS, null, date, config.getFileFormats());
+                TestConstants.LOCAL_TEST_REPO_ADDRESS, null, date, config.getFormats());
         Assert.assertTrue(content.isEmpty());
     }
 

--- a/src/test/java/reposense/system/CommandRunnerTest.java
+++ b/src/test/java/reposense/system/CommandRunnerTest.java
@@ -3,12 +3,14 @@ package reposense.system;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Date;
 
 import org.junit.Assert;
 import org.junit.Test;
 
+import reposense.parser.ArgsParser;
 import reposense.template.GitTestTemplate;
 import reposense.util.TestConstants;
 import reposense.util.TestUtil;
@@ -30,15 +32,29 @@ public class CommandRunnerTest extends GitTestTemplate {
     }
 
     @Test
+<<<<<<< HEAD
     public void logWithContentTest() {
         String content = CommandRunner.gitLog(
                 TestConstants.LOCAL_TEST_REPO_ADDRESS, null, null, config.getFileFormats());
+=======
+    public void log_existingFormats_hasContent() {
+        String content =
+                CommandRunner.gitLog(TestConstants.LOCAL_TEST_REPO_ADDRESS, null, null, ArgsParser.DEFAULT_FORMATS);
+>>>>>>> 8835b7d... Update tests to 3 point
         Assert.assertFalse(content.isEmpty());
     }
 
     @Test
-    public void logWithoutContentTest() {
+    public void log_nonExistingFormats_noContent() {
+        String content =
+                CommandRunner.gitLog(TestConstants.LOCAL_TEST_REPO_ADDRESS, null, null, Arrays.asList("py"));
+        Assert.assertTrue(content.isEmpty());
+    }
+
+    @Test
+    public void log_sinceDateInFuture_noContent() {
         Date date = TestUtil.getDate(2050, Calendar.JANUARY, 1);
+<<<<<<< HEAD
         String content = CommandRunner.gitLog(
                 TestConstants.LOCAL_TEST_REPO_ADDRESS, date, null, config.getFileFormats());
         Assert.assertTrue(content.isEmpty());
@@ -46,6 +62,14 @@ public class CommandRunnerTest extends GitTestTemplate {
         date = TestUtil.getDate(1950, Calendar.JANUARY, 1);
         content = CommandRunner.gitLog(
                 TestConstants.LOCAL_TEST_REPO_ADDRESS, null, date, config.getFileFormats());
+=======
+        String content =
+                CommandRunner.gitLog(TestConstants.LOCAL_TEST_REPO_ADDRESS, date, null, ArgsParser.DEFAULT_FORMATS);
+        Assert.assertTrue(content.isEmpty());
+
+        date = TestUtil.getDate(1950, Calendar.JANUARY, 1);
+        content = CommandRunner.gitLog(TestConstants.LOCAL_TEST_REPO_ADDRESS, null, date, ArgsParser.DEFAULT_FORMATS);
+>>>>>>> 8835b7d... Update tests to 3 point
         Assert.assertTrue(content.isEmpty());
     }
 

--- a/src/test/java/reposense/template/GitTestTemplate.java
+++ b/src/test/java/reposense/template/GitTestTemplate.java
@@ -11,7 +11,6 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
 
-import reposense.RepoSense;
 import reposense.authorship.FileInfoAnalyzer;
 import reposense.authorship.FileInfoExtractor;
 import reposense.authorship.model.FileInfo;
@@ -21,6 +20,7 @@ import reposense.git.GitDownloader;
 import reposense.git.GitDownloaderException;
 import reposense.model.Author;
 import reposense.model.RepoConfiguration;
+import reposense.parser.ArgsParser;
 import reposense.system.CommandRunner;
 import reposense.util.Constants;
 import reposense.util.FileUtil;
@@ -33,7 +33,7 @@ public class GitTestTemplate {
     @Before
     public void before() {
         config = new RepoConfiguration(TEST_ORG, TEST_REPO, "master");
-        config.setFileFormats(RepoSense.DEFAULT_FILE_FORMATS);
+        config.setFileFormats(ArgsParser.DEFAULT_FORMATS);
     }
 
     @BeforeClass

--- a/src/test/java/reposense/template/GitTestTemplate.java
+++ b/src/test/java/reposense/template/GitTestTemplate.java
@@ -33,7 +33,7 @@ public class GitTestTemplate {
     @Before
     public void before() {
         config = new RepoConfiguration(TEST_ORG, TEST_REPO, "master");
-        config.setFileFormats(ArgsParser.DEFAULT_FORMATS);
+        config.setFormats(ArgsParser.DEFAULT_FORMATS);
     }
 
     @BeforeClass


### PR DESCRIPTION
Fixes #56, #177

```
File formats .java and .adoc are hardcoded in the git log command of
RepoSense.

As the file formats are not changable, this means RepoSense may only
be useful for users who work on repository that consisting mainly of
java or adoc.

Let's allow an optional file formats to be passed in as a parameter so
that user could use RepoSense on repositories with different codebases.
```