### PR TITLE
build.gradle: fix output location for jar file after gradle build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ dependencies {
 
 shadowJar {
     archiveName = 'RepoSense.jar'
-    destinationDir = file('${buildDir}/jar/')
+    destinationDir = file("${buildDir}/jar/")
 }
 
 task myZip(dependsOn: 'npmRunSpuild', type: Zip) {


### PR DESCRIPTION
```
build.gradle defines the destination location whereby to
generate the jar file as '{${buildDir}/jar/'.

As single quotes are being used, the ${buildDir} is taken as
a literal String rather than as a template[1] for the build folder
location. This causes the jar file to be incorrectly generated in
the project root directory instead of the build folder.

Let's update build.gradle destination location for the jar file to
use double quotes as a templatable String instead.

[1]: SO post explaining the difference between single and double quotes in Groovy:
https://stackoverflow.com/questions/6761498/whats-the-difference-of-strings-within-single-or-double-quotes-in-groovy
```