### PR TITLE
Split config csv file to repo-config.csv and author-config.csv #245

### DIFF
--- a/author-config.csv
+++ b/author-config.csv
@@ -1,0 +1,5 @@
+Repository's Location,Branch,Author's GitHub ID,Author's Display Name,Author's Git Author Name,Ignore Glob List
+https://github.com/reposense/testrepo-Beta.git,master,nbriannl,Nbr,,
+https://github.com/reposense/testrepo-Beta.git,master,zacharytang,Zac,Zachary Tang,
+https://github.com/reposense/testrepo-Beta.git,master,April0616,Fan,LAPTOP-7KFM2KSP\User;Fan Yuting,
+https://github.com/reposense/testrepo-Beta.git,master,CindyTsai1,Cin,YuHsuan,

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -65,7 +65,7 @@ Argument List:
 1. If the dashboard was not loaded automatically, upload the `archive.zip` (generated in the OUTPUT_DIRECTORY) manually to load the data.
 ```
 Note:
-The contribution calculation is based on the daily commits made within 00:00 to 23:59 in GMT+8. <br>
+The contribution calculation is based on the daily commits made within 00:00 to 23:59 in GMT+8.
 Any other arguments entered with -view will be ignored.
 ```
 
@@ -107,12 +107,11 @@ to configure the list of authors to analyse and the options.
 
 [author-config.csv](../author-config.csv) is an example of a configuration file setup. It should contain the following columns:
 
