### PR TITLE
Authorship: incorrect line authorship when analyzing date range #203

### DIFF
--- a/src/functional/resources/dateRange/expected/reposense_testrepo-Beta_master/authorship.json
+++ b/src/functional/resources/dateRange/expected/reposense_testrepo-Beta_master/authorship.json
@@ -414,14 +414,14 @@
       {
         "lineNumber": 17,
         "author": {
-          "gitId": "zacharytang"
+          "gitId": "-"
         },
         "content": "Role: Developer +"
       },
       {
         "lineNumber": 18,
         "author": {
-          "gitId": "April0616"
+          "gitId": "-"
         },
         "content": "Responsibilities: UI"
       },
@@ -477,7 +477,7 @@
       {
         "lineNumber": 26,
         "author": {
-          "gitId": "nbriannl"
+          "gitId": "-"
         },
         "content": "Role: Developer +"
       },
@@ -630,11 +630,11 @@
       }
     ],
     "authorContributionMap": {
-      "zacharytang": 5,
+      "zacharytang": 4,
       "CindyTsai1": 3,
-      "nbriannl": 6,
-      "April0616": 6,
-      "-": 27
+      "nbriannl": 5,
+      "April0616": 5,
+      "-": 30
     }
   },
   {
@@ -6873,7 +6873,7 @@
       {
         "lineNumber": 891,
         "author": {
-          "gitId": "nbriannl"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -6901,7 +6901,7 @@
       {
         "lineNumber": 895,
         "author": {
-          "gitId": "nbriannl"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -6915,7 +6915,7 @@
       {
         "lineNumber": 897,
         "author": {
-          "gitId": "nbriannl"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -6929,7 +6929,7 @@
       {
         "lineNumber": 899,
         "author": {
-          "gitId": "nbriannl"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -6943,7 +6943,7 @@
       {
         "lineNumber": 901,
         "author": {
-          "gitId": "nbriannl"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -6971,7 +6971,7 @@
       {
         "lineNumber": 905,
         "author": {
-          "gitId": "April0616"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -6985,7 +6985,7 @@
       {
         "lineNumber": 907,
         "author": {
-          "gitId": "nbriannl"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -6999,7 +6999,7 @@
       {
         "lineNumber": 909,
         "author": {
-          "gitId": "nbriannl"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -7013,7 +7013,7 @@
       {
         "lineNumber": 911,
         "author": {
-          "gitId": "nbriannl"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -7027,7 +7027,7 @@
       {
         "lineNumber": 913,
         "author": {
-          "gitId": "April0616"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -7041,7 +7041,7 @@
       {
         "lineNumber": 915,
         "author": {
-          "gitId": "nbriannl"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -7055,7 +7055,7 @@
       {
         "lineNumber": 917,
         "author": {
-          "gitId": "nbriannl"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -7069,7 +7069,7 @@
       {
         "lineNumber": 919,
         "author": {
-          "gitId": "nbriannl"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -7083,7 +7083,7 @@
       {
         "lineNumber": 921,
         "author": {
-          "gitId": "nbriannl"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -7097,7 +7097,7 @@
       {
         "lineNumber": 923,
         "author": {
-          "gitId": "nbriannl"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -7111,7 +7111,7 @@
       {
         "lineNumber": 925,
         "author": {
-          "gitId": "nbriannl"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -7125,7 +7125,7 @@
       {
         "lineNumber": 927,
         "author": {
-          "gitId": "nbriannl"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -7139,7 +7139,7 @@
       {
         "lineNumber": 929,
         "author": {
-          "gitId": "nbriannl"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -7153,7 +7153,7 @@
       {
         "lineNumber": 931,
         "author": {
-          "gitId": "nbriannl"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -7167,7 +7167,7 @@
       {
         "lineNumber": 933,
         "author": {
-          "gitId": "nbriannl"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -7181,7 +7181,7 @@
       {
         "lineNumber": 935,
         "author": {
-          "gitId": "nbriannl"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -7195,7 +7195,7 @@
       {
         "lineNumber": 937,
         "author": {
-          "gitId": "nbriannl"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -7209,7 +7209,7 @@
       {
         "lineNumber": 939,
         "author": {
-          "gitId": "nbriannl"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -7223,7 +7223,7 @@
       {
         "lineNumber": 941,
         "author": {
-          "gitId": "nbriannl"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -7237,7 +7237,7 @@
       {
         "lineNumber": 943,
         "author": {
-          "gitId": "nbriannl"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -7251,7 +7251,7 @@
       {
         "lineNumber": 945,
         "author": {
-          "gitId": "nbriannl"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -7265,7 +7265,7 @@
       {
         "lineNumber": 947,
         "author": {
-          "gitId": "nbriannl"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -7279,7 +7279,7 @@
       {
         "lineNumber": 949,
         "author": {
-          "gitId": "nbriannl"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -7293,7 +7293,7 @@
       {
         "lineNumber": 951,
         "author": {
-          "gitId": "nbriannl"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -7307,7 +7307,7 @@
       {
         "lineNumber": 953,
         "author": {
-          "gitId": "nbriannl"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -7321,7 +7321,7 @@
       {
         "lineNumber": 955,
         "author": {
-          "gitId": "nbriannl"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -7335,7 +7335,7 @@
       {
         "lineNumber": 957,
         "author": {
-          "gitId": "nbriannl"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -7349,7 +7349,7 @@
       {
         "lineNumber": 959,
         "author": {
-          "gitId": "nbriannl"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -7363,7 +7363,7 @@
       {
         "lineNumber": 961,
         "author": {
-          "gitId": "nbriannl"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -7377,7 +7377,7 @@
       {
         "lineNumber": 963,
         "author": {
-          "gitId": "nbriannl"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -7391,7 +7391,7 @@
       {
         "lineNumber": 965,
         "author": {
-          "gitId": "nbriannl"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -7405,7 +7405,7 @@
       {
         "lineNumber": 967,
         "author": {
-          "gitId": "nbriannl"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -7419,7 +7419,7 @@
       {
         "lineNumber": 969,
         "author": {
-          "gitId": "nbriannl"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -7433,7 +7433,7 @@
       {
         "lineNumber": 971,
         "author": {
-          "gitId": "nbriannl"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -7447,14 +7447,14 @@
       {
         "lineNumber": 973,
         "author": {
-          "gitId": "nbriannl"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 974,
         "author": {
-          "gitId": "nbriannl"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -7713,7 +7713,7 @@
       {
         "lineNumber": 1011,
         "author": {
-          "gitId": "nbriannl"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -7727,7 +7727,7 @@
       {
         "lineNumber": 1013,
         "author": {
-          "gitId": "nbriannl"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -7776,7 +7776,7 @@
       {
         "lineNumber": 1020,
         "author": {
-          "gitId": "nbriannl"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -7790,7 +7790,7 @@
       {
         "lineNumber": 1022,
         "author": {
-          "gitId": "nbriannl"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -7825,7 +7825,7 @@
       {
         "lineNumber": 1027,
         "author": {
-          "gitId": "nbriannl"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -7874,7 +7874,7 @@
       {
         "lineNumber": 1034,
         "author": {
-          "gitId": "nbriannl"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -7895,7 +7895,7 @@
       {
         "lineNumber": 1037,
         "author": {
-          "gitId": "nbriannl"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -7909,7 +7909,7 @@
       {
         "lineNumber": 1039,
         "author": {
-          "gitId": "nbriannl"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -7951,7 +7951,7 @@
       {
         "lineNumber": 1045,
         "author": {
-          "gitId": "nbriannl"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -7972,7 +7972,7 @@
       {
         "lineNumber": 1048,
         "author": {
-          "gitId": "nbriannl"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -7986,7 +7986,7 @@
       {
         "lineNumber": 1050,
         "author": {
-          "gitId": "nbriannl"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -8021,7 +8021,7 @@
       {
         "lineNumber": 1055,
         "author": {
-          "gitId": "nbriannl"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -8042,7 +8042,7 @@
       {
         "lineNumber": 1058,
         "author": {
-          "gitId": "nbriannl"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -8175,14 +8175,14 @@
       {
         "lineNumber": 1077,
         "author": {
-          "gitId": "nbriannl"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 1078,
         "author": {
-          "gitId": "nbriannl"
+          "gitId": "-"
         },
         "content": "[discrete]"
       },
@@ -8196,21 +8196,21 @@
       {
         "lineNumber": 1080,
         "author": {
-          "gitId": "nbriannl"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 1081,
         "author": {
-          "gitId": "nbriannl"
+          "gitId": "-"
         },
         "content": "*MSS*"
       },
       {
         "lineNumber": 1082,
         "author": {
-          "gitId": "nbriannl"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -8252,21 +8252,21 @@
       {
         "lineNumber": 1088,
         "author": {
-          "gitId": "nbriannl"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 1089,
         "author": {
-          "gitId": "nbriannl"
+          "gitId": "-"
         },
         "content": "*Extensions*"
       },
       {
         "lineNumber": 1090,
         "author": {
-          "gitId": "nbriannl"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -8301,7 +8301,7 @@
       {
         "lineNumber": 1095,
         "author": {
-          "gitId": "nbriannl"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -8350,14 +8350,14 @@
       {
         "lineNumber": 1102,
         "author": {
-          "gitId": "nbriannl"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 1103,
         "author": {
-          "gitId": "nbriannl"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -8637,7 +8637,7 @@
       {
         "lineNumber": 1143,
         "author": {
-          "gitId": "nbriannl"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -8658,7 +8658,7 @@
       {
         "lineNumber": 1146,
         "author": {
-          "gitId": "nbriannl"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -8686,7 +8686,7 @@
       {
         "lineNumber": 1150,
         "author": {
-          "gitId": "nbriannl"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -8707,7 +8707,7 @@
       {
         "lineNumber": 1153,
         "author": {
-          "gitId": "nbriannl"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -8735,7 +8735,7 @@
       {
         "lineNumber": 1157,
         "author": {
-          "gitId": "CindyTsai1"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -8756,7 +8756,7 @@
       {
         "lineNumber": 1160,
         "author": {
-          "gitId": "CindyTsai1"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -8784,10 +8784,10 @@
     ],
     "authorContributionMap": {
       "zacharytang": 55,
-      "CindyTsai1": 211,
-      "nbriannl": 320,
-      "April0616": 92,
-      "-": 485
+      "CindyTsai1": 209,
+      "nbriannl": 253,
+      "April0616": 90,
+      "-": 556
     }
   },
   {
@@ -8985,7 +8985,7 @@
       {
         "lineNumber": 28,
         "author": {
-          "gitId": "zacharytang"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -9167,7 +9167,7 @@
       {
         "lineNumber": 54,
         "author": {
-          "gitId": "nbriannl"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -9832,7 +9832,7 @@
       {
         "lineNumber": 149,
         "author": {
-          "gitId": "nbriannl"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -9853,7 +9853,7 @@
       {
         "lineNumber": 152,
         "author": {
-          "gitId": "CindyTsai1"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -9881,7 +9881,7 @@
       {
         "lineNumber": 156,
         "author": {
-          "gitId": "CindyTsai1"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -9993,7 +9993,7 @@
       {
         "lineNumber": 172,
         "author": {
-          "gitId": "nbriannl"
+          "gitId": "-"
         },
         "content": "****"
       },
@@ -10021,7 +10021,7 @@
       {
         "lineNumber": 176,
         "author": {
-          "gitId": "nbriannl"
+          "gitId": "-"
         },
         "content": "****"
       },
@@ -10035,14 +10035,14 @@
       {
         "lineNumber": 178,
         "author": {
-          "gitId": "nbriannl"
+          "gitId": "-"
         },
         "content": "Examples:"
       },
       {
         "lineNumber": 179,
         "author": {
-          "gitId": "nbriannl"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -10385,7 +10385,7 @@
       {
         "lineNumber": 228,
         "author": {
-          "gitId": "CindyTsai1"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -10413,21 +10413,21 @@
       {
         "lineNumber": 232,
         "author": {
-          "gitId": "CindyTsai1"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 233,
         "author": {
-          "gitId": "CindyTsai1"
+          "gitId": "-"
         },
         "content": "****"
       },
       {
         "lineNumber": 234,
         "author": {
-          "gitId": "CindyTsai1"
+          "gitId": "-"
         },
         "content": "* The search is case insensitive. e.g `hans` will match `Hans`"
       },
@@ -10448,7 +10448,7 @@
       {
         "lineNumber": 237,
         "author": {
-          "gitId": "CindyTsai1"
+          "gitId": "-"
         },
         "content": "* Only full words will be matched e.g. `Han` will not match `Hans`"
       },
@@ -10504,28 +10504,28 @@
       {
         "lineNumber": 245,
         "author": {
-          "gitId": "CindyTsai1"
+          "gitId": "-"
         },
         "content": "****"
       },
       {
         "lineNumber": 246,
         "author": {
-          "gitId": "CindyTsai1"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 247,
         "author": {
-          "gitId": "CindyTsai1"
+          "gitId": "-"
         },
         "content": "Examples:"
       },
       {
         "lineNumber": 248,
         "author": {
-          "gitId": "CindyTsai1"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -10875,7 +10875,7 @@
       {
         "lineNumber": 298,
         "author": {
-          "gitId": "nbriannl"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -10903,7 +10903,7 @@
       {
         "lineNumber": 302,
         "author": {
-          "gitId": "nbriannl"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -11505,7 +11505,7 @@
       {
         "lineNumber": 388,
         "author": {
-          "gitId": "nbriannl"
+          "gitId": "-"
         },
         "content": "* `find Betsy` +"
       },
@@ -11526,7 +11526,7 @@
       {
         "lineNumber": 391,
         "author": {
-          "gitId": "nbriannl"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -12247,7 +12247,7 @@
       {
         "lineNumber": 494,
         "author": {
-          "gitId": "nbriannl"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -12884,7 +12884,7 @@
       {
         "lineNumber": 585,
         "author": {
-          "gitId": "CindyTsai1"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -13919,11 +13919,11 @@
       }
     ],
     "authorContributionMap": {
-      "zacharytang": 54,
-      "CindyTsai1": 71,
-      "nbriannl": 404,
+      "zacharytang": 53,
+      "CindyTsai1": 59,
+      "nbriannl": 393,
       "April0616": 39,
-      "-": 164
+      "-": 188
     }
   },
   {
@@ -22158,14 +22158,14 @@
       {
         "lineNumber": 43,
         "author": {
-          "gitId": "nbriannl"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 44,
         "author": {
-          "gitId": "April0616"
+          "gitId": "-"
         },
         "content": "    public DeleteCommand(Index targetIndex) {"
       },
@@ -22228,14 +22228,14 @@
       {
         "lineNumber": 53,
         "author": {
-          "gitId": "nbriannl"
+          "gitId": "-"
         },
         "content": "    }"
       },
       {
         "lineNumber": 54,
         "author": {
-          "gitId": "nbriannl"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -22438,7 +22438,7 @@
       {
         "lineNumber": 83,
         "author": {
-          "gitId": "April0616"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -22592,7 +22592,7 @@
       {
         "lineNumber": 105,
         "author": {
-          "gitId": "nbriannl"
+          "gitId": "-"
         },
         "content": "        }"
       },
@@ -22669,7 +22669,7 @@
       {
         "lineNumber": 116,
         "author": {
-          "gitId": "April0616"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -22704,14 +22704,14 @@
       {
         "lineNumber": 121,
         "author": {
-          "gitId": "April0616"
+          "gitId": "-"
         },
         "content": "        }"
       },
       {
         "lineNumber": 122,
         "author": {
-          "gitId": "April0616"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -22788,14 +22788,14 @@
       {
         "lineNumber": 133,
         "author": {
-          "gitId": "April0616"
+          "gitId": "-"
         },
         "content": "    }"
       },
       {
         "lineNumber": 134,
         "author": {
-          "gitId": "April0616"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -22893,9 +22893,9 @@
     ],
     "authorContributionMap": {
       "zacharytang": 2,
-      "nbriannl": 48,
-      "April0616": 56,
-      "-": 41
+      "nbriannl": 44,
+      "April0616": 49,
+      "-": 52
     }
   },
   {
@@ -23947,7 +23947,7 @@
       {
         "lineNumber": 150,
         "author": {
-          "gitId": "nbriannl"
+          "gitId": "-"
         },
         "content": "        }"
       },
@@ -25271,9 +25271,9 @@
     "authorContributionMap": {
       "zacharytang": 18,
       "CindyTsai1": 18,
-      "nbriannl": 57,
+      "nbriannl": 56,
       "April0616": 35,
-      "-": 210
+      "-": 211
     }
   },
   {
@@ -28250,7 +28250,7 @@
       {
         "lineNumber": 46,
         "author": {
-          "gitId": "zacharytang"
+          "gitId": "-"
         },
         "content": "        EventsCenter.getInstance().post(new JumpToListRequestEvent(targetIndex));"
       },
@@ -28333,8 +28333,8 @@
       }
     ],
     "authorContributionMap": {
-      "zacharytang": 6,
-      "-": 51
+      "zacharytang": 5,
+      "-": 52
     }
   },
   {
@@ -29989,49 +29989,49 @@
       {
         "lineNumber": 8,
         "author": {
-          "gitId": "April0616"
+          "gitId": "-"
         },
         "content": "import seedu.address.logic.commands.AddCommand;"
       },
       {
         "lineNumber": 9,
         "author": {
-          "gitId": "April0616"
+          "gitId": "-"
         },
         "content": "import seedu.address.logic.commands.ClearCommand;"
       },
       {
         "lineNumber": 10,
         "author": {
-          "gitId": "April0616"
+          "gitId": "-"
         },
         "content": "import seedu.address.logic.commands.Command;"
       },
       {
         "lineNumber": 11,
         "author": {
-          "gitId": "April0616"
+          "gitId": "-"
         },
         "content": "import seedu.address.logic.commands.DeleteCommand;"
       },
       {
         "lineNumber": 12,
         "author": {
-          "gitId": "April0616"
+          "gitId": "-"
         },
         "content": "import seedu.address.logic.commands.EditCommand;"
       },
       {
         "lineNumber": 13,
         "author": {
-          "gitId": "April0616"
+          "gitId": "-"
         },
         "content": "import seedu.address.logic.commands.ExitCommand;"
       },
       {
         "lineNumber": 14,
         "author": {
-          "gitId": "April0616"
+          "gitId": "-"
         },
         "content": "import seedu.address.logic.commands.FindCommand;"
       },
@@ -30045,28 +30045,28 @@
       {
         "lineNumber": 16,
         "author": {
-          "gitId": "April0616"
+          "gitId": "-"
         },
         "content": "import seedu.address.logic.commands.HelpCommand;"
       },
       {
         "lineNumber": 17,
         "author": {
-          "gitId": "April0616"
+          "gitId": "-"
         },
         "content": "import seedu.address.logic.commands.HistoryCommand;"
       },
       {
         "lineNumber": 18,
         "author": {
-          "gitId": "April0616"
+          "gitId": "-"
         },
         "content": "import seedu.address.logic.commands.ListCommand;"
       },
       {
         "lineNumber": 19,
         "author": {
-          "gitId": "April0616"
+          "gitId": "-"
         },
         "content": "import seedu.address.logic.commands.RedoCommand;"
       },
@@ -30080,14 +30080,14 @@
       {
         "lineNumber": 21,
         "author": {
-          "gitId": "April0616"
+          "gitId": "-"
         },
         "content": "import seedu.address.logic.commands.SelectCommand;"
       },
       {
         "lineNumber": 22,
         "author": {
-          "gitId": "April0616"
+          "gitId": "-"
         },
         "content": "import seedu.address.logic.commands.UndoCommand;"
       },
@@ -30831,8 +30831,8 @@
       "zacharytang": 22,
       "CindyTsai1": 4,
       "nbriannl": 7,
-      "April0616": 18,
-      "-": 76
+      "April0616": 5,
+      "-": 89
     }
   },
   {
@@ -31483,14 +31483,14 @@
       {
         "lineNumber": 69,
         "author": {
-          "gitId": "nbriannl"
+          "gitId": "-"
         },
         "content": "    }"
       },
       {
         "lineNumber": 70,
         "author": {
-          "gitId": "nbriannl"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -31503,9 +31503,9 @@
       }
     ],
     "authorContributionMap": {
-      "nbriannl": 33,
+      "nbriannl": 31,
       "April0616": 11,
-      "-": 27
+      "-": 29
     }
   },
   {
@@ -32179,14 +32179,14 @@
       {
         "lineNumber": 96,
         "author": {
-          "gitId": "nbriannl"
+          "gitId": "-"
         },
         "content": "    }"
       },
       {
         "lineNumber": 97,
         "author": {
-          "gitId": "nbriannl"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -32355,9 +32355,9 @@
     "authorContributionMap": {
       "zacharytang": 2,
       "CindyTsai1": 5,
-      "nbriannl": 34,
+      "nbriannl": 32,
       "April0616": 7,
-      "-": 72
+      "-": 74
     }
   },
   {
@@ -32815,28 +32815,28 @@
       {
         "lineNumber": 6,
         "author": {
-          "gitId": "April0616"
+          "gitId": "-"
         },
         "content": "import java.util.Collection;"
       },
       {
         "lineNumber": 7,
         "author": {
-          "gitId": "April0616"
+          "gitId": "-"
         },
         "content": "import java.util.HashSet;"
       },
       {
         "lineNumber": 8,
         "author": {
-          "gitId": "April0616"
+          "gitId": "-"
         },
         "content": "import java.util.Optional;"
       },
       {
         "lineNumber": 9,
         "author": {
-          "gitId": "April0616"
+          "gitId": "-"
         },
         "content": "import java.util.Set;"
       },
@@ -33949,17 +33949,17 @@
       {
         "lineNumber": 168,
         "author": {
-          "gitId": "CindyTsai1"
+          "gitId": "-"
         },
         "content": "}"
       }
     ],
     "authorContributionMap": {
       "zacharytang": 8,
-      "CindyTsai1": 12,
+      "CindyTsai1": 11,
       "nbriannl": 9,
-      "April0616": 51,
-      "-": 88
+      "April0616": 47,
+      "-": 93
     }
   },
   {
@@ -34544,42 +34544,42 @@
       {
         "lineNumber": 6,
         "author": {
-          "gitId": "April0616"
+          "gitId": "-"
         },
         "content": "import java.util.HashMap;"
       },
       {
         "lineNumber": 7,
         "author": {
-          "gitId": "April0616"
+          "gitId": "-"
         },
         "content": "import java.util.HashSet;"
       },
       {
         "lineNumber": 8,
         "author": {
-          "gitId": "April0616"
+          "gitId": "-"
         },
         "content": "import java.util.List;"
       },
       {
         "lineNumber": 9,
         "author": {
-          "gitId": "April0616"
+          "gitId": "-"
         },
         "content": "import java.util.Map;"
       },
       {
         "lineNumber": 10,
         "author": {
-          "gitId": "April0616"
+          "gitId": "-"
         },
         "content": "import java.util.Objects;"
       },
       {
         "lineNumber": 11,
         "author": {
-          "gitId": "April0616"
+          "gitId": "-"
         },
         "content": "import java.util.Set;"
       },
@@ -35846,7 +35846,7 @@
       {
         "lineNumber": 192,
         "author": {
-          "gitId": "April0616"
+          "gitId": "-"
         },
         "content": "        }"
       },
@@ -35860,14 +35860,14 @@
       {
         "lineNumber": 194,
         "author": {
-          "gitId": "April0616"
+          "gitId": "-"
         },
         "content": "    }"
       },
       {
         "lineNumber": 195,
         "author": {
-          "gitId": "April0616"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -36224,8 +36224,8 @@
     ],
     "authorContributionMap": {
       "nbriannl": 41,
-      "April0616": 19,
-      "-": 185
+      "April0616": 10,
+      "-": 194
     }
   },
   {
@@ -36794,7 +36794,7 @@
       {
         "lineNumber": 81,
         "author": {
-          "gitId": "nbriannl"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -36849,9 +36849,9 @@
       }
     ],
     "authorContributionMap": {
-      "nbriannl": 35,
+      "nbriannl": 34,
       "April0616": 5,
-      "-": 48
+      "-": 49
     }
   },
   {
@@ -37917,14 +37917,14 @@
       {
         "lineNumber": 152,
         "author": {
-          "gitId": "nbriannl"
+          "gitId": "-"
         },
         "content": "    }"
       },
       {
         "lineNumber": 153,
         "author": {
-          "gitId": "nbriannl"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -38308,9 +38308,9 @@
       }
     ],
     "authorContributionMap": {
-      "nbriannl": 78,
+      "nbriannl": 76,
       "April0616": 10,
-      "-": 119
+      "-": 121
     }
   },
   {
@@ -49627,14 +49627,14 @@
       {
         "lineNumber": 52,
         "author": {
-          "gitId": "nbriannl"
+          "gitId": "-"
         },
         "content": "    }"
       },
       {
         "lineNumber": 53,
         "author": {
-          "gitId": "nbriannl"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -49774,7 +49774,7 @@
       {
         "lineNumber": 73,
         "author": {
-          "gitId": "nbriannl"
+          "gitId": "-"
         },
         "content": "    @Subscribe"
       },
@@ -49830,7 +49830,7 @@
       {
         "lineNumber": 81,
         "author": {
-          "gitId": "nbriannl"
+          "gitId": "-"
         },
         "content": "        logger.info(LogsCenter.getEventHandlingLogMessage(event));"
       },
@@ -49844,7 +49844,7 @@
       {
         "lineNumber": 83,
         "author": {
-          "gitId": "nbriannl"
+          "gitId": "-"
         },
         "content": "    }"
       },
@@ -49857,8 +49857,8 @@
       }
     ],
     "authorContributionMap": {
-      "nbriannl": 22,
-      "-": 62
+      "nbriannl": 17,
+      "-": 67
     }
   },
   {
@@ -53100,7 +53100,7 @@
       {
         "lineNumber": 12,
         "author": {
-          "gitId": "April0616"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -53205,7 +53205,7 @@
       {
         "lineNumber": 27,
         "author": {
-          "gitId": "April0616"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -54032,8 +54032,8 @@
     "authorContributionMap": {
       "zacharytang": 3,
       "CindyTsai1": 3,
-      "April0616": 56,
-      "-": 82
+      "April0616": 54,
+      "-": 84
     }
   },
   {
@@ -54757,7 +54757,7 @@
       {
         "lineNumber": 16,
         "author": {
-          "gitId": "CindyTsai1"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -55085,8 +55085,8 @@
       }
     ],
     "authorContributionMap": {
-      "CindyTsai1": 21,
-      "-": 41
+      "CindyTsai1": 20,
+      "-": 42
     }
   },
   {
@@ -59884,14 +59884,14 @@
       {
         "lineNumber": 131,
         "author": {
-          "gitId": "April0616"
+          "gitId": "-"
         },
         "content": "        }"
       },
       {
         "lineNumber": 132,
         "author": {
-          "gitId": "April0616"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -59975,7 +59975,7 @@
       {
         "lineNumber": 144,
         "author": {
-          "gitId": "nbriannl"
+          "gitId": "-"
         },
         "content": "        @Override"
       },
@@ -60401,9 +60401,9 @@
       }
     ],
     "authorContributionMap": {
-      "nbriannl": 29,
-      "April0616": 5,
-      "-": 170
+      "nbriannl": 28,
+      "April0616": 3,
+      "-": 173
     }
   },
   {
@@ -61077,7 +61077,7 @@
       {
         "lineNumber": 96,
         "author": {
-          "gitId": "CindyTsai1"
+          "gitId": "-"
         },
         "content": "                .withTags(VALID_TAG_FRIEND).build();"
       },
@@ -61105,7 +61105,7 @@
       {
         "lineNumber": 100,
         "author": {
-          "gitId": "CindyTsai1"
+          "gitId": "-"
         },
         "content": "                .withTags(VALID_TAG_HUSBAND, VALID_TAG_FRIEND).build();"
       },
@@ -61553,9 +61553,9 @@
     ],
     "authorContributionMap": {
       "zacharytang": 7,
-      "CindyTsai1": 14,
+      "CindyTsai1": 12,
       "April0616": 20,
-      "-": 122
+      "-": 124
     }
   },
   {
@@ -62488,7 +62488,7 @@
       {
         "lineNumber": 133,
         "author": {
-          "gitId": "nbriannl"
+          "gitId": "-"
         },
         "content": "    @Test"
       },
@@ -63103,9 +63103,9 @@
       }
     ],
     "authorContributionMap": {
-      "nbriannl": 96,
+      "nbriannl": 95,
       "April0616": 9,
-      "-": 115
+      "-": 116
     }
   },
   {
@@ -69813,28 +69813,28 @@
       {
         "lineNumber": 19,
         "author": {
-          "gitId": "April0616"
+          "gitId": "-"
         },
         "content": "import seedu.address.logic.commands.AddCommand;"
       },
       {
         "lineNumber": 20,
         "author": {
-          "gitId": "April0616"
+          "gitId": "-"
         },
         "content": "import seedu.address.logic.commands.ClearCommand;"
       },
       {
         "lineNumber": 21,
         "author": {
-          "gitId": "April0616"
+          "gitId": "-"
         },
         "content": "import seedu.address.logic.commands.DeleteCommand;"
       },
       {
         "lineNumber": 22,
         "author": {
-          "gitId": "April0616"
+          "gitId": "-"
         },
         "content": "import seedu.address.logic.commands.EditCommand;"
       },
@@ -69848,42 +69848,42 @@
       {
         "lineNumber": 24,
         "author": {
-          "gitId": "April0616"
+          "gitId": "-"
         },
         "content": "import seedu.address.logic.commands.ExitCommand;"
       },
       {
         "lineNumber": 25,
         "author": {
-          "gitId": "April0616"
+          "gitId": "-"
         },
         "content": "import seedu.address.logic.commands.FindCommand;"
       },
       {
         "lineNumber": 26,
         "author": {
-          "gitId": "April0616"
+          "gitId": "-"
         },
         "content": "import seedu.address.logic.commands.HelpCommand;"
       },
       {
         "lineNumber": 27,
         "author": {
-          "gitId": "April0616"
+          "gitId": "-"
         },
         "content": "import seedu.address.logic.commands.HistoryCommand;"
       },
       {
         "lineNumber": 28,
         "author": {
-          "gitId": "April0616"
+          "gitId": "-"
         },
         "content": "import seedu.address.logic.commands.ListCommand;"
       },
       {
         "lineNumber": 29,
         "author": {
-          "gitId": "April0616"
+          "gitId": "-"
         },
         "content": "import seedu.address.logic.commands.RedoCommand;"
       },
@@ -69897,14 +69897,14 @@
       {
         "lineNumber": 31,
         "author": {
-          "gitId": "April0616"
+          "gitId": "-"
         },
         "content": "import seedu.address.logic.commands.SelectCommand;"
       },
       {
         "lineNumber": 32,
         "author": {
-          "gitId": "April0616"
+          "gitId": "-"
         },
         "content": "import seedu.address.logic.commands.UndoCommand;"
       },
@@ -70198,14 +70198,14 @@
       {
         "lineNumber": 74,
         "author": {
-          "gitId": "April0616"
+          "gitId": "-"
         },
         "content": "    }"
       },
       {
         "lineNumber": 75,
         "author": {
-          "gitId": "April0616"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -71857,8 +71857,8 @@
     ],
     "authorContributionMap": {
       "zacharytang": 155,
-      "April0616": 23,
-      "-": 132
+      "April0616": 9,
+      "-": 146
     }
   },
   {
@@ -71958,7 +71958,7 @@
       {
         "lineNumber": 14,
         "author": {
-          "gitId": "nbriannl"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -72560,14 +72560,14 @@
       {
         "lineNumber": 100,
         "author": {
-          "gitId": "nbriannl"
+          "gitId": "-"
         },
         "content": "    }"
       },
       {
         "lineNumber": 101,
         "author": {
-          "gitId": "nbriannl"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -72727,9 +72727,9 @@
       }
     ],
     "authorContributionMap": {
-      "nbriannl": 27,
+      "nbriannl": 24,
       "April0616": 66,
-      "-": 30
+      "-": 33
     }
   },
   {
@@ -73809,14 +73809,14 @@
       {
         "lineNumber": 154,
         "author": {
-          "gitId": "nbriannl"
+          "gitId": "-"
         },
         "content": "    }"
       },
       {
         "lineNumber": 155,
         "author": {
-          "gitId": "nbriannl"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -74775,9 +74775,9 @@
     ],
     "authorContributionMap": {
       "CindyTsai1": 25,
-      "nbriannl": 19,
+      "nbriannl": 17,
       "April0616": 53,
-      "-": 194
+      "-": 196
     }
   },
   {
@@ -75382,14 +75382,14 @@
       {
         "lineNumber": 21,
         "author": {
-          "gitId": "April0616"
+          "gitId": "-"
         },
         "content": "import seedu.address.model.person.Address;"
       },
       {
         "lineNumber": 22,
         "author": {
-          "gitId": "April0616"
+          "gitId": "-"
         },
         "content": "import seedu.address.model.person.Email;"
       },
@@ -75410,14 +75410,14 @@
       {
         "lineNumber": 25,
         "author": {
-          "gitId": "April0616"
+          "gitId": "-"
         },
         "content": "import seedu.address.model.person.Name;"
       },
       {
         "lineNumber": 26,
         "author": {
-          "gitId": "April0616"
+          "gitId": "-"
         },
         "content": "import seedu.address.model.person.Phone;"
       },
@@ -77160,8 +77160,8 @@
     ],
     "authorContributionMap": {
       "zacharytang": 28,
-      "April0616": 60,
-      "-": 186
+      "April0616": 56,
+      "-": 190
     }
   },
   {
@@ -82179,7 +82179,7 @@
       {
         "lineNumber": 178,
         "author": {
-          "gitId": "zacharytang"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -82213,10 +82213,10 @@
       }
     ],
     "authorContributionMap": {
-      "zacharytang": 15,
+      "zacharytang": 14,
       "CindyTsai1": 15,
       "April0616": 42,
-      "-": 110
+      "-": 111
     }
   },
   {
@@ -89815,7 +89815,7 @@
       {
         "lineNumber": 12,
         "author": {
-          "gitId": "April0616"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -90074,14 +90074,14 @@
       {
         "lineNumber": 49,
         "author": {
-          "gitId": "zacharytang"
+          "gitId": "-"
         },
         "content": "        assertCommandSuccess(command, expectedModel, expectedResultMessage);"
       },
       {
         "lineNumber": 50,
         "author": {
-          "gitId": "zacharytang"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -91655,10 +91655,10 @@
       }
     ],
     "authorContributionMap": {
-      "zacharytang": 56,
+      "zacharytang": 54,
       "CindyTsai1": 9,
-      "April0616": 16,
-      "-": 193
+      "April0616": 15,
+      "-": 196
     }
   },
   {
@@ -94381,35 +94381,35 @@
       {
         "lineNumber": 15,
         "author": {
-          "gitId": "zacharytang"
+          "gitId": "-"
         },
         "content": "import seedu.address.logic.commands.ClearCommand;"
       },
       {
         "lineNumber": 16,
         "author": {
-          "gitId": "zacharytang"
+          "gitId": "-"
         },
         "content": "import seedu.address.logic.commands.DeleteCommand;"
       },
       {
         "lineNumber": 17,
         "author": {
-          "gitId": "zacharytang"
+          "gitId": "-"
         },
         "content": "import seedu.address.logic.commands.FindCommand;"
       },
       {
         "lineNumber": 18,
         "author": {
-          "gitId": "zacharytang"
+          "gitId": "-"
         },
         "content": "import seedu.address.logic.commands.ListCommand;"
       },
       {
         "lineNumber": 19,
         "author": {
-          "gitId": "zacharytang"
+          "gitId": "-"
         },
         "content": "import seedu.address.logic.commands.RedoCommand;"
       },
@@ -94423,7 +94423,7 @@
       {
         "lineNumber": 21,
         "author": {
-          "gitId": "zacharytang"
+          "gitId": "-"
         },
         "content": "import seedu.address.logic.commands.UndoCommand;"
       },
@@ -94654,14 +94654,14 @@
       {
         "lineNumber": 54,
         "author": {
-          "gitId": "zacharytang"
+          "gitId": "-"
         },
         "content": "        ModelHelper.setFilteredList(expectedModel, BENSON, DANIEL); // first names of Benson and Daniel are \"Meier\""
       },
       {
         "lineNumber": 55,
         "author": {
-          "gitId": "zacharytang"
+          "gitId": "-"
         },
         "content": "        assertCommandSuccess(command, expectedModel);"
       },
@@ -95829,9 +95829,9 @@
       }
     ],
     "authorContributionMap": {
-      "zacharytang": 27,
+      "zacharytang": 19,
       "CindyTsai1": 8,
-      "-": 186
+      "-": 194
     }
   },
   {

--- a/src/functional/resources/dateRange/expected/reposense_testrepo-Beta_master/commits.json
+++ b/src/functional/resources/dateRange/expected/reposense_testrepo-Beta_master/commits.json
@@ -1676,10 +1676,10 @@
     ]
   },
   "authorFinalContributionMap": {
-    "zacharytang": 1865,
-    "CindyTsai1": 1094,
-    "nbriannl": 2022,
-    "April0616": 1683
+    "zacharytang": 1851,
+    "CindyTsai1": 1076,
+    "nbriannl": 1919,
+    "April0616": 1624
   },
   "authorContributionVariance": {
     "zacharytang": 33728.18,

--- a/src/functional/resources/dateRange/expected/reposense_testrepo-Charlie_master/authorship.json
+++ b/src/functional/resources/dateRange/expected/reposense_testrepo-Charlie_master/authorship.json
@@ -449,7 +449,7 @@
       {
         "lineNumber": 27,
         "author": {
-          "gitId": "charlesgoh"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -498,7 +498,7 @@
       {
         "lineNumber": 34,
         "author": {
-          "gitId": "charlesgoh"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -561,7 +561,7 @@
       {
         "lineNumber": 43,
         "author": {
-          "gitId": "charlesgoh"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -602,8 +602,8 @@
       }
     ],
     "authorContributionMap": {
-      "charlesgoh": 22,
-      "-": 26
+      "charlesgoh": 19,
+      "-": 29
     }
   },
   {
@@ -3041,7 +3041,7 @@
       {
         "lineNumber": 348,
         "author": {
-          "gitId": "Esilocke"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -3069,7 +3069,7 @@
       {
         "lineNumber": 352,
         "author": {
-          "gitId": "Esilocke"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -3083,7 +3083,7 @@
       {
         "lineNumber": 354,
         "author": {
-          "gitId": "Esilocke"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -3139,7 +3139,7 @@
       {
         "lineNumber": 362,
         "author": {
-          "gitId": "Esilocke"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -3188,7 +3188,7 @@
       {
         "lineNumber": 369,
         "author": {
-          "gitId": "Esilocke"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -3202,7 +3202,7 @@
       {
         "lineNumber": 371,
         "author": {
-          "gitId": "Esilocke"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -3237,7 +3237,7 @@
       {
         "lineNumber": 376,
         "author": {
-          "gitId": "Esilocke"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -3300,7 +3300,7 @@
       {
         "lineNumber": 385,
         "author": {
-          "gitId": "Esilocke"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -3321,7 +3321,7 @@
       {
         "lineNumber": 388,
         "author": {
-          "gitId": "Esilocke"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -3335,7 +3335,7 @@
       {
         "lineNumber": 390,
         "author": {
-          "gitId": "Esilocke"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -3349,7 +3349,7 @@
       {
         "lineNumber": 392,
         "author": {
-          "gitId": "Esilocke"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -3461,7 +3461,7 @@
       {
         "lineNumber": 408,
         "author": {
-          "gitId": "Esilocke"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -3475,14 +3475,14 @@
       {
         "lineNumber": 410,
         "author": {
-          "gitId": "Esilocke"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 411,
         "author": {
-          "gitId": "Esilocke"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -3496,7 +3496,7 @@
       {
         "lineNumber": 413,
         "author": {
-          "gitId": "Esilocke"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -3552,7 +3552,7 @@
       {
         "lineNumber": 421,
         "author": {
-          "gitId": "Esilocke"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -3566,7 +3566,7 @@
       {
         "lineNumber": 423,
         "author": {
-          "gitId": "Esilocke"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -3622,7 +3622,7 @@
       {
         "lineNumber": 431,
         "author": {
-          "gitId": "Esilocke"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -3636,7 +3636,7 @@
       {
         "lineNumber": 433,
         "author": {
-          "gitId": "charlesgoh"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -3657,7 +3657,7 @@
       {
         "lineNumber": 436,
         "author": {
-          "gitId": "charlesgoh"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -3671,7 +3671,7 @@
       {
         "lineNumber": 438,
         "author": {
-          "gitId": "charlesgoh"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -3692,7 +3692,7 @@
       {
         "lineNumber": 441,
         "author": {
-          "gitId": "charlesgoh"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -3706,7 +3706,7 @@
       {
         "lineNumber": 443,
         "author": {
-          "gitId": "charlesgoh"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -3720,7 +3720,7 @@
       {
         "lineNumber": 445,
         "author": {
-          "gitId": "charlesgoh"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -3741,7 +3741,7 @@
       {
         "lineNumber": 448,
         "author": {
-          "gitId": "charlesgoh"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -3755,7 +3755,7 @@
       {
         "lineNumber": 450,
         "author": {
-          "gitId": "charlesgoh"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -3769,7 +3769,7 @@
       {
         "lineNumber": 452,
         "author": {
-          "gitId": "charlesgoh"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -3783,7 +3783,7 @@
       {
         "lineNumber": 454,
         "author": {
-          "gitId": "charlesgoh"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -3839,7 +3839,7 @@
       {
         "lineNumber": 462,
         "author": {
-          "gitId": "charlesgoh"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -3853,7 +3853,7 @@
       {
         "lineNumber": 464,
         "author": {
-          "gitId": "charlesgoh"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -3909,7 +3909,7 @@
       {
         "lineNumber": 472,
         "author": {
-          "gitId": "Esilocke"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -3923,7 +3923,7 @@
       {
         "lineNumber": 474,
         "author": {
-          "gitId": "charlesgoh"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -3944,7 +3944,7 @@
       {
         "lineNumber": 477,
         "author": {
-          "gitId": "charlesgoh"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -3979,7 +3979,7 @@
       {
         "lineNumber": 482,
         "author": {
-          "gitId": "charlesgoh"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -3993,7 +3993,7 @@
       {
         "lineNumber": 484,
         "author": {
-          "gitId": "charlesgoh"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -4007,7 +4007,7 @@
       {
         "lineNumber": 486,
         "author": {
-          "gitId": "charlesgoh"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -4028,7 +4028,7 @@
       {
         "lineNumber": 489,
         "author": {
-          "gitId": "charlesgoh"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -4042,7 +4042,7 @@
       {
         "lineNumber": 491,
         "author": {
-          "gitId": "charlesgoh"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -4056,7 +4056,7 @@
       {
         "lineNumber": 493,
         "author": {
-          "gitId": "charlesgoh"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -4070,7 +4070,7 @@
       {
         "lineNumber": 495,
         "author": {
-          "gitId": "charlesgoh"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -4126,7 +4126,7 @@
       {
         "lineNumber": 503,
         "author": {
-          "gitId": "charlesgoh"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -4140,7 +4140,7 @@
       {
         "lineNumber": 505,
         "author": {
-          "gitId": "charlesgoh"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -4196,7 +4196,7 @@
       {
         "lineNumber": 513,
         "author": {
-          "gitId": "jeffreygohkw"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -4210,7 +4210,7 @@
       {
         "lineNumber": 515,
         "author": {
-          "gitId": "jeffreygohkw"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -4224,7 +4224,7 @@
       {
         "lineNumber": 517,
         "author": {
-          "gitId": "jeffreygohkw"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -5645,7 +5645,7 @@
       {
         "lineNumber": 720,
         "author": {
-          "gitId": "wangyiming1019"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -5666,7 +5666,7 @@
       {
         "lineNumber": 723,
         "author": {
-          "gitId": "wangyiming1019"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -5680,7 +5680,7 @@
       {
         "lineNumber": 725,
         "author": {
-          "gitId": "wangyiming1019"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -5736,7 +5736,7 @@
       {
         "lineNumber": 733,
         "author": {
-          "gitId": "jeffreygohkw"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -5750,7 +5750,7 @@
       {
         "lineNumber": 735,
         "author": {
-          "gitId": "wangyiming1019"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -5771,7 +5771,7 @@
       {
         "lineNumber": 738,
         "author": {
-          "gitId": "wangyiming1019"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -5806,7 +5806,7 @@
       {
         "lineNumber": 743,
         "author": {
-          "gitId": "wangyiming1019"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -5827,7 +5827,7 @@
       {
         "lineNumber": 746,
         "author": {
-          "gitId": "wangyiming1019"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -6002,7 +6002,7 @@
       {
         "lineNumber": 771,
         "author": {
-          "gitId": "wangyiming1019"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -6016,7 +6016,7 @@
       {
         "lineNumber": 773,
         "author": {
-          "gitId": "wangyiming1019"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -6044,7 +6044,7 @@
       {
         "lineNumber": 777,
         "author": {
-          "gitId": "wangyiming1019"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -6079,7 +6079,7 @@
       {
         "lineNumber": 782,
         "author": {
-          "gitId": "wangyiming1019"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -6093,7 +6093,7 @@
       {
         "lineNumber": 784,
         "author": {
-          "gitId": "wangyiming1019"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -6156,7 +6156,7 @@
       {
         "lineNumber": 793,
         "author": {
-          "gitId": "wangyiming1019"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -6219,7 +6219,7 @@
       {
         "lineNumber": 802,
         "author": {
-          "gitId": "wangyiming1019"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -6233,7 +6233,7 @@
       {
         "lineNumber": 804,
         "author": {
-          "gitId": "wangyiming1019"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -6254,7 +6254,7 @@
       {
         "lineNumber": 807,
         "author": {
-          "gitId": "wangyiming1019"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -6282,7 +6282,7 @@
       {
         "lineNumber": 811,
         "author": {
-          "gitId": "wangyiming1019"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -6303,7 +6303,7 @@
       {
         "lineNumber": 814,
         "author": {
-          "gitId": "wangyiming1019"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -6324,7 +6324,7 @@
       {
         "lineNumber": 817,
         "author": {
-          "gitId": "wangyiming1019"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -6429,7 +6429,7 @@
       {
         "lineNumber": 832,
         "author": {
-          "gitId": "wangyiming1019"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -6555,7 +6555,7 @@
       {
         "lineNumber": 850,
         "author": {
-          "gitId": "wangyiming1019"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -6576,7 +6576,7 @@
       {
         "lineNumber": 853,
         "author": {
-          "gitId": "wangyiming1019"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -6597,7 +6597,7 @@
       {
         "lineNumber": 856,
         "author": {
-          "gitId": "wangyiming1019"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -6618,7 +6618,7 @@
       {
         "lineNumber": 859,
         "author": {
-          "gitId": "wangyiming1019"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -6632,7 +6632,7 @@
       {
         "lineNumber": 861,
         "author": {
-          "gitId": "wangyiming1019"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -6695,7 +6695,7 @@
       {
         "lineNumber": 870,
         "author": {
-          "gitId": "wangyiming1019"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -8760,21 +8760,21 @@
       {
         "lineNumber": 1165,
         "author": {
-          "gitId": "Esilocke"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 1166,
         "author": {
-          "gitId": "Esilocke"
+          "gitId": "-"
         },
         "content": "*Extensions*"
       },
       {
         "lineNumber": 1167,
         "author": {
-          "gitId": "Esilocke"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -8907,7 +8907,7 @@
       {
         "lineNumber": 1186,
         "author": {
-          "gitId": "Esilocke"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -8921,7 +8921,7 @@
       {
         "lineNumber": 1188,
         "author": {
-          "gitId": "Esilocke"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -8963,7 +8963,7 @@
       {
         "lineNumber": 1194,
         "author": {
-          "gitId": "Esilocke"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -8977,7 +8977,7 @@
       {
         "lineNumber": 1196,
         "author": {
-          "gitId": "Esilocke"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -9229,7 +9229,7 @@
       {
         "lineNumber": 1232,
         "author": {
-          "gitId": "charlesgoh"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -9257,7 +9257,7 @@
       {
         "lineNumber": 1236,
         "author": {
-          "gitId": "charlesgoh"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -9375,11 +9375,11 @@
       }
     ],
     "authorContributionMap": {
-      "charlesgoh": 95,
-      "jeffreygohkw": 161,
-      "Esilocke": 204,
-      "wangyiming1019": 241,
-      "-": 551
+      "charlesgoh": 70,
+      "jeffreygohkw": 157,
+      "Esilocke": 178,
+      "wangyiming1019": 215,
+      "-": 632
     }
   },
   {
@@ -10123,7 +10123,7 @@
       {
         "lineNumber": 106,
         "author": {
-          "gitId": "wangyiming1019"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -10151,14 +10151,14 @@
       {
         "lineNumber": 110,
         "author": {
-          "gitId": "wangyiming1019"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 111,
         "author": {
-          "gitId": "wangyiming1019"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -10207,21 +10207,21 @@
       {
         "lineNumber": 118,
         "author": {
-          "gitId": "wangyiming1019"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 119,
         "author": {
-          "gitId": "wangyiming1019"
+          "gitId": "-"
         },
         "content": "Examples:"
       },
       {
         "lineNumber": 120,
         "author": {
-          "gitId": "wangyiming1019"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -10277,14 +10277,14 @@
       {
         "lineNumber": 128,
         "author": {
-          "gitId": "wangyiming1019"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 129,
         "author": {
-          "gitId": "Esilocke"
+          "gitId": "-"
         },
         "content": "\u003d\u003d\u003d Listing all persons : `list`"
       },
@@ -10354,7 +10354,7 @@
       {
         "lineNumber": 139,
         "author": {
-          "gitId": "Esilocke"
+          "gitId": "-"
         },
         "content": "\u003d\u003d\u003d Editing a person : `edit`"
       },
@@ -10641,7 +10641,7 @@
       {
         "lineNumber": 180,
         "author": {
-          "gitId": "Esilocke"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -10676,7 +10676,7 @@
       {
         "lineNumber": 185,
         "author": {
-          "gitId": "jeffreygohkw"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -10718,7 +10718,7 @@
       {
         "lineNumber": 191,
         "author": {
-          "gitId": "Esilocke"
+          "gitId": "-"
         },
         "content": "****"
       },
@@ -11411,7 +11411,7 @@
       {
         "lineNumber": 290,
         "author": {
-          "gitId": "wangyiming1019"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -11523,14 +11523,14 @@
       {
         "lineNumber": 306,
         "author": {
-          "gitId": "wangyiming1019"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 307,
         "author": {
-          "gitId": "wangyiming1019"
+          "gitId": "-"
         },
         "content": "****"
       },
@@ -11579,7 +11579,7 @@
       {
         "lineNumber": 314,
         "author": {
-          "gitId": "wangyiming1019"
+          "gitId": "-"
         },
         "content": "****"
       },
@@ -11691,7 +11691,7 @@
       {
         "lineNumber": 330,
         "author": {
-          "gitId": "Esilocke"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -11712,14 +11712,14 @@
       {
         "lineNumber": 333,
         "author": {
-          "gitId": "Esilocke"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 334,
         "author": {
-          "gitId": "Esilocke"
+          "gitId": "-"
         },
         "content": "****"
       },
@@ -11733,42 +11733,42 @@
       {
         "lineNumber": 336,
         "author": {
-          "gitId": "Esilocke"
+          "gitId": "-"
         },
         "content": "* The index refers to the index number shown in the most recent listing."
       },
       {
         "lineNumber": 337,
         "author": {
-          "gitId": "Esilocke"
+          "gitId": "-"
         },
         "content": "* The index *must be a positive integer* 1, 2, 3, ..."
       },
       {
         "lineNumber": 338,
         "author": {
-          "gitId": "Esilocke"
+          "gitId": "-"
         },
         "content": "****"
       },
       {
         "lineNumber": 339,
         "author": {
-          "gitId": "Esilocke"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 340,
         "author": {
-          "gitId": "Esilocke"
+          "gitId": "-"
         },
         "content": "Examples:"
       },
       {
         "lineNumber": 341,
         "author": {
-          "gitId": "Esilocke"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -12384,7 +12384,7 @@
       {
         "lineNumber": 429,
         "author": {
-          "gitId": "Esilocke"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -13581,7 +13581,7 @@
       {
         "lineNumber": 600,
         "author": {
-          "gitId": "wangyiming1019"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -13910,7 +13910,7 @@
       {
         "lineNumber": 647,
         "author": {
-          "gitId": "wangyiming1019"
+          "gitId": "-"
         },
         "content": "\u003d\u003d\u003d Clearing all entries : `clear`"
       },
@@ -14043,7 +14043,7 @@
       {
         "lineNumber": 666,
         "author": {
-          "gitId": "jeffreygohkw"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -14057,7 +14057,7 @@
       {
         "lineNumber": 668,
         "author": {
-          "gitId": "jeffreygohkw"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -14071,7 +14071,7 @@
       {
         "lineNumber": 670,
         "author": {
-          "gitId": "jeffreygohkw"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -14442,7 +14442,7 @@
       {
         "lineNumber": 723,
         "author": {
-          "gitId": "wangyiming1019"
+          "gitId": "-"
         },
         "content": "* *Help* : `help`"
       },
@@ -14554,21 +14554,21 @@
       {
         "lineNumber": 739,
         "author": {
-          "gitId": "Esilocke"
+          "gitId": "-"
         },
         "content": "* *History* : `history`"
       },
       {
         "lineNumber": 740,
         "author": {
-          "gitId": "Esilocke"
+          "gitId": "-"
         },
         "content": "* *Undo* : `undo`"
       },
       {
         "lineNumber": 741,
         "author": {
-          "gitId": "Esilocke"
+          "gitId": "-"
         },
         "content": "* *Redo* : `redo`"
       },
@@ -14624,10 +14624,10 @@
     ],
     "authorContributionMap": {
       "charlesgoh": 32,
-      "jeffreygohkw": 51,
-      "Esilocke": 272,
-      "wangyiming1019": 194,
-      "-": 199
+      "jeffreygohkw": 47,
+      "Esilocke": 255,
+      "wangyiming1019": 180,
+      "-": 234
     }
   },
   {
@@ -17498,14 +17498,14 @@
       {
         "lineNumber": 38,
         "author": {
-          "gitId": "charlesgoh"
+          "gitId": "-"
         },
         "content": "    public LogicManager(Model model) {"
       },
       {
         "lineNumber": 39,
         "author": {
-          "gitId": "charlesgoh"
+          "gitId": "-"
         },
         "content": "        this.model \u003d model;"
       },
@@ -17519,35 +17519,35 @@
       {
         "lineNumber": 41,
         "author": {
-          "gitId": "charlesgoh"
+          "gitId": "-"
         },
         "content": "        this.history \u003d new CommandHistory();"
       },
       {
         "lineNumber": 42,
         "author": {
-          "gitId": "charlesgoh"
+          "gitId": "-"
         },
         "content": "        this.addressBookParser \u003d new AddressBookParser();"
       },
       {
         "lineNumber": 43,
         "author": {
-          "gitId": "charlesgoh"
+          "gitId": "-"
         },
         "content": "        this.undoRedoStack \u003d new UndoRedoStack();"
       },
       {
         "lineNumber": 44,
         "author": {
-          "gitId": "charlesgoh"
+          "gitId": "-"
         },
         "content": "    }"
       },
       {
         "lineNumber": 45,
         "author": {
-          "gitId": "charlesgoh"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -17777,9 +17777,9 @@
       }
     ],
     "authorContributionMap": {
-      "charlesgoh": 13,
+      "charlesgoh": 6,
       "Esilocke": 8,
-      "-": 56
+      "-": 63
     }
   },
   {
@@ -25102,7 +25102,7 @@
       {
         "lineNumber": 129,
         "author": {
-          "gitId": "Esilocke"
+          "gitId": "-"
         },
         "content": "        try {"
       },
@@ -26607,7 +26607,7 @@
       {
         "lineNumber": 344,
         "author": {
-          "gitId": "Esilocke"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -26656,14 +26656,14 @@
       {
         "lineNumber": 351,
         "author": {
-          "gitId": "Esilocke"
+          "gitId": "-"
         },
         "content": "    }"
       },
       {
         "lineNumber": 352,
         "author": {
-          "gitId": "Esilocke"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -28190,9 +28190,9 @@
     "authorContributionMap": {
       "charlesgoh": 22,
       "jeffreygohkw": 152,
-      "Esilocke": 178,
+      "Esilocke": 174,
       "wangyiming1019": 15,
-      "-": 202
+      "-": 206
     }
   },
   {
@@ -29856,7 +29856,7 @@
       {
         "lineNumber": 51,
         "author": {
-          "gitId": "Esilocke"
+          "gitId": "-"
         },
         "content": "    }"
       },
@@ -29974,9 +29974,9 @@
       }
     ],
     "authorContributionMap": {
-      "Esilocke": 37,
+      "Esilocke": 36,
       "wangyiming1019": 1,
-      "-": 29
+      "-": 30
     }
   },
   {
@@ -33585,21 +33585,21 @@
       {
         "lineNumber": 105,
         "author": {
-          "gitId": "charlesgoh"
+          "gitId": "-"
         },
         "content": "            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));"
       },
       {
         "lineNumber": 106,
         "author": {
-          "gitId": "charlesgoh"
+          "gitId": "-"
         },
         "content": "        }"
       },
       {
         "lineNumber": 107,
         "author": {
-          "gitId": "charlesgoh"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -33648,7 +33648,7 @@
       {
         "lineNumber": 114,
         "author": {
-          "gitId": "jeffreygohkw"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -33690,7 +33690,7 @@
       {
         "lineNumber": 120,
         "author": {
-          "gitId": "jeffreygohkw"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -34200,11 +34200,11 @@
       }
     ],
     "authorContributionMap": {
-      "charlesgoh": 21,
-      "jeffreygohkw": 50,
+      "charlesgoh": 18,
+      "jeffreygohkw": 48,
       "Esilocke": 73,
       "wangyiming1019": 1,
-      "-": 47
+      "-": 52
     }
   },
   {
@@ -38578,7 +38578,7 @@
       {
         "lineNumber": 49,
         "author": {
-          "gitId": "Esilocke"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -39145,8 +39145,8 @@
     ],
     "authorContributionMap": {
       "charlesgoh": 4,
-      "Esilocke": 48,
-      "-": 77
+      "Esilocke": 47,
+      "-": 78
     }
   },
   {
@@ -39983,7 +39983,7 @@
       {
         "lineNumber": 26,
         "author": {
-          "gitId": "Esilocke"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -40122,8 +40122,8 @@
       }
     ],
     "authorContributionMap": {
-      "Esilocke": 15,
-      "-": 30
+      "Esilocke": 14,
+      "-": 31
     }
   },
   {
@@ -40960,63 +40960,63 @@
       {
         "lineNumber": 52,
         "author": {
-          "gitId": "jeffreygohkw"
+          "gitId": "-"
         },
         "content": "    /**"
       },
       {
         "lineNumber": 53,
         "author": {
-          "gitId": "jeffreygohkw"
+          "gitId": "-"
         },
         "content": "     * Parses a {@code Optional\u003cString\u003e name} into an {@code Optional\u003cName\u003e} if {@code name} is present."
       },
       {
         "lineNumber": 54,
         "author": {
-          "gitId": "jeffreygohkw"
+          "gitId": "-"
         },
         "content": "     * See header comment of this class regarding the use of {@code Optional} parameters."
       },
       {
         "lineNumber": 55,
         "author": {
-          "gitId": "jeffreygohkw"
+          "gitId": "-"
         },
         "content": "     */"
       },
       {
         "lineNumber": 56,
         "author": {
-          "gitId": "jeffreygohkw"
+          "gitId": "-"
         },
         "content": "    public static Optional\u003cName\u003e parseName(Optional\u003cString\u003e name) throws IllegalValueException {"
       },
       {
         "lineNumber": 57,
         "author": {
-          "gitId": "jeffreygohkw"
+          "gitId": "-"
         },
         "content": "        requireNonNull(name);"
       },
       {
         "lineNumber": 58,
         "author": {
-          "gitId": "jeffreygohkw"
+          "gitId": "-"
         },
         "content": "        return name.isPresent() ? Optional.of(new Name(name.get())) : Optional.empty();"
       },
       {
         "lineNumber": 59,
         "author": {
-          "gitId": "jeffreygohkw"
+          "gitId": "-"
         },
         "content": "    }"
       },
       {
         "lineNumber": 60,
         "author": {
-          "gitId": "jeffreygohkw"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -41093,63 +41093,63 @@
       {
         "lineNumber": 71,
         "author": {
-          "gitId": "jeffreygohkw"
+          "gitId": "-"
         },
         "content": "    /**"
       },
       {
         "lineNumber": 72,
         "author": {
-          "gitId": "jeffreygohkw"
+          "gitId": "-"
         },
         "content": "     * Parses a {@code Optional\u003cString\u003e phone} into an {@code Optional\u003cPhone\u003e} if {@code phone} is present."
       },
       {
         "lineNumber": 73,
         "author": {
-          "gitId": "jeffreygohkw"
+          "gitId": "-"
         },
         "content": "     * See header comment of this class regarding the use of {@code Optional} parameters."
       },
       {
         "lineNumber": 74,
         "author": {
-          "gitId": "jeffreygohkw"
+          "gitId": "-"
         },
         "content": "     */"
       },
       {
         "lineNumber": 75,
         "author": {
-          "gitId": "jeffreygohkw"
+          "gitId": "-"
         },
         "content": "    public static Optional\u003cPhone\u003e parsePhone(Optional\u003cString\u003e phone) throws IllegalValueException {"
       },
       {
         "lineNumber": 76,
         "author": {
-          "gitId": "jeffreygohkw"
+          "gitId": "-"
         },
         "content": "        requireNonNull(phone);"
       },
       {
         "lineNumber": 77,
         "author": {
-          "gitId": "jeffreygohkw"
+          "gitId": "-"
         },
         "content": "        return phone.isPresent() ? Optional.of(new Phone(phone.get())) : Optional.empty();"
       },
       {
         "lineNumber": 78,
         "author": {
-          "gitId": "jeffreygohkw"
+          "gitId": "-"
         },
         "content": "    }"
       },
       {
         "lineNumber": 79,
         "author": {
-          "gitId": "jeffreygohkw"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -41233,7 +41233,7 @@
       {
         "lineNumber": 91,
         "author": {
-          "gitId": "jeffreygohkw"
+          "gitId": "-"
         },
         "content": "     * Parses a {@code Optional\u003cString\u003e address} into an {@code Optional\u003cAddress\u003e} if {@code address} is present."
       },
@@ -41254,21 +41254,21 @@
       {
         "lineNumber": 94,
         "author": {
-          "gitId": "jeffreygohkw"
+          "gitId": "-"
         },
         "content": "    public static Optional\u003cAddress\u003e parseAddress(Optional\u003cString\u003e address) throws IllegalValueException {"
       },
       {
         "lineNumber": 95,
         "author": {
-          "gitId": "jeffreygohkw"
+          "gitId": "-"
         },
         "content": "        requireNonNull(address);"
       },
       {
         "lineNumber": 96,
         "author": {
-          "gitId": "jeffreygohkw"
+          "gitId": "-"
         },
         "content": "        return address.isPresent() ? Optional.of(new Address(address.get())) : Optional.empty();"
       },
@@ -41527,7 +41527,7 @@
       {
         "lineNumber": 133,
         "author": {
-          "gitId": "jeffreygohkw"
+          "gitId": "-"
         },
         "content": "     * Parses a {@code Optional\u003cString\u003e email} into an {@code Optional\u003cEmail\u003e} if {@code email} is present."
       },
@@ -41548,21 +41548,21 @@
       {
         "lineNumber": 136,
         "author": {
-          "gitId": "jeffreygohkw"
+          "gitId": "-"
         },
         "content": "    public static Optional\u003cEmail\u003e parseEmail(Optional\u003cString\u003e email) throws IllegalValueException {"
       },
       {
         "lineNumber": 137,
         "author": {
-          "gitId": "jeffreygohkw"
+          "gitId": "-"
         },
         "content": "        requireNonNull(email);"
       },
       {
         "lineNumber": 138,
         "author": {
-          "gitId": "jeffreygohkw"
+          "gitId": "-"
         },
         "content": "        return email.isPresent() ? Optional.of(new Email(email.get())) : Optional.empty();"
       },
@@ -41968,9 +41968,9 @@
     ],
     "authorContributionMap": {
       "charlesgoh": 23,
-      "jeffreygohkw": 55,
+      "jeffreygohkw": 29,
       "Esilocke": 39,
-      "-": 78
+      "-": 104
     }
   },
   {
@@ -43144,7 +43144,7 @@
       {
         "lineNumber": 88,
         "author": {
-          "gitId": "Esilocke"
+          "gitId": "-"
         },
         "content": "        }"
       },
@@ -44579,7 +44579,7 @@
       {
         "lineNumber": 293,
         "author": {
-          "gitId": "Esilocke"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -44726,9 +44726,9 @@
     ],
     "authorContributionMap": {
       "charlesgoh": 10,
-      "Esilocke": 107,
+      "Esilocke": 105,
       "wangyiming1019": 16,
-      "-": 180
+      "-": 182
     }
   },
   {
@@ -45360,7 +45360,7 @@
       {
         "lineNumber": 90,
         "author": {
-          "gitId": "Esilocke"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -45500,9 +45500,9 @@
     ],
     "authorContributionMap": {
       "charlesgoh": 6,
-      "Esilocke": 37,
+      "Esilocke": 36,
       "wangyiming1019": 18,
-      "-": 48
+      "-": 49
     }
   },
   {
@@ -47827,7 +47827,7 @@
       {
         "lineNumber": 29,
         "author": {
-          "gitId": "jeffreygohkw"
+          "gitId": "-"
         },
         "content": "    public Address(String address) throws IllegalValueException {"
       },
@@ -47890,14 +47890,14 @@
       {
         "lineNumber": 38,
         "author": {
-          "gitId": "jeffreygohkw"
+          "gitId": "-"
         },
         "content": "    }"
       },
       {
         "lineNumber": 39,
         "author": {
-          "gitId": "jeffreygohkw"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -48183,9 +48183,9 @@
       }
     ],
     "authorContributionMap": {
-      "jeffreygohkw": 17,
+      "jeffreygohkw": 14,
       "Esilocke": 6,
-      "-": 56
+      "-": 59
     }
   },
   {
@@ -48355,7 +48355,7 @@
       {
         "lineNumber": 24,
         "author": {
-          "gitId": "jeffreygohkw"
+          "gitId": "-"
         },
         "content": "    public Email(String email) throws IllegalValueException {"
       },
@@ -48425,14 +48425,14 @@
       {
         "lineNumber": 34,
         "author": {
-          "gitId": "jeffreygohkw"
+          "gitId": "-"
         },
         "content": "    }"
       },
       {
         "lineNumber": 35,
         "author": {
-          "gitId": "jeffreygohkw"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -48718,9 +48718,9 @@
       }
     ],
     "authorContributionMap": {
-      "jeffreygohkw": 17,
+      "jeffreygohkw": 14,
       "Esilocke": 6,
-      "-": 52
+      "-": 55
     }
   },
   {
@@ -48932,7 +48932,7 @@
       {
         "lineNumber": 30,
         "author": {
-          "gitId": "jeffreygohkw"
+          "gitId": "-"
         },
         "content": "    public Name(String name) throws IllegalValueException {"
       },
@@ -48981,14 +48981,14 @@
       {
         "lineNumber": 37,
         "author": {
-          "gitId": "jeffreygohkw"
+          "gitId": "-"
         },
         "content": "    }"
       },
       {
         "lineNumber": 38,
         "author": {
-          "gitId": "jeffreygohkw"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -49281,8 +49281,8 @@
       }
     ],
     "authorContributionMap": {
-      "jeffreygohkw": 17,
-      "-": 62
+      "jeffreygohkw": 14,
+      "-": 65
     }
   },
   {
@@ -51508,7 +51508,7 @@
       {
         "lineNumber": 25,
         "author": {
-          "gitId": "jeffreygohkw"
+          "gitId": "-"
         },
         "content": "    public Phone(String phone) throws IllegalValueException {"
       },
@@ -51578,14 +51578,14 @@
       {
         "lineNumber": 35,
         "author": {
-          "gitId": "jeffreygohkw"
+          "gitId": "-"
         },
         "content": "    }"
       },
       {
         "lineNumber": 36,
         "author": {
-          "gitId": "jeffreygohkw"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -51871,9 +51871,9 @@
       }
     ],
     "authorContributionMap": {
-      "jeffreygohkw": 18,
+      "jeffreygohkw": 15,
       "Esilocke": 6,
-      "-": 52
+      "-": 55
     }
   },
   {
@@ -52936,14 +52936,14 @@
       {
         "lineNumber": 8,
         "author": {
-          "gitId": "charlesgoh"
+          "gitId": "-"
         },
         "content": "import java.util.Iterator;"
       },
       {
         "lineNumber": 9,
         "author": {
-          "gitId": "charlesgoh"
+          "gitId": "-"
         },
         "content": "import java.util.List;"
       },
@@ -54448,14 +54448,14 @@
       {
         "lineNumber": 224,
         "author": {
-          "gitId": "charlesgoh"
+          "gitId": "-"
         },
         "content": "    }"
       },
       {
         "lineNumber": 225,
         "author": {
-          "gitId": "charlesgoh"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -54580,9 +54580,9 @@
       }
     ],
     "authorContributionMap": {
-      "charlesgoh": 92,
+      "charlesgoh": 88,
       "wangyiming1019": 30,
-      "-": 120
+      "-": 124
     }
   },
   {
@@ -61766,7 +61766,7 @@
       {
         "lineNumber": 26,
         "author": {
-          "gitId": "jeffreygohkw"
+          "gitId": "-"
         },
         "content": "    @XmlElement(required \u003d true)"
       },
@@ -61794,7 +61794,7 @@
       {
         "lineNumber": 30,
         "author": {
-          "gitId": "jeffreygohkw"
+          "gitId": "-"
         },
         "content": "    @XmlElement(required \u003d true)"
       },
@@ -61822,7 +61822,7 @@
       {
         "lineNumber": 34,
         "author": {
-          "gitId": "jeffreygohkw"
+          "gitId": "-"
         },
         "content": "    @XmlElement(required \u003d true)"
       },
@@ -62403,9 +62403,9 @@
     ],
     "authorContributionMap": {
       "charlesgoh": 10,
-      "jeffreygohkw": 30,
+      "jeffreygohkw": 27,
       "wangyiming1019": 6,
-      "-": 70
+      "-": 73
     }
   },
   {
@@ -64765,14 +64765,14 @@
       {
         "lineNumber": 80,
         "author": {
-          "gitId": "jeffreygohkw"
+          "gitId": "-"
         },
         "content": "    }"
       },
       {
         "lineNumber": 81,
         "author": {
-          "gitId": "jeffreygohkw"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -64995,8 +64995,8 @@
       }
     ],
     "authorContributionMap": {
-      "jeffreygohkw": 39,
-      "-": 73
+      "jeffreygohkw": 37,
+      "-": 75
     }
   },
   {
@@ -71659,7 +71659,7 @@
       {
         "lineNumber": 34,
         "author": {
-          "gitId": "wangyiming1019"
+          "gitId": "-"
         },
         "content": "import seedu.address.testutil.PersonBuilder;"
       },
@@ -72541,14 +72541,14 @@
       {
         "lineNumber": 160,
         "author": {
-          "gitId": "Esilocke"
+          "gitId": "-"
         },
         "content": "        }"
       },
       {
         "lineNumber": 161,
         "author": {
-          "gitId": "Esilocke"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -72744,7 +72744,7 @@
       {
         "lineNumber": 189,
         "author": {
-          "gitId": "Esilocke"
+          "gitId": "-"
         },
         "content": "        @Override"
       },
@@ -72849,7 +72849,7 @@
       {
         "lineNumber": 204,
         "author": {
-          "gitId": "charlesgoh"
+          "gitId": "-"
         },
         "content": "        }"
       },
@@ -73464,10 +73464,10 @@
       }
     ],
     "authorContributionMap": {
-      "charlesgoh": 5,
-      "Esilocke": 105,
-      "wangyiming1019": 25,
-      "-": 156
+      "charlesgoh": 4,
+      "Esilocke": 102,
+      "wangyiming1019": 24,
+      "-": 161
     }
   },
   {
@@ -76147,7 +76147,7 @@
       {
         "lineNumber": 61,
         "author": {
-          "gitId": "Esilocke"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -76532,7 +76532,7 @@
       {
         "lineNumber": 116,
         "author": {
-          "gitId": "wangyiming1019"
+          "gitId": "-"
         },
         "content": "                .withTags(VALID_TAG_HUSBAND, VALID_TAG_FRIEND).build();"
       },
@@ -77107,9 +77107,9 @@
     "authorContributionMap": {
       "charlesgoh": 7,
       "jeffreygohkw": 12,
-      "Esilocke": 35,
-      "wangyiming1019": 16,
-      "-": 127
+      "Esilocke": 34,
+      "wangyiming1019": 15,
+      "-": 129
     }
   },
   {
@@ -79795,7 +79795,7 @@
       {
         "lineNumber": 98,
         "author": {
-          "gitId": "jeffreygohkw"
+          "gitId": "-"
         },
         "content": "    @Test"
       },
@@ -79809,21 +79809,21 @@
       {
         "lineNumber": 100,
         "author": {
-          "gitId": "jeffreygohkw"
+          "gitId": "-"
         },
         "content": "        showFirstPersonOnly(model);"
       },
       {
         "lineNumber": 101,
         "author": {
-          "gitId": "jeffreygohkw"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 102,
         "author": {
-          "gitId": "jeffreygohkw"
+          "gitId": "-"
         },
         "content": "        ReadOnlyPerson personInFilteredList \u003d model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());"
       },
@@ -79935,21 +79935,21 @@
       {
         "lineNumber": 118,
         "author": {
-          "gitId": "jeffreygohkw"
+          "gitId": "-"
         },
         "content": "        EditCommand editCommand \u003d prepareCommand(INDEX_FIRST_PERSON,"
       },
       {
         "lineNumber": 119,
         "author": {
-          "gitId": "jeffreygohkw"
+          "gitId": "-"
         },
         "content": "                new EditPersonDescriptorBuilder().withName(VALID_NAME_BOB).build());"
       },
       {
         "lineNumber": 120,
         "author": {
-          "gitId": "jeffreygohkw"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -79963,14 +79963,14 @@
       {
         "lineNumber": 122,
         "author": {
-          "gitId": "jeffreygohkw"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 123,
         "author": {
-          "gitId": "jeffreygohkw"
+          "gitId": "-"
         },
         "content": "        Model expectedModel \u003d new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());"
       },
@@ -79984,7 +79984,7 @@
       {
         "lineNumber": 125,
         "author": {
-          "gitId": "jeffreygohkw"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -80145,14 +80145,14 @@
       {
         "lineNumber": 148,
         "author": {
-          "gitId": "jeffreygohkw"
+          "gitId": "-"
         },
         "content": "    }"
       },
       {
         "lineNumber": 149,
         "author": {
-          "gitId": "jeffreygohkw"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -80725,8 +80725,8 @@
       }
     ],
     "authorContributionMap": {
-      "jeffreygohkw": 59,
-      "-": 171
+      "jeffreygohkw": 47,
+      "-": 183
     }
   },
   {
@@ -87536,14 +87536,14 @@
       {
         "lineNumber": 230,
         "author": {
-          "gitId": "Esilocke"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 231,
         "author": {
-          "gitId": "Esilocke"
+          "gitId": "-"
         },
         "content": "        // two invalid values, only first invalid value reported"
       },
@@ -87571,7 +87571,7 @@
       {
         "lineNumber": 235,
         "author": {
-          "gitId": "Esilocke"
+          "gitId": "-"
         },
         "content": "    }"
       },
@@ -87585,8 +87585,8 @@
     ],
     "authorContributionMap": {
       "charlesgoh": 33,
-      "Esilocke": 92,
-      "-": 111
+      "Esilocke": 89,
+      "-": 114
     }
   },
   {
@@ -88443,7 +88443,7 @@
       {
         "lineNumber": 63,
         "author": {
-          "gitId": "wangyiming1019"
+          "gitId": "-"
         },
         "content": "    @Test"
       },
@@ -88758,7 +88758,7 @@
       {
         "lineNumber": 108,
         "author": {
-          "gitId": "wangyiming1019"
+          "gitId": "-"
         },
         "content": "    @Test"
       },
@@ -88842,7 +88842,7 @@
       {
         "lineNumber": 120,
         "author": {
-          "gitId": "wangyiming1019"
+          "gitId": "-"
         },
         "content": "    @Test"
       },
@@ -88954,7 +88954,7 @@
       {
         "lineNumber": 136,
         "author": {
-          "gitId": "wangyiming1019"
+          "gitId": "-"
         },
         "content": "    @Test"
       },
@@ -89115,7 +89115,7 @@
       {
         "lineNumber": 159,
         "author": {
-          "gitId": "wangyiming1019"
+          "gitId": "-"
         },
         "content": "    @Test"
       },
@@ -89430,7 +89430,7 @@
       {
         "lineNumber": 204,
         "author": {
-          "gitId": "wangyiming1019"
+          "gitId": "-"
         },
         "content": "    @Test"
       },
@@ -89563,7 +89563,7 @@
       {
         "lineNumber": 223,
         "author": {
-          "gitId": "wangyiming1019"
+          "gitId": "-"
         },
         "content": "    @Test"
       },
@@ -89654,7 +89654,7 @@
       {
         "lineNumber": 236,
         "author": {
-          "gitId": "wangyiming1019"
+          "gitId": "-"
         },
         "content": "    @Test"
       },
@@ -90230,8 +90230,8 @@
       "charlesgoh": 21,
       "jeffreygohkw": 68,
       "Esilocke": 3,
-      "wangyiming1019": 97,
-      "-": 128
+      "wangyiming1019": 89,
+      "-": 136
     }
   },
   {
@@ -94296,28 +94296,28 @@
       {
         "lineNumber": 8,
         "author": {
-          "gitId": "charlesgoh"
+          "gitId": "-"
         },
         "content": "import java.util.ArrayList;"
       },
       {
         "lineNumber": 9,
         "author": {
-          "gitId": "charlesgoh"
+          "gitId": "-"
         },
         "content": "import java.util.Arrays;"
       },
       {
         "lineNumber": 10,
         "author": {
-          "gitId": "charlesgoh"
+          "gitId": "-"
         },
         "content": "import java.util.Collection;"
       },
       {
         "lineNumber": 11,
         "author": {
-          "gitId": "charlesgoh"
+          "gitId": "-"
         },
         "content": "import java.util.Collections;"
       },
@@ -94331,7 +94331,7 @@
       {
         "lineNumber": 13,
         "author": {
-          "gitId": "charlesgoh"
+          "gitId": "-"
         },
         "content": "import java.util.List;"
       },
@@ -95765,9 +95765,9 @@
       }
     ],
     "authorContributionMap": {
-      "charlesgoh": 119,
+      "charlesgoh": 114,
       "Esilocke": 8,
-      "-": 90
+      "-": 95
     }
   },
   {
@@ -95825,7 +95825,7 @@
       {
         "lineNumber": 8,
         "author": {
-          "gitId": "jeffreygohkw"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -95985,8 +95985,8 @@
       }
     ],
     "authorContributionMap": {
-      "jeffreygohkw": 10,
-      "-": 20
+      "jeffreygohkw": 9,
+      "-": 21
     }
   },
   {
@@ -96044,7 +96044,7 @@
       {
         "lineNumber": 8,
         "author": {
-          "gitId": "jeffreygohkw"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -96337,8 +96337,8 @@
       }
     ],
     "authorContributionMap": {
-      "jeffreygohkw": 10,
-      "-": 39
+      "jeffreygohkw": 9,
+      "-": 40
     }
   },
   {
@@ -96396,7 +96396,7 @@
       {
         "lineNumber": 8,
         "author": {
-          "gitId": "jeffreygohkw"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -96591,8 +96591,8 @@
       }
     ],
     "authorContributionMap": {
-      "jeffreygohkw": 10,
-      "-": 25
+      "jeffreygohkw": 9,
+      "-": 26
     }
   },
   {
@@ -96650,7 +96650,7 @@
       {
         "lineNumber": 8,
         "author": {
-          "gitId": "jeffreygohkw"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -96838,8 +96838,8 @@
       }
     ],
     "authorContributionMap": {
-      "jeffreygohkw": 10,
-      "-": 24
+      "jeffreygohkw": 9,
+      "-": 25
     }
   },
   {
@@ -104229,7 +104229,7 @@
       {
         "lineNumber": 42,
         "author": {
-          "gitId": "charlesgoh"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -104655,8 +104655,8 @@
       }
     ],
     "authorContributionMap": {
-      "charlesgoh": 18,
-      "-": 84
+      "charlesgoh": 17,
+      "-": 85
     }
   },
   {

--- a/src/functional/resources/dateRange/expected/reposense_testrepo-Charlie_master/commits.json
+++ b/src/functional/resources/dateRange/expected/reposense_testrepo-Charlie_master/commits.json
@@ -1676,10 +1676,10 @@
     ]
   },
   "authorFinalContributionMap": {
-    "charlesgoh": 1029,
-    "jeffreygohkw": 2191,
-    "Esilocke": 3408,
-    "wangyiming1019": 2411
+    "charlesgoh": 980,
+    "jeffreygohkw": 2122,
+    "Esilocke": 3348,
+    "wangyiming1019": 2361
   },
   "authorContributionVariance": {
     "charlesgoh": 9899.015,

--- a/src/main/java/reposense/authorship/FileInfoAnalyzer.java
+++ b/src/main/java/reposense/authorship/FileInfoAnalyzer.java
@@ -82,6 +82,11 @@ public class FileInfoAnalyzer {
         for (String line : blameResultLines) {
             String authorRawName = line.substring(AUTHOR_NAME_OFFSET);
             Author author = authorAliasMap.getOrDefault(authorRawName, new Author(Author.UNKNOWN_AUTHOR_GIT_ID));
+
+            if (!fileInfo.isFileLineTracked(lineCount)) {
+                author = new Author(Author.UNKNOWN_AUTHOR_GIT_ID);
+            }
+
             fileInfo.setLineAuthor(lineCount++, author);
         }
     }
@@ -90,7 +95,7 @@ public class FileInfoAnalyzer {
      * Returns the analysis result from running git blame on {@code filePath}.
      */
     private static String getGitBlameResult(RepoConfiguration config, String filePath) {
-        return CommandRunner.blameRaw(config.getRepoRoot(), filePath, config.getSinceDate(), config.getUntilDate());
+        return CommandRunner.blameRaw(config.getRepoRoot(), filePath);
     }
 
     /**

--- a/src/main/java/reposense/authorship/FileInfoExtractor.java
+++ b/src/main/java/reposense/authorship/FileInfoExtractor.java
@@ -199,7 +199,6 @@ public class FileInfoExtractor {
         Matcher filePathMatcher = FILE_PATH_PATTERN.matcher(fileDiffResult);
 
         if (!filePathMatcher.find()) {
-            logger.severe(fileDiffResult);
             throw new AssertionError("Should not have error matching file path pattern inside file diff result!");
         }
 

--- a/src/main/java/reposense/authorship/FileInfoExtractor.java
+++ b/src/main/java/reposense/authorship/FileInfoExtractor.java
@@ -11,6 +11,8 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -18,6 +20,7 @@ import reposense.authorship.model.FileInfo;
 import reposense.authorship.model.LineInfo;
 import reposense.git.GitChecker;
 import reposense.model.RepoConfiguration;
+import reposense.system.CommandRunner;
 import reposense.system.LogsManager;
 
 /**
@@ -25,6 +28,19 @@ import reposense.system.LogsManager;
  */
 public class FileInfoExtractor {
     private static final Logger logger = LogsManager.getLogger(FileInfoExtractor.class);
+
+    private static final String DIFF_FILE_CHUNK_SEPARATOR = "\ndiff --git a/.*\n";
+    private static final String BINARY_FILE_SYMBOL = "\nBinary files ";
+    private static final String FILE_DELETED_METADATA = "deleted file mode 100644\n";
+    private static final String LINE_CHUNKS_SEPARATOR = "\n@@ ";
+    private static final String LINE_INSERTED_SYMBOL = "+";
+
+    private static final int CHUNK_HEADER_LINE_INDEX = 0;
+    private static final int CHUNK_STARTING_LINE_GROUP_INDEX = 2;
+    private static final int FILE_PATH_GROUP_INDEX = 2;
+
+    private static final Pattern CHUNK_HEADER_PATTERN = Pattern.compile("-(\\d+)[,\\d]* \\+(\\d+).*");
+    private static final Pattern FILE_PATH_PATTERN = Pattern.compile("\n(\\+\\+\\+ b/)(.*)\n");
 
     /**
      * Extracts a list of relevant files given in {@code config}.
@@ -35,19 +51,93 @@ public class FileInfoExtractor {
         // checks out to the latest commit of the date range to ensure the FileInfo generated correspond to the
         // git blame file analyze output
         GitChecker.checkoutToDate(config.getRepoRoot(), config.getBranch(), config.getUntilDate());
-        ArrayList<FileInfo> fileInfos = new ArrayList<>();
-        getAllFileInfo(config, Paths.get(config.getRepoRoot()), fileInfos);
+        List<FileInfo> fileInfos = new ArrayList<>();
+        String lastCommitHash = CommandRunner.getCommitHashBeforeDate(
+                config.getRepoRoot(), config.getBranch(), config.getSinceDate());
+
+        if (!lastCommitHash.isEmpty()) {
+            fileInfos = getEditedFileInfos(config, lastCommitHash);
+        } else {
+            getAllFileInfo(config, Paths.get(config.getRepoRoot()), fileInfos);
+        }
+
         fileInfos.sort(Comparator.comparing(FileInfo::getPath));
+        return fileInfos;
+    }
+
+    /**
+     * Generates a list of relevant {@code FileInfo} for all files that were edited in between the current
+     * commit and the {@code lastCommitHash} commit, marks each {@code LineInfo} for each {@code FileInfo} on
+     * whether they have been inserted within the commit range or not, and returns it.
+     */
+    public static List<FileInfo> getEditedFileInfos(RepoConfiguration config, String lastCommitHash) {
+        List<FileInfo> fileInfos = new ArrayList<>();
+
+        String diffResult = CommandRunner.diffCommit(config.getRepoRoot(), lastCommitHash);
+
+        // no diff between the 2 commits, return an empty list
+        if (diffResult.isEmpty()) {
+            return fileInfos;
+        }
+
+        String[] fileDiffResultList = diffResult.split(DIFF_FILE_CHUNK_SEPARATOR);
+
+        for (String fileDiffResult : fileDiffResultList) {
+            // file deleted or is a binary file, skip it
+            if (fileDiffResult.startsWith(FILE_DELETED_METADATA) || fileDiffResult.contains(BINARY_FILE_SYMBOL)) {
+                continue;
+            }
+
+            String filePath = getFilePathFromDiffPattern(fileDiffResult);
+            if (isFormatInsideWhiteList(filePath, config.getFormats())) {
+                FileInfo currentFileInfo = generateFileInfo(config.getRepoRoot(), filePath);
+                setLinesToTrack(currentFileInfo, fileDiffResult);
+                fileInfos.add(currentFileInfo);
+            }
+        }
 
         return fileInfos;
+    }
+
+    /**
+     * Analyzes the {@code fileDiffResult} and marks each {@code LineInfo} in {@code FileInfo} on whether they were
+     * inserted in between the commit range.
+     */
+    private static void setLinesToTrack(FileInfo fileInfo, String fileDiffResult) {
+        String[] lineChangedChunks = fileDiffResult.split(LINE_CHUNKS_SEPARATOR);
+        List<LineInfo> lineInfos = fileInfo.getLines();
+        int fileLinePointer = 0;
+
+        for (int chunkIndex = 1; chunkIndex < lineChangedChunks.length; chunkIndex++) {
+            String lineChangedChunk = lineChangedChunks[chunkIndex];
+            String[] linesChangedInChunk = lineChangedChunk.split("\n");
+            int chunkStartingLineNumber = getChunkStartingLineNumber(linesChangedInChunk[CHUNK_HEADER_LINE_INDEX]);
+
+            // mark all untouched lines between chunks as untracked
+            while (fileLinePointer < chunkStartingLineNumber - 1) {
+                lineInfos.get(fileLinePointer++).setTracked(false);
+            }
+
+            for (int lineIndex = 1; lineIndex < linesChangedInChunk.length; lineIndex++) {
+                String lineChanged = linesChangedInChunk[lineIndex];
+                // set line added to be tracked
+                if (lineChanged.startsWith(LINE_INSERTED_SYMBOL)) {
+                    lineInfos.get(fileLinePointer++).setTracked(true);
+                }
+            }
+        }
+
+        // set all remaining lines in file that were untouched to be untracked
+        while (fileLinePointer < lineInfos.size()) {
+            lineInfos.get(fileLinePointer++).setTracked(false);
+        }
     }
 
     /**
      * Traverses each file from the repo root directory, generates the {@code FileInfo} for each relevant file found
      * based on {@code config} and inserts it into {@code fileInfos}.
      */
-    private static void getAllFileInfo(
-            RepoConfiguration config, Path directory, ArrayList<FileInfo> fileInfos) {
+    private static void getAllFileInfo(RepoConfiguration config, Path directory, List<FileInfo> fileInfos) {
         try (Stream<Path> pathStream = Files.list(directory)) {
             for (Path filePath : pathStream.collect(Collectors.toList())) {
                 String relativePath = filePath.toString().substring(config.getRepoRoot().length());
@@ -60,7 +150,7 @@ public class FileInfoExtractor {
                 }
 
                 if (isFormatInsideWhiteList(relativePath, config.getFormats())) {
-                    fileInfos.add(generateFileInfo(config.getRepoRoot(), relativePath.replace('\\', '/')));
+                    fileInfos.add(generateFileInfo(config.getRepoRoot(), relativePath));
                 }
             }
         } catch (IOException ioe) {
@@ -73,8 +163,9 @@ public class FileInfoExtractor {
      * {@code relativePath} file.
      */
     public static FileInfo generateFileInfo(String repoRoot, String relativePath) {
-        FileInfo fileInfo = new FileInfo(relativePath);
-        Path path = Paths.get(repoRoot, relativePath);
+        FileInfo fileInfo = new FileInfo(relativePath.replace('\\', '/'));
+        Path path = Paths.get(repoRoot, fileInfo.getPath());
+
         try (BufferedReader br = new BufferedReader(new FileReader(path.toFile()))) {
             String line;
             int lineNum = 1;
@@ -99,5 +190,33 @@ public class FileInfoExtractor {
      */
     private static boolean isFormatInsideWhiteList(String relativePath, List<String> formatsWhiteList) {
         return formatsWhiteList.stream().anyMatch(format -> relativePath.endsWith("." + format));
+    }
+
+    /**
+     * Returns the file path by matching the pattern inside {@code fileDiffResult}.
+     */
+    private static String getFilePathFromDiffPattern(String fileDiffResult) {
+        Matcher filePathMatcher = FILE_PATH_PATTERN.matcher(fileDiffResult);
+
+        if (!filePathMatcher.find()) {
+            logger.severe(fileDiffResult);
+            throw new AssertionError("Should not have error matching file path pattern inside file diff result!");
+        }
+
+        return filePathMatcher.group(FILE_PATH_GROUP_INDEX);
+    }
+
+    /**
+     * Returns the chunk's starting line number, within the file diff result, by matching the pattern inside
+     * {@code chunkHeader}.
+     */
+    private static int getChunkStartingLineNumber(String chunkHeader) {
+        Matcher chunkHeaderMatcher = CHUNK_HEADER_PATTERN.matcher(chunkHeader);
+
+        if (!chunkHeaderMatcher.find()) {
+            throw new AssertionError("Should not have error matching line number pattern inside chunk header!");
+        }
+
+        return Integer.parseInt(chunkHeaderMatcher.group(CHUNK_STARTING_LINE_GROUP_INDEX));
     }
 }

--- a/src/main/java/reposense/authorship/model/FileInfo.java
+++ b/src/main/java/reposense/authorship/model/FileInfo.java
@@ -40,7 +40,17 @@ public class FileInfo {
         return path;
     }
 
+    /**
+     * Sets the {@code Author} of the {@code LineInfo} in {@code lineNumber} for this {@code FileInfo}.
+     */
     public void setLineAuthor(int lineNumber, Author author) {
         lines.get(lineNumber).setAuthor(author);
+    }
+
+    /**
+     * Returns true if the {@code LineInfo} in {@code lineNumber} index is being tracked.
+     */
+    public boolean isFileLineTracked(int lineNumber) {
+        return getLines().get(lineNumber).isTracked();
     }
 }

--- a/src/main/java/reposense/authorship/model/LineInfo.java
+++ b/src/main/java/reposense/authorship/model/LineInfo.java
@@ -13,11 +13,15 @@ public class LineInfo {
     private String content;
     private ArrayList<IssueInfo> issues;
 
+    private transient boolean isTracked;
+
     public LineInfo(int lineNumber, String content) {
         this.lineNumber = lineNumber;
         //V this line is commented to reduce the size of the output JSON
         //this.issues = new ArrayList<>();
         this.content = content;
+
+        isTracked = true;
     }
 
     public ArrayList<IssueInfo> getIssues() {
@@ -39,6 +43,15 @@ public class LineInfo {
     public String getContent() {
         return content;
     }
+
+    public void setTracked(boolean isTracked) {
+        this.isTracked = isTracked;
+    }
+
+    public boolean isTracked() {
+        return isTracked;
+    }
+
 
     public boolean hasIssue() {
         return !issues.isEmpty();

--- a/src/main/java/reposense/system/CommandRunner.java
+++ b/src/main/java/reposense/system/CommandRunner.java
@@ -55,11 +55,10 @@ public class CommandRunner {
         runCommand(rootPath, checkoutCommand);
     }
 
-    public static String blameRaw(String root, String fileDirectory, Date sinceDate, Date untilDate) {
+    public static String blameRaw(String root, String fileDirectory) {
         Path rootPath = Paths.get(root);
 
         String blameCommand = "git blame -w --line-porcelain";
-        blameCommand += convertToGitDateRangeArgs(sinceDate, untilDate);
         blameCommand += " " + addQuote(fileDirectory);
         blameCommand += getAuthorFilterCommand();
 
@@ -72,6 +71,29 @@ public class CommandRunner {
                 rootPath,
                 "java -jar checkstyle-7.7-all.jar -c /google_checks.xml -f xml " + absoluteDirectory
         );
+    }
+
+    /**
+     * Returns the git diff result of the current commit compared to {@code lastCommitHash}, without any context.
+     */
+    public static String diffCommit(String root, String lastCommitHash) {
+        Path rootPath = Paths.get(root);
+        return runCommand(rootPath, "git diff -U0 " + lastCommitHash);
+    }
+
+    /**
+     * Returns the latest commit hash before {@code date}.
+     * Returns an empty {@code String} if {@code date} is null, or there is no such commit.
+     */
+    public static String getCommitHashBeforeDate(String root, String branchName, Date date) {
+        if (date == null) {
+            return "";
+        }
+
+        Path rootPath = Paths.get(root);
+        String revListCommand = "git rev-list -1 --before="
+                + GIT_LOG_SINCE_DATE_FORMAT.format(date) + " " + branchName;
+        return runCommand(rootPath, revListCommand);
     }
 
     public static String cloneRepo(String org, String repoName) throws IOException {

--- a/src/test/java/reposense/authorship/FileInfoExtractorTest.java
+++ b/src/test/java/reposense/authorship/FileInfoExtractorTest.java
@@ -2,6 +2,8 @@ package reposense.authorship;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Calendar;
+import java.util.Date;
 import java.util.List;
 
 import org.junit.Assert;
@@ -12,6 +14,7 @@ import reposense.git.GitChecker;
 import reposense.model.Author;
 import reposense.template.GitTestTemplate;
 import reposense.util.TestConstants;
+import reposense.util.TestUtil;
 
 
 public class FileInfoExtractorTest extends GitTestTemplate {
@@ -31,6 +34,35 @@ public class FileInfoExtractorTest extends GitTestTemplate {
         Assert.assertTrue(isFileExistence(Paths.get("blameTest.java"), files));
         Assert.assertTrue(isFileExistence(Paths.get("newPos/movedFile.java"), files));
         Assert.assertTrue(isFileExistence(Paths.get("inMasterBranch.java"), files));
+    }
+
+    @Test
+    public void extractFileInfos_sinceDateFebrauaryNineToLatestCommit_success() {
+        Date date = TestUtil.getDate(2018, Calendar.FEBRUARY, 9);
+        config.setSinceDate(date);
+
+        List<FileInfo> files = FileInfoExtractor.extractFileInfos(config);
+        Assert.assertEquals(3, files.size());
+
+        // files edited within commit range
+        Assert.assertTrue(isFileExistence(Paths.get("README.md"), files));
+        Assert.assertTrue(isFileExistence(Paths.get("newPos/movedFile.java"), files));
+        Assert.assertTrue(isFileExistence(Paths.get("annotationTest.java"), files));
+
+        // files not edited within commit range
+        Assert.assertFalse(isFileExistence(Paths.get("inMasterBranch.java"), files));
+        Assert.assertFalse(isFileExistence(Paths.get("blameTest.java"), files));
+        Assert.assertFalse(isFileExistence(Paths.get("newFile.java"), files));
+    }
+
+    @Test
+    public void extractFileInfos_sinceDateAfterLatestCommit_emptyResult() {
+        Date date = TestUtil.getDate(2050, 12, 31);
+        config.setSinceDate(date);
+
+        List<FileInfo> files = FileInfoExtractor.extractFileInfos(config);
+        Assert.assertTrue(files.isEmpty());
+
     }
 
     @Test

--- a/src/test/java/reposense/system/CommandRunnerTest.java
+++ b/src/test/java/reposense/system/CommandRunnerTest.java
@@ -67,8 +67,7 @@ public class CommandRunnerTest extends GitTestTemplate {
 
     @Test(expected = RuntimeException.class)
     public void blameRaw_nonExistentFile_throwsRunTimeException() {
-        String content = CommandRunner.blameRaw(TestConstants.LOCAL_TEST_REPO_ADDRESS, "nonExistentFile");
-        Assert.assertFalse(content.isEmpty());
+        CommandRunner.blameRaw(TestConstants.LOCAL_TEST_REPO_ADDRESS, "nonExistentFile");
     }
 
     @Test

--- a/src/test/java/reposense/system/CommandRunnerTest.java
+++ b/src/test/java/reposense/system/CommandRunnerTest.java
@@ -16,6 +16,8 @@ import reposense.util.TestUtil;
 
 
 public class CommandRunnerTest extends GitTestTemplate {
+    private static final String LATEST_COMMIT_HASH = "2d87a431fcbb8f73a731b6df0fcbee962c85c250";
+    private static final String FEBRUARY_EIGHT_COMMIT_HASH = "768015345e70f06add2a8b7d1f901dc07bf70582";
 
     @Test
     public void cloneTest() {
@@ -58,28 +60,74 @@ public class CommandRunnerTest extends GitTestTemplate {
     }
 
     @Test
-    public void blameRawTest() {
-        Date sinceDate = TestUtil.getDate(1950, Calendar.JANUARY, 1);
-        Date untilDate = TestUtil.getDate(2050, Calendar.JANUARY, 1);
-
-        // supply both sinceDate and untilDate -> success
-        String content = CommandRunner.blameRaw(
-                TestConstants.LOCAL_TEST_REPO_ADDRESS, "blameTest.java", sinceDate, untilDate);
+    public void blameRaw_validFile_success() {
+        String content = CommandRunner.blameRaw(TestConstants.LOCAL_TEST_REPO_ADDRESS, "blameTest.java");
         Assert.assertFalse(content.isEmpty());
+    }
 
-        // supply only untilDate -> success
-        content = CommandRunner.blameRaw(
-                TestConstants.LOCAL_TEST_REPO_ADDRESS, "blameTest.java", null, untilDate);
+    @Test(expected = RuntimeException.class)
+    public void blameRaw_nonExistentFile_throwsRunTimeException() {
+        String content = CommandRunner.blameRaw(TestConstants.LOCAL_TEST_REPO_ADDRESS, "nonExistentFile");
         Assert.assertFalse(content.isEmpty());
+    }
 
-        // supply only since sinceDate -> success
-        content = CommandRunner.blameRaw(
-                TestConstants.LOCAL_TEST_REPO_ADDRESS, "blameTest.java", sinceDate, null);
-        Assert.assertFalse(content.isEmpty());
+    @Test
+    public void diffCommit_validCommitHash_success() {
+        String diffResult = CommandRunner.diffCommit(config.getRepoRoot(), FEBRUARY_EIGHT_COMMIT_HASH);
+        Assert.assertFalse(diffResult.isEmpty());
+    }
 
-        // no sinceDate or untilDate supplied -> success
-        content = CommandRunner.blameRaw(
-                TestConstants.LOCAL_TEST_REPO_ADDRESS, "blameTest.java", null, null);
-        Assert.assertFalse(content.isEmpty());
+    @Test
+    public void diffCommit_emptyCommitHash_emptyResult() {
+        String diffResult = CommandRunner.diffCommit(config.getRepoRoot(), LATEST_COMMIT_HASH);
+        Assert.assertTrue(diffResult.isEmpty());
+    }
+
+    @Test
+    public void diffCommit_latestCommitHash_emptyResult() {
+        String diffResult = CommandRunner.diffCommit(config.getRepoRoot(), "");
+        Assert.assertTrue(diffResult.isEmpty());
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void diffCommit_invalidCommitHash_throwsRunTimeException() {
+        CommandRunner.diffCommit(config.getRepoRoot(), "invalidBranch");
+    }
+
+    @Test
+    public void getCommitHashBeforeDate_beforeInitialCommitDate_emptyResult() {
+        Date date = TestUtil.getDate(2018, Calendar.FEBRUARY, 4);
+        String commitHash = CommandRunner.getCommitHashBeforeDate(config.getRepoRoot(), config.getBranch(), date);
+        Assert.assertTrue(commitHash.isEmpty());
+    }
+
+    @Test
+    public void getCommitHashBeforeDate_afterLatestCommitDate_success() {
+        Date date = TestUtil.getDate(2018, Calendar.MAY, 10);
+        String commitHash = CommandRunner.getCommitHashBeforeDate(config.getRepoRoot(), config.getBranch(), date);
+
+        // result from git has a newline at the end
+        Assert.assertEquals(LATEST_COMMIT_HASH + "\n", commitHash);
+    }
+
+    @Test
+    public void getCommitHashBeforeDate_februaryNineDate_success() {
+        Date date = TestUtil.getDate(2018, Calendar.FEBRUARY, 9);
+        String commitHash = CommandRunner.getCommitHashBeforeDate(config.getRepoRoot(), config.getBranch(), date);
+
+        // result from git has a newline at the end
+        Assert.assertEquals(FEBRUARY_EIGHT_COMMIT_HASH + "\n", commitHash);
+    }
+
+    @Test
+    public void getCommitHashBeforeDate_nullDate_emptyResult() {
+        String commitHash = CommandRunner.getCommitHashBeforeDate(config.getRepoRoot(), config.getBranch(), null);
+        Assert.assertTrue(commitHash.isEmpty());
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void getCommitHashBeforeDate_invalidBranch_throwsRunTimeException() {
+        Date date = TestUtil.getDate(2018, Calendar.FEBRUARY, 9);
+        CommandRunner.getCommitHashBeforeDate(config.getRepoRoot(), "invalidBranch", date);
     }
 }


### PR DESCRIPTION
Fixes #203 
Depends on #212 
```
When a date range is supplied, the FileInfoAnalyzer will only
git blame on the range of commits that fall within the given
date range.

This may cause the authorship of certain lines that have not
been touched at all during the date range to be incorrectly
authored to a random author that commited in that date range.

Let's update the git blame command to run the git blame from
initial to the latest commit of that date range. In addition, let's
also update FileInfoExtractor to only track lines that were added
within the date range, and add them into the final authorship count.
```


Below was edited by @eugenepeh, for reference purpose
```diff
diff --git a/docs/UserGuide.md b/docs/UserGuide.md
index 6f0b634..a8af6df 100644
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -18 +18 @@
-Usage: `java -jar RepoSense.jar -config CSV_CONFIG_FILE_PATH [-output OUTPUT_DIRECTORY] [-since DD/MM/YYYY] [-until DD/MM/YYYY]`
+Usage: `java -jar RepoSense.jar -config CSV_CONFIG_FILE_PATH [-output OUTPUT_DIRECTORY] [-since DD/MM/YYYY] [-until DD/MM/YYYY] [-formats FORMAT...]`
@@ -25 +25 @@ Sample usage:
-$ java -jar RepoSense.jar -config CSV_path.csv -output output_path/ -since 01/10/2017 -until 01/11/2017
+$ java -jar RepoSense.jar -config CSV_path.csv -output output_path/ -since 01/10/2017 -until 01/11/2017 -formats java adoc js
@@ -31,2 +31,3 @@ Argument List:
-- since : Optional. start date of analysis. Format: `DD/MM/YYYY`
-- until : Optional. end date of analysis. Format: `DD/MM/YYYY`
+- since : Optional. The start date of analysis. Format: `DD/MM/YYYY`
+- until : Optional. The end date of analysis. Format: `DD/MM/YYYY`
+- formats : Optional. The file formats to analyse. Formats: `alphanumerical file formats`. If not provided, the following file formats will be used. `adoc, cs, css, fxml, gradle, html, java, js, json, jsp, md, py, tag, xml`
```