### PR TITLE
Allow location to be supplied into CSV Config File

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -75,8 +75,7 @@ The `CSV Config File` contains the list of repositories, and the corresponding t
 
 Column Name | Explanation
 ----------- | -----------
-Organization | Organization of the target repository
-Repository | Name of the target repository
+Repository's Location | The `GitHub URL` or `Disk Path` to the git repository
 Branch | The branch to analyse in the target repository
 Author's GitHub ID | GitHub ID of the target contributor in the repository
 Author's Display Name | Optional Field. The value of this field, if not empty, will be displayed in the dashboard instead of author's GitHub ID.

--- a/sample.csv
+++ b/sample.csv
@@ -1,9 +1,9 @@
 Repository's Location,Branch,Author's GitHub ID,Author's Display Name,Author's Git Author Name
-https://github.com/testrepo-Beta/main.git,master,nbriannl,Nbr,
-https://github.com/testrepo-Beta/main.git,master,zacharytang,Zac,Zachary Tang
-https://github.com/testrepo-Beta/main.git,master,April0616,Fan,LAPTOP-7KFM2KSP\User;Fan Yuting
-https://github.com/testrepo-Beta/main.git,master,CindyTsai1,Cin,YuHsuan
-https://github.com/testrepo-Delta/main.git,master,lithiumlkid,Ahm,
-https://github.com/testrepo-Delta/main.git,master,codeeong,Cod,
-https://github.com/testrepo-Delta/main.git,master,jordancjq,Jor,
-https://github.com/testrepo-Delta/main.git,master,lohtianwei,Loh,
+https://github.com/reposense/testrepo-Beta.git,master,nbriannl,Nbr,
+https://github.com/reposense/testrepo-Beta.git,master,zacharytang,Zac,Zachary Tang
+https://github.com/reposense/testrepo-Beta.git,master,April0616,Fan,LAPTOP-7KFM2KSP\User;Fan Yuting
+https://github.com/reposense/testrepo-Beta.git,master,CindyTsai1,Cin,YuHsuan
+https://github.com/reposense/testrepo-Delta.git,master,lithiumlkid,Ahm,
+https://github.com/reposense/testrepo-Delta.git,master,codeeong,Cod,
+https://github.com/reposense/testrepo-Delta.git,master,jordancjq,Jor,
+https://github.com/reposense/testrepo-Delta.git,master,lohtianwei,Loh,

--- a/sample.csv
+++ b/sample.csv
@@ -1,9 +1,9 @@
 Repository's Location,Branch,Author's GitHub ID,Author's Display Name,Author's Git Author Name
-https://github.com/CS2103AUG2017-W09-B1/main.git,master,nbriannl,Nbr,
-https://github.com/CS2103AUG2017-W09-B1/main.git,master,zacharytang,Zac,Zachary Tang
-https://github.com/CS2103AUG2017-W09-B1/main.git,master,April0616,Fan,LAPTOP-7KFM2KSP\User;Fan Yuting
-https://github.com/CS2103AUG2017-W09-B1/main.git,master,CindyTsai1,Cin,YuHsuan
-https://github.com/CS2103JAN2018-F14-B1/main.git,master,lithiumlkid,Ahm,
-https://github.com/CS2103JAN2018-F14-B1/main.git,master,codeeong,Cod,
-https://github.com/CS2103JAN2018-F14-B1/main.git,master,jordancjq,Jor,
-https://github.com/CS2103JAN2018-F14-B1/main.git,master,lohtianwei,Loh,
+https://github.com/testrepo-Beta/main.git,master,nbriannl,Nbr,
+https://github.com/testrepo-Beta/main.git,master,zacharytang,Zac,Zachary Tang
+https://github.com/testrepo-Beta/main.git,master,April0616,Fan,LAPTOP-7KFM2KSP\User;Fan Yuting
+https://github.com/testrepo-Beta/main.git,master,CindyTsai1,Cin,YuHsuan
+https://github.com/testrepo-Delta/main.git,master,lithiumlkid,Ahm,
+https://github.com/testrepo-Delta/main.git,master,codeeong,Cod,
+https://github.com/testrepo-Delta/main.git,master,jordancjq,Jor,
+https://github.com/testrepo-Delta/main.git,master,lohtianwei,Loh,

--- a/sample.csv
+++ b/sample.csv
@@ -1,4 +1,4 @@
-Repo location,branch,Author's GitHub ID,Author's Display Name,Author's Git Author Name
+Repository's Location,Branch,Author's GitHub ID,Author's Display Name,Author's Git Author Name
 https://github.com/CS2103AUG2017-W09-B1/main.git,master,nbriannl,Nbr,
 https://github.com/CS2103AUG2017-W09-B1/main.git,master,zacharytang,Zac,Zachary Tang
 https://github.com/CS2103AUG2017-W09-B1/main.git,master,April0616,Fan,LAPTOP-7KFM2KSP\User;Fan Yuting

--- a/sample.csv
+++ b/sample.csv
@@ -1,9 +1,9 @@
-Organization,Repository,branch,Author's GitHub ID,Author's Display Name,Author's Git Author Name
-CS2103AUG2017-W09-B1,main,master,nbriannl,Nbr,
-CS2103AUG2017-W09-B1,main,master,zacharytang,Zac,Zachary Tang
-CS2103AUG2017-W09-B1,main,master,April0616,Fan,LAPTOP-7KFM2KSP\User;Fan Yuting
-CS2103AUG2017-W09-B1,main,master,CindyTsai1,Cin,YuHsuan
-CS2103JAN2018-F14-B1,main,master,lithiumlkid,Ahm,
-CS2103JAN2018-F14-B1,main,master,codeeong,Cod,
-CS2103JAN2018-F14-B1,main,master,jordancjq,Jor,
-CS2103JAN2018-F14-B1,main,master,lohtianwei,Loh,
+Repo location,branch,Author's GitHub ID,Author's Display Name,Author's Git Author Name
+https://github.com/CS2103AUG2017-W09-B1/main.git,master,nbriannl,Nbr,
+https://github.com/CS2103AUG2017-W09-B1/main.git,master,zacharytang,Zac,Zachary Tang
+https://github.com/CS2103AUG2017-W09-B1/main.git,master,April0616,Fan,LAPTOP-7KFM2KSP\User;Fan Yuting
+https://github.com/CS2103AUG2017-W09-B1/main.git,master,CindyTsai1,Cin,YuHsuan
+https://github.com/CS2103JAN2018-F14-B1/main.git,master,lithiumlkid,Ahm,
+https://github.com/CS2103JAN2018-F14-B1/main.git,master,codeeong,Cod,
+https://github.com/CS2103JAN2018-F14-B1/main.git,master,jordancjq,Jor,
+https://github.com/CS2103JAN2018-F14-B1/main.git,master,lohtianwei,Loh,