-```
+<h5>
 Note:
 If author-config.csv is not used or the repositories being analyzed are not specified by any authors
-in author-config.csv, please add Standalone Configuration to those repostories.
-```
-> [Link to Standalone Configuration](#standalone-configuration)
+in author-config.csv, please add <a href="#standalone-configuration">Standalone Configuration</a> to those repostories.
+</h5>
 
 Column Name | Explanation
 ----------- | -----------

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -93,7 +93,8 @@ gradlew run -Dargs="-view output_path/reposense-report"
 ## CSV Config Files
 #### Repository configuration file
 to configure the list of repositories to analyze and the respective repository level options.
-repo-config.csv is an example of a configuration file setup. It should contain the following columns:
+
+[repo-config.csv](../repo-config.csv) is an example of a configuration file setup. It should contain the following columns:
 
 Column Name | Explanation
 ----------- | -----------
@@ -103,7 +104,8 @@ Branch | The branch to analyse in the target repository
 
 #### Author configuration file [Optional]
 to configure the list of authors to analyse and the options.
-author-config.csv is an example of a configuration file setup. It should contain the following columns:
+
+[author-config.csv](../author-config.csv) is an example of a configuration file setup. It should contain the following columns:
 
 ```
 Note:
@@ -111,8 +113,6 @@ If author-config.csv is not used or repositories that are not in author-config.c
 please add Standalone Configuration to those repostories.
 ```
 > [Link to Standalone Configuration](#standalone-configuration)
-
-[author-config.csv](../author-config.csv) is an example of a configuration file setup. It should contain the following columns:
 
 Column Name | Explanation
 ----------- | -----------

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -109,7 +109,7 @@ to configure the list of authors to analyse and the options.
 
 ```
 Note:
-If author-config.csv is not used or repositories that are not in author-config.csv,
+If author-config.csv is not used or the repositories being analyzed are not specified by any authors in author-config.csv,
 please add Standalone Configuration to those repostories.
 ```
 > [Link to Standalone Configuration](#standalone-configuration)

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -91,8 +91,9 @@ gradlew run -Dargs="-view output_path/reposense-report"
 `-Dargs="..."` uses the same argument format as mentioned above.
 
 ## CSV Config Files
-The `repo-config.csv` contains the location and the branch of repositories to analyze.
-[repo-config.csv](../repo-config.csv) is an example of a configuration file setup. It should contain the following columns:
+#### Repository configuration file
+to configure the list of repositories to analyze and the respective repository level options.
+repo-config.csv is an example of a configuration file setup. It should contain the following columns:
 
 Column Name | Explanation
 ----------- | -----------
@@ -100,15 +101,18 @@ Repository's Location | The `GitHub URL` or `Disk Path` to the git repository
 Branch | The branch to analyse in the target repository
 [Optional] Ignore Global List | The list of file path globs to ignore during analysis for each author. More details on the Java glob standard [here](https://javapapers.com/java/glob-with-java-nio/)
 
-The [Optional]`author-config.csv` contains the list of repositories, and the corresponding target authors to track contribution of.
+#### Author configuration file [Optional]
+to configure the list of authors to analyse and the options.
+author-config.csv is an example of a configuration file setup. It should contain the following columns:
 
 ```
 Note:
 If author-config.csv is not used or repositories that are not in author-config.csv,
-please add [Standalone Configuration](#standalone-configuration) to those repostories.
+please add Standalone Configuration to those repostories.
 ```
+> [Link to Standalone Configuration](#standalone-configuration)
 
-[repo-config.csv](../author-config.csv) is an example of a configuration file setup. It should contain the following columns:
+[author-config.csv](../author-config.csv) is an example of a configuration file setup. It should contain the following columns:
 
 Column Name | Explanation
 ----------- | -----------
@@ -117,7 +121,7 @@ Branch | The branch to analyse in the target repository
 Author's GitHub ID | GitHub ID of the target contributor in the repository
 Author's Display Name | Optional Field. The value of this field, if not empty, will be displayed in the dashboard instead of author's GitHub ID.
 [Optional] Author's Git Author Name | Detailed explanation below
-[Optional] Ignore Global List | The list of file path globs to ignore during analysis for this author on top of what is already specified in `repo-config.csv`. More details on the Java glob standard [here](https://javapapers.com/java/glob-with-java-nio/)
+[Optional] Ignore Global List | The list of file path globs to ignore during analysis for this author on top of what is already specified in `author-config.csv`. More details on the Java glob standard [here](https://javapapers.com/java/glob-with-java-nio/)
 
 #### Git Author Name
 `Git Author Name` refers to the customizable author's display name set in the local `.gitconfig` file.

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -109,8 +109,8 @@ to configure the list of authors to analyse and the options.
 
 ```
 Note:
-If author-config.csv is not used or the repositories being analyzed are not specified by any authors in author-config.csv,
-please add Standalone Configuration to those repostories.
+If author-config.csv is not used or the repositories being analyzed are not specified by any authors
+in author-config.csv, please add Standalone Configuration to those repostories.
 ```
 > [Link to Standalone Configuration](#standalone-configuration)
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -14,7 +14,7 @@
 ## How to Generate Report
 1. Download the latest executable Jar from our [release](https://github.com/reposense/RepoSense/releases/latest).
    * Alternatively, you can compile the executable Jar yourself by following our [build from source guide](Build.md).
-1. Execute it on the OS terminal. <br>
+1. Execute it on the OS terminal.  <br/>
 
 ### Using repo-config.csv file
 Usage: `java -jar RepoSense.jar -config CONFIG_DIRECTORY [-output OUTPUT_DIRECTORY] [-since DD/MM/YYYY] [-until DD/MM/YYYY] [-formats FORMAT...]`
@@ -49,7 +49,7 @@ Argument List:
 ## How to View Dashboard
 ### With jar
 1. Ensure that you have generated the report.
-1. Execute it on the OS terminal. <br>
+1. Execute it on the OS terminal. <br/>
 Usage `java -jar RepoSense.jar -view REPORT_DIRECTORY`
 
 ```
@@ -71,8 +71,8 @@ Any other arguments entered with -view will be ignored.
 
 ### Other option:
 1. Clone this repository (or [download as zip](https://github.com/reposense/RepoSense/archive/master.zip))
-1. Execute the following command on the OS terminal inside the project directory.<br>
-Usage: `gradlew run -Dargs="(-config ./configs/ | -repos https://github.com/reposense/RepoSense.git https://github.com/se-edu/collate.git | -view report_path/) [-output OUTPUT_DIRECTORY] [-since DD/MM/YYYY] [-until DD/MM/YYYY] [-formats FORMAT...]"` <br>
+1. Execute the following command on the OS terminal inside the project directory. <br/>
+Usage: `gradlew run -Dargs="(-config ./configs/ | -repos https://github.com/reposense/RepoSense.git https://github.com/se-edu/collate.git | -view report_path/) [-output OUTPUT_DIRECTORY] [-since DD/MM/YYYY] [-until DD/MM/YYYY] [-formats FORMAT...]"` <br/>
 
 Sample usage to generate the report with config files:
 ```
@@ -92,8 +92,7 @@ gradlew run -Dargs="-view output_path/reposense-report"
 
 ## CSV Config Files
 #### Repository configuration file
-to configure the list of repositories to analyze and the respective repository level options.
-
+to configure the list of repositories to analyze and the respective repository level options. <br/>
 [repo-config.csv](../repo-config.csv) is an example of a configuration file setup. It should contain the following columns:
 
 Column Name | Explanation
@@ -103,8 +102,7 @@ Branch | The branch to analyse in the target repository
 [Optional] Ignore Global List | The list of file path globs to ignore during analysis for each author. More details on the Java glob standard [here](https://javapapers.com/java/glob-with-java-nio/)
 
 #### Author configuration file [Optional]
-to configure the list of authors to analyse and the options.
-
+to configure the list of authors to analyse and the options. <br/>
 [author-config.csv](../author-config.csv) is an example of a configuration file setup. It should contain the following columns:
 
 <h5>

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -25,7 +25,7 @@ Sample usage to generate the report:
 $ java -jar RepoSense.jar -config ./configs/ -output output_path/ -since 01/10/2017 -until 01/11/2017 -formats java adoc js
 ```
 Argument List:
-- config : Mandatory. The path to the directory that contains the configuration file, repo-config.csv.
+- config : Mandatory. The path to the directory that contains the configuration file(s).
 - output : Optional. The path to the dashboard generated. If not provided, it will be generated in the current directory.
 - since : Optional. The start date of analysis. Format: `DD/MM/YYYY`
 - until : Optional. The end date of analysis. Format: `DD/MM/YYYY`
@@ -100,7 +100,14 @@ Repository's Location | The `GitHub URL` or `Disk Path` to the git repository
 Branch | The branch to analyse in the target repository
 [Optional] Ignore Global List | The list of file path globs to ignore during analysis for each author. More details on the Java glob standard [here](https://javapapers.com/java/glob-with-java-nio/)
 
-The `author-config.csv` contains the list of repositories, and the corresponding target authors to track contribution of.
+The [Optional]`author-config.csv` contains the list of repositories, and the corresponding target authors to track contribution of.
+
+```
+Note:
+If author-config.csv is not used or repositories that are not in author-config.csv,
+please add [Standalone Configuration](#standalone-configuration) to those repostories.
+```
+
 [repo-config.csv](../author-config.csv) is an example of a configuration file setup. It should contain the following columns:
 
 Column Name | Explanation

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -3,7 +3,7 @@
 ## Quick Start
 1. Ensure that you have the necessary [dependencies](#dependencies).
 1. Read up on [How to Generate Dashboard](#how-to-generate-dashboard).
-1. Fill up the [CSV Config File](#csv-config-file).
+1. Fill up the [CSV Config Files](#csv-config-files).
 1. Perform the execution to generate the [dashboard](#dashboard).
 
 ## Dependencies
@@ -74,7 +74,7 @@ Any other arguments entered with -view will be ignored.
 1. Execute the following command on the OS terminal inside the project directory.<br>
 Usage: `gradlew run -Dargs="(-config ./configs/ | -repos https://github.com/reposense/RepoSense.git https://github.com/se-edu/collate.git | -view report_path/) [-output OUTPUT_DIRECTORY] [-since DD/MM/YYYY] [-until DD/MM/YYYY] [-formats FORMAT...]"` <br>
 
-Sample usage to generate the report with a csv config file:
+Sample usage to generate the report with config files:
 ```
 $ gradlew run -Dargs="-config ./configs/ -output output_path/ -since 01/10/2017 -until 01/11/2017 -formats java adoc js"
 
@@ -90,9 +90,18 @@ gradlew run -Dargs="-view output_path/reposense-report"
 ```
 `-Dargs="..."` uses the same argument format as mentioned above.
 
-## CSV Config File
-The `CSV Config File` contains the list of repositories, and the corresponding target authors to track contribution of.
+## CSV Config Files
+The `repo-config.csv` contains the location and the branch of repositories to analyze.
 [repo-config.csv](../repo-config.csv) is an example of a configuration file setup. It should contain the following columns:
+
+Column Name | Explanation
+----------- | -----------
+Repository's Location | The `GitHub URL` or `Disk Path` to the git repository
+Branch | The branch to analyse in the target repository
+[Optional] Ignore Global List | The list of file path globs to ignore during analysis for each author. More details on the Java glob standard [here](https://javapapers.com/java/glob-with-java-nio/)
+
+The `author-config.csv` contains the list of repositories, and the corresponding target authors to track contribution of.
+[repo-config.csv](../author-config.csv) is an example of a configuration file setup. It should contain the following columns:
 
 Column Name | Explanation
 ----------- | -----------
@@ -101,7 +110,7 @@ Branch | The branch to analyse in the target repository
 Author's GitHub ID | GitHub ID of the target contributor in the repository
 Author's Display Name | Optional Field. The value of this field, if not empty, will be displayed in the dashboard instead of author's GitHub ID.
 [Optional] Author's Git Author Name | Detailed explanation below
-[Optional] Ignore Global List | The list of file path globs to ignore during analysis for each author. More details on the Java glob standard [here](https://javapapers.com/java/glob-with-java-nio/)
+[Optional] Ignore Global List | The list of file path globs to ignore during analysis for this author on top of what is already specified in `repo-config.csv`. More details on the Java glob standard [here](https://javapapers.com/java/glob-with-java-nio/)
 
 #### Git Author Name
 `Git Author Name` refers to the customizable author's display name set in the local `.gitconfig` file.
@@ -133,7 +142,7 @@ git config --global user.name “YOUR_GITHUB_ID_HERE”
 ```
 For more information, do visit this [FAQ](https://www.git-tower.com/learn/git/faq/change-author-name-email) on changing Git Author Identity.
 
-If an author's `Git Author Name` is not the same as his `GitHub ID`, the `Git Author Name` needs to be filled into the CSV config file for accurate consolidation.
+If an author's `Git Author Name` is not the same as his `GitHub ID`, the `Git Author Name` needs to be filled into the `author-config.csv` file for accurate consolidation.
 In the event that the author has more than one `Git Author Name`, multiple values can be entered in the `Git Author Name` column by using a semicolon `;` separator.
 For example,`Alice;Bob`.
 

--- a/repo-config.csv
+++ b/repo-config.csv
@@ -1,7 +1,4 @@
-Repository's Location,Branch,Author's GitHub ID,Author's Display Name,Author's Git Author Name,Ignore Glob List
-https://github.com/reposense/testrepo-Delta.git,master,,,,
-https://github.com/reposense/testrepo-Beta.git,master,nbriannl,Nbr,,
-https://github.com/reposense/testrepo-Beta.git,master,zacharytang,Zac,Zachary Tang,
-https://github.com/reposense/testrepo-Beta.git,master,April0616,Fan,LAPTOP-7KFM2KSP\User;Fan Yuting,
-https://github.com/reposense/testrepo-Beta.git,master,CindyTsai1,Cin,YuHsuan,
-https://github.com/reposense/RepoSense.git,master,,,,
+Repository's Location,Branch,Ignore Glob List
+https://github.com/reposense/testrepo-Beta.git,master,
+https://github.com/reposense/testrepo-Delta.git,master,
+https://github.com/reposense/RepoSense.git,master,

--- a/src/functional/resources/author-config.csv
+++ b/src/functional/resources/author-config.csv
@@ -1,0 +1,9 @@
+Repository's Location,Branch,Author's GitHub ID,Author's Display Name,Author's Git Author Name,Ignore Glob List
+https://github.com/reposense/testrepo-Beta.git,master,nbriannl,Nbr,,
+https://github.com/reposense/testrepo-Beta.git,master,zacharytang,Zac,Zachary Tang,
+https://github.com/reposense/testrepo-Beta.git,master,April0616,Fan,LAPTOP-7KFM2KSP\User;Fan Yuting,
+https://github.com/reposense/testrepo-Beta.git,master,CindyTsai1,Cin,YuHsuan,
+https://github.com/reposense/testrepo-Charlie.git,master,charlesgoh,Cha,Charles Goh,
+https://github.com/reposense/testrepo-Charlie.git,master,Esilocke,Esi,,
+https://github.com/reposense/testrepo-Charlie.git,master,jeffreygohkw,Jef,Jeffrey Goh,
+https://github.com/reposense/testrepo-Charlie.git,master,wangyiming1019,Wan,ACER\kyle;Wang Yiming,

--- a/src/functional/resources/repo-config.csv
+++ b/src/functional/resources/repo-config.csv
@@ -1,10 +1,4 @@
-Repository's Location,Branch,Author's GitHub ID,Author's Display Name,Author's Git Author Name,Ignore Glob List
-https://github.com/reposense/testrepo-Beta.git,master,nbriannl,Nbr,,
-https://github.com/reposense/testrepo-Beta.git,master,zacharytang,Zac,Zachary Tang,
-https://github.com/reposense/testrepo-Beta.git,master,April0616,Fan,LAPTOP-7KFM2KSP\User;Fan Yuting,
-https://github.com/reposense/testrepo-Beta.git,master,CindyTsai1,Cin,YuHsuan,
-https://github.com/reposense/testrepo-Charlie.git,master,charlesgoh,Cha,Charles Goh,
-https://github.com/reposense/testrepo-Charlie.git,master,Esilocke,Esi,,
-https://github.com/reposense/testrepo-Charlie.git,master,jeffreygohkw,Jef,Jeffrey Goh,
-https://github.com/reposense/testrepo-Charlie.git,master,wangyiming1019,Wan,ACER\kyle;Wang Yiming,
-https://github.com/reposense/testrepo-Delta.git,master,,,
+Repository's Location,Branch,Ignore Glob List
+https://github.com/reposense/testrepo-Beta.git,master,
+https://github.com/reposense/testrepo-Charlie.git,master,
+https://github.com/reposense/testrepo-Delta.git,master,

--- a/src/main/java/reposense/RepoSense.java
+++ b/src/main/java/reposense/RepoSense.java
@@ -72,7 +72,8 @@ public class RepoSense {
             authorConfigs = new AuthorConfigCsvParser(cliArguments.getAuthorConfigFilePath()).parse();
             RepoConfiguration.merge(repoConfigs, authorConfigs);
         } catch (IOException ioe) {
-            // Ignore IOException thrown as author-config.csv file is optional
+            // IOException thrown as author-config.csv is not found.
+            // Ignore exception as the file is optional.
         }
 
         return repoConfigs;

--- a/src/main/java/reposense/RepoSense.java
+++ b/src/main/java/reposense/RepoSense.java
@@ -15,9 +15,10 @@ import reposense.model.LocationsCliArguments;
 import reposense.model.RepoConfiguration;
 import reposense.model.ViewCliArguments;
 import reposense.parser.ArgsParser;
-import reposense.parser.CsvParser;
+import reposense.parser.AuthorConfigCsvParser;
 import reposense.parser.InvalidLocationException;
 import reposense.parser.ParseException;
+import reposense.parser.RepoConfigCsvParser;
 import reposense.report.ReportGenerator;
 import reposense.system.DashboardServer;
 import reposense.system.LogsManager;
@@ -64,7 +65,17 @@ public class RepoSense {
      * @throws IOException if user-supplied csv file does not exists or is not readable.
      */
     public static List<RepoConfiguration> getRepoConfigurations(ConfigCliArguments cliArguments) throws IOException {
-        return CsvParser.parse(cliArguments.getConfigFolderPath());
+        List<RepoConfiguration> repoConfigs = new RepoConfigCsvParser(cliArguments.getRepoConfigFilePath()).parse();
+        List<RepoConfiguration> authorConfigs = null;
+
+        try {
+            authorConfigs = new AuthorConfigCsvParser(cliArguments.getAuthorConfigFilePath()).parse();
+            RepoConfiguration.merge(repoConfigs, authorConfigs);
+        } catch (IOException ioe) {
+            // Ignore IOException thrown as author-config.csv file is optional
+        }
+
+        return repoConfigs;
     }
 
     /**

--- a/src/main/java/reposense/model/Author.java
+++ b/src/main/java/reposense/model/Author.java
@@ -52,6 +52,10 @@ public class Author {
         return ignoreGlobMatcher;
     }
 
+    public void appendIgnoreGlobList(List<String> ignoreGlobList) {
+        this.ignoreGlobList.addAll(ignoreGlobList);
+    }
+
     @Override
     public boolean equals(Object other) {
         // short circuit if same object

--- a/src/main/java/reposense/model/ConfigCliArguments.java
+++ b/src/main/java/reposense/model/ConfigCliArguments.java
@@ -5,22 +5,31 @@ import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 
+import reposense.parser.AuthorConfigCsvParser;
+import reposense.parser.RepoConfigCsvParser;
+
 /**
  * Represents command line arguments user supplied when running the program with mandatory field -config.
  */
 public class ConfigCliArguments extends CliArguments {
-    private Path configFolderPath;
+    private Path repoConfigFilePath;
+    private Path authorConfigFilePath;
 
     public ConfigCliArguments(Path configFolderPath,
             Path outputFilePath, Optional<Date> sinceDate, Optional<Date> untilDate, List<String> formats) {
-        this.configFolderPath = configFolderPath;
+        this.repoConfigFilePath = configFolderPath.resolve(RepoConfigCsvParser.REPO_CONFIG_FILENAME);
+        this.authorConfigFilePath = configFolderPath.resolve(AuthorConfigCsvParser.AUTHOR_CONFIG_FILENAME);
         this.outputFilePath = outputFilePath;
         this.sinceDate = sinceDate;
         this.untilDate = untilDate;
         this.formats = formats;
     }
 
-    public Path getConfigFolderPath() {
-        return configFolderPath;
+    public Path getRepoConfigFilePath() {
+        return repoConfigFilePath;
+    }
+
+    public Path getAuthorConfigFilePath() {
+        return authorConfigFilePath;
     }
 }

--- a/src/main/java/reposense/model/RepoConfiguration.java
+++ b/src/main/java/reposense/model/RepoConfiguration.java
@@ -239,8 +239,12 @@ public class RepoConfiguration {
     public void setAuthorList(List<Author> authorList) {
         this.authorList = authorList;
 
-        // Set GitHub Id as default alias
-        authorList.forEach(author -> addAuthorAliases(author, Arrays.asList(author.getGitId())));
+        authorList.forEach(author -> {
+            // Set GitHub Id as default alias
+            addAuthorAliases(author, Arrays.asList(author.getGitId()));
+            // Propagate RepoConfiguration IgnoreGlobList to Author
+            author.appendIgnoreGlobList(this.getIgnoreGlobList());
+        });
     }
 
     public TreeMap<String, Author> getAuthorAliasMap() {

--- a/src/main/java/reposense/model/RepoConfiguration.java
+++ b/src/main/java/reposense/model/RepoConfiguration.java
@@ -102,7 +102,8 @@ public class RepoConfiguration {
             int index = repoConfigs.indexOf(authorConfig);
 
             if (index == -1) {
-                logger.warning("Author information does not belong to any repository.");
+                logger.warning(String.format(
+                        "Repository %s is not found in repo-config.csv.", authorConfig.getLocation()));
                 continue;
             }
 
@@ -111,7 +112,6 @@ public class RepoConfiguration {
             repoConfig.setAuthorList(authorConfig.getAuthorList());
             repoConfig.setAuthorDisplayNameMap(authorConfig.getAuthorDisplayNameMap());
             repoConfig.setAuthorAliasMap(authorConfig.getAuthorAliasMap());
-            repoConfig.setIgnoreGlobList(authorConfig.getIgnoreGlobList());
         }
     }
 
@@ -139,7 +139,7 @@ public class RepoConfiguration {
 
             authorList.add(author);
             author.setAuthorAliases(sa.getAuthorNames());
-            author.setIgnoreGlobList(sa.getIgnoreGlobList());
+            author.setIgnoreGlobList(authorIgnoreGlobList);
 
             this.setAuthorDisplayName(author, displayName);
             this.addAuthorAliases(author, Arrays.asList(sa.getGithubId()));

--- a/src/main/java/reposense/model/StandaloneAuthor.java
+++ b/src/main/java/reposense/model/StandaloneAuthor.java
@@ -9,7 +9,7 @@ import java.util.List;
 public class StandaloneAuthor {
     private String githubId;
     private String displayName;
-    private List<String>  authorNames;
+    private List<String> authorNames;
     private List<String> ignoreGlobList;
 
     public String getGithubId() {

--- a/src/main/java/reposense/parser/ArgsParser.java
+++ b/src/main/java/reposense/parser/ArgsParser.java
@@ -49,7 +49,7 @@ public class ArgsParser {
         mutexParser.addArgument("-config")
                 .type(new ConfigFolderArgumentType())
                 .metavar("PATH")
-                .help("The directory that contains the configuration file, repo-config.csv.");
+                .help("The directory containing the config files.");
 
         mutexParser.addArgument("-repos")
                 .nargs("+")

--- a/src/main/java/reposense/parser/AuthorConfigCsvParser.java
+++ b/src/main/java/reposense/parser/AuthorConfigCsvParser.java
@@ -12,7 +12,7 @@ public class AuthorConfigCsvParser extends CsvParser<RepoConfiguration> {
     public static final String AUTHOR_CONFIG_FILENAME = "author-config.csv";
 
     /**
-     * Positions of the elements of a line in author-config.csv config file
+     * Positions of the elements of a line in author-config.csv config file.
      */
     private static final int LOCATION_POSITION = 0;
     private static final int BRANCH_POSITION = 1;

--- a/src/main/java/reposense/parser/AuthorConfigCsvParser.java
+++ b/src/main/java/reposense/parser/AuthorConfigCsvParser.java
@@ -1,0 +1,120 @@
+package reposense.parser;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.List;
+
+import reposense.model.Author;
+import reposense.model.RepoConfiguration;
+
+public class AuthorConfigCsvParser extends CsvParser<RepoConfiguration> {
+    public static final String AUTHOR_CONFIG_FILENAME = "author-config.csv";
+
+    /**
+     * Positions of the elements of a line in author-config.csv config file
+     */
+    private static final int LOCATION_POSITION = 0;
+    private static final int BRANCH_POSITION = 1;
+    private static final int GITHUB_ID_POSITION = 2;
+    private static final int DISPLAY_NAME_POSITION = 3;
+    private static final int ALIAS_POSITION = 4;
+    private static final int IGNORE_GLOB_LIST_POSITION = 5;
+
+    public AuthorConfigCsvParser(Path csvFilePath) throws IOException {
+        super(csvFilePath);
+    }
+
+    /**
+     * Gets the list of positions that are mandatory for verification.
+     */
+    @Override
+    protected int[] mandatoryPositions() {
+        return new int[] {
+            LOCATION_POSITION,
+            BRANCH_POSITION,
+            GITHUB_ID_POSITION,
+        };
+    }
+
+    /**
+     * Processes the csv file line by line and add created {@code RepoConfiguration} into {@code results} but
+     * skips {@code author} already exists in a {@code RepoConfiguration} that has same {@code location} and
+     * {@code branch}.
+     */
+    @Override
+    protected void processLine(List<RepoConfiguration> results, String[] elements)
+            throws ParseException {
+        String location = getValueInElement(elements, LOCATION_POSITION);
+        String branch = getValueInElement(elements, BRANCH_POSITION);
+        String gitHubId = getValueInElement(elements, GITHUB_ID_POSITION);
+        String displayName = getValueInElement(elements, DISPLAY_NAME_POSITION);
+        List<String> aliases = getManyValueInElement(elements, ALIAS_POSITION);
+        List<String> ignoreGlobList = getManyValueInElement(elements, IGNORE_GLOB_LIST_POSITION);
+
+        RepoConfiguration config = getRepoConfiguration(results, location, branch);
+
+        Author author = new Author(gitHubId);
+
+        if (config.containsAuthor(author)) {
+            logger.warning(String.format(
+                    "Skipping author as %s already in repository %s", author.getGitId(), config.getDisplayName()));
+            return;
+        }
+
+        config.addAuthor(author);
+        setDisplayName(config, author, displayName);
+        setAliases(config, author, gitHubId, aliases);
+        setAuthorIgnoreGlobList(author, ignoreGlobList);
+
+        results.add(config);
+    }
+
+
+    /**
+     * Gets an existing {@code RepoConfiguration} from {@code results} if {@code location} and {@code branch} matches.
+     * Otherwise adds a newly created {@code RepoConfigurtion} into {@code results} and returns it.
+     *
+     * @throws InvalidLocationException if {@code location} is invalid.
+     */
+    private static RepoConfiguration getRepoConfiguration(
+            List<RepoConfiguration> results, String location, String branch) throws InvalidLocationException {
+        RepoConfiguration config = new RepoConfiguration(location, branch);
+        int index = results.indexOf(config);
+
+        return index != -1 ? results.get(index) : config;
+    }
+
+    /**
+     * Associates {@code displayName} to {@code author}, if provided and not empty.
+     * Otherwise, use github id from {@code author}.
+     */
+    private static void setDisplayName(RepoConfiguration config, Author author, String displayName) {
+        config.setAuthorDisplayName(author, !displayName.isEmpty() ? displayName : author.getGitId());
+    }
+
+    /**
+     * Associates {@code gitHubId} and additional {@code aliases} to {@code author}.
+     */
+    private static void setAliases(RepoConfiguration config, Author author, String gitHubId, List<String> aliases) {
+        config.addAuthorAliases(author, Arrays.asList(gitHubId));
+
+        if (aliases.isEmpty()) {
+            return;
+        }
+
+        config.addAuthorAliases(author, aliases);
+        author.setAuthorAliases(aliases);
+    }
+
+    /**
+     * Sets the list of globs to ignore for the {@code author} for file analysis.
+     */
+    private static void setAuthorIgnoreGlobList(Author author, List<String> ignoreGlobList) {
+        if (ignoreGlobList.isEmpty()) {
+            return;
+        }
+
+        author.setIgnoreGlobList(ignoreGlobList);
+    }
+}

--- a/src/main/java/reposense/parser/ConfigFolderArgumentType.java
+++ b/src/main/java/reposense/parser/ConfigFolderArgumentType.java
@@ -19,11 +19,11 @@ public class ConfigFolderArgumentType implements ArgumentType<Path> {
         // Piggyback on library methods to do file existence checks
         Arguments.fileType().verifyExists().verifyIsDirectory().verifyCanRead().convert(parser, arg, value);
 
-        if (Files.exists(Paths.get(value).resolve(CsvParser.REPO_CONFIG_FILENAME))) {
+        if (Files.exists(Paths.get(value).resolve(RepoConfigCsvParser.REPO_CONFIG_FILENAME))) {
             return Paths.get(value);
         }
 
-        throw new ArgumentParserException(String.format(
-                PARSE_EXCEPTION_MESSAGE_MISSING_REQUIRED_CONFIG_FILES, CsvParser.REPO_CONFIG_FILENAME), parser);
+        throw new ArgumentParserException(String.format(PARSE_EXCEPTION_MESSAGE_MISSING_REQUIRED_CONFIG_FILES,
+                RepoConfigCsvParser.REPO_CONFIG_FILENAME), parser);
     }
 }

--- a/src/main/java/reposense/parser/CsvParser.java
+++ b/src/main/java/reposense/parser/CsvParser.java
@@ -68,7 +68,7 @@ public abstract class CsvParser<T> {
 
     private boolean isLineMalformed(final String[] elements, int lineNumber, String line) {
         for (int position : mandatoryPositions()) {
-            if (!containsValueInElementsAndNotEmpty(elements, position)) {
+            if (!containsValueAtPosition(elements, position)) {
                 logger.warning(String.format(MESSAGE_MALFORMED_LINE_FORMAT, lineNumber, line));
                 return true;
             }
@@ -81,7 +81,7 @@ public abstract class CsvParser<T> {
      * Checks that {@code position} in within the range of {@code element} array and
      * value in {@code position} is not empty.
      */
-    private boolean containsValueInElementsAndNotEmpty(final String[] elements, int position) {
+    private boolean containsValueAtPosition(final String[] elements, int position) {
         return elements.length > position && !elements[position].isEmpty();
     }
 
@@ -91,7 +91,7 @@ public abstract class CsvParser<T> {
      * Otherwise returns an empty string.
      */
     protected String getValueInElement(final String[] elements, int position) {
-        return (containsValueInElementsAndNotEmpty(elements, position)) ? elements[position] : "";
+        return (containsValueAtPosition(elements, position)) ? elements[position] : "";
     }
 
     /**
@@ -101,7 +101,7 @@ public abstract class CsvParser<T> {
      * Otherwise returns an empty array.
      */
     protected List<String> getManyValueInElement(final String[] elements, int position) {
-        if (!containsValueInElementsAndNotEmpty(elements, position)) {
+        if (!containsValueAtPosition(elements, position)) {
             return Collections.emptyList();
         }
 

--- a/src/main/java/reposense/parser/CsvParser.java
+++ b/src/main/java/reposense/parser/CsvParser.java
@@ -68,7 +68,7 @@ public abstract class CsvParser<T> {
 
     private boolean isLineMalformed(final String[] elements, int lineNumber, String line) {
         for (int position : mandatoryPositions()) {
-            if (!isValueInElementsAndNotEmpty(elements, position)) {
+            if (!containsValueInElementsAndNotEmpty(elements, position)) {
                 logger.warning(String.format(MESSAGE_MALFORMED_LINE_FORMAT, lineNumber, line));
                 return true;
             }
@@ -81,7 +81,7 @@ public abstract class CsvParser<T> {
      * Checks that {@code position} in within the range of {@code element} array and
      * value in {@code position} is not empty.
      */
-    private boolean isValueInElementsAndNotEmpty(final String[] elements, int position) {
+    private boolean containsValueInElementsAndNotEmpty(final String[] elements, int position) {
         return elements.length > position && !elements[position].isEmpty();
     }
 
@@ -91,7 +91,7 @@ public abstract class CsvParser<T> {
      * Otherwise returns an empty string.
      */
     protected String getValueInElement(final String[] elements, int position) {
-        return (isValueInElementsAndNotEmpty(elements, position)) ? elements[position] : "";
+        return (containsValueInElementsAndNotEmpty(elements, position)) ? elements[position] : "";
     }
 
     /**
@@ -101,7 +101,7 @@ public abstract class CsvParser<T> {
      * Otherwise returns an empty array.
      */
     protected List<String> getManyValueInElement(final String[] elements, int position) {
-        if (!isValueInElementsAndNotEmpty(elements, position)) {
+        if (!containsValueInElementsAndNotEmpty(elements, position)) {
             return Collections.emptyList();
         }
 

--- a/src/main/java/reposense/parser/RepoConfigCsvParser.java
+++ b/src/main/java/reposense/parser/RepoConfigCsvParser.java
@@ -1,0 +1,54 @@
+package reposense.parser;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+
+import reposense.model.RepoConfiguration;
+
+public class RepoConfigCsvParser extends CsvParser<RepoConfiguration> {
+    public static final String REPO_CONFIG_FILENAME = "repo-config.csv";
+
+    /**
+     * Positions of the elements of a line in repo-config.csv config file
+     */
+    private static final int LOCATION_POSITION = 0;
+    private static final int BRANCH_POSITION = 1;
+    private static final int IGNORE_GLOB_LIST_POSITION = 2;
+
+    public RepoConfigCsvParser(Path csvFilePath) throws IOException {
+        super(csvFilePath);
+    }
+
+    /**
+     * Gets the list of positions that are mandatory for verification.
+     */
+    @Override
+    protected int[] mandatoryPositions() {
+        return new int[] {
+            LOCATION_POSITION,
+            BRANCH_POSITION
+        };
+    }
+
+    /**
+     * Processes the csv file line by line and add created {@code RepoConfiguration} into {@code results} but
+     * ignores duplicated {@code RepoConfiguration} if there exists one that has same {@code location} and
+     * {@code branch}.
+     */
+    @Override
+    protected void processLine(List<RepoConfiguration> results, String[] elements) throws InvalidLocationException {
+        String location = getValueInElement(elements, LOCATION_POSITION);
+        String branch = getValueInElement(elements, BRANCH_POSITION);
+        List<String> ignoreGlobList = getManyValueInElement(elements, IGNORE_GLOB_LIST_POSITION);
+
+        RepoConfiguration config = new RepoConfiguration(location, branch, ignoreGlobList);
+
+        if (results.contains(config)) {
+            logger.warning("Ignoring duplicated repository " + location + " " + branch);
+            return;
+        }
+
+        results.add(config);
+    }
+}

--- a/src/test/java/reposense/parser/ArgsParserTest.java
+++ b/src/test/java/reposense/parser/ArgsParserTest.java
@@ -34,7 +34,10 @@ public class ArgsParserTest {
     private static final Path CONFIG_FOLDER_RELATIVE = PROJECT_DIRECTORY.relativize(CONFIG_FOLDER_ABSOLUTE);
     private static final Path OUTPUT_DIRECTORY_RELATIVE = PROJECT_DIRECTORY.relativize(OUTPUT_DIRECTORY_ABSOLUTE);
     private static final String DEFAULT_MANDATORY_ARGS = "-config " + CONFIG_FOLDER_ABSOLUTE + " ";
-    private static final Path REPO_CONFIG_CSV_FILE = CONFIG_FOLDER_ABSOLUTE.resolve(CsvParser.REPO_CONFIG_FILENAME);
+    private static final Path REPO_CONFIG_CSV_FILE =
+            CONFIG_FOLDER_ABSOLUTE.resolve(RepoConfigCsvParser.REPO_CONFIG_FILENAME);
+    private static final Path AUTHOR_CONFIG_CSV_FILE =
+            CONFIG_FOLDER_ABSOLUTE.resolve(AuthorConfigCsvParser.AUTHOR_CONFIG_FILENAME);
 
     private static final String TEST_REPO_REPOSENSE = "https://github.com/reposense/RepoSense.git";
     private static final String TEST_REPO_BETA = "https://github.com/reposense/testrepo-Beta.git";
@@ -49,7 +52,9 @@ public class ArgsParserTest {
         CliArguments cliArguments = ArgsParser.parse(translateCommandline(input));
         Assert.assertTrue(cliArguments instanceof ConfigCliArguments);
         Assert.assertTrue(Files.isSameFile(
-                CONFIG_FOLDER_ABSOLUTE, ((ConfigCliArguments) cliArguments).getConfigFolderPath()));
+                REPO_CONFIG_CSV_FILE, ((ConfigCliArguments) cliArguments).getRepoConfigFilePath()));
+        Assert.assertTrue(Files.isSameFile(
+                AUTHOR_CONFIG_CSV_FILE, ((ConfigCliArguments) cliArguments).getAuthorConfigFilePath()));
         Assert.assertTrue(Files.isSameFile(
                 OUTPUT_DIRECTORY_ABSOLUTE.resolve(ArgsParser.DEFAULT_REPORT_NAME), cliArguments.getOutputFilePath()));
 
@@ -69,7 +74,9 @@ public class ArgsParserTest {
         CliArguments cliArguments = ArgsParser.parse(translateCommandline(input));
         Assert.assertTrue(cliArguments instanceof ConfigCliArguments);
         Assert.assertTrue(Files.isSameFile(
-                CONFIG_FOLDER_ABSOLUTE, ((ConfigCliArguments) cliArguments).getConfigFolderPath()));
+                REPO_CONFIG_CSV_FILE, ((ConfigCliArguments) cliArguments).getRepoConfigFilePath()));
+        Assert.assertTrue(Files.isSameFile(
+                AUTHOR_CONFIG_CSV_FILE, ((ConfigCliArguments) cliArguments).getAuthorConfigFilePath()));
         Assert.assertTrue(Files.isSameFile(
                 OUTPUT_DIRECTORY_ABSOLUTE.resolve(ArgsParser.DEFAULT_REPORT_NAME), cliArguments.getOutputFilePath()));
 
@@ -88,7 +95,9 @@ public class ArgsParserTest {
         CliArguments cliArguments = ArgsParser.parse(translateCommandline(input));
         Assert.assertTrue(cliArguments instanceof ConfigCliArguments);
         Assert.assertTrue(Files.isSameFile(
-                CONFIG_FOLDER_ABSOLUTE, ((ConfigCliArguments) cliArguments).getConfigFolderPath()));
+                REPO_CONFIG_CSV_FILE, ((ConfigCliArguments) cliArguments).getRepoConfigFilePath()));
+        Assert.assertTrue(Files.isSameFile(
+                AUTHOR_CONFIG_CSV_FILE, ((ConfigCliArguments) cliArguments).getAuthorConfigFilePath()));
         // Optional arguments have default values
         Assert.assertEquals(Optional.empty(), cliArguments.getSinceDate());
         Assert.assertEquals(Optional.empty(), cliArguments.getUntilDate());
@@ -99,7 +108,9 @@ public class ArgsParserTest {
         cliArguments = ArgsParser.parse(translateCommandline(input));
         Assert.assertTrue(cliArguments instanceof ConfigCliArguments);
         Assert.assertTrue(Files.isSameFile(
-                CONFIG_FOLDER_RELATIVE, ((ConfigCliArguments) cliArguments).getConfigFolderPath()));
+                REPO_CONFIG_CSV_FILE, ((ConfigCliArguments) cliArguments).getRepoConfigFilePath()));
+        Assert.assertTrue(Files.isSameFile(
+                AUTHOR_CONFIG_CSV_FILE, ((ConfigCliArguments) cliArguments).getAuthorConfigFilePath()));
         // Optional arguments have default values
         Assert.assertEquals(Optional.empty(), cliArguments.getSinceDate());
         Assert.assertEquals(Optional.empty(), cliArguments.getUntilDate());
@@ -125,14 +136,18 @@ public class ArgsParserTest {
         CliArguments cliArguments = ArgsParser.parse(translateCommandline(input));
         Assert.assertTrue(cliArguments instanceof ConfigCliArguments);
         Assert.assertTrue(Files.isSameFile(
-                CONFIG_FOLDER_ABSOLUTE, ((ConfigCliArguments) cliArguments).getConfigFolderPath()));
+                REPO_CONFIG_CSV_FILE, ((ConfigCliArguments) cliArguments).getRepoConfigFilePath()));
+        Assert.assertTrue(Files.isSameFile(
+                AUTHOR_CONFIG_CSV_FILE, ((ConfigCliArguments) cliArguments).getAuthorConfigFilePath()));
         Assert.assertTrue(Files.isSameFile(expectedRelativeOutputDirectoryPath, cliArguments.getOutputFilePath()));
 
         input = String.format("-config %s -output %s", CONFIG_FOLDER_RELATIVE, OUTPUT_DIRECTORY_ABSOLUTE);
         cliArguments = ArgsParser.parse(translateCommandline(input));
         Assert.assertTrue(cliArguments instanceof ConfigCliArguments);
         Assert.assertTrue(Files.isSameFile(
-                CONFIG_FOLDER_RELATIVE, ((ConfigCliArguments) cliArguments).getConfigFolderPath()));
+                REPO_CONFIG_CSV_FILE, ((ConfigCliArguments) cliArguments).getRepoConfigFilePath()));
+        Assert.assertTrue(Files.isSameFile(
+                AUTHOR_CONFIG_CSV_FILE, ((ConfigCliArguments) cliArguments).getAuthorConfigFilePath()));
         Assert.assertTrue(Files.isSameFile(expectedAbsoluteOutputDirectoryPath, cliArguments.getOutputFilePath()));
     }
 

--- a/src/test/resources/cli_location_test/author-config.csv
+++ b/src/test/resources/cli_location_test/author-config.csv
@@ -1,0 +1,1 @@
+Repository's Location,Branch,Author's GitHub ID,Author's Display Name,Author's Git Author Name,Ignore Glob List

--- a/src/test/resources/cli_location_test/repo-config.csv
+++ b/src/test/resources/cli_location_test/repo-config.csv
@@ -1,4 +1,4 @@
-Repository's Location,Branch,Author's GitHub ID,Author's Display Name,Author's Git Author Name,Ignore Glob List
-https://github.com/reposense/testrepo-Beta.git,master,,,
-https://github.com/reposense/testrepo-Charlie.git,master,,,
-https://github.com/reposense/testrepo-Delta.git,master,,,
+Repository's Location,Branch,Ignore Glob List
+https://github.com/reposense/testrepo-Beta.git,master,
+https://github.com/reposense/testrepo-Charlie.git,master,
+https://github.com/reposense/testrepo-Delta.git,master,


### PR DESCRIPTION
Part of #245 
```
RepoSense uses a CSV config file for all repository information.

Following #234, analysis can be done at author level.
To make author level analysis available to the users, the CSV config
file has to be broken down into repo-config.csv and author-config.csv.

Let's split the CSV config file to repo-config.csv and author-config.csv.
```