### PR TITLE
README.md: fix broken links

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ The features of the report includes:
 * Filtering and sorting of authors
 
 ## Documentations
-* [**User Guide**](docs/user_guide.md)
-* [**Developer Guide**](docs/developer_guide.md)
+* [**User Guide**](docs/UserGuide.md)
+* [**Developer Guide**](docs/DeveloperGuide.md)
 
 ## Contributing
 We welcome pull requests. Please read the [contribution guidelines](docs/Process.md#how-to-contribute-to-the-reposense-repository) before starting work on one.

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -10,8 +10,7 @@
 ## Dependencies
 1. **JDK `1.8.0_60`** or later.
 2. **git `2.14`** or later on the command line.
- * Check that this tool exist on your OS terminal by typing its name on the terminal and ensure that the terminal does not output messages such as `not found` or `not recognized`.
-
+ > Type `git --version` on your OS terminal and ensure that you have the correct version of **git**.
 
 ## How to Generate Dashboard
 1. Download the latest executable Jar on our [release](https://github.com/reposense/RepoSense/releases/latest).


### PR DESCRIPTION
```
Due to renaming of developer_guide.md to DeveloperGuide.md 
and user_guide.md to UserGuide.md, the links in README.md leading
to those two documents are now broken.

Let's fix those broken links.
```