### PR TITLE
Dashboard: synchronize code panel display name #156

### DIFF
--- a/frontend/src/index.jade
+++ b/frontend/src/index.jade
@@ -31,7 +31,7 @@ html
           .tab-content
             .tab-panes
               #tab-authorship.tab-pane(v-if="isTabAuthorship")
-                v_authorship(v-bind:repo="tabRepo", v-bind:author="tabAuthor")
+                v_authorship(v-bind:repo="tabRepo", v-bind:author="tabAuthor", v-bind:name="tabAuthorName")
 
       template(v-else)
         .empty please enter a report directory or upload a report zip
@@ -74,7 +74,7 @@ html
             .summary-charts--title(v-if="filterGroupRepos") {{ repo[0].repoPath }}
             .summary-chart(v-for="(user, i) in repo", v-bind:class="{indented:filterGroupRepos}")
               .summary-chart__title(
-                v-on:click="$emit('view-authorship', {author:user.name, repo:user.repoName})"
+                v-on:click="$emit('view-authorship', {author:user.name, repo:user.repoName, name:user.displayName})"
               )
                 .summary-chart__title--index {{ i+1 }}
                 .summary-chart__title--repo(v-if="!filterGroupRepos") {{ user.repoPath }}
@@ -101,7 +101,7 @@ html
       #authorship
         .title
           .repoName {{ repo }}
-          .author {{ author }}
+          .author {{ name }} ({{ author }})
 
         .files(v-if="isLoaded")
           .file(v-for="file in files")

--- a/frontend/src/static/js/main.js
+++ b/frontend/src/static/js/main.js
@@ -13,8 +13,9 @@ window.app = new window.Vue({
     isTabAuthorship: false,
     isTabIssues: false,
 
-    tabAuthor: '',
     tabRepo: '',
+    tabAuthor: '',
+    tabAuthorName: '',
   },
   methods: {
     // model functions //
@@ -66,8 +67,9 @@ window.app = new window.Vue({
 
     updateTabAuthorship(obj) {
       this.deactivateTabs();
-      this.tabAuthor = obj.author;
       this.tabRepo = obj.repo;
+      this.tabAuthor = obj.author;
+      this.tabAuthorName = obj.name;
 
       this.isTabActive = true;
       this.isTabAuthorship = true;

--- a/frontend/src/static/js/v_authorship.js
+++ b/frontend/src/static/js/v_authorship.js
@@ -11,7 +11,7 @@ window.toggleNext = function toggleNext(ele) {
 };
 
 window.vAuthorship = {
-  props: ['repo', 'author'],
+  props: ['repo', 'author', 'name'],
   template: window.$('v_authorship').innerHTML,
   data() {
     return {


### PR DESCRIPTION
closes #156. after #171

proposed message
```
The dashboard's overview displays the DisplayName as specified in the CSV
config file while the side panel displays the gitHub ID instead.

This may cause confusion to users as the display name and for overview and the
side panel is different.

Let's update the side panel to show the the same display name as overview.
```

![image](https://user-images.githubusercontent.com/1430854/42203255-c3ebc39e-7ed0-11e8-87f2-53c6c6284c94.png)