### PR TITLE
Dashboard: restore view state using query parameters #224

### DIFF
--- a/frontend/src/index.jade
+++ b/frontend/src/index.jade
@@ -62,6 +62,11 @@ html
             .mui-textfield.summary-picker__date
               input(type="date", v-model="filterUntilDate")
               label until
+          .mui-select.summary-picker__input
+            select(v-model="filterTimeFrame")
+              option(value="day") Day 
+              option(value="week") Week 
+            label details 
           .mui-checkbox.summary-picker__checkboxes.summary-picker__input
             label
               input(type="checkbox", v-model="filterSortReverse").summary-picker__checkbox
@@ -69,9 +74,6 @@ html
             label
               input(type="checkbox", v-model="filterGroupRepos").summary-picker__checkbox
               span group by repo
-            label
-              input(type="checkbox", v-model="filterGroupWeek").summary-picker__checkbox
-              span week
         #summary-charts
           .summary-charts(v-for="repo of filtered", v-if="repo.length>0")
             .summary-charts--title(v-if="filterGroupRepos") {{ repo[0].repoPath }}

--- a/frontend/src/index.jade
+++ b/frontend/src/index.jade
@@ -64,9 +64,9 @@ html
               label until
           .mui-select.summary-picker__input
             select(v-model="filterTimeFrame")
-              option(value="day") Day 
-              option(value="week") Week 
-            label granularity 
+              option(value="day") Day
+              option(value="week") Week
+            label granularity
           .mui-checkbox.summary-picker__checkboxes.summary-picker__input
             label
               input(type="checkbox", v-model="filterSortReverse").summary-picker__checkbox

--- a/frontend/src/index.jade
+++ b/frontend/src/index.jade
@@ -66,7 +66,7 @@ html
             select(v-model="filterTimeFrame")
               option(value="day") Day 
               option(value="week") Week 
-            label details 
+            label granularity 
           .mui-checkbox.summary-picker__checkboxes.summary-picker__input
             label
               input(type="checkbox", v-model="filterSortReverse").summary-picker__checkbox

--- a/frontend/src/static/js/api.js
+++ b/frontend/src/static/js/api.js
@@ -1,7 +1,6 @@
 // utility functions //
 window.$ = id => document.getElementById(id);
 window.enquery = (key, val) => `${key}=${encodeURIComponent(val)}`;
-
 const REPORT_DIR = '.';
 
 // data retrieval functions //

