### PR TITLE
Dashboard: determine date range only after all repo data are loaded

### DIFF
--- a/frontend/src/static/css/style.scss
+++ b/frontend/src/static/css/style.scss
@@ -73,6 +73,8 @@ header{
         height:100%;
         overflow-y:scroll;
         flex-grow:1;
+
+        text-align:center;
     }
 
     #tabs-wrapper{

--- a/frontend/src/static/js/main.js
+++ b/frontend/src/static/js/main.js
@@ -40,6 +40,7 @@ window.app = new window.Vue({
 
         this.userUpdated = false;
         this.loadedRepo = 0;
+
         return Promise.all(names.map((name) => (
           window.api.loadCommits(name)
             .then(() => { this.loadedRepo += 1; })

--- a/frontend/src/static/js/main.js
+++ b/frontend/src/static/js/main.js
@@ -33,20 +33,20 @@ window.app = new window.Vue({
       this.updateReportView();
     },
     updateReportView() {
-      window.api.loadSummary((names) => {
+      window.api.loadSummary().then((names) => {
         this.repos = window.REPOS;
         this.repoLength = Object.keys(window.REPOS).length;
         this.loadedRepo = 0;
 
-        names.forEach((name) => {
-          window.api.loadCommits(name, () => this.addUsers());
-        });
+        this.userUpdated = false;
+        this.loadedRepo = 0;
+        return Promise.all(names.map((name) => (
+          window.api.loadCommits(name)
+            .then(() => { this.loadedRepo += 1; })
+        )));
+      }).then(() => {
+        this.userUpdated = true;
       });
-    },
-    addUsers() {
-      this.userUpdated = false;
-      this.loadedRepo += 1;
-      this.userUpdated = true;
     },
     getUsers() {
       const full = [];
@@ -57,7 +57,6 @@ window.app = new window.Vue({
       });
       return full;
     },
-
     deactivateTabs() {
       this.isTabAuthorship = false;
     },

--- a/frontend/src/static/js/v_authorship.js
+++ b/frontend/src/static/js/v_authorship.js
@@ -27,10 +27,8 @@ window.vAuthorship = {
       if (repo.files) {
         this.processFiles(repo.files);
       } else {
-        window.api.loadAuthorship(
-          this.info.repo,
-          files => this.processFiles(files),
-        );
+        window.api.loadAuthorship(this.repo)
+          .then(files => this.processFiles(files));
       }
     },
 


### PR DESCRIPTION
**proposed message**
```
The dashboard as of v1.1.1 is loaded dynamically after each
`commits.json` is loaded.

If the filter date range is not defined, the range will be determined
by the first and last commits of that particular repository. This start
and end dates will then be set as the filter dates to be used for later
rendering of the other repositories.

However, this leads to a problem when the repositories are of a
different date range, if the earlier repository is loaded first, the
date range will not be able to display the ramps in the later
repository, vice versa.

To fix this issue, let's only determine the date ranges after all the
`commits.json` of the repositories is loaded. However, in doing this,
we would only be able to display the ramps after all the repositories
are loaded.

Assuming a steady and rather fast connection to the data server, this
probably wouldn't be an issue, since we are able to load the files
rather quickly, so let's do this anyways.
```