### PR TITLE
Fix ramp chart positioning #197

### DIFF
--- a/frontend/src/index.jade
+++ b/frontend/src/index.jade
@@ -94,8 +94,8 @@ html
                   v-bind:href="getSliceLink(user, slice)", target="_blank",
                   v-bind:class="'summary-chart__ramp__slice--color'+j%5",
                   v-bind:style="{\
-                    borderLeftWidth: getWidth(slice)+'em',\
-                    right: (sliceCount-j-1)*sliceWidth + '%'\
+                    borderLeftWidth: getWidth(slice) + 'em',\
+                    right: (((user.commits.length-j-1)/user.commits.length) * 100) + '%'\
                   }"
                 )
               .summary-chart__contrib(v-bind:title="'total contribution: '+user.totalCommits")

--- a/frontend/src/static/js/v_summary.js
+++ b/frontend/src/static/js/v_summary.js
@@ -40,7 +40,6 @@ window.vSummary = {
   data() {
     return {
       filtered: [],
-      rampScale: 0.1,
       filterSearch: '',
       filterSort: 'totalCommits',
       filterSortReverse: false,
@@ -49,6 +48,7 @@ window.vSummary = {
       filterSinceDate: '',
       filterUntilDate: '',
       filterHash: '',
+      rampSize: 0.01,
     };
   },
   watch: {
@@ -75,12 +75,6 @@ window.vSummary = {
     },
   },
   computed: {
-    sliceCount() {
-      return this.filtered[0][0].commits.length;
-    },
-    sliceWidth() {
-      return 100 / this.sliceCount;
-    },
     avgCommitSize() {
       let totalCommits = 0;
       let totalCount = 0;
@@ -117,9 +111,8 @@ window.vSummary = {
         return 0;
       }
 
-      let size = this.sliceWidth;
-      size *= slice.insertions / this.avgCommitSize;
-      return Math.max(size * this.rampScale, 0.5);
+      const newSize = 100 * (slice.insertions / this.avgCommitSize);
+      return Math.max(newSize * this.rampSize, 0.5);
     },
     getSliceTitle(slice) {
       return `contribution on ${slice.sinceDate
@@ -225,8 +218,8 @@ window.vSummary = {
       });
       this.filtered = full;
 
-      this.sortFiltered();
       this.getDates();
+      this.sortFiltered();
     },
     splitCommitsWeek(user) {
       const { commits } = user;

--- a/frontend/src/static/js/v_summary.js
+++ b/frontend/src/static/js/v_summary.js
@@ -284,7 +284,7 @@ window.vSummary = {
 
       user.dailyCommits.forEach((commit) => {
         const date = commit.sinceDate;
-        if (date >= sinceDate && date <= untilDate) {
+        if (date >= sinceDate && date < untilDate) {
           user.commits.push(commit);
         }
       });

--- a/frontend/src/static/js/v_summary.js
+++ b/frontend/src/static/js/v_summary.js
@@ -236,9 +236,11 @@ window.vSummary = {
 
         for (let dayId = 0; dayId < 7; dayId += 1) {
           const commit = commits[(weekId * 7) + dayId];
-          week.insertions += commit.insertions;
-          week.deletions += commit.deletions;
-          week.untilDate = commit.untilDate;
+          if (commit) {
+            week.insertions += commit.insertions;
+            week.deletions += commit.deletions;
+            week.untilDate = commit.untilDate;
+          }
         }
 
         res.push(week);

--- a/frontend/src/static/js/v_summary.js
+++ b/frontend/src/static/js/v_summary.js
@@ -295,7 +295,7 @@ window.vSummary = {
       diff = getIntervalDay(untilDate, userLast.sinceDate);
 
       const endMs = (new Date(userLast.sinceDate)).getTime();
-      for (let paddingId = 0; paddingId < diff; paddingId += 1) {
+      for (let paddingId = 1; paddingId < diff; paddingId += 1) {
         user.commits.push({
           insertions: 0,
           deletions: 0,

--- a/frontend/src/static/js/v_summary.js
+++ b/frontend/src/static/js/v_summary.js
@@ -284,7 +284,7 @@ window.vSummary = {
 
       user.dailyCommits.forEach((commit) => {
         const date = commit.sinceDate;
-        if (date > sinceDate && date < untilDate) {
+        if (date >= sinceDate && date <= untilDate) {
           user.commits.push(commit);
         }
       });


### PR DESCRIPTION
fixes #197, fixes #201 

```
When the dashboard loads two projects of different date range, some of
the dashboard attributes will be messed up and this affects the
rendering of the ramp charts.

More specifically, the `sliceWidth` and `sliceCount` will be affected
by the date range and will cause the dashboard to incorrectly "thinks"
that it has more slices then it actually does, and hence causing it to
be incorrectly displayed squashed up together.

Let's remove the attributes in `v_summary` and generate the width and
position of the slices from the actual array of slices instead.
```