### PR TITLE
Add support for file exclusion patterns #218

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -80,7 +80,7 @@ Branch | The branch to analyse in the target repository
 Author's GitHub ID | GitHub ID of the target contributor in the repository
 Author's Display Name | Optional Field. The value of this field, if not empty, will be displayed in the dashboard instead of author's GitHub ID.
 [Optional] Author's Git Author Name | Detailed explanation below
-[Optional] Ignore Global List | The list of file path globs to ignore analyze. The glob list should be specified on the first author of the repository. More details on the Java glob standard [here](https://javapapers.com/java/glob-with-java-nio/)
+[Optional] Ignore Global List | The list of file path globs to ignore during analysis. The glob list should be specified on the first author of the repository. More details on the Java glob standard [here](https://javapapers.com/java/glob-with-java-nio/)
 
 #### Git Author Name
 `Git Author Name` refers to the customizable author's display name set in the local `.gitconfig` file.

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -80,6 +80,7 @@ Branch | The branch to analyse in the target repository
 Author's GitHub ID | GitHub ID of the target contributor in the repository
 Author's Display Name | Optional Field. The value of this field, if not empty, will be displayed in the dashboard instead of author's GitHub ID.
 [Optional] Author's Git Author Name | Detailed explanation below
+[Optional] Ignore Global List | The list of file path globs to ignore analyze. More details on the Java glob standard [here](https://javapapers.com/java/glob-with-java-nio/)
 
 #### Git Author Name
 `Git Author Name` refers to the customizable author's display name set in the local `.gitconfig` file.

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -80,7 +80,7 @@ Branch | The branch to analyse in the target repository
 Author's GitHub ID | GitHub ID of the target contributor in the repository
 Author's Display Name | Optional Field. The value of this field, if not empty, will be displayed in the dashboard instead of author's GitHub ID.
 [Optional] Author's Git Author Name | Detailed explanation below
-[Optional] Ignore Global List | The list of file path globs to ignore analyze. More details on the Java glob standard [here](https://javapapers.com/java/glob-with-java-nio/)
+[Optional] Ignore Global List | The list of file path globs to ignore analyze. The glob list should be specified on the first author of the repository. More details on the Java glob standard [here](https://javapapers.com/java/glob-with-java-nio/)
 
 #### Git Author Name
 `Git Author Name` refers to the customizable author's display name set in the local `.gitconfig` file.

--- a/sample.csv
+++ b/sample.csv
@@ -1,9 +1,9 @@
-Repository's Location,Branch,Author's GitHub ID,Author's Display Name,Author's Git Author Name
-https://github.com/reposense/testrepo-Beta.git,master,nbriannl,Nbr,
-https://github.com/reposense/testrepo-Beta.git,master,zacharytang,Zac,Zachary Tang
-https://github.com/reposense/testrepo-Beta.git,master,April0616,Fan,LAPTOP-7KFM2KSP\User;Fan Yuting
-https://github.com/reposense/testrepo-Beta.git,master,CindyTsai1,Cin,YuHsuan
-https://github.com/reposense/testrepo-Delta.git,master,lithiumlkid,Ahm,
-https://github.com/reposense/testrepo-Delta.git,master,codeeong,Cod,
-https://github.com/reposense/testrepo-Delta.git,master,jordancjq,Jor,
-https://github.com/reposense/testrepo-Delta.git,master,lohtianwei,Loh,
+Repository's Location,Branch,Author's GitHub ID,Author's Display Name,Author's Git Author Name,Ignore Glob List
+https://github.com/reposense/testrepo-Beta.git,master,nbriannl,Nbr,,
+https://github.com/reposense/testrepo-Beta.git,master,zacharytang,Zac,Zachary Tang,
+https://github.com/reposense/testrepo-Beta.git,master,April0616,Fan,LAPTOP-7KFM2KSP\User;Fan Yuting,
+https://github.com/reposense/testrepo-Beta.git,master,CindyTsai1,Cin,YuHsuan,
+https://github.com/reposense/testrepo-Delta.git,master,lithiumlkid,Ahm,,
+https://github.com/reposense/testrepo-Delta.git,master,codeeong,Cod,,
+https://github.com/reposense/testrepo-Delta.git,master,jordancjq,Jor,,
+https://github.com/reposense/testrepo-Delta.git,master,lohtianwei,Loh,,

--- a/src/functional/resources/sample.csv
+++ b/src/functional/resources/sample.csv
@@ -1,9 +1,9 @@
-Repository's Location,Branch,Author's GitHub ID,Author's Display Name,Author's Git Author Name
-https://github.com/reposense/testrepo-Beta.git,master,nbriannl,Nbr,
-https://github.com/reposense/testrepo-Beta.git,master,zacharytang,Zac,Zachary Tang
-https://github.com/reposense/testrepo-Beta.git,master,April0616,Fan,LAPTOP-7KFM2KSP\User;Fan Yuting
-https://github.com/reposense/testrepo-Beta.git,master,CindyTsai1,Cin,YuHsuan
-https://github.com/reposense/testrepo-Charlie.git,master,charlesgoh,Cha,Charles Goh
-https://github.com/reposense/testrepo-Charlie.git,master,Esilocke,Esi,
-https://github.com/reposense/testrepo-Charlie.git,master,jeffreygohkw,Jef,Jeffrey Goh
-https://github.com/reposense/testrepo-Charlie.git,master,wangyiming1019,Wan,ACER\kyle;Wang Yiming
+Repository's Location,Branch,Author's GitHub ID,Author's Display Name,Author's Git Author Name,Ignore Glob List
+https://github.com/reposense/testrepo-Beta.git,master,nbriannl,Nbr,,
+https://github.com/reposense/testrepo-Beta.git,master,zacharytang,Zac,Zachary Tang,
+https://github.com/reposense/testrepo-Beta.git,master,April0616,Fan,LAPTOP-7KFM2KSP\User;Fan Yuting,
+https://github.com/reposense/testrepo-Beta.git,master,CindyTsai1,Cin,YuHsuan,
+https://github.com/reposense/testrepo-Charlie.git,master,charlesgoh,Cha,Charles Goh,
+https://github.com/reposense/testrepo-Charlie.git,master,Esilocke,Esi,,
+https://github.com/reposense/testrepo-Charlie.git,master,jeffreygohkw,Jef,Jeffrey Goh,
+https://github.com/reposense/testrepo-Charlie.git,master,wangyiming1019,Wan,ACER\kyle;Wang Yiming,

--- a/src/main/java/reposense/builder/ConfigurationBuilder.java
+++ b/src/main/java/reposense/builder/ConfigurationBuilder.java
@@ -29,7 +29,7 @@ public class ConfigurationBuilder {
     }
 
     public ConfigurationBuilder ignoreDirectoryList(List<String> list) {
-        config.setIgnoreDirectoryList(list);
+        config.setIgnoreGlobList(list);
         return this;
     }
 

--- a/src/main/java/reposense/commits/CommitInfoExtractor.java
+++ b/src/main/java/reposense/commits/CommitInfoExtractor.java
@@ -24,16 +24,8 @@ public class CommitInfoExtractor {
         logger.info("Extracting commits info for " + config.getLocation() + "...");
 
         GitChecker.checkoutBranch(config.getRepoRoot(), config.getBranch());
-        String gitLogResult = getGitLogResult(config);
+        String gitLogResult = CommandRunner.gitLog(config);
         return parseGitLogResults(gitLogResult);
-    }
-
-    /**
-     * Returns the git log information for the repo for the date range in {@code config}.
-     */
-    private static String getGitLogResult(RepoConfiguration config) {
-        return CommandRunner.gitLog(
-                config.getRepoRoot(), config.getSinceDate(), config.getUntilDate(), config.getFormats());
     }
 
     /**

--- a/src/main/java/reposense/model/RepoConfiguration.java
+++ b/src/main/java/reposense/model/RepoConfiguration.java
@@ -36,7 +36,7 @@ public class RepoConfiguration {
     private transient boolean needCheckStyle = false;
     private transient List<String> formats;
     private transient int commitNum = 1;
-    private transient List<String> ignoreDirectoryList = new ArrayList<>();
+    private transient List<String> ignoreGlobList = new ArrayList<>();
     private transient List<Author> authorList = new ArrayList<>();
     private transient TreeMap<String, Author> authorAliasMap = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
     private transient Map<Author, String> authorDisplayNameMap = new HashMap<>();
@@ -147,12 +147,12 @@ public class RepoConfiguration {
         this.annotationOverwrite = annotationOverwrite;
     }
 
-    public List<String> getIgnoreDirectoryList() {
-        return ignoreDirectoryList;
+    public List<String> getIgnoreGlobList() {
+        return ignoreGlobList;
     }
 
-    public void setIgnoreDirectoryList(List<String> ignoreDirectoryList) {
-        this.ignoreDirectoryList = ignoreDirectoryList;
+    public void setIgnoreGlobList(List<String> ignoreGlobList) {
+        this.ignoreGlobList = ignoreGlobList;
     }
 
     public List<Author> getAuthorList() {

--- a/src/main/java/reposense/parser/CsvParser.java
+++ b/src/main/java/reposense/parser/CsvParser.java
@@ -102,7 +102,11 @@ public class CsvParser {
         config.getAuthorList().add(author);
         setDisplayName(elements, config, author);
         setAliases(elements, config, author);
-        setIgnoreGlobList(elements, config);
+
+        // prevent overriding the glob list if another author in the same repo also specifies
+        if (config.getIgnoreGlobList().isEmpty()) {
+            setIgnoreGlobList(elements, config);
+        }
     }
 
     /**
@@ -135,10 +139,10 @@ public class CsvParser {
      * Sets the list of globs to ignore inside {@code config} for the file analysis.
      */
     private static void setIgnoreGlobList(String[] elements, RepoConfiguration config) {
-        boolean areIgnoreGlobListInElements = elements.length > IGNORE_GLOB_LIST_POSITION
+        boolean isIgnoreGlobListInElements = elements.length > IGNORE_GLOB_LIST_POSITION
                 && !elements[IGNORE_GLOB_LIST_POSITION].isEmpty();
 
-        if (areIgnoreGlobListInElements) {
+        if (isIgnoreGlobListInElements) {
             List<String> ignoreGlobList = Arrays.asList(
                     elements[IGNORE_GLOB_LIST_POSITION].split(AUTHOR_ALIAS_AND_GLOB_SEPARATOR));
             config.setIgnoreGlobList(ignoreGlobList);

--- a/src/main/java/reposense/parser/CsvParser.java
+++ b/src/main/java/reposense/parser/CsvParser.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.logging.Level;
@@ -19,7 +20,7 @@ import reposense.system.LogsManager;
  */
 public class CsvParser {
     private static final String ELEMENT_SEPARATOR = ",";
-    private static final String AUTHOR_ALIAS_SEPARATOR = ";";
+    private static final String AUTHOR_ALIAS_AND_GLOB_SEPARATOR = ";";
 
     private static final String MESSAGE_UNABLE_TO_READ_CSV_FILE = "Unable to read the supplied CSV file.";
     private static final String MESSAGE_MALFORMED_LINE_FORMAT = "Warning! line %d in configuration file is malformed.\n"
@@ -33,6 +34,7 @@ public class CsvParser {
     private static final int GITHUB_ID_POSITION = 2;
     private static final int DISPLAY_NAME_POSITION = 3;
     private static final int ALIAS_POSITION = 4;
+    private static final int IGNORE_GLOB_LIST_POSITION = 5;
 
     private static final Logger logger = LogsManager.getLogger(CsvParser.class);
 
@@ -100,6 +102,7 @@ public class CsvParser {
         config.getAuthorList().add(author);
         setDisplayName(elements, config, author);
         setAliases(elements, config, author);
+        setIgnoreGlobList(elements, config);
     }
 
     /**
@@ -123,8 +126,22 @@ public class CsvParser {
                 && !elements[ALIAS_POSITION].isEmpty();
 
         if (areAliasesInElements) {
-            String[] aliases = elements[ALIAS_POSITION].split(AUTHOR_ALIAS_SEPARATOR);
+            String[] aliases = elements[ALIAS_POSITION].split(AUTHOR_ALIAS_AND_GLOB_SEPARATOR);
             config.setAuthorAliases(author, aliases);
+        }
+    }
+
+    /**
+     * Sets the list of globs to ignore inside {@code config} for the file analysis.
+     */
+    private static void setIgnoreGlobList(String[] elements, RepoConfiguration config) {
+        boolean areIgnoreGlobListInElements = elements.length > IGNORE_GLOB_LIST_POSITION
+                && !elements[IGNORE_GLOB_LIST_POSITION].isEmpty();
+
+        if (areIgnoreGlobListInElements) {
+            List<String> ignoreGlobList = Arrays.asList(
+                    elements[IGNORE_GLOB_LIST_POSITION].split(AUTHOR_ALIAS_AND_GLOB_SEPARATOR));
+            config.setIgnoreGlobList(ignoreGlobList);
         }
     }
 }

--- a/src/test/java/reposense/authorship/FileInfoExtractorTest.java
+++ b/src/test/java/reposense/authorship/FileInfoExtractorTest.java
@@ -3,6 +3,7 @@ package reposense.authorship;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Calendar;
+import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 
@@ -61,7 +62,30 @@ public class FileInfoExtractorTest extends GitTestTemplate {
 
         List<FileInfo> files = FileInfoExtractor.extractFileInfos(config);
         Assert.assertTrue(files.isEmpty());
+    }
 
+    @Test
+    public void extractFileInfos_ignoreAllJavaFiles_success() {
+        config.setIgnoreGlobList(Collections.singletonList("**.java"));
+
+        List<FileInfo> files = FileInfoExtractor.extractFileInfos(config);
+        Assert.assertEquals(1, files.size());
+    }
+
+    @Test
+    public void extractFileInfos_ignoreRootDirectoryJavaFiles_success() {
+        config.setIgnoreGlobList(Collections.singletonList("*.java"));
+
+        List<FileInfo> files = FileInfoExtractor.extractFileInfos(config);
+        Assert.assertEquals(2, files.size());
+    }
+
+    @Test
+    public void extractFileInfos_ignoreNewPosDirectory_success() {
+        config.setIgnoreGlobList(Collections.singletonList("newPos/**"));
+
+        List<FileInfo> files = FileInfoExtractor.extractFileInfos(config);
+        Assert.assertEquals(5, files.size());
     }
 
     @Test

--- a/src/test/java/reposense/system/CommandRunnerTest.java
+++ b/src/test/java/reposense/system/CommandRunnerTest.java
@@ -44,6 +44,15 @@ public class CommandRunnerTest extends GitTestTemplate {
     }
 
     @Test
+    public void gitLog_includeAllJavaFiles_success() {
+        config.setFormats(Collections.singletonList("java"));
+        String content = CommandRunner.gitLog(config);
+        String[] contentLines = content.split("\n");
+        int expectedNumberCommits = 8;
+        Assert.assertEquals(convertNumberExpectedCommitsToGitLogLines(expectedNumberCommits), contentLines.length);
+    }
+
+    @Test
     public void gitLog_includeAllJavaFilesIgnoreMovedFile_success() {
         config.setFormats(Collections.singletonList("java"));
         config.setIgnoreGlobList(Collections.singletonList("**movedFile.java"));


### PR DESCRIPTION
#Fixes #218 
```
RepoSense only accepts an inclusive list of file formats to analyze.

However, users may wish to specifically exclude analyze of some
files or folders, such as large data files or test folders, as they may
not be meaningful to analyze.

Let's add back-end support to exclude analyzing of files of specified
glob patterns, which can be done in git log by using pathspec[1].

[1] Intro to Git's pathspec:
https://kgrz.io/git-intro-to-pathspec.html
```