--- a/frontend/src/static/js/api.js
+++ b/frontend/src/static/js/api.js
@@ -8,20 +8,19 @@ function loadJSON(fname) {
   if (window.REPORT_ZIP) {
     return window.REPORT_ZIP.file(fname.slice(2)).async('text')
       .then(txt => JSON.parse(txt));
-  } else {
-    return new Promise((resolve) => {
-      const xhr = new XMLHttpRequest();
-      xhr.open('GET', fname);
-      xhr.onload = function xhrOnload() {
-        if (xhr.status === 200) {
-          resolve(JSON.parse(xhr.responseText));
-        } else {
-          window.alert('unable to get file');
-        }
-      };
-      xhr.send(null);
-    });
   }
+  return new Promise((resolve) => {
+    const xhr = new XMLHttpRequest();
+    xhr.open('GET', fname);
+    xhr.onload = function xhrOnload() {
+      if (xhr.status === 200) {
+        resolve(JSON.parse(xhr.responseText));
+      } else {
+        window.alert('unable to get file');
+      }
+    };
+    xhr.send(null);
+  });
 }
 
 window.api = {

--- a/frontend/src/static/js/main.js
+++ b/frontend/src/static/js/main.js
@@ -1,6 +1,20 @@
 window.REPORT_ZIP = null;
 window.REPOS = {};
 
+window.hashParams = {};
+window.addHash = function addHash(newKey, newVal) {
+  const { hashParams } = window;
+  hashParams[newKey] = newVal;
+
+  const hash = [];
+  const enquery = (key, val) => `${key}=${encodeURIComponent(val)}`;
+  Object.keys(hashParams).forEach((hashKey) => {
+    hash.push(enquery(hashKey, hashParams[hashKey]));
+  });
+
+  window.location.hash = hash.join('&');
+};
+
 window.app = new window.Vue({
   el: '#app',
   data: {

--- a/frontend/src/static/js/main.js
+++ b/frontend/src/static/js/main.js
@@ -27,7 +27,7 @@ window.app = new window.Vue({
     isTabAuthorship: false,
     tabInfo: {},
     tabAuthorship: {},
-    creationDate: "",
+    creationDate: '',
   },
   methods: {
     // model functions //
@@ -55,7 +55,7 @@ window.app = new window.Vue({
         this.userUpdated = false;
         this.loadedRepo = 0;
 
-        return Promise.all(names.map((name) => (
+        return Promise.all(names.map(name => (
           window.api.loadCommits(name)
             .then(() => { this.loadedRepo += 1; })
         )));

--- a/frontend/src/static/js/v_summary.js
+++ b/frontend/src/static/js/v_summary.js
@@ -168,7 +168,7 @@ window.vSummary = {
         window.hashParams[key] = decodeURIComponent(val);
       });
 
-      const convertBool = txt => (txt==='true');
+      const convertBool = txt => (txt === 'true');
       const hash = window.hashParams;
 
       if (hash.search) { this.filterSearch = hash.search; }

--- a/frontend/src/static/js/v_summary.js
+++ b/frontend/src/static/js/v_summary.js
@@ -44,7 +44,7 @@ window.vSummary = {
       filterSort: 'displayName',
       filterSortReverse: false,
       filterGroupRepos: true,
-      filterGroupWeek: false,
+      filterTimeFrame: 'day',
       filterSinceDate: '',
       filterUntilDate: '',
       filterHash: '',
@@ -64,7 +64,7 @@ window.vSummary = {
     filterGroupRepos() {
       this.getFiltered();
     },
-    filterGroupWeek() {
+    filterTimeFrame() {
       this.getFiltered();
     },
     filterSinceDate() {
@@ -153,10 +153,13 @@ window.vSummary = {
       this.filterSearch = this.filterSearch.toLowerCase();
       addHash('search', this.filterSearch);
       addHash('sort', this.filterSort);
-      addHash('reverse', this.filterSortReverse);
-      addHash('repoSort', this.filterGroupRepos);
+
       addHash('since', this.filterSinceDate);
       addHash('until', this.filterUntilDate);
+      addHash('timeframe', this.filterTimeFrame);
+
+      addHash('reverse', this.filterSortReverse);
+      addHash('repoSort', this.filterGroupRepos);
     },
     renderFilterHash() {
       const params = window.location.hash.slice(1).split('&');
@@ -165,13 +168,18 @@ window.vSummary = {
         window.hashParams[key] = decodeURIComponent(val);
       });
 
+      const convertBool = txt => (txt==='true');
       const hash = window.hashParams;
+
       if (hash.search) { this.filterSearch = hash.search; }
       if (hash.sort) { this.filterSort = hash.sort; }
-      if (hash.reverse) { this.filterSortReverse = hash.reverse; }
-      if (hash.repoSort) { this.filterGroupRepos = hash.repoSort; }
+
       if (hash.since) { this.filterSinceDate = hash.since; }
       if (hash.until) { this.filterUntilDate = hash.until; }
+      if (hash.timeframe) { this.filterTimeFrame = hash.timeframe; }
+
+      if (hash.reverse) { this.filterSortReverse = convertBool(hash.reverse); }
+      if (hash.repoSort) { this.filterGroupRepos = convertBool(hash.repoSort); }
     },
 
     getDates() {
@@ -216,7 +224,7 @@ window.vSummary = {
         repo.users.forEach((user) => {
           if (user.searchPath.search(this.filterSearch) > -1) {
             this.getUserCommits(user);
-            if (this.filterGroupWeek) {
+            if (this.filterTimeFrame === 'week') {
               this.splitCommitsWeek(user);
             }
 
@@ -279,7 +287,7 @@ window.vSummary = {
         untilDate = userLast.sinceDate;
       }
 
-      if (this.filterGroupWeek) {
+      if (this.filterTimeFrame === 'week') {
         sinceDate = dateRounding(sinceDate, 1);
       }
       let diff = getIntervalDay(userFirst.sinceDate, sinceDate);
@@ -301,7 +309,7 @@ window.vSummary = {
         }
       });
 
-      if (this.filterGroupWeek) {
+      if (this.filterTimeFrame === 'week') {
         untilDate = dateRounding(untilDate);
       }
       diff = getIntervalDay(untilDate, userLast.sinceDate);

--- a/frontend/src/static/js/v_summary.js
+++ b/frontend/src/static/js/v_summary.js
@@ -148,20 +148,32 @@ window.vSummary = {
 
     // model functions //
     getFilterHash() {
-      const { enquery } = window;
+      const { addHash } = window;
 
       this.filterSearch = this.filterSearch.toLowerCase();
-      this.filterHash = [
-        enquery('search', this.filterSearch),
-        enquery('sort', this.filterSort),
-        enquery('reverse', this.filterSortReverse),
-        enquery('repoSort', this.filterGroupRepos),
-        enquery('since', this.filterSinceDate),
-        enquery('until', this.filterUntilDate),
-      ].join('&');
-
-      window.location.hash = this.filterHash;
+      addHash('search', this.filterSearch);
+      addHash('sort', this.filterSort);
+      addHash('reverse', this.filterSortReverse);
+      addHash('repoSort', this.filterGroupRepos);
+      addHash('since', this.filterSinceDate);
+      addHash('until', this.filterUntilDate);
     },
+    renderFilterHash() {
+      const params = window.location.hash.slice(1).split('&');
+      params.forEach((param) => {
+        const [key, val] = param.split('=');
+        window.hashParams[key] = decodeURIComponent(val);
+      });
+
+      const hash = window.hashParams;
+      if (hash.search) { this.filterSearch = hash.search; }
+      if (hash.sort) { this.filterSort = hash.sort; }
+      if (hash.reverse) { this.filterSortReverse = hash.reverse; }
+      if (hash.repoSort) { this.filterGroupRepos = hash.repoSort; }
+      if (hash.since) { this.filterSinceDate = hash.since; }
+      if (hash.until) { this.filterUntilDate = hash.until; }
+    },
+
     getDates() {
       if (this.filterSinceDate && this.filterUntilDate) {
         return;
@@ -333,6 +345,7 @@ window.vSummary = {
     },
   },
   created() {
+    this.renderFilterHash();
     this.getFiltered();
   },
 };


### PR DESCRIPTION
fixes #224 

```
The summary dashboard plays an important role in highlighting and filtering the
report data to provide the most relevant view for the users.

Permalinks was a feature implemented in the previous dashboard that enables the
users to quickly save the state of the dashboard to quickly return to it when
needed.

While useful, this feature was not core to the usage of the dashboard, hence
left out during the feature for feature reimplementation during the dashboard
structural changes.

Lets implement this permalink feature in the main vue module. New fields will
be emitted from their individual modules into the global  object.

The summary module will read the information from the global object then load
the filtered view accordingly.

Implementing it in the main modules also provides us the option of opening up
other modules for the permalink features if needed in the future.
```