### PR TITLE
Fix code panel not showing the correct files #214

### DIFF
--- a/frontend/src/index.jade
+++ b/frontend/src/index.jade
@@ -32,10 +32,8 @@ html
             .tab-panes
               #tab-authorship.tab-pane(v-if="isTabAuthorship")
                 v_authorship(
-                  v-bind:key="tabAuthorship.repo+'_'+tabAuthorship.author"
-                  v-bind:repo="tabAuthorship.repo",
-                  v-bind:author="tabAuthorship.author",
-                  v-bind:name="tabAuthorship.name")
+                  v-bind:key="generateKey(tabInfo.tabAuthorship)",
+                  v-bind:info="tabInfo.tabAuthorship")
 
       template(v-else)
         .empty please enter a report directory or upload a report zip
@@ -104,8 +102,8 @@ html
     vuetemplate#v_authorship
       #authorship
         .title
-          .repoName {{ repo }}
-          .author {{ name }} ({{ author }})
+          .repoName {{ info.repo }}
+          .author {{ info.name }} ({{ info.author }})
 
         .files(v-if="isLoaded")
           .file(v-for="file in files")

--- a/frontend/src/index.jade
+++ b/frontend/src/index.jade
@@ -31,7 +31,11 @@ html
           .tab-content
             .tab-panes
               #tab-authorship.tab-pane(v-if="isTabAuthorship")
-                v_authorship(v-bind:repo="tabRepo", v-bind:author="tabAuthor", v-bind:name="tabAuthorName")
+                v_authorship(
+                  v-bind:key="tabAuthorship.repo+'_'+tabAuthorship.author"
+                  v-bind:repo="tabAuthorship.repo", 
+                  v-bind:author="tabAuthorship.author", 
+                  v-bind:name="tabAuthorship.name")
 
       template(v-else)
         .empty please enter a report directory or upload a report zip

--- a/frontend/src/index.jade
+++ b/frontend/src/index.jade
@@ -33,8 +33,8 @@ html
               #tab-authorship.tab-pane(v-if="isTabAuthorship")
                 v_authorship(
                   v-bind:key="tabAuthorship.repo+'_'+tabAuthorship.author"
-                  v-bind:repo="tabAuthorship.repo", 
-                  v-bind:author="tabAuthorship.author", 
+                  v-bind:repo="tabAuthorship.repo",
+                  v-bind:author="tabAuthorship.author",
                   v-bind:name="tabAuthorship.name")
 
       template(v-else)

--- a/frontend/src/static/js/main.js
+++ b/frontend/src/static/js/main.js
@@ -11,11 +11,7 @@ window.app = new window.Vue({
 
     isTabActive: false,
     isTabAuthorship: false,
-    isTabIssues: false,
-
-    tabRepo: '',
-    tabAuthor: '',
-    tabAuthorName: '',
+    tabAuthorship: {},
   },
   methods: {
     // model functions //
@@ -62,14 +58,11 @@ window.app = new window.Vue({
 
     deactivateTabs() {
       this.isTabAuthorship = false;
-      this.isTabIssues = false;
     },
 
     updateTabAuthorship(obj) {
       this.deactivateTabs();
-      this.tabRepo = obj.repo;
-      this.tabAuthor = obj.author;
-      this.tabAuthorName = obj.name;
+      this.tabAuthorship = { ...obj };
 
       this.isTabActive = true;
       this.isTabAuthorship = true;

--- a/frontend/src/static/js/main.js
+++ b/frontend/src/static/js/main.js
@@ -11,6 +11,7 @@ window.app = new window.Vue({
 
     isTabActive: false,
     isTabAuthorship: false,
+    tabInfo: {},
     tabAuthorship: {},
   },
   methods: {
@@ -62,10 +63,14 @@ window.app = new window.Vue({
 
     updateTabAuthorship(obj) {
       this.deactivateTabs();
-      this.tabAuthorship = { ...obj };
+      this.tabInfo.tabAuthorship = { ...obj };
 
       this.isTabActive = true;
       this.isTabAuthorship = true;
+    },
+
+    generateKey(dataObj) {
+      return JSON.stringify(dataObj);
     },
   },
   components: {

--- a/frontend/src/static/js/v_authorship.js
+++ b/frontend/src/static/js/v_authorship.js
@@ -11,7 +11,7 @@ window.toggleNext = function toggleNext(ele) {
 };
 
 window.vAuthorship = {
-  props: ['repo', 'author', 'name'],
+  props: ['info'],
   template: window.$('v_authorship').innerHTML,
   data() {
     return {
@@ -20,24 +20,15 @@ window.vAuthorship = {
     };
   },
 
-  watch: {
-    repo() {
-      this.initiate();
-    },
-    author() {
-      this.initiate();
-    },
-  },
-
   methods: {
     initiate() {
-      const repo = window.REPOS[this.repo];
+      const repo = window.REPOS[this.info.repo];
 
       if (repo.files) {
         this.processFiles(repo.files);
       } else {
         window.api.loadAuthorship(
-          this.repo,
+          this.info.repo,
           files => this.processFiles(files),
         );
       }
@@ -50,7 +41,7 @@ window.vAuthorship = {
       const segments = [];
 
       lines.forEach((line) => {
-        const authored = (line.author && line.author.gitId === this.author);
+        const authored = (line.author && line.author.gitId === this.info.author);
 
         if (authored !== lastState || lastId === -1) {
           segments.push({
@@ -120,7 +111,7 @@ window.vAuthorship = {
       const res = [];
 
       files.forEach((file) => {
-        if (file.authorContributionMap[this.author]) {
+        if (file.authorContributionMap[this.info.author]) {
           const out = {};
           out.path = file.path;
 


### PR DESCRIPTION
fixes #214

```
As the tab content is changed, some of the data for the vue module will
be overwritten and it messes up the display of the authorship tab,
causing the case where multiple files gets jumbled up together and the
display goes wild.

To prevent that from happening, let's tag the `v_authorship` module
with a key which forces vue to re-render `v_summary` as a new instance
with a fresh set of data.
```