### PR TITLE
Remove navbar to optimize usage of vertical space.

### DIFF
--- a/frontend/src/index.jade
+++ b/frontend/src/index.jade
@@ -94,8 +94,8 @@ html
                   v-bind:href="getSliceLink(user, slice)", target="_blank",
                   v-bind:class="'summary-chart__ramp__slice--color'+j%5",
                   v-bind:style="{\
-                    borderLeftWidth: getWidth(slice)+'em',\
-                    right: (sliceCount-j-1)*sliceWidth + '%'\
+                    borderLeftWidth: getWidth(slice) + 'em',\
+                    right: (((user.commits.length-j-1)/user.commits.length) * 100) + '%'\
                   }"
                 )
               .summary-chart__contrib(v-bind:title="'total contribution: '+user.totalCommits")

--- a/frontend/src/index.jade
+++ b/frontend/src/index.jade
@@ -52,6 +52,13 @@ html
               option(value="displayName") Author Name
               option(value="searchPath") Team Name
             label sort by
+          .summary-picker__input
+            .mui-textfield.summary-picker__date
+              input(type="date", v-model="filterSinceDate")
+              label since
+            .mui-textfield.summary-picker__date
+              input(type="date", v-model="filterUntilDate")
+              label until
           .mui-checkbox.summary-picker__checkboxes.summary-picker__input
             label
               input(type="checkbox", v-model="filterSortReverse").summary-picker__checkbox
@@ -62,13 +69,6 @@ html
             label
               input(type="checkbox", v-model="filterGroupWeek").summary-picker__checkbox
               span week
-          .summary-picker__input
-            .mui-textfield.summary-picker__date
-              input(type="date", v-model="filterSinceDate")
-              label since
-            .mui-textfield.summary-picker__date
-              input(type="date", v-model="filterUntilDate")
-              label until
         #summary-charts
           .summary-charts(v-for="repo of filtered", v-if="repo.length>0")
             .summary-charts--title(v-if="filterGroupRepos") {{ repo[0].repoPath }}

--- a/frontend/src/index.jade
+++ b/frontend/src/index.jade
@@ -7,20 +7,14 @@ html
     link(rel="stylesheet", href="static/css/style.css")
 
     script(src="https://use.fontawesome.com/releases/v5.0.13/js/all.js", defer=True)
