### PR TITLE
Add more default file types to analyze #177

### DIFF
--- a/src/functional/java/reposense/Entry.java
+++ b/src/functional/java/reposense/Entry.java
@@ -28,7 +28,7 @@ import reposense.util.TestUtil;
 public class Entry {
     private static final String FT_TEMP_DIR = "ft_temp";
     private static final String EXPECTED_FOLDER = "expected";
-    private static final List<String> TESTING_FILE_TYPES = Arrays.asList(".java", ".adoc");
+    private static final List<String> TESTING_FILE_TYPES = Arrays.asList("java", "adoc");
 
     @Before
     public void setUp() throws IOException {
@@ -63,7 +63,7 @@ public class Entry {
 
         CliArguments cliArguments = ArgsParser.parse(translateCommandline(input));
         List<RepoConfiguration> configs = CsvParser.parse(cliArguments.getConfigFilePath());
-        RepoConfiguration.setFileTypesToRepoConfigs(configs, TESTING_FILE_TYPES);
+        RepoConfiguration.setFormatsToRepoConfigs(configs, TESTING_FILE_TYPES);
         RepoConfiguration.setDatesToRepoConfigs(configs, cliArguments.getSinceDate(), cliArguments.getUntilDate());
 
         ReportGenerator.generateReposReport(configs, FT_TEMP_DIR);

--- a/src/functional/java/reposense/Entry.java
+++ b/src/functional/java/reposense/Entry.java
@@ -7,6 +7,7 @@ import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -27,6 +28,7 @@ import reposense.util.TestUtil;
 public class Entry {
     private static final String FT_TEMP_DIR = "ft_temp";
     private static final String EXPECTED_FOLDER = "expected";
+    private static final List<String> TESTING_FILE_TYPES = Arrays.asList(".java", ".adoc");
 
     @Before
     public void setUp() throws IOException {
@@ -61,6 +63,7 @@ public class Entry {
 
         CliArguments cliArguments = ArgsParser.parse(translateCommandline(input));
         List<RepoConfiguration> configs = CsvParser.parse(cliArguments.getConfigFilePath());
+        RepoConfiguration.setFileTypesToRepoConfigs(configs, TESTING_FILE_TYPES);
         RepoConfiguration.setDatesToRepoConfigs(configs, cliArguments.getSinceDate(), cliArguments.getUntilDate());
 
         ReportGenerator.generateReposReport(configs, FT_TEMP_DIR);

--- a/src/functional/java/reposense/Entry.java
+++ b/src/functional/java/reposense/Entry.java
@@ -28,7 +28,7 @@ import reposense.util.TestUtil;
 public class Entry {
     private static final String FT_TEMP_DIR = "ft_temp";
     private static final String EXPECTED_FOLDER = "expected";
-    private static final List<String> TESTING_FILE_TYPES = Arrays.asList("java", "adoc");
+    private static final List<String> TESTING_FILE_FORMATS = Arrays.asList("java", "adoc");
 
     @Before
     public void setUp() throws IOException {
@@ -63,7 +63,7 @@ public class Entry {
 
         CliArguments cliArguments = ArgsParser.parse(translateCommandline(input));
         List<RepoConfiguration> configs = CsvParser.parse(cliArguments.getConfigFilePath());
-        RepoConfiguration.setFormatsToRepoConfigs(configs, TESTING_FILE_TYPES);
+        RepoConfiguration.setFormatsToRepoConfigs(configs, TESTING_FILE_FORMATS);
         RepoConfiguration.setDatesToRepoConfigs(configs, cliArguments.getSinceDate(), cliArguments.getUntilDate());
 
         ReportGenerator.generateReposReport(configs, FT_TEMP_DIR);

--- a/src/main/java/reposense/RepoSense.java
+++ b/src/main/java/reposense/RepoSense.java
@@ -1,6 +1,7 @@
 package reposense;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -14,6 +15,9 @@ import reposense.report.ReportGenerator;
 import reposense.system.LogsManager;
 
 public class RepoSense {
+    public static final List<String> DEFAULT_FILE_FORMATS = Arrays.asList("java", "adoc", "js", "md", "css",
+            "html", "cs", "json", "xml", "py", "fxml", "tag", "jsp", "gradle");
+
     private static final Logger logger = LogsManager.getLogger(RepoSense.class);
 
     public static void main(String[] args) {
@@ -21,6 +25,7 @@ public class RepoSense {
             CliArguments cliArguments = ArgsParser.parse(args);
 
             List<RepoConfiguration> configs = CsvParser.parse(cliArguments.getConfigFilePath());
+            RepoConfiguration.setFormatsToRepoConfigs(configs, DEFAULT_FILE_FORMATS);
             RepoConfiguration.setDatesToRepoConfigs(configs, cliArguments.getSinceDate(), cliArguments.getUntilDate());
 
             ReportGenerator.generateReposReport(

--- a/src/main/java/reposense/authorship/FileInfoExtractor.java
+++ b/src/main/java/reposense/authorship/FileInfoExtractor.java
@@ -58,7 +58,7 @@ public class FileInfoExtractor {
                     getAllFileInfo(config, filePath, fileInfos);
                 }
 
-                if (relativePath.endsWith(".java") || relativePath.endsWith(".adoc")) {
+                if (isFileWhiteListed(relativePath, config.getWhiteListedFileTypes())) {
                     fileInfos.add(generateFileInfo(config.getRepoRoot(), relativePath.replace('\\', '/')));
                 }
             }
@@ -91,5 +91,12 @@ public class FileInfoExtractor {
      */
     private static boolean shouldIgnore(String name, List<String> ignoreList) {
         return ignoreList.stream().anyMatch(name::contains);
+    }
+
+    /**
+     * Returns true if the {@code relativePath}'s file type is inside {@code whiteListedFileTypes}.
+     */
+    private static boolean isFileWhiteListed(String relativePath, List<String> whiteListedFileTypes) {
+        return whiteListedFileTypes.stream().anyMatch(relativePath::endsWith);
     }
 }

--- a/src/main/java/reposense/authorship/FileInfoExtractor.java
+++ b/src/main/java/reposense/authorship/FileInfoExtractor.java
@@ -58,7 +58,7 @@ public class FileInfoExtractor {
                     getAllFileInfo(config, filePath, fileInfos);
                 }
 
-                if (isFileFormatWhiteListed(relativePath, config.getFileFormats())) {
+                if (isFileFormatInsideWhiteList(relativePath, config.getFileFormats())) {
                     fileInfos.add(generateFileInfo(config.getRepoRoot(), relativePath.replace('\\', '/')));
                 }
             }
@@ -96,7 +96,7 @@ public class FileInfoExtractor {
     /**
      * Returns true if the {@code relativePath}'s file type is inside {@code fileFormatsWhiteList}.
      */
-    private static boolean isFileFormatWhiteListed(String relativePath, List<String> fileFormatsWhiteList) {
+    private static boolean isFileFormatInsideWhiteList(String relativePath, List<String> fileFormatsWhiteList) {
         return fileFormatsWhiteList.stream().anyMatch(fileFormat -> relativePath.endsWith("." + fileFormat));
     }
 }

--- a/src/main/java/reposense/authorship/FileInfoExtractor.java
+++ b/src/main/java/reposense/authorship/FileInfoExtractor.java
@@ -58,7 +58,7 @@ public class FileInfoExtractor {
                     getAllFileInfo(config, filePath, fileInfos);
                 }
 
-                if (isFileWhiteListed(relativePath, config.getWhiteListedFileTypes())) {
+                if (isFileFormatWhiteListed(relativePath, config.getFileFormats())) {
                     fileInfos.add(generateFileInfo(config.getRepoRoot(), relativePath.replace('\\', '/')));
                 }
             }
@@ -94,9 +94,9 @@ public class FileInfoExtractor {
     }
 
     /**
-     * Returns true if the {@code relativePath}'s file type is inside {@code whiteListedFileTypes}.
+     * Returns true if the {@code relativePath}'s file type is inside {@code fileFormatsWhiteList}.
      */
-    private static boolean isFileWhiteListed(String relativePath, List<String> whiteListedFileTypes) {
-        return whiteListedFileTypes.stream().anyMatch(relativePath::endsWith);
+    private static boolean isFileFormatWhiteListed(String relativePath, List<String> fileFormatsWhiteList) {
+        return fileFormatsWhiteList.stream().anyMatch(fileFormat -> relativePath.endsWith("." + fileFormat));
     }
 }

--- a/src/main/java/reposense/commits/CommitInfoExtractor.java
+++ b/src/main/java/reposense/commits/CommitInfoExtractor.java
@@ -33,7 +33,7 @@ public class CommitInfoExtractor {
      */
     private static String getGitLogResult(RepoConfiguration config) {
         return CommandRunner.gitLog(
-                config.getRepoRoot(), config.getSinceDate(), config.getUntilDate(), config.getWhiteListedFileTypes());
+                config.getRepoRoot(), config.getSinceDate(), config.getUntilDate(), config.getFileFormats());
     }
 
     /**

--- a/src/main/java/reposense/commits/CommitInfoExtractor.java
+++ b/src/main/java/reposense/commits/CommitInfoExtractor.java
@@ -32,7 +32,8 @@ public class CommitInfoExtractor {
      * Returns the git log information for the repo for the date range in {@code config}.
      */
     private static String getGitLogResult(RepoConfiguration config) {
-        return CommandRunner.gitLog(config.getRepoRoot(), config.getSinceDate(), config.getUntilDate());
+        return CommandRunner.gitLog(
+                config.getRepoRoot(), config.getSinceDate(), config.getUntilDate(), config.getWhiteListedFileTypes());
     }
 
     /**

--- a/src/main/java/reposense/model/RepoConfiguration.java
+++ b/src/main/java/reposense/model/RepoConfiguration.java
@@ -1,7 +1,6 @@
 package reposense.model;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
@@ -21,9 +20,8 @@ public class RepoConfiguration {
     private Date untilDate;
 
     private transient boolean needCheckStyle = false;
+    private transient List<String> fileFormats;
     private transient int commitNum = 1;
-    private transient List<String> whiteListedFileTypes = Arrays.asList(".java", ".adoc", ".js", ".md", ".css",
-            ".html", ".cs", ".json", ".xml", ".py", ".fxml", ".tag", ".jsp", ".gradle");
     private transient List<String> ignoreDirectoryList = new ArrayList<>();
     private transient List<Author> authorList = new ArrayList<>();
     private transient TreeMap<String, Author> authorAliasMap = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
@@ -46,10 +44,10 @@ public class RepoConfiguration {
     }
 
     /**
-     * Sets all {@code RepoConfiguration} in {@code configs} to have {@code whiteListedFileTypes} set.
+     * Sets all {@code RepoConfiguration} in {@code configs} to have {@code fileFormats} set.
      */
-    public static void setFileTypesToRepoConfigs(List<RepoConfiguration> configs, List<String> whiteListedFileTypes) {
-        configs.forEach(config -> config.setWhiteListedFileTypes(whiteListedFileTypes));
+    public static void setFormatsToRepoConfigs(List<RepoConfiguration> configs, List<String> fileFormats) {
+        configs.forEach(config -> config.setFileFormats(fileFormats));
     }
 
     @Override
@@ -175,16 +173,16 @@ public class RepoConfiguration {
         return displayName;
     }
 
+    public List<String> getFileFormats() {
+        return fileFormats;
+    }
+
+    public void setFileFormats(List<String> fileFormats) {
+        this.fileFormats = fileFormats;
+    }
+
     public void setAuthorDisplayName(Author author, String displayName) {
         authorDisplayNameMap.put(author, displayName);
-    }
-
-    public List<String> getWhiteListedFileTypes() {
-        return whiteListedFileTypes;
-    }
-
-    public void setWhiteListedFileTypes(List<String> whiteListedFileTypes) {
-        this.whiteListedFileTypes = whiteListedFileTypes;
     }
 
     public void setAuthorAliases(Author author, String... aliases) {

--- a/src/main/java/reposense/model/RepoConfiguration.java
+++ b/src/main/java/reposense/model/RepoConfiguration.java
@@ -1,6 +1,7 @@
 package reposense.model;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
@@ -21,6 +22,8 @@ public class RepoConfiguration {
 
     private transient boolean needCheckStyle = false;
     private transient int commitNum = 1;
+    private transient List<String> whiteListedFileTypes = Arrays.asList(".java", ".adoc", ".js", ".md", ".css",
+            ".html", ".cs", ".json", ".xml", ".py", ".fxml", ".tag", ".jsp", ".gradle");
     private transient List<String> ignoreDirectoryList = new ArrayList<>();
     private transient List<Author> authorList = new ArrayList<>();
     private transient TreeMap<String, Author> authorAliasMap = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
@@ -40,6 +43,13 @@ public class RepoConfiguration {
             config.setSinceDate(sinceDate.orElse(null));
             config.setUntilDate(untilDate.orElse(null));
         }
+    }
+
+    /**
+     * Sets all {@code RepoConfiguration} in {@code configs} to have {@code whiteListedFileTypes} set.
+     */
+    public static void setFileTypesToRepoConfigs(List<RepoConfiguration> configs, List<String> whiteListedFileTypes) {
+        configs.forEach(config -> config.setWhiteListedFileTypes(whiteListedFileTypes));
     }
 
     @Override
@@ -167,6 +177,14 @@ public class RepoConfiguration {
 
     public void setAuthorDisplayName(Author author, String displayName) {
         authorDisplayNameMap.put(author, displayName);
+    }
+
+    public List<String> getWhiteListedFileTypes() {
+        return whiteListedFileTypes;
+    }
+
+    public void setWhiteListedFileTypes(List<String> whiteListedFileTypes) {
+        this.whiteListedFileTypes = whiteListedFileTypes;
     }
 
     public void setAuthorAliases(Author author, String... aliases) {

--- a/src/main/java/reposense/system/CommandRunner.java
+++ b/src/main/java/reposense/system/CommandRunner.java
@@ -7,22 +7,23 @@ import java.nio.file.Paths;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.List;
 
 import reposense.util.Constants;
 
 public class CommandRunner {
-
     private static final DateFormat GIT_LOG_SINCE_DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd'T'00:00:00+08:00");
     private static final DateFormat GIT_LOG_UNTIL_DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd'T'23:59:59+08:00");
 
     private static boolean isWindows = isWindows();
 
-    public static String gitLog(String root, Date sinceDate, Date untilDate) {
+    public static String gitLog(String root, Date sinceDate, Date untilDate, List<String> whiteListedFileTypes) {
         Path rootPath = Paths.get(root);
 
         String command = "git log --no-merges ";
         command += getGitDateRangeArgs(sinceDate, untilDate);
-        command += " --pretty=format:\"%h|%aN|%ad|%s\" --date=iso --shortstat -- \"*.java\" -- \"*.adoc\"";
+        command += " --pretty=format:\"%h|%aN|%ad|%s\" --date=iso --shortstat";
+        command += getGitFileTypesArgs(whiteListedFileTypes);
 
         return runCommand(rootPath, command);
     }
@@ -151,4 +152,13 @@ public class CommandRunner {
 
         return gitDateRangeArgs;
     }
+
+    private static String getGitFileTypesArgs(List<String> fileTypeList) {
+        StringBuilder gitFileTypeArgsBuilder = new StringBuilder();
+
+        fileTypeList.forEach(fileType -> gitFileTypeArgsBuilder.append(" -- \"*").append(fileType).append("\""));
+
+        return gitFileTypeArgsBuilder.toString();
+    }
+
 }

--- a/src/main/java/reposense/system/CommandRunner.java
+++ b/src/main/java/reposense/system/CommandRunner.java
@@ -21,9 +21,9 @@ public class CommandRunner {
         Path rootPath = Paths.get(root);
 
         String command = "git log --no-merges ";
-        command += getGitDateRangeArgs(sinceDate, untilDate);
+        command += convertToGitDateRangeArgs(sinceDate, untilDate);
         command += " --pretty=format:\"%h|%aN|%ad|%s\" --date=iso --shortstat";
-        command += convertToGitFileFormatssArgs(fileFormats);
+        command += convertToGitFileFormatsArgs(fileFormats);
 
         return runCommand(rootPath, command);
     }
@@ -60,7 +60,7 @@ public class CommandRunner {
         Path rootPath = Paths.get(root);
 
         String blameCommand = "git blame -w -C -C -M --line-porcelain";
-        blameCommand += getGitDateRangeArgs(sinceDate, untilDate);
+        blameCommand += convertToGitDateRangeArgs(sinceDate, untilDate);
         blameCommand += " " + addQuote(fileDirectory);
         blameCommand += getAuthorFilterCommand();
 
@@ -140,7 +140,7 @@ public class CommandRunner {
     /**
      * Returns the {@code String} command to specify the date range of commits to analyze for `git` commands.
      */
-    private static String getGitDateRangeArgs(Date sinceDate, Date untilDate) {
+    private static String convertToGitDateRangeArgs(Date sinceDate, Date untilDate) {
         String gitDateRangeArgs = "";
 
         if (sinceDate != null) {
@@ -156,7 +156,7 @@ public class CommandRunner {
     /**
      * Returns the {@code String} command to specify the file formats to analyze for `git` commands.
      */
-    private static String convertToGitFileFormatssArgs(List<String> fileFormats) {
+    private static String convertToGitFileFormatsArgs(List<String> fileFormats) {
         StringBuilder gitFileFormatsArgsBuilder = new StringBuilder();
 
         final String cmdFormat = " -- " + addQuote("*.%s");

--- a/src/main/java/reposense/system/CommandRunner.java
+++ b/src/main/java/reposense/system/CommandRunner.java
@@ -17,13 +17,13 @@ public class CommandRunner {
 
     private static boolean isWindows = isWindows();
 
-    public static String gitLog(String root, Date sinceDate, Date untilDate, List<String> whiteListedFileTypes) {
+    public static String gitLog(String root, Date sinceDate, Date untilDate, List<String> fileFormats) {
         Path rootPath = Paths.get(root);
 
         String command = "git log --no-merges ";
         command += getGitDateRangeArgs(sinceDate, untilDate);
         command += " --pretty=format:\"%h|%aN|%ad|%s\" --date=iso --shortstat";
-        command += convertToGitFileTypesArgs(whiteListedFileTypes);
+        command += convertToGitFileFormatssArgs(fileFormats);
 
         return runCommand(rootPath, command);
     }
@@ -154,16 +154,16 @@ public class CommandRunner {
     }
 
     /**
-     * Returns the {@code String} command to specify the file types to analyze for `git` commands.
+     * Returns the {@code String} command to specify the file formats to analyze for `git` commands.
      */
-    private static String convertToGitFileTypesArgs(List<String> fileFormats) {
-        StringBuilder gitFileTypeArgsBuilder = new StringBuilder();
+    private static String convertToGitFileFormatssArgs(List<String> fileFormats) {
+        StringBuilder gitFileFormatsArgsBuilder = new StringBuilder();
 
         final String cmdFormat = " -- " + addQuote("*.%s");
         fileFormats.stream()
                 .map(format -> String.format(cmdFormat, format))
-                .forEach(gitFileTypeArgsBuilder::append);
+                .forEach(gitFileFormatsArgsBuilder::append);
 
-        return gitFileTypeArgsBuilder.toString();
+        return gitFileFormatsArgsBuilder.toString();
     }
 }

--- a/src/main/java/reposense/system/CommandRunner.java
+++ b/src/main/java/reposense/system/CommandRunner.java
@@ -23,7 +23,7 @@ public class CommandRunner {
         String command = "git log --no-merges ";
         command += getGitDateRangeArgs(sinceDate, untilDate);
         command += " --pretty=format:\"%h|%aN|%ad|%s\" --date=iso --shortstat";
-        command += getGitFileTypesArgs(whiteListedFileTypes);
+        command += convertToGitFileTypesArgs(whiteListedFileTypes);
 
         return runCommand(rootPath, command);
     }
@@ -153,12 +153,17 @@ public class CommandRunner {
         return gitDateRangeArgs;
     }
 
-    private static String getGitFileTypesArgs(List<String> fileTypeList) {
+    /**
+     * Returns the {@code String} command to specify the file types to analyze for `git` commands.
+     */
+    private static String convertToGitFileTypesArgs(List<String> fileFormats) {
         StringBuilder gitFileTypeArgsBuilder = new StringBuilder();
 
-        fileTypeList.forEach(fileType -> gitFileTypeArgsBuilder.append(" -- \"*").append(fileType).append("\""));
+        final String cmdFormat = " -- " + addQuote("*.%s");
+        fileFormats.stream()
+                .map(format -> String.format(cmdFormat, format))
+                .forEach(gitFileTypeArgsBuilder::append);
 
         return gitFileTypeArgsBuilder.toString();
     }
-
 }

--- a/src/test/java/reposense/authorship/FileInfoExtractorTest.java
+++ b/src/test/java/reposense/authorship/FileInfoExtractorTest.java
@@ -21,7 +21,7 @@ public class FileInfoExtractorTest extends GitTestTemplate {
         config.getAuthorAliasMap().put(TestConstants.FAKE_AUTHOR_NAME, new Author(TestConstants.FAKE_AUTHOR_NAME));
         GitChecker.checkout(config.getRepoRoot(), TestConstants.TEST_COMMIT_HASH);
         List<FileInfo> files = FileInfoExtractor.extractFileInfos(config);
-        Assert.assertEquals(files.size(), 5);
+        Assert.assertEquals(files.size(), 6);
         Assert.assertTrue(isFileExistence(Paths.get("annotationTest.java"), files));
         Assert.assertTrue(isFileExistence(Paths.get("blameTest.java"), files));
         Assert.assertTrue(isFileExistence(Paths.get("newPos/movedFile.java"), files));

--- a/src/test/java/reposense/system/CommandRunnerTest.java
+++ b/src/test/java/reposense/system/CommandRunnerTest.java
@@ -31,18 +31,21 @@ public class CommandRunnerTest extends GitTestTemplate {
 
     @Test
     public void logWithContentTest() {
-        String content = CommandRunner.gitLog(TestConstants.LOCAL_TEST_REPO_ADDRESS, null, null);
+        String content = CommandRunner.gitLog(
+                TestConstants.LOCAL_TEST_REPO_ADDRESS, null, null, config.getWhiteListedFileTypes());
         Assert.assertFalse(content.isEmpty());
     }
 
     @Test
     public void logWithoutContentTest() {
         Date date = TestUtil.getDate(2050, Calendar.JANUARY, 1);
-        String content = CommandRunner.gitLog(TestConstants.LOCAL_TEST_REPO_ADDRESS, date, null);
+        String content = CommandRunner.gitLog(
+                TestConstants.LOCAL_TEST_REPO_ADDRESS, date, null, config.getWhiteListedFileTypes());
         Assert.assertTrue(content.isEmpty());
 
         date = TestUtil.getDate(1950, Calendar.JANUARY, 1);
-        content = CommandRunner.gitLog(TestConstants.LOCAL_TEST_REPO_ADDRESS, null, date);
+        content = CommandRunner.gitLog(
+                TestConstants.LOCAL_TEST_REPO_ADDRESS, null, date, config.getWhiteListedFileTypes());
         Assert.assertTrue(content.isEmpty());
     }
 

--- a/src/test/java/reposense/system/CommandRunnerTest.java
+++ b/src/test/java/reposense/system/CommandRunnerTest.java
@@ -32,7 +32,7 @@ public class CommandRunnerTest extends GitTestTemplate {
     @Test
     public void logWithContentTest() {
         String content = CommandRunner.gitLog(
-                TestConstants.LOCAL_TEST_REPO_ADDRESS, null, null, config.getWhiteListedFileTypes());
+                TestConstants.LOCAL_TEST_REPO_ADDRESS, null, null, config.getFileFormats());
         Assert.assertFalse(content.isEmpty());
     }
 
@@ -40,12 +40,12 @@ public class CommandRunnerTest extends GitTestTemplate {
     public void logWithoutContentTest() {
         Date date = TestUtil.getDate(2050, Calendar.JANUARY, 1);
         String content = CommandRunner.gitLog(
-                TestConstants.LOCAL_TEST_REPO_ADDRESS, date, null, config.getWhiteListedFileTypes());
+                TestConstants.LOCAL_TEST_REPO_ADDRESS, date, null, config.getFileFormats());
         Assert.assertTrue(content.isEmpty());
 
         date = TestUtil.getDate(1950, Calendar.JANUARY, 1);
         content = CommandRunner.gitLog(
-                TestConstants.LOCAL_TEST_REPO_ADDRESS, null, date, config.getWhiteListedFileTypes());
+                TestConstants.LOCAL_TEST_REPO_ADDRESS, null, date, config.getFileFormats());
         Assert.assertTrue(content.isEmpty());
     }
 

--- a/src/test/java/reposense/template/GitTestTemplate.java
+++ b/src/test/java/reposense/template/GitTestTemplate.java
@@ -11,6 +11,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
 
+import reposense.RepoSense;
 import reposense.authorship.FileInfoAnalyzer;
 import reposense.authorship.FileInfoExtractor;
 import reposense.authorship.model.FileInfo;
@@ -32,6 +33,7 @@ public class GitTestTemplate {
     @Before
     public void before() {
         config = new RepoConfiguration(TEST_ORG, TEST_REPO, "master");
+        config.setFileFormats(RepoSense.DEFAULT_FILE_FORMATS);
     }
 
     @BeforeClass


### PR DESCRIPTION
Fixes #177
```
RepoSense only tracks '.java' and '.adoc' file types for analyse.

This may not be sufficient for visualization as not many other projects that
are not mainly coded in Java or use asciidoctor for their documents.

Let's include more file types by default in the analysis.
```