### PR TITLE
Fix invalid path when accessing jar resources  #194

### DIFF
--- a/sample.csv
+++ b/sample.csv
@@ -3,10 +3,6 @@ CS2103AUG2017-W09-B1,main,master,nbriannl,Nbr,
 CS2103AUG2017-W09-B1,main,master,zacharytang,Zac,Zachary Tang
 CS2103AUG2017-W09-B1,main,master,April0616,Fan,LAPTOP-7KFM2KSP\User;Fan Yuting
 CS2103AUG2017-W09-B1,main,master,CindyTsai1,Cin,YuHsuan
-CS2103AUG2017-W09-B2,main,master,charlesgoh,Cha,Charles Goh
-CS2103AUG2017-W09-B2,main,master,Esilocke,Esi,
-CS2103AUG2017-W09-B2,main,master,jeffreygohkw,Jef,Jeffrey Goh
-CS2103AUG2017-W09-B2,main,master,wangyiming1019,Wan,ACER\kyle;Wang Yiming
 CS2103JAN2018-F14-B1,main,master,lithiumlkid,Ahm,
 CS2103JAN2018-F14-B1,main,master,codeeong,Cod,
 CS2103JAN2018-F14-B1,main,master,jordancjq,Jor,

--- a/src/main/java/reposense/report/ReportGenerator.java
+++ b/src/main/java/reposense/report/ReportGenerator.java
@@ -29,8 +29,10 @@ public class ReportGenerator {
     /**
      * Generates the authorship and commits JSON file for each repo in {@code configs} at {@code outputPath}, as
      * well as the summary JSON file of all the repos.
+     *
+     * @throws IOException if templateZip.zip does not exists in jar file.
      */
-    public static void generateReposReport(List<RepoConfiguration> configs, String outputPath) {
+    public static void generateReposReport(List<RepoConfiguration> configs, String outputPath) throws IOException {
         InputStream is = RepoSense.class.getResourceAsStream(TEMPLATE_FILE);
         FileUtil.copyTemplate(is, outputPath);
 

--- a/src/main/java/reposense/report/ReportGenerator.java
+++ b/src/main/java/reposense/report/ReportGenerator.java
@@ -1,7 +1,7 @@
 package reposense.report;
 
-import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
@@ -24,15 +24,15 @@ public class ReportGenerator {
     private static final Logger logger = LogsManager.getLogger(ReportGenerator.class);
 
     // zip file which contains all the dashboard template files
-    private static final String TEMPLATE_FILE = new File(RepoSense.class.getClassLoader()
-            .getResource("templateZip.zip").getFile()).toString();
+    private static final String TEMPLATE_FILE = "/templateZip.zip";
 
     /**
      * Generates the authorship and commits JSON file for each repo in {@code configs} at {@code outputPath}, as
      * well as the summary JSON file of all the repos.
      */
     public static void generateReposReport(List<RepoConfiguration> configs, String outputPath) {
-        FileUtil.copyTemplate(TEMPLATE_FILE, outputPath);
+        InputStream is = RepoSense.class.getResourceAsStream(TEMPLATE_FILE);
+        FileUtil.copyTemplate(is, outputPath);
 
         for (RepoConfiguration config : configs) {
             Path repoReportDirectory = Paths.get(outputPath, config.getDisplayName());

--- a/src/main/java/reposense/util/FileUtil.java
+++ b/src/main/java/reposense/util/FileUtil.java
@@ -102,22 +102,21 @@ public class FileUtil {
 
     /**
      * Unzips the contents of the {@code zipSourcePath} into {@code outputPath}.
+     * @throws IOException if {@code zipSourcePath} is an invalid path.
      */
-    public static void unzip(Path zipSourcePath, Path outputPath) {
-        try (
-                InputStream is = Files.newInputStream(zipSourcePath);
-        ) {
+    public static void unzip(Path zipSourcePath, Path outputPath) throws IOException {
+        try (InputStream is = Files.newInputStream(zipSourcePath)) {
             unzip(is, outputPath);
-        } catch (IOException e) {
-            logger.log(Level.SEVERE, e.getMessage(), e);
         }
     }
 
-    public static void unzip(InputStream is, Path outputPath) {
-        ZipEntry entry;
-        try (
-                ZipInputStream zis = new ZipInputStream(is)
-        ) {
+    /**
+     * Unzips the contents of the {@code is} into {@code outputPath}.
+     * @throws IOException if {@code is} refers to an invalid path.
+     */
+    public static void unzip(InputStream is, Path outputPath) throws IOException {
+        try (ZipInputStream zis = new ZipInputStream(is)) {
+            ZipEntry entry;
             Files.createDirectories(outputPath);
             while ((entry = zis.getNextEntry()) != null) {
                 Path path = Paths.get(outputPath.toString(), entry.getName());
@@ -138,8 +137,6 @@ public class FileUtil {
                 }
                 zis.closeEntry();
             }
-        } catch (IOException e) {
-            logger.log(Level.SEVERE, e.getMessage(), e);
         }
     }
 

--- a/src/main/java/reposense/util/FileUtil.java
+++ b/src/main/java/reposense/util/FileUtil.java
@@ -142,8 +142,9 @@ public class FileUtil {
 
     /**
      * Copies the template files from {@code sourcePath} to the {@code outputPath}.
+     * @throws IOException if {@code is} refers to an invalid path.
      */
-    public static void copyTemplate(InputStream is, String outputPath) {
+    public static void copyTemplate(InputStream is, String outputPath) throws IOException {
         FileUtil.unzip(is, Paths.get(outputPath));
     }
 

--- a/src/main/java/reposense/util/FileUtil.java
+++ b/src/main/java/reposense/util/FileUtil.java
@@ -104,9 +104,18 @@ public class FileUtil {
      * Unzips the contents of the {@code zipSourcePath} into {@code outputPath}.
      */
     public static void unzip(Path zipSourcePath, Path outputPath) {
-        ZipEntry entry;
         try (
                 InputStream is = Files.newInputStream(zipSourcePath);
+        ) {
+            unzip(is, outputPath);
+        } catch (IOException e) {
+            logger.log(Level.SEVERE, e.getMessage(), e);
+        }
+    }
+
+    public static void unzip(InputStream is, Path outputPath) {
+        ZipEntry entry;
+        try (
                 ZipInputStream zis = new ZipInputStream(is)
         ) {
             Files.createDirectories(outputPath);
@@ -137,8 +146,8 @@ public class FileUtil {
     /**
      * Copies the template files from {@code sourcePath} to the {@code outputPath}.
      */
-    public static void copyTemplate(String sourcePath, String outputPath) {
-        FileUtil.unzip(Paths.get(sourcePath), Paths.get(outputPath));
+    public static void copyTemplate(InputStream is, String outputPath) {
+        FileUtil.unzip(is, Paths.get(outputPath));
     }
 
     /**

--- a/src/test/java/reposense/util/FileUtilTest.java
+++ b/src/test/java/reposense/util/FileUtilTest.java
@@ -44,7 +44,7 @@ public class FileUtilTest {
     }
 
     @Test
-    public void unzip_invalidZipFile_fail() {
+    public void unzip_invalidZipFile_fail() throws IOException {
         Path invalidZipFile = Paths.get(FILE_UTIL_TEST_DIRECTORY.toString(), "test.csv");
         FileUtil.unzip(invalidZipFile, FILE_UTIL_TEST_DIRECTORY);
         Assert.assertFalse(Files.exists(Paths.get(FILE_UTIL_TEST_DIRECTORY.toString(), "test")));


### PR DESCRIPTION
Fixes #194 

```
RepoSense 1.1RC2 executed as a JAR throws an InvalidPathException when
accessing templateZip.zip.

This is because the location of the templateZip.zip cannot be located
by its path on the disk but by its relative path in the JAR file. 

So let's change the way to retrieve templateZip.zip from 
RepoSense.class.getClassLoader().getResource("templateZip.zip") to 
RepoSense.class.getResourceAsStream("/templateZip.zip").
```