### PR TITLE
Dashboard: default view: sort by name within repo #223

### DIFF
--- a/frontend/src/static/js/v_summary.js
+++ b/frontend/src/static/js/v_summary.js
@@ -41,7 +41,7 @@ window.vSummary = {
     return {
       filtered: [],
       filterSearch: '',
-      filterSort: 'totalCommits',
+      filterSort: 'displayName',
       filterSortReverse: false,
       filterGroupRepos: true,
       filterGroupWeek: false,

--- a/sample.csv
+++ b/sample.csv
@@ -1,9 +1,6 @@
 Repository's Location,Branch,Author's GitHub ID,Author's Display Name,Author's Git Author Name,Ignore Glob List
+https://github.com/reposense/testrepo-Delta.git,master,,,,
 https://github.com/reposense/testrepo-Beta.git,master,nbriannl,Nbr,,
 https://github.com/reposense/testrepo-Beta.git,master,zacharytang,Zac,Zachary Tang,
 https://github.com/reposense/testrepo-Beta.git,master,April0616,Fan,LAPTOP-7KFM2KSP\User;Fan Yuting,
 https://github.com/reposense/testrepo-Beta.git,master,CindyTsai1,Cin,YuHsuan,
-https://github.com/reposense/testrepo-Delta.git,master,lithiumlkid,Ahm,,
-https://github.com/reposense/testrepo-Delta.git,master,codeeong,Cod,,
-https://github.com/reposense/testrepo-Delta.git,master,jordancjq,Jor,,
-https://github.com/reposense/testrepo-Delta.git,master,lohtianwei,Loh,,


### PR DESCRIPTION
fixes #223 

```
The current dashboard as of v1.1.1a sorts the users in the repository
by the number of contributions they have made for the project in that
time period.

This however puts an unnecessary focus on the contribution LoC which
may not be a true reflection of the users' contribution. Let's change
the default view to sort the users by their names instead.
```