--- a/src/functional/resources/dateRange/expected/summary.json
+++ b/src/functional/resources/dateRange/expected/summary.json
@@ -1,6 +1,6 @@
 [
   {
-    "organization": "reposense",
+    "location": "https://github.com/reposense/testrepo-Beta.git",
     "repoName": "testrepo-Beta",
     "branch": "master",
     "displayName": "reposense_testrepo-Beta_master",
@@ -8,7 +8,7 @@
     "untilDate": "2017-10-30"
   },
   {
-    "organization": "reposense",
+    "location": "https://github.com/reposense/testrepo-Charlie.git",
     "repoName": "testrepo-Charlie",
     "branch": "master",
     "displayName": "reposense_testrepo-Charlie_master",

--- a/src/functional/resources/dateRange/expected/summary.json
+++ b/src/functional/resources/dateRange/expected/summary.json
@@ -1,6 +1,7 @@
 [
   {
     "location": "https://github.com/reposense/testrepo-Beta.git",
+    "organization": "reposense",
     "repoName": "testrepo-Beta",
     "branch": "master",
     "displayName": "reposense_testrepo-Beta_master",
@@ -9,6 +10,7 @@
   },
   {
     "location": "https://github.com/reposense/testrepo-Charlie.git",
+    "organization": "reposense",
     "repoName": "testrepo-Charlie",
     "branch": "master",
     "displayName": "reposense_testrepo-Charlie_master",

--- a/src/functional/resources/noDateRange/expected/summary.json
+++ b/src/functional/resources/noDateRange/expected/summary.json
@@ -1,12 +1,12 @@
 [
   {
-    "organization": "reposense",
+    "location": "https://github.com/reposense/testrepo-Beta.git",
     "repoName": "testrepo-Beta",
     "branch": "master",
     "displayName": "reposense_testrepo-Beta_master"
   },
   {
-    "organization": "reposense",
+    "location": "https://github.com/reposense/testrepo-Charlie.git",
     "repoName": "testrepo-Charlie",
     "branch": "master",
     "displayName": "reposense_testrepo-Charlie_master"

--- a/src/functional/resources/noDateRange/expected/summary.json
+++ b/src/functional/resources/noDateRange/expected/summary.json
@@ -1,12 +1,14 @@
 [
   {
     "location": "https://github.com/reposense/testrepo-Beta.git",
+    "organization": "reposense",
     "repoName": "testrepo-Beta",
     "branch": "master",
     "displayName": "reposense_testrepo-Beta_master"
   },
   {
     "location": "https://github.com/reposense/testrepo-Charlie.git",
+    "organization": "reposense",
     "repoName": "testrepo-Charlie",
     "branch": "master",
     "displayName": "reposense_testrepo-Charlie_master"

--- a/src/functional/resources/sample.csv
+++ b/src/functional/resources/sample.csv
@@ -1,4 +1,4 @@
-Repo location,branch,Author's GitHub ID,Author's Display Name,Author's Git Author Name
+Repository's Location,Branch,Author's GitHub ID,Author's Display Name,Author's Git Author Name
 https://github.com/reposense/testrepo-Beta.git,master,nbriannl,Nbr,
 https://github.com/reposense/testrepo-Beta.git,master,zacharytang,Zac,Zachary Tang
 https://github.com/reposense/testrepo-Beta.git,master,April0616,Fan,LAPTOP-7KFM2KSP\User;Fan Yuting

--- a/src/functional/resources/sample.csv
+++ b/src/functional/resources/sample.csv
@@ -1,9 +1,9 @@
-Organization,Repository,branch,Author's GitHub ID,Author's Display Name,Author's Git Author Name
-reposense,testrepo-Beta,master,nbriannl,Nbr,
-reposense,testrepo-Beta,master,zacharytang,Zac,Zachary Tang
-reposense,testrepo-Beta,master,April0616,Fan,LAPTOP-7KFM2KSP\User;Fan Yuting
-reposense,testrepo-Beta,master,CindyTsai1,Cin,YuHsuan
-reposense,testrepo-Charlie,master,charlesgoh,Cha,Charles Goh
-reposense,testrepo-Charlie,master,Esilocke,Esi,
-reposense,testrepo-Charlie,master,jeffreygohkw,Jef,Jeffrey Goh
-reposense,testrepo-Charlie,master,wangyiming1019,Wan,ACER\kyle;Wang Yiming
+Repo location,branch,Author's GitHub ID,Author's Display Name,Author's Git Author Name
+https://github.com/reposense/testrepo-Beta.git,master,nbriannl,Nbr,
+https://github.com/reposense/testrepo-Beta.git,master,zacharytang,Zac,Zachary Tang
+https://github.com/reposense/testrepo-Beta.git,master,April0616,Fan,LAPTOP-7KFM2KSP\User;Fan Yuting
+https://github.com/reposense/testrepo-Beta.git,master,CindyTsai1,Cin,YuHsuan
+https://github.com/reposense/testrepo-Charlie.git,master,charlesgoh,Cha,Charles Goh
+https://github.com/reposense/testrepo-Charlie.git,master,Esilocke,Esi,
+https://github.com/reposense/testrepo-Charlie.git,master,jeffreygohkw,Jef,Jeffrey Goh
+https://github.com/reposense/testrepo-Charlie.git,master,wangyiming1019,Wan,ACER\kyle;Wang Yiming

--- a/src/main/java/reposense/authorship/FileInfoExtractor.java
+++ b/src/main/java/reposense/authorship/FileInfoExtractor.java
@@ -53,7 +53,7 @@ public class FileInfoExtractor {
      * Extracts a list of relevant files given in {@code config}.
      */
     public static List<FileInfo> extractFileInfos(RepoConfiguration config) {
-        logger.info("Extracting relevant file infos " + config.getDisplayName() + "...");
+        logger.info("Extracting relevant file infos " + config.getLocation() + "...");
 
         // checks out to the latest commit of the date range to ensure the FileInfo generated correspond to the
         // git blame file analyze output

--- a/src/main/java/reposense/builder/ConfigurationBuilder.java
+++ b/src/main/java/reposense/builder/ConfigurationBuilder.java
@@ -4,12 +4,13 @@ import java.util.List;
 
 import reposense.model.Author;
 import reposense.model.RepoConfiguration;
+import reposense.parser.ParseException;
 
 
 public class ConfigurationBuilder {
     private RepoConfiguration config;
 
-    public ConfigurationBuilder(String location, String branch) {
+    public ConfigurationBuilder(String location, String branch) throws ParseException {
         config = new RepoConfiguration(location, branch);
     }
 

--- a/src/main/java/reposense/builder/ConfigurationBuilder.java
+++ b/src/main/java/reposense/builder/ConfigurationBuilder.java
@@ -9,8 +9,8 @@ import reposense.model.RepoConfiguration;
 public class ConfigurationBuilder {
     private RepoConfiguration config;
 
-    public ConfigurationBuilder(String organization, String repoName, String branch) {
-        config = new RepoConfiguration(organization, repoName, branch);
+    public ConfigurationBuilder(String location, String branch) {
+        config = new RepoConfiguration(location, branch);
     }
 
     public ConfigurationBuilder needCheckStyle(boolean value) {

--- a/src/main/java/reposense/builder/ConfigurationBuilder.java
+++ b/src/main/java/reposense/builder/ConfigurationBuilder.java
@@ -4,13 +4,12 @@ import java.util.List;
 
 import reposense.model.Author;
 import reposense.model.RepoConfiguration;
-import reposense.parser.ParseException;
-
+import reposense.parser.InvalidLocationException;
 
 public class ConfigurationBuilder {
     private RepoConfiguration config;
 
-    public ConfigurationBuilder(String location, String branch) throws ParseException {
+    public ConfigurationBuilder(String location, String branch) throws InvalidLocationException {
         config = new RepoConfiguration(location, branch);
     }
 

--- a/src/main/java/reposense/commits/CommitInfoExtractor.java
+++ b/src/main/java/reposense/commits/CommitInfoExtractor.java
@@ -21,7 +21,7 @@ public class CommitInfoExtractor {
      * Extracts out and returns the raw information of each commit for the repo in {@code config}.
      */
     public static List<CommitInfo> extractCommitInfos(RepoConfiguration config) {
-        logger.info("Extracting commits info for " + config.getDisplayName() + "...");
+        logger.info("Extracting commits info for " + config.getLocation() + "...");
 
         GitChecker.checkoutBranch(config.getRepoRoot(), config.getBranch());
         String gitLogResult = getGitLogResult(config);

--- a/src/main/java/reposense/git/GitDownloader.java
+++ b/src/main/java/reposense/git/GitDownloader.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import reposense.model.RepoConfiguration;
 import reposense.system.CommandRunner;
 import reposense.system.LogsManager;
 import reposense.util.FileUtil;
@@ -15,12 +16,12 @@ public class GitDownloader {
 
     private static final Logger logger = LogsManager.getLogger(GitDownloader.class);
 
-    public static void downloadRepo(String location, String displayName, String repoName, String branchName)
+    public static void downloadRepo(RepoConfiguration repoConfig)
             throws GitDownloaderException {
         try {
-            FileUtil.deleteDirectory(FileUtil.getRepoDirectory(displayName));
-            logger.info("Cloning " + location + "...");
-            CommandRunner.cloneRepo(location, displayName);
+            FileUtil.deleteDirectory(repoConfig.getRepoRoot());
+            logger.info("Cloning " + repoConfig.getLocation() + "...");
+            CommandRunner.cloneRepo(repoConfig.getLocation(), repoConfig.getDisplayName());
             logger.info("Cloning completed!");
         } catch (RuntimeException rte) {
             logger.log(Level.SEVERE, "Error encountered in Git Cloning, will attempt to continue analyzing", rte);
@@ -32,7 +33,7 @@ public class GitDownloader {
         }
 
         try {
-            GitChecker.checkout(FileUtil.getRepoDirectory(displayName, repoName), branchName);
+            GitChecker.checkout(repoConfig.getRepoRoot(), repoConfig.getBranch());
         } catch (RuntimeException e) {
             logger.log(Level.SEVERE, "Branch does not exist! Analyze terminated.", e);
             throw new GitDownloaderException(e);

--- a/src/main/java/reposense/git/GitDownloader.java
+++ b/src/main/java/reposense/git/GitDownloader.java
@@ -15,12 +15,12 @@ public class GitDownloader {
 
     private static final Logger logger = LogsManager.getLogger(GitDownloader.class);
 
-    public static void downloadRepo(String organization, String repoName, String branchName)
+    public static void downloadRepo(String location, String displayName, String repoName, String branchName)
             throws GitDownloaderException {
         try {
-            FileUtil.deleteDirectory(FileUtil.getRepoDirectory(organization, repoName));
-            logger.info("Cloning " + organization + "/" + repoName + "...");
-            CommandRunner.cloneRepo(organization, repoName);
+            FileUtil.deleteDirectory(FileUtil.getRepoDirectory(displayName));
+            logger.info("Cloning " + location + "...");
+            CommandRunner.cloneRepo(location, displayName);
             logger.info("Cloning completed!");
         } catch (RuntimeException rte) {
             logger.log(Level.SEVERE, "Error encountered in Git Cloning, will attempt to continue analyzing", rte);
@@ -32,7 +32,7 @@ public class GitDownloader {
         }
 
         try {
-            GitChecker.checkout(FileUtil.getRepoDirectory(organization, repoName), branchName);
+            GitChecker.checkout(FileUtil.getRepoDirectory(displayName, repoName), branchName);
         } catch (RuntimeException e) {
             logger.log(Level.SEVERE, "Branch does not exist! Analyze terminated.", e);
             throw new GitDownloaderException(e);

--- a/src/main/java/reposense/model/RepoConfiguration.java
+++ b/src/main/java/reposense/model/RepoConfiguration.java
@@ -226,7 +226,7 @@ public class RepoConfiguration {
 
         try {
             Path pathLocation = Paths.get(location);
-            isValidPathLocation = Files.exists(pathLocation) && location.endsWith(GIT_LINK_SUFFIX);
+            isValidPathLocation = Files.exists(pathLocation);
         } catch (InvalidPathException ipe) {
             // Ignore exception
         }

--- a/src/main/java/reposense/model/RepoConfiguration.java
+++ b/src/main/java/reposense/model/RepoConfiguration.java
@@ -41,7 +41,7 @@ public class RepoConfiguration {
 
 
     /**
-     * @throws ParseException if {@code location} is not a valid .git link or {@code Path}.
+     * @throws ParseException if {@code location} cannot be represented by a {@code URL} or {@code Path}.
      */
     public RepoConfiguration(String location, String branch) throws ParseException {
         this.location = location;
@@ -208,6 +208,10 @@ public class RepoConfiguration {
         return repoName;
     }
 
+    /**
+     * Verifies {@code location} can be presented as a {@code URL} or {@code Path}.
+     * @throws ParseException if otherwise.
+     */
     private void verifyLocation(String location) throws ParseException {
         boolean isPathLocation = false;
         boolean isGitLocation = false;

--- a/src/main/java/reposense/model/RepoConfiguration.java
+++ b/src/main/java/reposense/model/RepoConfiguration.java
@@ -20,6 +20,7 @@ import reposense.parser.ParseException;
 import reposense.util.FileUtil;
 
 public class RepoConfiguration {
+    private static final String GIT_LINK_SUFFIX = ".git";
     private static final Pattern GIT_REPOSITORY_LOCATION_PATTERN =
             Pattern.compile("^.*github.com\\/(?<org>.+?)\\/(?<repoName>.+?)\\.git$");
 
@@ -225,7 +226,7 @@ public class RepoConfiguration {
 
         try {
             new URL(location);
-            isGitLocation = true;
+            isGitLocation = location.endsWith(GIT_LINK_SUFFIX);
         } catch (MalformedURLException mue) {
             // Ignore exception
         }

--- a/src/main/java/reposense/model/RepoConfiguration.java
+++ b/src/main/java/reposense/model/RepoConfiguration.java
@@ -34,6 +34,10 @@ public class RepoConfiguration {
     private transient Map<Author, String> authorDisplayNameMap = new HashMap<>();
     private transient boolean annotationOverwrite = true;
 
+    /**
+     * Creates a {@code RepoConfiguration}.
+     * {@code location} must be a Github .git link or a {@code Path}.
+     */
     public RepoConfiguration(String location, String branch) {
         this.location = location;
         this.branch = branch;
@@ -45,7 +49,6 @@ public class RepoConfiguration {
             repoName = matcher.group("repoName");
             displayName = organization + "_" + repoName + "_" + branch;
         } else {
-            // Location must be a Path
             repoName = Paths.get(location).getFileName().toString();
             displayName = repoName + "_" + branch;
         }

--- a/src/main/java/reposense/model/RepoConfiguration.java
+++ b/src/main/java/reposense/model/RepoConfiguration.java
@@ -10,7 +10,6 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.TreeMap;
 import java.util.regex.Matcher;

--- a/src/main/java/reposense/model/RepoConfiguration.java
+++ b/src/main/java/reposense/model/RepoConfiguration.java
@@ -3,6 +3,7 @@ package reposense.model;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.file.Files;
+import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
@@ -40,8 +41,7 @@ public class RepoConfiguration {
 
 
     /**
-     * Creates a {@code RepoConfiguration}.
-     * {@code location} must be a Github .git link or a {@code Path}.
+     * @throws ParseException if {@code location} is not a valid .git link or {@code Path}.
      */
     public RepoConfiguration(String location, String branch) throws ParseException {
         this.location = location;
@@ -209,9 +209,15 @@ public class RepoConfiguration {
     }
 
     private void verifyLocation(String location) throws ParseException {
-        Path pathLocation = Paths.get(location);
-        boolean isPathLocation = Files.exists(pathLocation);
+        boolean isPathLocation = false;
         boolean isGitLocation = false;
+
+        try {
+            Path pathLocation = Paths.get(location);
+            isPathLocation = Files.exists(pathLocation);
+        } catch (InvalidPathException ipe) {
+            // Ignore exception
+        }
 
         try {
             new URL(location);

--- a/src/main/java/reposense/model/RepoConfiguration.java
+++ b/src/main/java/reposense/model/RepoConfiguration.java
@@ -26,6 +26,7 @@ public class RepoConfiguration {
             Pattern.compile("^.*github.com\\/(?<org>.+?)\\/(?<repoName>.+?)\\.git$");
 
     private String location;
+    private String organization;
     private String repoName;
     private String branch;
     private String displayName;
@@ -53,7 +54,7 @@ public class RepoConfiguration {
         Matcher matcher = GIT_REPOSITORY_LOCATION_PATTERN.matcher(location);
 
         if (matcher.matches()) {
-            String organization = matcher.group("org");
+            organization = matcher.group("org");
             repoName = matcher.group("repoName");
             displayName = organization + "_" + repoName + "_" + branch;
         } else {

--- a/src/main/java/reposense/parser/CsvParser.java
+++ b/src/main/java/reposense/parser/CsvParser.java
@@ -58,8 +58,8 @@ public class CsvParser {
             }
         } catch (IOException ioe) {
             throw new IOException(MESSAGE_UNABLE_TO_READ_CSV_FILE, ioe);
-        } catch (ParseException pe) {
-            logger.log(Level.WARNING, pe.getMessage(), pe);
+        } catch (InvalidLocationException ile) {
+            logger.log(Level.WARNING, ile.getMessage(), ile);
         }
 
         return repoConfigurations;
@@ -70,7 +70,7 @@ public class CsvParser {
      * {@code RepoConfiguration} containing the {@code Author} and add it to the {@code repoConfigurations} otherwise.
      */
     private static void processLine(List<RepoConfiguration> repoConfigurations, String line, int lineNumber)
-            throws ParseException {
+            throws InvalidLocationException {
         if (line.isEmpty()) {
             return;
         }

--- a/src/main/java/reposense/parser/CsvParser.java
+++ b/src/main/java/reposense/parser/CsvParser.java
@@ -3,13 +3,11 @@ package reposense.parser;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import reposense.model.Author;
@@ -30,21 +28,13 @@ public class CsvParser {
     /**
      * Positions of the elements of a line in the user-supplied CSV file
      */
-    private static final int LOCATION = 0;
+    private static final int LOCATION_POSITION = 0;
     private static final int BRANCH_POSITION = 1;
     private static final int GITHUB_ID_POSITION = 2;
     private static final int DISPLAY_NAME_POSITION = 3;
     private static final int ALIAS_POSITION = 4;
 
     private static final Logger logger = LogsManager.getLogger(CsvParser.class);
-
-    private static final String WINDOWS_PATH_REGEX =
-            "^(?:[a-zA-Z]\\:|\\\\\\\\[\\w\\.]+\\\\[\\w.$]+)\\\\(?:[\\w]+\\\\)*\\w([\\w.])+$";
-    private static final String UNIX_PATH_REGEX = "^(/[^/ ]*)+/?$";
-    private static final Pattern GIT_URL_PATTERN =
-            Pattern.compile("(?:git|ssh|https?|git@[-\\w.]+):(\\/\\/)?(.*?)(\\.git)(\\/?|\\#[-\\d\\w._]+?)$");
-    private static final Pattern PATH_PATTERN =
-            Pattern.compile(WINDOWS_PATH_REGEX + "|" + UNIX_PATH_REGEX);
 
     /**
      * Returns a list of {@code RepoConfiguration}, each of which corresponds to a data line in the csv file.
@@ -92,9 +82,9 @@ public class CsvParser {
             return;
         }
 
-        String location = elements[LOCATION];
+        String location = elements[LOCATION_POSITION];
         String branch = elements[BRANCH_POSITION];
-        RepoConfiguration config = buildRepoConfig(location, branch);
+        RepoConfiguration config = new RepoConfiguration(location, branch);
 
         int index = repoConfigurations.indexOf(config);
 
@@ -136,23 +126,5 @@ public class CsvParser {
             String[] aliases = elements[ALIAS_POSITION].split(AUTHOR_ALIAS_SEPARATOR);
             config.setAuthorAliases(author, aliases);
         }
-    }
-
-    private static RepoConfiguration buildRepoConfig(String location, String branch) throws ParseException {
-        if (PATH_PATTERN.matcher(location).matches()) {
-            Path pathLocation = Paths.get(location);
-
-            if (!Files.exists(pathLocation)) {
-                throw new ParseException("Repository path location does not exists");
-            }
-
-            return new RepoConfiguration(pathLocation.toString(), branch);
-        }
-
-        if (GIT_URL_PATTERN.matcher(location).matches()) {
-            return new RepoConfiguration(location, branch);
-        }
-
-        throw new ParseException("Url location to git repository is invalid");
     }
 }

--- a/src/main/java/reposense/parser/InvalidLocationException.java
+++ b/src/main/java/reposense/parser/InvalidLocationException.java
@@ -1,0 +1,7 @@
+package reposense.parser;
+
+public class InvalidLocationException extends Exception {
+    public InvalidLocationException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/reposense/parser/InvalidLocationException.java
+++ b/src/main/java/reposense/parser/InvalidLocationException.java
@@ -1,5 +1,8 @@
 package reposense.parser;
 
+/**
+ * Signals that location cannot be represented by {@code URL} or {@code Path}.
+ */
 public class InvalidLocationException extends Exception {
     public InvalidLocationException(String message) {
         super(message);

--- a/src/main/java/reposense/report/ReportGenerator.java
+++ b/src/main/java/reposense/report/ReportGenerator.java
@@ -39,7 +39,8 @@ public class ReportGenerator {
         for (RepoConfiguration config : configs) {
             Path repoReportDirectory = Paths.get(outputPath, config.getDisplayName());
             try {
-                GitDownloader.downloadRepo(config.getOrganization(), config.getRepoName(), config.getBranch());
+                GitDownloader.downloadRepo(
+                        config.getLocation(), config.getDisplayName(), config.getRepoName(), config.getBranch());
                 FileUtil.createDirectory(repoReportDirectory);
             } catch (GitDownloaderException gde) {
                 logger.log(Level.WARNING, "Exception met while trying to clone the repo, will skip this one", gde);

--- a/src/main/java/reposense/report/ReportGenerator.java
+++ b/src/main/java/reposense/report/ReportGenerator.java
@@ -17,7 +17,6 @@ import reposense.git.GitDownloader;
 import reposense.git.GitDownloaderException;
 import reposense.model.RepoConfiguration;
 import reposense.system.LogsManager;
-import reposense.util.Constants;
 import reposense.util.FileUtil;
 
 public class ReportGenerator {
@@ -39,8 +38,7 @@ public class ReportGenerator {
         for (RepoConfiguration config : configs) {
             Path repoReportDirectory = Paths.get(outputPath, config.getDisplayName());
             try {
-                GitDownloader.downloadRepo(
-                        config.getLocation(), config.getDisplayName(), config.getRepoName(), config.getBranch());
+                GitDownloader.downloadRepo(config);
                 FileUtil.createDirectory(repoReportDirectory);
             } catch (GitDownloaderException gde) {
                 logger.log(Level.WARNING, "Exception met while trying to clone the repo, will skip this one", gde);
@@ -55,7 +53,7 @@ public class ReportGenerator {
             generateIndividualRepoReport(commitSummary, authorshipSummary, repoReportDirectory.toString());
 
             try {
-                FileUtil.deleteDirectory(Constants.REPOS_ADDRESS);
+                FileUtil.deleteDirectory(FileUtil.REPOS_ADDRESS);
             } catch (IOException ioe) {
                 logger.log(Level.WARNING, "Error deleting report directory.", ioe);
             }

--- a/src/main/java/reposense/system/CommandRunner.java
+++ b/src/main/java/reposense/system/CommandRunner.java
@@ -99,7 +99,7 @@ public class CommandRunner {
     public static String cloneRepo(String location, String displayName) throws IOException {
         Path rootPath = Paths.get(FileUtil.REPOS_ADDRESS, displayName);
         Files.createDirectories(rootPath);
-        return runCommand(rootPath, "git clone " + location);
+        return runCommand(rootPath, "git clone " + addQuote(location));
     }
 
     private static String runCommand(Path path, String command) {

--- a/src/main/java/reposense/system/CommandRunner.java
+++ b/src/main/java/reposense/system/CommandRunner.java
@@ -9,7 +9,7 @@ import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.List;
 
-import reposense.util.Constants;
+import reposense.util.FileUtil;
 
 public class CommandRunner {
     private static final DateFormat GIT_LOG_SINCE_DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd'T'00:00:00+08:00");
@@ -97,7 +97,7 @@ public class CommandRunner {
     }
 
     public static String cloneRepo(String location, String displayName) throws IOException {
-        Path rootPath = Paths.get(Constants.REPOS_ADDRESS, displayName);
+        Path rootPath = Paths.get(FileUtil.REPOS_ADDRESS, displayName);
         Files.createDirectories(rootPath);
         return runCommand(rootPath, "git clone " + location);
     }

--- a/src/main/java/reposense/system/CommandRunner.java
+++ b/src/main/java/reposense/system/CommandRunner.java
@@ -96,10 +96,10 @@ public class CommandRunner {
         return runCommand(rootPath, revListCommand);
     }
 
-    public static String cloneRepo(String org, String repoName) throws IOException {
-        Path rootPath = Paths.get(Constants.REPOS_ADDRESS, org);
+    public static String cloneRepo(String location, String displayName) throws IOException {
+        Path rootPath = Paths.get(Constants.REPOS_ADDRESS, displayName);
         Files.createDirectories(rootPath);
-        return runCommand(rootPath, "git clone " + Constants.GITHUB_URL_ROOT + org + "/" + repoName);
+        return runCommand(rootPath, "git clone " + location);
     }
 
     private static String runCommand(Path path, String command) {

--- a/src/main/java/reposense/util/Constants.java
+++ b/src/main/java/reposense/util/Constants.java
@@ -2,5 +2,4 @@ package reposense.util;
 
 public class Constants {
     public static final String REPOS_ADDRESS = "repos";
-    public static final String GITHUB_URL_ROOT = "https://github.com/";
 }

--- a/src/main/java/reposense/util/Constants.java
+++ b/src/main/java/reposense/util/Constants.java
@@ -1,5 +1,0 @@
-package reposense.util;
-
-public class Constants {
-    public static final String REPOS_ADDRESS = "repos";
-}

--- a/src/main/java/reposense/util/FileUtil.java
+++ b/src/main/java/reposense/util/FileUtil.java
@@ -51,8 +51,18 @@ public class FileUtil {
         }
     }
 
-    public static String getRepoDirectory(String org, String repoName) {
-        return Constants.REPOS_ADDRESS + File.separator + org + File.separator + repoName + File.separator;
+    public static String getRepoDirectory(String displayName) {
+        return Constants.REPOS_ADDRESS + File.separator + displayName + File.separator;
+    }
+
+    public static String getRepoDirectory(String displayName, String repoName) {
+        String path = Constants.REPOS_ADDRESS + File.separator + displayName + File.separator;
+
+        if (!repoName.isEmpty()) {
+            path += repoName + File.separator;
+        }
+
+        return path;
     }
 
     public static void deleteDirectory(String root) throws IOException {

--- a/src/main/java/reposense/util/FileUtil.java
+++ b/src/main/java/reposense/util/FileUtil.java
@@ -28,6 +28,7 @@ import reposense.system.LogsManager;
 
 
 public class FileUtil {
+    public static final String REPOS_ADDRESS = "repos";
 
     // zip file which contains all the specified file types
     public static final String ZIP_FILE = "archive.zip";
@@ -49,20 +50,6 @@ public class FileUtil {
         } catch (FileNotFoundException e) {
             logger.log(Level.SEVERE, e.getMessage(), e);
         }
-    }
-
-    public static String getRepoDirectory(String displayName) {
-        return getRepoDirectory(displayName, "");
-    }
-
-    public static String getRepoDirectory(String displayName, String repoName) {
-        String path = Constants.REPOS_ADDRESS + File.separator + displayName + File.separator;
-
-        if (!repoName.isEmpty()) {
-            path += repoName + File.separator;
-        }
-
-        return path;
     }
 
     public static void deleteDirectory(String root) throws IOException {

--- a/src/main/java/reposense/util/FileUtil.java
+++ b/src/main/java/reposense/util/FileUtil.java
@@ -52,7 +52,7 @@ public class FileUtil {
     }
 
     public static String getRepoDirectory(String displayName) {
-        return Constants.REPOS_ADDRESS + File.separator + displayName + File.separator;
+        return getRepoDirectory(displayName, "");
     }
 
     public static String getRepoDirectory(String displayName, String repoName) {

--- a/src/test/java/reposense/authorship/FileInfoExtractorTest.java
+++ b/src/test/java/reposense/authorship/FileInfoExtractorTest.java
@@ -13,7 +13,6 @@ import reposense.authorship.model.FileInfo;
 import reposense.git.GitChecker;
 import reposense.model.Author;
 import reposense.template.GitTestTemplate;
-import reposense.util.TestConstants;
 import reposense.util.TestUtil;
 
 
@@ -25,9 +24,9 @@ public class FileInfoExtractorTest extends GitTestTemplate {
 
     @Test
     public void extractFileInfosTest() {
-        config.getAuthorAliasMap().put(TestConstants.MAIN_AUTHOR_NAME, new Author(TestConstants.MAIN_AUTHOR_NAME));
-        config.getAuthorAliasMap().put(TestConstants.FAKE_AUTHOR_NAME, new Author(TestConstants.FAKE_AUTHOR_NAME));
-        GitChecker.checkout(config.getRepoRoot(), TestConstants.TEST_COMMIT_HASH);
+        config.getAuthorAliasMap().put(MAIN_AUTHOR_NAME, new Author(MAIN_AUTHOR_NAME));
+        config.getAuthorAliasMap().put(FAKE_AUTHOR_NAME, new Author(FAKE_AUTHOR_NAME));
+        GitChecker.checkout(config.getRepoRoot(), TEST_COMMIT_HASH);
         List<FileInfo> files = FileInfoExtractor.extractFileInfos(config);
         Assert.assertEquals(files.size(), 6);
         Assert.assertTrue(isFileExistence(Paths.get("annotationTest.java"), files));

--- a/src/test/java/reposense/git/GitCheckerTest.java
+++ b/src/test/java/reposense/git/GitCheckerTest.java
@@ -1,5 +1,6 @@
 package reposense.git;
 
+import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -10,11 +11,22 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import reposense.template.GitTestTemplate;
+import reposense.util.Constants;
 import reposense.util.TestConstants;
 import reposense.util.TestUtil;
 
 
 public class GitCheckerTest extends GitTestTemplate {
+    @Test
+    public void checkoutDiskLocation() throws GitDownloaderException, IOException {
+        Path diskLocation = Paths.get(TestConstants.LOCAL_TEST_REPO_ADDRESS).toAbsolutePath();
+        GitDownloader.downloadRepo(diskLocation.toString(),
+                TestConstants.DISK_REPO_DISPLAY_NAME, TestConstants.TEST_REPO, "master");
+        Path clonedDiskLocation =
+                Paths.get(Constants.REPOS_ADDRESS, TestConstants.DISK_REPO_DISPLAY_NAME).toAbsolutePath();
+        TestUtil.compareDirectories(diskLocation, clonedDiskLocation);
+    }
+
     @Test
     public void checkoutBranchTest() {
         Path branchFile = Paths.get(TestConstants.LOCAL_TEST_REPO_ADDRESS, "inTestBranch.java");

--- a/src/test/java/reposense/git/GitCheckerTest.java
+++ b/src/test/java/reposense/git/GitCheckerTest.java
@@ -21,7 +21,7 @@ public class GitCheckerTest extends GitTestTemplate {
     @Test
     public void checkout_fromDiskLocation_success() throws GitDownloaderException, IOException,
             InvalidLocationException {
-        Path diskLocation = Paths.get(LOCAL_TEST_REPO_ADDRESS).toAbsolutePath();
+        Path diskLocation = Paths.get(config.getRepoRoot()).toAbsolutePath();
         RepoConfiguration diskConfig = new RepoConfiguration(diskLocation.toString(), "master");
         GitDownloader.downloadRepo(diskConfig);
         Path clonedDiskLocation = Paths.get(FileUtil.REPOS_ADDRESS, DISK_REPO_DISPLAY_NAME).toAbsolutePath();
@@ -30,29 +30,29 @@ public class GitCheckerTest extends GitTestTemplate {
 
     @Test
     public void checkoutBranchTest() {
-        Path branchFile = Paths.get(LOCAL_TEST_REPO_ADDRESS, "inTestBranch.java");
+        Path branchFile = Paths.get(config.getRepoRoot(), "inTestBranch.java");
         Assert.assertFalse(Files.exists(branchFile));
 
-        GitChecker.checkoutBranch(LOCAL_TEST_REPO_ADDRESS, "test");
+        GitChecker.checkoutBranch(config.getRepoRoot(), "test");
         Assert.assertTrue(Files.exists(branchFile));
     }
 
     @Test
     public void checkoutHashTest() {
-        Path newFile = Paths.get(LOCAL_TEST_REPO_ADDRESS, "newFile.java");
+        Path newFile = Paths.get(config.getRepoRoot(), "newFile.java");
         Assert.assertTrue(Files.exists(newFile));
 
-        GitChecker.checkout(LOCAL_TEST_REPO_ADDRESS, FIRST_COMMIT_HASH);
+        GitChecker.checkout(config.getRepoRoot(), FIRST_COMMIT_HASH);
         Assert.assertFalse(Files.exists(newFile));
     }
 
     @Test
     public void checkoutToDateTest() {
-        Path newFile = Paths.get(LOCAL_TEST_REPO_ADDRESS, "newFile.java");
+        Path newFile = Paths.get(config.getRepoRoot(), "newFile.java");
         Assert.assertTrue(Files.exists(newFile));
 
         Date untilDate = TestUtil.getDate(2018, Calendar.FEBRUARY, 6);
-        GitChecker.checkoutToDate(LOCAL_TEST_REPO_ADDRESS, config.getBranch(), untilDate);
+        GitChecker.checkoutToDate(config.getRepoRoot(), config.getBranch(), untilDate);
         Assert.assertFalse(Files.exists(newFile));
     }
 }

--- a/src/test/java/reposense/git/GitCheckerTest.java
+++ b/src/test/java/reposense/git/GitCheckerTest.java
@@ -14,7 +14,6 @@ import reposense.model.RepoConfiguration;
 import reposense.parser.InvalidLocationException;
 import reposense.template.GitTestTemplate;
 import reposense.util.FileUtil;
-import reposense.util.TestConstants;
 import reposense.util.TestUtil;
 
 
@@ -43,7 +42,7 @@ public class GitCheckerTest extends GitTestTemplate {
         Path newFile = Paths.get(LOCAL_TEST_REPO_ADDRESS, "newFile.java");
         Assert.assertTrue(Files.exists(newFile));
 
-        GitChecker.checkout(LOCAL_TEST_REPO_ADDRESS, TestConstants.FIRST_COMMIT_HASH);
+        GitChecker.checkout(LOCAL_TEST_REPO_ADDRESS, FIRST_COMMIT_HASH);
         Assert.assertFalse(Files.exists(newFile));
     }
 

--- a/src/test/java/reposense/git/GitCheckerTest.java
+++ b/src/test/java/reposense/git/GitCheckerTest.java
@@ -18,7 +18,7 @@ import reposense.util.TestUtil;
 
 public class GitCheckerTest extends GitTestTemplate {
     @Test
-    public void checkoutDiskLocation() throws GitDownloaderException, IOException {
+    public void checkout_fromDiskLocation_success() throws GitDownloaderException, IOException {
         Path diskLocation = Paths.get(TestConstants.LOCAL_TEST_REPO_ADDRESS).toAbsolutePath();
         GitDownloader.downloadRepo(diskLocation.toString(),
                 TestConstants.DISK_REPO_DISPLAY_NAME, TestConstants.TEST_REPO, "master");

--- a/src/test/java/reposense/git/GitCheckerTest.java
+++ b/src/test/java/reposense/git/GitCheckerTest.java
@@ -22,7 +22,7 @@ public class GitCheckerTest extends GitTestTemplate {
     @Test
     public void checkout_fromDiskLocation_success() throws GitDownloaderException, IOException,
             InvalidLocationException {
-        Path diskLocation = Paths.get(DISK_TEST_REPO_ADDRESS).toAbsolutePath();
+        Path diskLocation = Paths.get(LOCAL_TEST_REPO_ADDRESS).toAbsolutePath();
         RepoConfiguration diskConfig = new RepoConfiguration(diskLocation.toString(), "master");
         GitDownloader.downloadRepo(diskConfig);
         Path clonedDiskLocation = Paths.get(FileUtil.REPOS_ADDRESS, DISK_REPO_DISPLAY_NAME).toAbsolutePath();

--- a/src/test/java/reposense/git/GitCheckerTest.java
+++ b/src/test/java/reposense/git/GitCheckerTest.java
@@ -10,48 +10,50 @@ import java.util.Date;
 import org.junit.Assert;
 import org.junit.Test;
 
+import reposense.model.RepoConfiguration;
+import reposense.parser.InvalidLocationException;
 import reposense.template.GitTestTemplate;
-import reposense.util.Constants;
+import reposense.util.FileUtil;
 import reposense.util.TestConstants;
 import reposense.util.TestUtil;
 
 
 public class GitCheckerTest extends GitTestTemplate {
     @Test
-    public void checkout_fromDiskLocation_success() throws GitDownloaderException, IOException {
-        Path diskLocation = Paths.get(TestConstants.LOCAL_TEST_REPO_ADDRESS).toAbsolutePath();
-        GitDownloader.downloadRepo(diskLocation.toString(),
-                TestConstants.DISK_REPO_DISPLAY_NAME, TestConstants.TEST_REPO, "master");
-        Path clonedDiskLocation =
-                Paths.get(Constants.REPOS_ADDRESS, TestConstants.DISK_REPO_DISPLAY_NAME).toAbsolutePath();
+    public void checkout_fromDiskLocation_success() throws GitDownloaderException, IOException,
+            InvalidLocationException {
+        Path diskLocation = Paths.get(DISK_TEST_REPO_ADDRESS).toAbsolutePath();
+        RepoConfiguration diskConfig = new RepoConfiguration(diskLocation.toString(), "master");
+        GitDownloader.downloadRepo(diskConfig);
+        Path clonedDiskLocation = Paths.get(FileUtil.REPOS_ADDRESS, DISK_REPO_DISPLAY_NAME).toAbsolutePath();
         TestUtil.compareDirectories(diskLocation, clonedDiskLocation);
     }
 
     @Test
     public void checkoutBranchTest() {
-        Path branchFile = Paths.get(TestConstants.LOCAL_TEST_REPO_ADDRESS, "inTestBranch.java");
+        Path branchFile = Paths.get(LOCAL_TEST_REPO_ADDRESS, "inTestBranch.java");
         Assert.assertFalse(Files.exists(branchFile));
 
-        GitChecker.checkoutBranch(TestConstants.LOCAL_TEST_REPO_ADDRESS, "test");
+        GitChecker.checkoutBranch(LOCAL_TEST_REPO_ADDRESS, "test");
         Assert.assertTrue(Files.exists(branchFile));
     }
 
     @Test
     public void checkoutHashTest() {
-        Path newFile = Paths.get(TestConstants.LOCAL_TEST_REPO_ADDRESS, "newFile.java");
+        Path newFile = Paths.get(LOCAL_TEST_REPO_ADDRESS, "newFile.java");
         Assert.assertTrue(Files.exists(newFile));
 
-        GitChecker.checkout(TestConstants.LOCAL_TEST_REPO_ADDRESS, TestConstants.FIRST_COMMIT_HASH);
+        GitChecker.checkout(LOCAL_TEST_REPO_ADDRESS, TestConstants.FIRST_COMMIT_HASH);
         Assert.assertFalse(Files.exists(newFile));
     }
 
     @Test
     public void checkoutToDateTest() {
-        Path newFile = Paths.get(TestConstants.LOCAL_TEST_REPO_ADDRESS, "newFile.java");
+        Path newFile = Paths.get(LOCAL_TEST_REPO_ADDRESS, "newFile.java");
         Assert.assertTrue(Files.exists(newFile));
 
         Date untilDate = TestUtil.getDate(2018, Calendar.FEBRUARY, 6);
-        GitChecker.checkoutToDate(TestConstants.LOCAL_TEST_REPO_ADDRESS, config.getBranch(), untilDate);
+        GitChecker.checkoutToDate(LOCAL_TEST_REPO_ADDRESS, config.getBranch(), untilDate);
         Assert.assertFalse(Files.exists(newFile));
     }
 }

--- a/src/test/java/reposense/system/CommandRunnerTest.java
+++ b/src/test/java/reposense/system/CommandRunnerTest.java
@@ -20,28 +20,28 @@ public class CommandRunnerTest extends GitTestTemplate {
 
     @Test
     public void cloneTest() {
-        Path dir = Paths.get(LOCAL_TEST_REPO_ADDRESS);
+        Path dir = Paths.get(config.getRepoRoot());
         Assert.assertTrue(Files.exists(dir));
     }
 
     @Test
     public void checkoutTest() {
-        CommandRunner.checkout(LOCAL_TEST_REPO_ADDRESS, "test");
-        Path branchFile = Paths.get(LOCAL_TEST_REPO_ADDRESS, "inTestBranch.java");
+        CommandRunner.checkout(config.getRepoRoot(), "test");
+        Path branchFile = Paths.get(config.getRepoRoot(), "inTestBranch.java");
         Assert.assertTrue(Files.exists(branchFile));
     }
 
     @Test
     public void log_existingFormats_hasContent() {
         String content =
-                CommandRunner.gitLog(LOCAL_TEST_REPO_ADDRESS, null, null, config.getFormats());
+                CommandRunner.gitLog(config.getRepoRoot(), null, null, config.getFormats());
         Assert.assertFalse(content.isEmpty());
     }
 
     @Test
     public void log_nonExistingFormats_noContent() {
         String content =
-                CommandRunner.gitLog(LOCAL_TEST_REPO_ADDRESS, null, null, Arrays.asList("py"));
+                CommandRunner.gitLog(config.getRepoRoot(), null, null, Arrays.asList("py"));
         Assert.assertTrue(content.isEmpty());
     }
 
@@ -49,24 +49,24 @@ public class CommandRunnerTest extends GitTestTemplate {
     public void log_sinceDateInFuture_noContent() {
         Date date = TestUtil.getDate(2050, Calendar.JANUARY, 1);
         String content = CommandRunner.gitLog(
-                LOCAL_TEST_REPO_ADDRESS, date, null, config.getFormats());
+                config.getRepoRoot(), date, null, config.getFormats());
         Assert.assertTrue(content.isEmpty());
 
         date = TestUtil.getDate(1950, Calendar.JANUARY, 1);
         content = CommandRunner.gitLog(
-                LOCAL_TEST_REPO_ADDRESS, null, date, config.getFormats());
+                config.getRepoRoot(), null, date, config.getFormats());
         Assert.assertTrue(content.isEmpty());
     }
 
     @Test
     public void blameRaw_validFile_success() {
-        String content = CommandRunner.blameRaw(LOCAL_TEST_REPO_ADDRESS, "blameTest.java");
+        String content = CommandRunner.blameRaw(config.getRepoRoot(), "blameTest.java");
         Assert.assertFalse(content.isEmpty());
     }
 
     @Test(expected = RuntimeException.class)
     public void blameRaw_nonExistentFile_throwsRunTimeException() {
-        CommandRunner.blameRaw(LOCAL_TEST_REPO_ADDRESS, "nonExistentFile");
+        CommandRunner.blameRaw(config.getRepoRoot(), "nonExistentFile");
     }
 
     @Test

--- a/src/test/java/reposense/system/CommandRunnerTest.java
+++ b/src/test/java/reposense/system/CommandRunnerTest.java
@@ -11,7 +11,6 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import reposense.template.GitTestTemplate;
-import reposense.util.TestConstants;
 import reposense.util.TestUtil;
 
 
@@ -21,28 +20,28 @@ public class CommandRunnerTest extends GitTestTemplate {
 
     @Test
     public void cloneTest() {
-        Path dir = Paths.get(TestConstants.LOCAL_TEST_REPO_ADDRESS);
+        Path dir = Paths.get(LOCAL_TEST_REPO_ADDRESS);
         Assert.assertTrue(Files.exists(dir));
     }
 
     @Test
     public void checkoutTest() {
-        CommandRunner.checkout(TestConstants.LOCAL_TEST_REPO_ADDRESS, "test");
-        Path branchFile = Paths.get(TestConstants.LOCAL_TEST_REPO_ADDRESS, "inTestBranch.java");
+        CommandRunner.checkout(LOCAL_TEST_REPO_ADDRESS, "test");
+        Path branchFile = Paths.get(LOCAL_TEST_REPO_ADDRESS, "inTestBranch.java");
         Assert.assertTrue(Files.exists(branchFile));
     }
 
     @Test
     public void log_existingFormats_hasContent() {
         String content =
-                CommandRunner.gitLog(TestConstants.LOCAL_TEST_REPO_ADDRESS, null, null, config.getFormats());
+                CommandRunner.gitLog(LOCAL_TEST_REPO_ADDRESS, null, null, config.getFormats());
         Assert.assertFalse(content.isEmpty());
     }
 
     @Test
     public void log_nonExistingFormats_noContent() {
         String content =
-                CommandRunner.gitLog(TestConstants.LOCAL_TEST_REPO_ADDRESS, null, null, Arrays.asList("py"));
+                CommandRunner.gitLog(LOCAL_TEST_REPO_ADDRESS, null, null, Arrays.asList("py"));
         Assert.assertTrue(content.isEmpty());
     }
 
@@ -50,24 +49,24 @@ public class CommandRunnerTest extends GitTestTemplate {
     public void log_sinceDateInFuture_noContent() {
         Date date = TestUtil.getDate(2050, Calendar.JANUARY, 1);
         String content = CommandRunner.gitLog(
-                TestConstants.LOCAL_TEST_REPO_ADDRESS, date, null, config.getFormats());
+                LOCAL_TEST_REPO_ADDRESS, date, null, config.getFormats());
         Assert.assertTrue(content.isEmpty());
 
         date = TestUtil.getDate(1950, Calendar.JANUARY, 1);
         content = CommandRunner.gitLog(
-                TestConstants.LOCAL_TEST_REPO_ADDRESS, null, date, config.getFormats());
+                LOCAL_TEST_REPO_ADDRESS, null, date, config.getFormats());
         Assert.assertTrue(content.isEmpty());
     }
 
     @Test
     public void blameRaw_validFile_success() {
-        String content = CommandRunner.blameRaw(TestConstants.LOCAL_TEST_REPO_ADDRESS, "blameTest.java");
+        String content = CommandRunner.blameRaw(LOCAL_TEST_REPO_ADDRESS, "blameTest.java");
         Assert.assertFalse(content.isEmpty());
     }
 
     @Test(expected = RuntimeException.class)
     public void blameRaw_nonExistentFile_throwsRunTimeException() {
-        CommandRunner.blameRaw(TestConstants.LOCAL_TEST_REPO_ADDRESS, "nonExistentFile");
+        CommandRunner.blameRaw(LOCAL_TEST_REPO_ADDRESS, "nonExistentFile");
     }
 
     @Test

--- a/src/test/java/reposense/template/GitTestTemplate.java
+++ b/src/test/java/reposense/template/GitTestTemplate.java
@@ -30,8 +30,7 @@ public class GitTestTemplate {
     protected static final String TEST_REPO_GIT_LOCATION = "https://github.com/" + TEST_ORG + "/" + TEST_REPO + ".git";
     protected static final String LOCAL_TEST_REPO_ADDRESS = FileUtil.REPOS_ADDRESS
             + File.separator + TEST_ORG + "_" + TEST_REPO + "_" + "master" + File.separator + TEST_REPO;
-    protected static final String DISK_TEST_REPO_ADDRESS = LOCAL_TEST_REPO_ADDRESS + "/.git";
-    protected static final String DISK_REPO_DISPLAY_NAME = "DISK_TEST_REPO";
+    protected static final String DISK_REPO_DISPLAY_NAME = "testrepo-Alpha_master";
     protected static RepoConfiguration config;
 
     @Before

--- a/src/test/java/reposense/template/GitTestTemplate.java
+++ b/src/test/java/reposense/template/GitTestTemplate.java
@@ -1,6 +1,5 @@
 package reposense.template;
 
-import java.io.File;
 import java.io.IOException;
 
 import org.junit.After;
@@ -24,11 +23,7 @@ import reposense.system.CommandRunner;
 import reposense.util.FileUtil;
 
 public class GitTestTemplate {
-    protected static final String TEST_ORG = "reposense";
-    protected static final String TEST_REPO = "testrepo-Alpha";
-    protected static final String TEST_REPO_GIT_LOCATION = "https://github.com/" + TEST_ORG + "/" + TEST_REPO + ".git";
-    protected static final String LOCAL_TEST_REPO_ADDRESS = FileUtil.REPOS_ADDRESS
-            + File.separator + TEST_ORG + "_" + TEST_REPO + "_" + "master" + File.separator + TEST_REPO;
+    protected static final String TEST_REPO_GIT_LOCATION = "https://github.com/reposense/testrepo-Alpha.git";
     protected static final String DISK_REPO_DISPLAY_NAME = "testrepo-Alpha_master";
     protected static final String FIRST_COMMIT_HASH = "7d7584f";
     protected static final String TEST_COMMIT_HASH = "2fb6b9b";
@@ -58,7 +53,7 @@ public class GitTestTemplate {
 
     @After
     public void after() {
-        CommandRunner.checkout(LOCAL_TEST_REPO_ADDRESS, "master");
+        CommandRunner.checkout(config.getRepoRoot(), "master");
     }
 
     private static void deleteRepos() throws IOException {
@@ -66,7 +61,7 @@ public class GitTestTemplate {
     }
 
     public FileInfo generateTestFileInfo(String relativePath) {
-        FileInfo fileInfo = FileInfoExtractor.generateFileInfo(LOCAL_TEST_REPO_ADDRESS, relativePath);
+        FileInfo fileInfo = FileInfoExtractor.generateFileInfo(config.getRepoRoot(), relativePath);
 
         config.getAuthorAliasMap().put(MAIN_AUTHOR_NAME, new Author(MAIN_AUTHOR_NAME));
         config.getAuthorAliasMap().put(FAKE_AUTHOR_NAME, new Author(FAKE_AUTHOR_NAME));

--- a/src/test/java/reposense/template/GitTestTemplate.java
+++ b/src/test/java/reposense/template/GitTestTemplate.java
@@ -1,9 +1,6 @@
 package reposense.template;
 
-import static reposense.util.TestConstants.TEST_REPO;
-import static reposense.util.TestConstants.TEST_REPO_DISPLAY_NAME;
-import static reposense.util.TestConstants.TEST_REPO_GIT_LOCATION;
-
+import java.io.File;
 import java.io.IOException;
 
 import org.junit.After;
@@ -22,26 +19,33 @@ import reposense.git.GitDownloaderException;
 import reposense.model.Author;
 import reposense.model.RepoConfiguration;
 import reposense.parser.ArgsParser;
-import reposense.parser.ParseException;
+import reposense.parser.InvalidLocationException;
 import reposense.system.CommandRunner;
-import reposense.util.Constants;
 import reposense.util.FileUtil;
 import reposense.util.TestConstants;
 
 public class GitTestTemplate {
-
-    protected RepoConfiguration config;
+    protected static final String TEST_ORG = "reposense";
+    protected static final String TEST_REPO = "testrepo-Alpha";
+    protected static final String TEST_REPO_GIT_LOCATION = "https://github.com/" + TEST_ORG + "/" + TEST_REPO + ".git";
+    protected static final String LOCAL_TEST_REPO_ADDRESS = FileUtil.REPOS_ADDRESS
+            + File.separator + TEST_ORG + "_" + TEST_REPO + "_" + "master" + File.separator + TEST_REPO;
+    protected static final String DISK_TEST_REPO_ADDRESS = LOCAL_TEST_REPO_ADDRESS + "/.git";
+    protected static final String DISK_REPO_DISPLAY_NAME = "DISK_TEST_REPO";
+    protected static RepoConfiguration config;
 
     @Before
-    public void before() throws ParseException {
+    public void before() throws InvalidLocationException {
         config = new RepoConfiguration(TEST_REPO_GIT_LOCATION, "master");
         config.setFormats(ArgsParser.DEFAULT_FORMATS);
     }
 
     @BeforeClass
-    public static void beforeClass() throws GitDownloaderException, IOException {
+    public static void beforeClass() throws GitDownloaderException, IOException, InvalidLocationException {
         deleteRepos();
-        GitDownloader.downloadRepo(TEST_REPO_GIT_LOCATION, TEST_REPO_DISPLAY_NAME, TEST_REPO, "master");
+        config = new RepoConfiguration(TEST_REPO_GIT_LOCATION, "master");
+        config.setFormats(ArgsParser.DEFAULT_FORMATS);
+        GitDownloader.downloadRepo(config);
     }
 
     @AfterClass
@@ -51,15 +55,15 @@ public class GitTestTemplate {
 
     @After
     public void after() {
-        CommandRunner.checkout(TestConstants.LOCAL_TEST_REPO_ADDRESS, "master");
+        CommandRunner.checkout(LOCAL_TEST_REPO_ADDRESS, "master");
     }
 
     private static void deleteRepos() throws IOException {
-        FileUtil.deleteDirectory(Constants.REPOS_ADDRESS);
+        FileUtil.deleteDirectory(FileUtil.REPOS_ADDRESS);
     }
 
     public FileInfo generateTestFileInfo(String relativePath) {
-        FileInfo fileInfo = FileInfoExtractor.generateFileInfo(TestConstants.LOCAL_TEST_REPO_ADDRESS, relativePath);
+        FileInfo fileInfo = FileInfoExtractor.generateFileInfo(LOCAL_TEST_REPO_ADDRESS, relativePath);
 
         config.getAuthorAliasMap().put(TestConstants.MAIN_AUTHOR_NAME, new Author(TestConstants.MAIN_AUTHOR_NAME));
         config.getAuthorAliasMap().put(TestConstants.FAKE_AUTHOR_NAME, new Author(TestConstants.FAKE_AUTHOR_NAME));

--- a/src/test/java/reposense/template/GitTestTemplate.java
+++ b/src/test/java/reposense/template/GitTestTemplate.java
@@ -22,7 +22,6 @@ import reposense.parser.ArgsParser;
 import reposense.parser.InvalidLocationException;
 import reposense.system.CommandRunner;
 import reposense.util.FileUtil;
-import reposense.util.TestConstants;
 
 public class GitTestTemplate {
     protected static final String TEST_ORG = "reposense";
@@ -31,6 +30,11 @@ public class GitTestTemplate {
     protected static final String LOCAL_TEST_REPO_ADDRESS = FileUtil.REPOS_ADDRESS
             + File.separator + TEST_ORG + "_" + TEST_REPO + "_" + "master" + File.separator + TEST_REPO;
     protected static final String DISK_REPO_DISPLAY_NAME = "testrepo-Alpha_master";
+    protected static final String FIRST_COMMIT_HASH = "7d7584f";
+    protected static final String TEST_COMMIT_HASH = "2fb6b9b";
+    protected static final String MAIN_AUTHOR_NAME = "harryggg";
+    protected static final String FAKE_AUTHOR_NAME = "fakeAuthor";
+
     protected static RepoConfiguration config;
 
     @Before
@@ -64,8 +68,8 @@ public class GitTestTemplate {
     public FileInfo generateTestFileInfo(String relativePath) {
         FileInfo fileInfo = FileInfoExtractor.generateFileInfo(LOCAL_TEST_REPO_ADDRESS, relativePath);
 
-        config.getAuthorAliasMap().put(TestConstants.MAIN_AUTHOR_NAME, new Author(TestConstants.MAIN_AUTHOR_NAME));
-        config.getAuthorAliasMap().put(TestConstants.FAKE_AUTHOR_NAME, new Author(TestConstants.FAKE_AUTHOR_NAME));
+        config.getAuthorAliasMap().put(MAIN_AUTHOR_NAME, new Author(MAIN_AUTHOR_NAME));
+        config.getAuthorAliasMap().put(FAKE_AUTHOR_NAME, new Author(FAKE_AUTHOR_NAME));
 
         return fileInfo;
     }
@@ -78,9 +82,9 @@ public class GitTestTemplate {
     public void assertFileAnalysisCorrectness(FileResult fileResult) {
         for (LineInfo line : fileResult.getLines()) {
             if (line.getContent().startsWith("fake")) {
-                Assert.assertEquals(line.getAuthor(), new Author(TestConstants.FAKE_AUTHOR_NAME));
+                Assert.assertEquals(line.getAuthor(), new Author(FAKE_AUTHOR_NAME));
             } else {
-                Assert.assertNotEquals(line.getAuthor(), new Author(TestConstants.FAKE_AUTHOR_NAME));
+                Assert.assertNotEquals(line.getAuthor(), new Author(FAKE_AUTHOR_NAME));
             }
         }
     }

--- a/src/test/java/reposense/template/GitTestTemplate.java
+++ b/src/test/java/reposense/template/GitTestTemplate.java
@@ -22,6 +22,7 @@ import reposense.git.GitDownloaderException;
 import reposense.model.Author;
 import reposense.model.RepoConfiguration;
 import reposense.parser.ArgsParser;
+import reposense.parser.ParseException;
 import reposense.system.CommandRunner;
 import reposense.util.Constants;
 import reposense.util.FileUtil;
@@ -32,7 +33,7 @@ public class GitTestTemplate {
     protected RepoConfiguration config;
 
     @Before
-    public void before() {
+    public void before() throws ParseException {
         config = new RepoConfiguration(TEST_REPO_GIT_LOCATION, "master");
         config.setFormats(ArgsParser.DEFAULT_FORMATS);
     }

--- a/src/test/java/reposense/template/GitTestTemplate.java
+++ b/src/test/java/reposense/template/GitTestTemplate.java
@@ -1,7 +1,8 @@
 package reposense.template;
 
-import static reposense.util.TestConstants.TEST_ORG;
 import static reposense.util.TestConstants.TEST_REPO;
+import static reposense.util.TestConstants.TEST_REPO_DISPLAY_NAME;
+import static reposense.util.TestConstants.TEST_REPO_GIT_LOCATION;
 
 import java.io.IOException;
 
@@ -32,14 +33,14 @@ public class GitTestTemplate {
 
     @Before
     public void before() {
-        config = new RepoConfiguration(TEST_ORG, TEST_REPO, "master");
+        config = new RepoConfiguration(TEST_REPO_GIT_LOCATION, "master");
         config.setFormats(ArgsParser.DEFAULT_FORMATS);
     }
 
     @BeforeClass
     public static void beforeClass() throws GitDownloaderException, IOException {
         deleteRepos();
-        GitDownloader.downloadRepo(TEST_ORG, TEST_REPO, "master");
+        GitDownloader.downloadRepo(TEST_REPO_GIT_LOCATION, TEST_REPO_DISPLAY_NAME, TEST_REPO, "master");
     }
 
     @AfterClass

--- a/src/test/java/reposense/util/TestConstants.java
+++ b/src/test/java/reposense/util/TestConstants.java
@@ -1,9 +1,0 @@
-package reposense.util;
-
-public class TestConstants {
-    public static final String FIRST_COMMIT_HASH = "7d7584f";
-    public static final String TEST_COMMIT_HASH = "2fb6b9b";
-
-    public static final String MAIN_AUTHOR_NAME = "harryggg";
-    public static final String FAKE_AUTHOR_NAME = "fakeAuthor";
-}

--- a/src/test/java/reposense/util/TestConstants.java
+++ b/src/test/java/reposense/util/TestConstants.java
@@ -1,18 +1,6 @@
 package reposense.util;
 
-import java.io.File;
-
 public class TestConstants {
-    public static final String TEST_ORG = "reposense";
-    public static final String TEST_REPO = "testrepo-Alpha";
-    public static final String TEST_REPO_DISPLAY_NAME = TEST_ORG + "_" + TEST_REPO + "_" + "master";
-    public static final String TEST_REPO_GIT_LOCATION = "https://github.com/" + TEST_ORG + "/" + TEST_REPO + ".git";
-
-    public static final String DISK_REPO_DISPLAY_NAME = "DISK_TEST_REPO";
-
-    public static final String LOCAL_TEST_REPO_ADDRESS = Constants.REPOS_ADDRESS
-            + File.separator + TEST_ORG + "_" + TEST_REPO + "_" + "master" + File.separator + TEST_REPO;
-
     public static final String FIRST_COMMIT_HASH = "7d7584f";
     public static final String TEST_COMMIT_HASH = "2fb6b9b";
 

--- a/src/test/java/reposense/util/TestConstants.java
+++ b/src/test/java/reposense/util/TestConstants.java
@@ -6,9 +6,9 @@ public class TestConstants {
     public static final String TEST_ORG = "reposense";
     public static final String TEST_REPO = "testrepo-Alpha";
     public static final String TEST_REPO_DISPLAY_NAME = TEST_ORG + "_" + TEST_REPO + "_" + "master";
+    public static final String TEST_REPO_GIT_LOCATION = "https://github.com/" + TEST_ORG + "/" + TEST_REPO + ".git";
 
-    public static final String TEST_REPO_GIT_LOCATION =
-            "https://github.com/" + TEST_ORG + "/" + TEST_REPO + ".git";
+    public static final String DISK_REPO_DISPLAY_NAME = "DISK_TEST_REPO";
 
     public static final String LOCAL_TEST_REPO_ADDRESS = Constants.REPOS_ADDRESS
             + File.separator + TEST_ORG + "_" + TEST_REPO + "_" + "master" + File.separator + TEST_REPO;
@@ -18,6 +18,4 @@ public class TestConstants {
 
     public static final String MAIN_AUTHOR_NAME = "harryggg";
     public static final String FAKE_AUTHOR_NAME = "fakeAuthor";
-
-    public static final String DISK_REPO_DISPLAY_NAME = "DISK_TEST_REPO";
 }

--- a/src/test/java/reposense/util/TestConstants.java
+++ b/src/test/java/reposense/util/TestConstants.java
@@ -5,12 +5,19 @@ import java.io.File;
 public class TestConstants {
     public static final String TEST_ORG = "reposense";
     public static final String TEST_REPO = "testrepo-Alpha";
+    public static final String TEST_REPO_DISPLAY_NAME = TEST_ORG + "_" + TEST_REPO + "_" + "master";
+
+    public static final String TEST_REPO_GIT_LOCATION =
+            "https://github.com/" + TEST_ORG + "/" + TEST_REPO + ".git";
+
     public static final String LOCAL_TEST_REPO_ADDRESS = Constants.REPOS_ADDRESS
-            + File.separator + TEST_ORG + File.separator + TEST_REPO;
+            + File.separator + TEST_ORG + "_" + TEST_REPO + "_" + "master" + File.separator + TEST_REPO;
 
     public static final String FIRST_COMMIT_HASH = "7d7584f";
     public static final String TEST_COMMIT_HASH = "2fb6b9b";
 
     public static final String MAIN_AUTHOR_NAME = "harryggg";
     public static final String FAKE_AUTHOR_NAME = "fakeAuthor";
+
+    public static final String DISK_REPO_DISPLAY_NAME = "DISK_TEST_REPO";
 }


### PR DESCRIPTION
```
Representing a repository with organization and repository name in 
the config csv file may only satisfies basic usage.

By generalizing it to location allows cloning from disk locations or using
of more complex .git links.
i.e. https://username@github.com/organization/repository.git. 

Let's use location in the config csv file to make git clone more versatile.
```