### PR TITLE
Fix #51: ramp chart selection does not work after search feature is used

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ repos/
 logs/
 out/
 ft_temp/
+outputs/

--- a/template/index.html
+++ b/template/index.html
@@ -61,38 +61,38 @@
               },
               methods: vueMethods
           });
-          $(".author_name_tag").click(function() {
-              displayName = $(this).attr("displayName");
-              author = $(this).attr("author");
-              authorDisplayName = $(this).attr("authorDisplayName");
-              url = displayName + "/" + "index.html?author=" + author+"&authorDisplayName=" +authorDisplayName;
-              $(".author_block").removeClass("highlighted_block");
-              $("#" + author).addClass("highlighted_block");
-              $(".progress-chart-box").animate({
-                  width: "30%"
-              }, 300);
-              $(".code-review-box").animate({
-                  width: "70%"
-              }, 300, function() {
-                  $(".report-frame").attr('src', url);
-              });
-          });
-
-          $(".hide_button").click(function() {
-              $(".report-frame").attr('src', 'about:blank')
-              $(".author_block").removeClass("highlighted_block");
-              setTimeout((function() {
-                  $(".progress-chart-box").animate({
-                      width: "100%"
-                  }, 300);
-                  $(".code-review-box").animate({
-                      width: "0%"
-                  }, 300);
-
-              }), 200);
-          });
 
           $(function() {
+              $("body").on("click", ".author_name_tag", function() {
+                  displayName = $(this).attr("displayName");
+                  author = $(this).attr("author");
+                  authorDisplayName = $(this).attr("authorDisplayName");
+                  url = displayName + "/" + "index.html?author=" + author+"&authorDisplayName=" +authorDisplayName;
+                  $(".author_block").removeClass("highlighted_block");
+                  $("#" + author).addClass("highlighted_block");
+                  $(".progress-chart-box").animate({
+                      width: "30%"
+                  }, 300);
+                  $(".code-review-box").animate({
+                      width: "70%"
+                  }, 300, function() {
+                      $(".report-frame").attr('src', url);
+                  });
+              });
+
+              $("body").on("click", ".hide_button", function() {
+                  $(".report-frame").attr('src', 'about:blank')
+                  $(".author_block").removeClass("highlighted_block");
+                  setTimeout((function() {
+                      $(".progress-chart-box").animate({
+                          width: "100%"
+                      }, 300);
+                      $(".code-review-box").animate({
+                          width: "0%"
+                      }, 300);
+
+                  }), 200);
+               });
               $(document).tooltip();
               $("#minDatePicker").val(minDateRange);
               $("#maxDatePicker").val(maxDateRange);


### PR DESCRIPTION
Upon click on ramp chart, the click event fires an ajax call to `result.js` load relevant authorship details. The event binding is lost when DOM is reloaded. Therefore, using jQuery's `on` method when document ready will bind event to `element` other than `event target`. Details see here https://stackoverflow.com/questions/13767919/jquery-event-wont-fire-after-ajax-call