### PR TITLE
Fix dashboard padding function

### DIFF
--- a/frontend/src/static/js/api.js
+++ b/frontend/src/static/js/api.js
@@ -5,15 +5,15 @@ window.enquery = (key, val) => `${key}=${encodeURIComponent(val)}`;
 const REPORT_DIR = '.';
 
 // data retrieval functions //
-function loadJSON(file, fn) {
+function loadJSON(fname, fn) {
   const err = () => window.alert('unable to get file');
 
   if (window.REPORT_ZIP) {
-    window.REPORT_ZIP.file(file.slice(2)).async('text')
+    window.REPORT_ZIP.file(fname.slice(2)).async('text')
       .then(txt => fn(JSON.parse(txt)));
   } else {
     const xhr = new XMLHttpRequest();
-    xhr.open('GET', file);
+    xhr.open('GET', fname);
     xhr.onload = function xhrOnload() {
       if (xhr.status === 200) {
         fn(JSON.parse(xhr.responseText));

--- a/frontend/src/static/js/api.js
+++ b/frontend/src/static/js/api.js
@@ -2,14 +2,14 @@
 window.$ = id => document.getElementById(id);
 window.enquery = (key, val) => `${key}=${encodeURIComponent(val)}`;
 
-const REPORT_DIR = '';
+const REPORT_DIR = '.';
 
 // data retrieval functions //
 function loadJSON(file, fn) {
   const err = () => window.alert('unable to get file');
 
   if (window.REPORT_ZIP) {
-    window.REPORT_ZIP.file(file.slice(1)).async('text')
+    window.REPORT_ZIP.file(file.slice(2)).async('text')
       .then(txt => fn(JSON.parse(txt)));
   } else {
     const xhr = new XMLHttpRequest();

--- a/frontend/src/static/js/v_summary.js
+++ b/frontend/src/static/js/v_summary.js
@@ -258,6 +258,10 @@ window.vSummary = {
       const userFirst = user.dailyCommits[0];
       const userLast = user.dailyCommits[user.dailyCommits.length - 1];
 
+      if(!userFirst){
+        return null;
+      }
+
       let sinceDate = this.filterSinceDate;
       if (!sinceDate) {
         ({ sinceDate } = userFirst);

--- a/frontend/src/static/js/v_summary.js
+++ b/frontend/src/static/js/v_summary.js
@@ -258,7 +258,7 @@ window.vSummary = {
       const userFirst = user.dailyCommits[0];
       const userLast = user.dailyCommits[user.dailyCommits.length - 1];
 
-      if(!userFirst){
+      if (!userFirst) {
         return null;
       }
 
@@ -308,6 +308,8 @@ window.vSummary = {
           untilDate: getDateStr(endMs + ((paddingId + 1) * DAY_IN_MS)),
         });
       }
+
+      return null;
     },
     sortFiltered() {
       const full = [];

--- a/sample.csv
+++ b/sample.csv
@@ -7,3 +7,7 @@ CS2103AUG2017-W09-B2,main,master,charlesgoh,Cha,Charles Goh
 CS2103AUG2017-W09-B2,main,master,Esilocke,Esi,
 CS2103AUG2017-W09-B2,main,master,jeffreygohkw,Jef,Jeffrey Goh
 CS2103AUG2017-W09-B2,main,master,wangyiming1019,Wan,ACER\kyle;Wang Yiming
+CS2103JAN2018-F14-B1,main,master,lithiumlkid,AHMAD...HAZAT,
+CS2103JAN2018-F14-B1,main,master,codeeong,CODEE...EN CI,
+CS2103JAN2018-F14-B1,main,master,jordancjq,JORDA...IA QI,
+CS2103JAN2018-F14-B1,main,master,lohtianwei,LOH T...N WEI,

--- a/sample.csv
+++ b/sample.csv
@@ -7,7 +7,7 @@ CS2103AUG2017-W09-B2,main,master,charlesgoh,Cha,Charles Goh
 CS2103AUG2017-W09-B2,main,master,Esilocke,Esi,
 CS2103AUG2017-W09-B2,main,master,jeffreygohkw,Jef,Jeffrey Goh
 CS2103AUG2017-W09-B2,main,master,wangyiming1019,Wan,ACER\kyle;Wang Yiming
-CS2103JAN2018-F14-B1,main,master,lithiumlkid,AHMAD...HAZAT,
-CS2103JAN2018-F14-B1,main,master,codeeong,CODEE...EN CI,
-CS2103JAN2018-F14-B1,main,master,jordancjq,JORDA...IA QI,
-CS2103JAN2018-F14-B1,main,master,lohtianwei,LOH T...N WEI,
+CS2103JAN2018-F14-B1,main,master,lithiumlkid,Ahm,
+CS2103JAN2018-F14-B1,main,master,codeeong,Cod,
+CS2103JAN2018-F14-B1,main,master,jordancjq,Jor,
+CS2103JAN2018-F14-B1,main,master,lohtianwei,Loh,

--- a/template/static/js/api.js
+++ b/template/static/js/api.js
@@ -5,15 +5,15 @@ window.enquery = (key, val) => `${key}=${encodeURIComponent(val)}`;
 const REPORT_DIR = '.';
 
 // data retrieval functions //
-function loadJSON(file, fn) {
+function loadJSON(fname, fn) {
   const err = () => window.alert('unable to get file');
 
   if (window.REPORT_ZIP) {
-    window.REPORT_ZIP.file(file.slice(2)).async('text')
+    window.REPORT_ZIP.file(fname.slice(2)).async('text')
       .then(txt => fn(JSON.parse(txt)));
   } else {
     const xhr = new XMLHttpRequest();
-    xhr.open('GET', file);
+    xhr.open('GET', fname);
     xhr.onload = function xhrOnload() {
       if (xhr.status === 200) {
         fn(JSON.parse(xhr.responseText));

--- a/template/static/js/api.js
+++ b/template/static/js/api.js
@@ -2,14 +2,14 @@
 window.$ = id => document.getElementById(id);
 window.enquery = (key, val) => `${key}=${encodeURIComponent(val)}`;
 
-const REPORT_DIR = '';
+const REPORT_DIR = '.';
 
 // data retrieval functions //
 function loadJSON(file, fn) {
   const err = () => window.alert('unable to get file');
 
   if (window.REPORT_ZIP) {
-    window.REPORT_ZIP.file(file.slice(1)).async('text')
+    window.REPORT_ZIP.file(file.slice(2)).async('text')
       .then(txt => fn(JSON.parse(txt)));
   } else {
     const xhr = new XMLHttpRequest();

--- a/template/static/js/v_summary.js
+++ b/template/static/js/v_summary.js
@@ -258,6 +258,10 @@ window.vSummary = {
       const userFirst = user.dailyCommits[0];
       const userLast = user.dailyCommits[user.dailyCommits.length - 1];
 
+      if(!userFirst){
+        return null;
+      }
+
       let sinceDate = this.filterSinceDate;
       if (!sinceDate) {
         ({ sinceDate } = userFirst);

--- a/template/static/js/v_summary.js
+++ b/template/static/js/v_summary.js
@@ -258,7 +258,7 @@ window.vSummary = {
       const userFirst = user.dailyCommits[0];
       const userLast = user.dailyCommits[user.dailyCommits.length - 1];
 
-      if(!userFirst){
+      if (!userFirst) {
         return null;
       }
 
@@ -308,6 +308,8 @@ window.vSummary = {
           untilDate: getDateStr(endMs + ((paddingId + 1) * DAY_IN_MS)),
         });
       }
+
+      return null;
     },
     sortFiltered() {
       const full = [];


### PR DESCRIPTION
also fixes #186 

```
When displaying contributors with no commit history, the dashboard will
crash and stop rendering ramp charts for subsequent repositories.

This is caused by the padding of the ramp charts. The padding is added
to the ramp chart to align the charts across different users and
projects.

The amount of padding required is calculated from the `sinceDate` of
the first and last date entry of the user. This becomes problematic
when the user have no date entries at all, causing the system to run
into problem, and hence, skipping the ramp chart generation for the
particular project.

To fix this, let's alter the padding function to take into the edge
case of a empty date range, and artifically fill up the whole timeline
with generated empty dates.
```