### PR TITLE
Fix empty ramps when overriding RepoConfiguration

### DIFF
--- a/_reposense/config.json
+++ b/_reposense/config.json
@@ -4,27 +4,32 @@
 		{
 			"githubId": "AdityaA1998",
 			"displayName": "Aditya",
-			"authorNames": ["AdityaA1998"]
+			"authorNames": ["AdityaA1998"],
+			"ignoreGlobList": []
 		},
 		{
 			"githubId": "eugenepeh",
 			"displayName": "Eugene",
-			"authorNames": ["Eugene Peh"]
+			"authorNames": ["Eugene Peh"],
+			"ignoreGlobList": []
 		},
 		{
 			"githubId": "ongspxm",
 			"displayName": "Metta",
-			"authorNames": ["Metta Ong"]
+			"authorNames": ["Metta Ong"],
+			"ignoreGlobList": []
 		},
 		{
 			"githubId": "yamidark",
 			"displayName": "Jun An",
-			"authorNames": ["Jun An"]
+			"authorNames": ["Jun An"],
+			"ignoreGlobList": []
 		},
 		{
 			"githubId": "yong24s",
 			"displayName": "Yong Hao",
-			"authorNames": ["Yong Hao TENG"]
+			"authorNames": ["Yong Hao TENG"],
+			"ignoreGlobList": []
 		}
 	]
 }

--- a/src/main/java/reposense/model/RepoConfiguration.java
+++ b/src/main/java/reposense/model/RepoConfiguration.java
@@ -8,10 +8,12 @@ import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.TreeMap;
 import java.util.regex.Matcher;
@@ -91,6 +93,9 @@ public class RepoConfiguration {
             String displayName = !sa.getDisplayName().isEmpty() ? sa.getDisplayName() : sa.getGithubId();
 
             authorList.add(author);
+            author.setAuthorAliases(Arrays.asList(sa.getAuthorNames()));
+            author.setIgnoreGlobList(Arrays.asList(sa.getIgnoreGlobList()));
+
             setAuthorDisplayName(author, displayName);
             setAuthorAliases(author, sa.getGithubId());
             setAuthorAliases(author, sa.getAuthorNames());
@@ -123,7 +128,7 @@ public class RepoConfiguration {
 
     @Override
     public int hashCode() {
-        return location.hashCode();
+        return Objects.hash(location, branch);
     }
 
     public Map<Author, String> getAuthorDisplayNameMap() {

--- a/src/main/java/reposense/model/StandaloneAuthor.java
+++ b/src/main/java/reposense/model/StandaloneAuthor.java
@@ -7,11 +7,13 @@ public class StandaloneAuthor {
     private String githubId;
     private String displayName;
     private String[] authorNames;
+    private String[] ignoreGlobList;
 
-    public StandaloneAuthor(String githubId, String displayName, String[] authorNames) {
+    public StandaloneAuthor(String githubId, String displayName, String[] authorNames, String[] ignoreGlobList) {
         this.githubId = githubId;
         this.displayName = displayName;
         this.authorNames = authorNames;
+        this.ignoreGlobList = ignoreGlobList;
     }
 
     public String getGithubId() {
@@ -28,5 +30,13 @@ public class StandaloneAuthor {
         }
 
         return authorNames;
+    }
+
+    public String[] getIgnoreGlobList() {
+        if (ignoreGlobList == null) {
+            return new String[]{};
+        }
+
+        return ignoreGlobList;
     }
 }

--- a/src/main/java/reposense/report/ReportGenerator.java
+++ b/src/main/java/reposense/report/ReportGenerator.java
@@ -42,9 +42,11 @@ public class ReportGenerator {
     public static void generateReposReport(List<RepoConfiguration> configs, String outputPath,
             String generationDate) throws IOException {
         InputStream is = RepoSense.class.getResourceAsStream(TEMPLATE_FILE);
+        System.out.println(configs.size());
         FileUtil.copyTemplate(is, outputPath);
 
         for (RepoConfiguration config : configs) {
+            System.out.println(config.getBranch());
             Path repoReportDirectory = Paths.get(outputPath, config.getDisplayName());
             try {
                 GitDownloader.downloadRepo(config);


### PR DESCRIPTION
```
When a repo has a _reposense/config.json configuration file,
the RepoConfiguration will be reset to the new config.json file,
and all authors are reset as well.

However, these reset authors does not have their author aliases
or ignore glob list set inside them. This may cause some of the
commit info to be missing as we are filtering commits by author
names and aliases.

Let's fix this by updating the
RepoConfiguration#update(StandAloneConfig) to set the
author aliases and ignore glob list for each author inside the
config.json file.
```