-    script(src="https://cdnjs.cloudflare.com/ajax/libs/muicss/0.9.39/js/mui.min.js")
     script(src="https://cdnjs.cloudflare.com/ajax/libs/vue/2.5.16/vue.min.js")
     script(src="https://cdnjs.cloudflare.com/ajax/libs/jszip/3.1.5/jszip.min.js")
 
     script(src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/highlight.min.js")
   body
     div#app
-      header.mui-appbar.wrapper
-        .content
-          .logo.mui--text-title RepoSense
-
       #app-wrapper(v-if="userUpdated")
         #summary-wrapper
-          .buffer.mui--appbar-height
           .summary-status(v-if="loadedRepo<repoLength") Loading repos ... {{ loadedRepo }} / {{ repoLength }}
           v_summary(
             v-bind:repos="getUsers()",
@@ -30,7 +24,6 @@ html
         #tabs-wrapper(v-if="isTabActive")
           .tab-close(v-on:click="isTabActive=false")
             i.fas.fa-caret-right
-          .buffer.mui--appbar-height
           ul.mui-tabs__bar
             li(v-bind:class="{'mui--is-active':isTabAuthorship}")
               a(v-on:click="deactivateTabs(); isTabAuthorship=true;")
@@ -48,7 +41,7 @@ html
 
     vuetemplate#v_summary
       #summary.wrapper
-        form.summary-picker.content.mui-form--inline(v-on:submit.prevent="getFiltered();")
+        form.summary-picker.mui-form--inline(v-on:submit.prevent="getFiltered();")
           .mui-textfield.summary-picker__input
             input.summary-picker__search(type="text", v-model="filterSearch")
             label search

--- a/frontend/src/static/css/style.scss
+++ b/frontend/src/static/css/style.scss
@@ -114,10 +114,14 @@ header{
 }
 
 .summary-picker{
+    display:flex;
+    justify-content:center;
+    align-items:flex-end;
     margin-bottom:2rem;
 
     &__input{
-        margin:0.5rem;
+        margin:0 0.5rem;
+        text-align:left;
     }
 
     &__search{

--- a/frontend/src/static/js/v_summary.js
+++ b/frontend/src/static/js/v_summary.js
@@ -40,7 +40,6 @@ window.vSummary = {
   data() {
     return {
       filtered: [],
-      rampScale: 0.1,
       filterSearch: '',
       filterSort: 'totalCommits',
       filterSortReverse: false,
@@ -49,6 +48,7 @@ window.vSummary = {
       filterSinceDate: '',
       filterUntilDate: '',
       filterHash: '',
+      rampSize: 0.01,
     };
   },
   watch: {
@@ -75,12 +75,6 @@ window.vSummary = {
     },
   },
   computed: {
-    sliceCount() {
-      return this.filtered[0][0].commits.length;
-    },
-    sliceWidth() {
-      return 100 / this.sliceCount;
-    },
     avgCommitSize() {
       let totalCommits = 0;
       let totalCount = 0;
@@ -117,9 +111,8 @@ window.vSummary = {
         return 0;
       }
 
-      let size = this.sliceWidth;
-      size *= slice.insertions / this.avgCommitSize;
-      return Math.max(size * this.rampScale, 0.5);
+      const newSize = 100 * (slice.insertions / this.avgCommitSize);
+      return Math.max(newSize * this.rampSize, 0.5);
     },
     getSliceTitle(slice) {
       return `contribution on ${slice.sinceDate
@@ -225,8 +218,8 @@ window.vSummary = {
       });
       this.filtered = full;
 
-      this.sortFiltered();
       this.getDates();
+      this.sortFiltered();
     },
     splitCommitsWeek(user) {
       const { commits } = user;

--- a/frontend/src/static/js/v_summary.js
+++ b/frontend/src/static/js/v_summary.js
@@ -284,7 +284,7 @@ window.vSummary = {
 
       user.dailyCommits.forEach((commit) => {
         const date = commit.sinceDate;
-        if (date >= sinceDate && date <= untilDate) {
+        if (date >= sinceDate && date < untilDate) {
           user.commits.push(commit);
         }
       });

--- a/frontend/src/static/js/v_summary.js
+++ b/frontend/src/static/js/v_summary.js
@@ -236,9 +236,11 @@ window.vSummary = {
 
         for (let dayId = 0; dayId < 7; dayId += 1) {
           const commit = commits[(weekId * 7) + dayId];
-          week.insertions += commit.insertions;
-          week.deletions += commit.deletions;
-          week.untilDate = commit.untilDate;
+          if (commit) {
+            week.insertions += commit.insertions;
+            week.deletions += commit.deletions;
+            week.untilDate = commit.untilDate;
+          }
         }
 
         res.push(week);

--- a/frontend/src/static/js/v_summary.js
+++ b/frontend/src/static/js/v_summary.js
@@ -295,7 +295,7 @@ window.vSummary = {
       diff = getIntervalDay(untilDate, userLast.sinceDate);
 
       const endMs = (new Date(userLast.sinceDate)).getTime();
-      for (let paddingId = 0; paddingId < diff; paddingId += 1) {
+      for (let paddingId = 1; paddingId < diff; paddingId += 1) {
         user.commits.push({
           insertions: 0,
           deletions: 0,

--- a/frontend/src/static/js/v_summary.js
+++ b/frontend/src/static/js/v_summary.js
@@ -284,7 +284,7 @@ window.vSummary = {
 
       user.dailyCommits.forEach((commit) => {
         const date = commit.sinceDate;
-        if (date > sinceDate && date < untilDate) {
+        if (date >= sinceDate && date <= untilDate) {
           user.commits.push(commit);
         }
       });


### PR DESCRIPTION
```
After the removal of the feature to support multiple reports, the navigation
bar contains only the reposense logo.

The bar now plays only an aesthetic role and has no functional purpose, which
is a waste of vertical space.

Similarly the filters on the summary tab could be more concisely displayed to
fully ultilize vertical space.

Let's make the necessary UI changes to improve vertical space usage.
```

![image](https://user-images.githubusercontent.com/1430854/42613039-5069ec36-85d1-11e8-849d-2edac05f7650.png)