### PR TITLE
Add repo file exclusion patterns to standalone config #244

### DIFF
--- a/_reposense/config.json
+++ b/_reposense/config.json
@@ -18,13 +18,12 @@
 			"githubId": "ongspxm",
 			"displayName": "Metta",
 			"authorNames": ["Metta Ong"],
-			"ignoreGlobList": [""]
+			"ignoreGlobList": ["**.java"]
 		},
 		{
 			"githubId": "yamidark",
 			"displayName": "Jun An",
-			"authorNames": ["Jun An"],
-			"ignoreGlobList": [""]
+			"authorNames": ["Jun An"]
 		},
 		{
 			"githubId": "yong24s",

--- a/_reposense/config.json
+++ b/_reposense/config.json
@@ -1,11 +1,12 @@
 {
+	"ignoreGlobList": ["**.css", "**.js"],
 	"authors":
 	[
 		{
 			"githubId": "AdityaA1998",
 			"displayName": "Aditya",
 			"authorNames": ["AdityaA1998"],
-			"ignoreGlobList": []
+			"ignoreGlobList": [""]
 		},
 		{
 			"githubId": "eugenepeh",
@@ -17,19 +18,19 @@
 			"githubId": "ongspxm",
 			"displayName": "Metta",
 			"authorNames": ["Metta Ong"],
-			"ignoreGlobList": []
+			"ignoreGlobList": [""]
 		},
 		{
 			"githubId": "yamidark",
 			"displayName": "Jun An",
 			"authorNames": ["Jun An"],
-			"ignoreGlobList": []
+			"ignoreGlobList": [""]
 		},
 		{
 			"githubId": "yong24s",
 			"displayName": "Yong Hao",
 			"authorNames": ["Yong Hao TENG"],
-			"ignoreGlobList": []
+			"ignoreGlobList": ["**.css", "**.js"]
 		}
 	]
 }

--- a/_reposense/config.json
+++ b/_reposense/config.json
@@ -1,5 +1,5 @@
 {
-	"ignoreGlobList": ["**.adocs", "**collate"],
+	"ignoreGlobList": ["**.adoc", "collate**"],
 	"authors":
 	[
 		{

--- a/_reposense/config.json
+++ b/_reposense/config.json
@@ -1,12 +1,11 @@
 {
-	"ignoreGlobList": ["**.css", "**.js"],
+	"ignoreGlobList": ["**.adocs", "**collate"],
 	"authors":
 	[
 		{
 			"githubId": "AdityaA1998",
 			"displayName": "Aditya",
-			"authorNames": ["AdityaA1998"],
-			"ignoreGlobList": [""]
+			"authorNames": ["AdityaA1998"]
 		},
 		{
 			"githubId": "eugenepeh",
@@ -16,19 +15,19 @@
 		{
 			"githubId": "ongspxm",
 			"displayName": "Metta",
-			"authorNames": ["Metta Ong"],
-			"ignoreGlobList": []
+			"authorNames": ["Metta Ong"]
 		},
 		{
 			"githubId": "yamidark",
 			"displayName": "Jun An",
-			"authorNames": ["Jun An"]
+			"authorNames": ["Jun An"],
+			"ignoreGlobList": ["**.html", "**.jade"]
 		},
 		{
 			"githubId": "yong24s",
 			"displayName": "Yong Hao",
 			"authorNames": ["Yong Hao TENG"],
-			"ignoreGlobList": ["**.css", "**.js"]
+			"ignoreGlobList": ["**.css", "**.html", "**.jade", "**.js"]
 		}
 	]
 }

--- a/_reposense/config.json
+++ b/_reposense/config.json
@@ -11,14 +11,13 @@
 		{
 			"githubId": "eugenepeh",
 			"displayName": "Eugene",
-			"authorNames": ["Eugene Peh"],
-			"ignoreGlobList": []
+			"authorNames": ["Eugene Peh"]
 		},
 		{
 			"githubId": "ongspxm",
 			"displayName": "Metta",
 			"authorNames": ["Metta Ong"],
-			"ignoreGlobList": ["**.java"]
+			"ignoreGlobList": []
 		},
 		{
 			"githubId": "yamidark",

--- a/docs/StandaloneConfiguration.md
+++ b/docs/StandaloneConfiguration.md
@@ -5,8 +5,8 @@
 
 ### Verify your standalone configuration
 
-#### Using location to github repository
-1. Run RepoSense using the link to the repository i.e. `https://github.com/reposense/RepoSense.git`. RepoSense will run the analysis on the `master` branch and use the authors provided in your repository for analysis.
+#### Using github repository url location(s)
+1. Run RepoSense using the url link to the repository i.e. `https://github.com/reposense/RepoSense.git`. RepoSense will run the analysis on the `master` branch and use the authors provided in your repository for analysis.
 
 #### Using repo-config.csv
 1. Create a [`repo-config.csv`](example.csv) and include the location and branch of the your repository. For example, `https://github.com/reposense/RepoSense.git,master`.

--- a/docs/StandaloneConfiguration.md
+++ b/docs/StandaloneConfiguration.md
@@ -9,17 +9,18 @@
 ```
 {
   "ignoreGlobList": ["**.dat", "**.js"],    
-  "authors": [                              
-  {                                            
-    "githubId": "alice",                       
-    "displayName": "Alice T.",
-    "authorNames": ["AT", "A"],
-    "ignoreGlobList": ["**.css"]
-  },
-  {
-    "githubId": "bob"
-  }
- ]
+  "authors":
+  [
+    {
+      "githubId": "alice",
+      "displayName": "Alice T.",
+      "authorNames": ["AT", "A"],
+      "ignoreGlobList": ["**.css"]
+    },
+    {
+      "githubId": "bob"
+    }
+  ]
 }
 ```
 #### Line-by-line explanation

--- a/docs/StandaloneConfiguration.md
+++ b/docs/StandaloneConfiguration.md
@@ -28,4 +28,4 @@ Download the latest executable Jar on our [release](https://github.com/reposense
 #### Using github repository url location(s)
 1. Run RepoSense using the url link to your repository i.e. `https://github.com/reposense/RepoSense.git`. RepoSense will run the analysis on the `master` branch and use the authors provided in your repository for analysis.
 
-`java -jar RepoSense.jar -repos https://github.com/reposense/RepoSense.git`
+```java -jar RepoSense.jar -repos https://github.com/reposense/RepoSense.git```

--- a/docs/StandaloneConfiguration.md
+++ b/docs/StandaloneConfiguration.md
@@ -7,14 +7,14 @@
 ```
 {
   "ignoreGlobList": ["**.dat", "**.js"],    <-- Repository level's list of file formats to ignore 
-  "authors": [                              <-- If a setting is common between Repository and Author,
-  {                                             configuration of Author level will always take precedence
-    "githubId": "alice",                        over Repository level.
+  "authors": [                              
+  {                                            
+    "githubId": "alice",                       
     "displayName": "Alice T.",
     "authorNames": ["AT", "A"],
-    "ignoreGlobList": [""]                  <-- Author level's list of file formats to ignore.
-  },                                            Use "" to override Repository level settings.
-  {
+    "ignoreGlobList": ["**.css"]            <-- Author level's is cumulative to Repository level's ignoreGlobList.
+  },                                            Thus, the actual ignoreGlobList for alice would contains
+  {                                             css, dat and js.
     "githubId": "bob"                       
                                             <-- Optional information can be left out to prevent clutter.
   }

--- a/docs/StandaloneConfiguration.md
+++ b/docs/StandaloneConfiguration.md
@@ -4,5 +4,10 @@
 1. Fill it up with author information, such as the GitHub Id, Display Name (Optional) and the [Author Names](UserGuide.md#git-author-name) (Optional).
 
 ### Verify your standalone configuration
+
+#### Using location to github repository
+1. Run RepoSense using the link to the repository i.e. `https://github.com/reposense/RepoSense.git`. RepoSense will run the analysis on the `master` branch and use the authors provided in your repository for analysis.
+
+#### Using repo-config.csv
 1. Create a [`repo-config.csv`](example.csv) and include the location and branch of the your repository. For example, `https://github.com/reposense/RepoSense.git,master`.
 1. Then, run RepoSense with the above created `repo-config.csv`. RepoSense will use the authors provided in your repository for analysis.

--- a/docs/StandaloneConfiguration.md
+++ b/docs/StandaloneConfiguration.md
@@ -1,18 +1,18 @@
 # RepoSense - Guide to Setup Standalone Configuration
-
+### Quick Start
 1. Add [_reposense/config.json](../_reposense/config.json) to the root of your repository.
 1. Fill it up with author information, such as the GitHub Id, Display Name (Optional), [Author Names](UserGuide.md#git-author-name)  (Optional), [Ignore Glob List](UserGuide.md#csv-config-file) (Optional).
 
-#### Detailed Explanation
+### Detailed explanation of the structure of repo-config.json
 ```
 {
-  "ignoreGlobList": ["**.dat", "**.js"],    <-- Repository level's list of file format to ignore 
+  "ignoreGlobList": ["**.dat", "**.js"],    <-- Repository level's list of file formats to ignore 
   "authors": [                              <-- If a setting is common between Repository and Author,
   {                                             configuration of Author level will always take precedence
     "githubId": "alice",                        over Repository level.
     "displayName": "Alice T.",
     "authorNames": ["AT", "A"],
-    "ignoreGlobList": [""]                  <-- Author level's list of file format to ignore.
+    "ignoreGlobList": [""]                  <-- Author level's list of file formats to ignore.
   },                                            Use "" to override Repository level settings.
   {
     "githubId": "bob"                       

--- a/docs/StandaloneConfiguration.md
+++ b/docs/StandaloneConfiguration.md
@@ -1,7 +1,26 @@
 # RepoSense - Guide to Setup Standalone Configuration
 
 1. Add [_reposense/config.json](../_reposense/config.json) to the root of your repository.
-1. Fill it up with author information, such as the GitHub Id, Display Name (Optional) and the [Author Names](UserGuide.md#git-author-name) (Optional).
+1. Fill it up with author information, such as the GitHub Id, Display Name (Optional), [Author Names](UserGuide.md#git-author-name)  (Optional), [Ignore Glob List](UserGuide.md#csv-config-file) (Optional).
+
+#### Detailed Explanation
+```
+{
+  "ignoreGlobList": ["**.dat", "**.js"],    <-- Repository level's list of file format to ignore 
+  "authors": [                              <-- If a setting is common between Repository and Author,
+  {                                             configuration of Author level will always take precedence
+    "githubId": "alice",                        over Repository level.
+    "displayName": "Alice T.",
+    "authorNames": ["AT", "A"],
+    "ignoreGlobList": [""]                  <-- Author level's list of file format to ignore.
+  },                                            Use "" to override Repository level settings.
+  {
+    "githubId": "bob"                       
+                                            <-- Optional information can be left out to prevent clutter.
+  }
+ ]
+}
+```
 
 ### Verify your standalone configuration
 

--- a/docs/StandaloneConfiguration.md
+++ b/docs/StandaloneConfiguration.md
@@ -23,7 +23,7 @@
 ```
 
 ### Verify your standalone configuration
-Download the latest executable Jar on our [release](https://github.com/reposense/RepoSense/releases/latest).
+Download the latest executable Jar from our [release](https://github.com/reposense/RepoSense/releases/latest).
 
 #### Using github repository url location(s)
 1. Run RepoSense using the url link to your repository i.e. `https://github.com/reposense/RepoSense.git`. RepoSense will run the analysis on the `master` branch and use the authors provided in your repository for analysis.

--- a/docs/StandaloneConfiguration.md
+++ b/docs/StandaloneConfiguration.md
@@ -28,4 +28,4 @@ Download the latest executable Jar on our [release](https://github.com/reposense
 #### Using github repository url location(s)
 1. Run RepoSense using the url link to your repository i.e. `https://github.com/reposense/RepoSense.git`. RepoSense will run the analysis on the `master` branch and use the authors provided in your repository for analysis.
 
-> $ java -jar RepoSense.jar -repos https://github.com/reposense/RepoSense.git
+`java -jar RepoSense.jar -repos https://github.com/reposense/RepoSense.git`

--- a/docs/StandaloneConfiguration.md
+++ b/docs/StandaloneConfiguration.md
@@ -28,4 +28,6 @@ Download the latest executable Jar on our [release](https://github.com/reposense
 #### Using github repository url location(s)
 1. Run RepoSense using the url link to your repository i.e. `https://github.com/reposense/RepoSense.git`. RepoSense will run the analysis on the `master` branch and use the authors provided in your repository for analysis.
 
-```java -jar RepoSense.jar -repos https://github.com/reposense/RepoSense.git```
+```
+java -jar RepoSense.jar -repos https://github.com/reposense/RepoSense.git
+```

--- a/docs/StandaloneConfiguration.md
+++ b/docs/StandaloneConfiguration.md
@@ -23,10 +23,9 @@
 ```
 
 ### Verify your standalone configuration
+Download the latest executable Jar on our [release](https://github.com/reposense/RepoSense/releases/latest).
 
 #### Using github repository url location(s)
-1. Run RepoSense using the url link to the repository i.e. `https://github.com/reposense/RepoSense.git`. RepoSense will run the analysis on the `master` branch and use the authors provided in your repository for analysis.
+1. Run RepoSense using the url link to your repository i.e. `https://github.com/reposense/RepoSense.git`. RepoSense will run the analysis on the `master` branch and use the authors provided in your repository for analysis.
 
-#### Using repo-config.csv
-1. Create a [`repo-config.csv`](example.csv) and include the location and branch of the your repository. For example, `https://github.com/reposense/RepoSense.git,master`.
-1. Then, run RepoSense with the above created `repo-config.csv`. RepoSense will use the authors provided in your repository for analysis.
+> $ java -jar RepoSense.jar -repos https://github.com/reposense/RepoSense.git

--- a/docs/StandaloneConfiguration.md
+++ b/docs/StandaloneConfiguration.md
@@ -4,24 +4,35 @@
 1. Fill it up with author information, such as the GitHub Id, Display Name (Optional), [Author Names](UserGuide.md#git-author-name)  (Optional), [Ignore Glob List](UserGuide.md#csv-config-file) (Optional).
 
 ### Detailed explanation of the structure of repo-config.json
+
+#### Typical format of repo-config.json
 ```
 {
-  "ignoreGlobList": ["**.dat", "**.js"],    <-- Repository level's list of file formats to ignore 
+  "ignoreGlobList": ["**.dat", "**.js"],    
   "authors": [                              
   {                                            
     "githubId": "alice",                       
     "displayName": "Alice T.",
     "authorNames": ["AT", "A"],
-    "ignoreGlobList": ["**.css"]            <-- Author level's is cumulative to Repository level's ignoreGlobList.
-  },                                            Thus, the actual ignoreGlobList for alice would contains
-  {                                             css, dat and js.
-    "githubId": "bob"                       
-                                            <-- Optional information can be left out to prevent clutter.
+    "ignoreGlobList": ["**.css"]
+  },
+  {
+    "githubId": "bob"
   }
  ]
 }
 ```
+#### Line-by-line explanation
+```
+"ignoreGlobList": ["**.dat", "**.js"]  <-- Repository level's list of file formats to ignore.
 
+"ignoreGlobList": ["**.css"]           <-- Author level's ignoreGlobList adds on to the Repository level's.
+                                           Thus, the actual ignoreGlobList for alice would contain
+                                           css, dat and js.
+
+"githubId": "bob"                      <-- Only githubId is mandatory.
+                                           Optional information can be left out to prevent clutter.
+```
 ### Verify your standalone configuration
 Download the latest executable Jar from our [release](https://github.com/reposense/RepoSense/releases/latest).
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -12,7 +12,7 @@
  > Type `git --version` on your OS terminal and ensure that you have the correct version of **git**.
 
 ## How to Generate Report
-1. Download the latest executable Jar on our [release](https://github.com/reposense/RepoSense/releases/latest).
+1. Download the latest executable Jar from our [release](https://github.com/reposense/RepoSense/releases/latest).
    * Alternatively, you can compile the executable Jar yourself by following our [build from source guide](Build.md).
 1. Execute it on the OS terminal. <br>
 

--- a/repo-config.csv
+++ b/repo-config.csv
@@ -1,2 +1,7 @@
 Repository's Location,Branch,Author's GitHub ID,Author's Display Name,Author's Git Author Name,Ignore Glob List
-https://github.com/yong24s/RepoSense.git,244-file-exclusion-config,,,,
+https://github.com/reposense/testrepo-Delta.git,master,,,,
+https://github.com/reposense/testrepo-Beta.git,master,nbriannl,Nbr,,
+https://github.com/reposense/testrepo-Beta.git,master,zacharytang,Zac,Zachary Tang,
+https://github.com/reposense/testrepo-Beta.git,master,April0616,Fan,LAPTOP-7KFM2KSP\User;Fan Yuting,
+https://github.com/reposense/testrepo-Beta.git,master,CindyTsai1,Cin,YuHsuan,
+https://github.com/reposense/RepoSense.git,master,,,,

--- a/repo-config.csv
+++ b/repo-config.csv
@@ -1,7 +1,2 @@
 Repository's Location,Branch,Author's GitHub ID,Author's Display Name,Author's Git Author Name,Ignore Glob List
-https://github.com/reposense/testrepo-Delta.git,master,,,,
-https://github.com/reposense/testrepo-Beta.git,master,nbriannl,Nbr,,
-https://github.com/reposense/testrepo-Beta.git,master,zacharytang,Zac,Zachary Tang,
-https://github.com/reposense/testrepo-Beta.git,master,April0616,Fan,LAPTOP-7KFM2KSP\User;Fan Yuting,
-https://github.com/reposense/testrepo-Beta.git,master,CindyTsai1,Cin,YuHsuan,
-https://github.com/reposense/RepoSense.git,master,,,,
+https://github.com/yong24s/RepoSense.git,244-file-exclusion-config,,,,

--- a/src/functional/resources/noDateRange/expected/reposense_testrepo-Delta_master/authorship.json
+++ b/src/functional/resources/noDateRange/expected/reposense_testrepo-Delta_master/authorship.json
@@ -75,7 +75,7 @@
       {
         "lineNumber": 11,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "image::docs/images/MyTeamManagerLogo.png[width\u003d\"100\", align\u003d\"center\"]"
       },
@@ -187,14 +187,14 @@
       {
         "lineNumber": 27,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "My Team Manager (MTM) is a desktop based team managing application for football team managers. +"
       },
       {
         "lineNumber": 28,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "It uses a Command Line Interface (CLI)."
       },
@@ -208,14 +208,14 @@
       {
         "lineNumber": 30,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "MTM is equipped with multiple features in helping you efficiently"
       },
       {
         "lineNumber": 31,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "and effectively manage your players, while keeping track of the team\u0027s schedule. +"
       },
@@ -229,63 +229,63 @@
       {
         "lineNumber": 33,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "With MTM\u0027s aesthetically pleasing graphical user interface, viewing critical information will be quick and painless."
       },
       {
         "lineNumber": 34,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "Never lose track of your training schedule again! +"
       },
       {
         "lineNumber": 35,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 36,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "Say goodbye to manual tracking of information on excel sheet after excel sheet!"
       },
       {
         "lineNumber": 37,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 38,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "\u003d\u003d What MTM Can Do - Key Features"
       },
       {
         "lineNumber": 39,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 40,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "* Set up Teams"
       },
       {
         "lineNumber": 41,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "* Add Players to Teams"
       },
@@ -299,14 +299,14 @@
       {
         "lineNumber": 43,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "* View, Edit and Delete Players"
       },
       {
         "lineNumber": 44,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "* Sort players by field of choice"
       },
@@ -440,8 +440,7 @@
     "authorContributionMap": {
       "lithiumlkid": 5,
       "jordancjq": 16,
-      "codeeong": 16,
-      "-": 25
+      "-": 41
     }
   },
   {
@@ -1117,7 +1116,7 @@
       {
         "lineNumber": 16,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "By: `F14-B1`      Since: `Mar 2018`      Licence: `MIT`"
       },
@@ -4099,7 +4098,7 @@
       {
         "lineNumber": 442,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "\u003d\u003d\u003d Player-Related Enhancements"
       },
@@ -6948,14 +6947,14 @@
       {
         "lineNumber": 849,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "\u003d\u003d\u003d Team-Related Enhancements"
       },
       {
         "lineNumber": 850,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -7039,7 +7038,7 @@
       {
         "lineNumber": 862,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -9608,7 +9607,7 @@
       {
         "lineNumber": 1229,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "\u003d\u003d\u003d User Experience Enhancements"
       },
@@ -10427,7 +10426,7 @@
       {
         "lineNumber": 1346,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "\u003d\u003d\u003d\u003d Team Display Bar `[since v1.3]`"
       },
@@ -10448,91 +10447,91 @@
       {
         "lineNumber": 1349,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "The Team Display Bar is implemented as `TeamDisplay` in the UI Component and renders `TeamDisplay.fxml`."
       },
       {
         "lineNumber": 1350,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "It is called from `MainWindow` and highlights"
       },
       {
         "lineNumber": 1351,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "the current team that has been selected in the Command Line Interface by the user. +"
       },
       {
         "lineNumber": 1352,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 1353,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "It calls the `Team` model and displays the `Player` cards associated with that `Team`."
       },
       {
         "lineNumber": 1354,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "It contains event handler methods such as handleShowNewTeamEvent(), handleHighlightSelectedTeamEvent(),"
       },
       {
         "lineNumber": 1355,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "and handleDeselectTeamEvent(), which update the UI accordingly. +"
       },
       {
         "lineNumber": 1356,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 1357,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "The component interactions can be seen in the high level sequence diagram for `TeamDisplay` below, using the example of a `create` command:"
       },
       {
         "lineNumber": 1358,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 1359,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ".Component interactions for `create Team` command"
       },
       {
         "lineNumber": 1360,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "image::ShowNewTeamDiagram.png[width\u003d\"800\"]"
       },
       {
         "lineNumber": 1361,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -10546,7 +10545,7 @@
       {
         "lineNumber": 1363,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "Code snippet from \u0027TeamDisplay\u0027 to show initialisation of UI component and event handlers:"
       },
@@ -10595,7 +10594,7 @@
       {
         "lineNumber": 1370,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -10616,119 +10615,119 @@
       {
         "lineNumber": 1373,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        //...initialise Teams code..."
       },
       {
         "lineNumber": 1374,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        registerAsAnEventHandler(this);"
       },
       {
         "lineNumber": 1375,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    }"
       },
       {
         "lineNumber": 1376,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 1377,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    @Subscribe"
       },
       {
         "lineNumber": 1378,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    private void handleShowNewTeamEvent(ShowNewTeamNameEvent event) {"
       },
       {
         "lineNumber": 1379,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        //...handleShowNewTeamEvent code..."
       },
       {
         "lineNumber": 1380,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    }"
       },
       {
         "lineNumber": 1381,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 1382,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    @Subscribe"
       },
       {
         "lineNumber": 1383,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    private void handleHighlightSelectedTeamEvent(HighlightSelectedTeamEvent event) {"
       },
       {
         "lineNumber": 1384,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        //...handleHighlightSelectedTeamEvent code..."
       },
       {
         "lineNumber": 1385,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    }"
       },
       {
         "lineNumber": 1386,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 1387,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    @Subscribe"
       },
       {
         "lineNumber": 1388,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    private void handleDeselectTeamEvent(DeselectTeamEvent event) {"
       },
       {
         "lineNumber": 1389,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        //...handleDeselectTeamEvent code..."
       },
@@ -10749,14 +10748,14 @@
       {
         "lineNumber": 1392,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "----"
       },
       {
         "lineNumber": 1393,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -10777,7 +10776,7 @@
       {
         "lineNumber": 1396,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -10833,7 +10832,7 @@
       {
         "lineNumber": 1404,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -10847,7 +10846,7 @@
       {
         "lineNumber": 1406,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "\u003d\u003d\u003d\u003d Player Details Pane `[since v1.4]`"
       },
@@ -10861,84 +10860,84 @@
       {
         "lineNumber": 1408,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 1409,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "The `Player Details` pane is implemented as `PlayerDetails` in the UI Component."
       },
       {
         "lineNumber": 1410,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "It is called from `PlayerListPanel`. It renders `PlayerDetails.fxml` and displays the selected `PersonCard`."
       },
       {
         "lineNumber": 1411,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "It calls the `Person` model and displays the fields in the `Person` model that are not displayed in the left panel."
       },
       {
         "lineNumber": 1412,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "It contains the event handler method handlePersonDetailsChangedEvent(), which updates the UI component when the `edit `"
       },
       {
         "lineNumber": 1413,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "or `remark` commands are entered. +"
       },
       {
         "lineNumber": 1414,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 1415,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "The component interactions can be seen in the high level sequence diagram for `PlayerDetails` below, using the example of a `remark` command:"
       },
       {
         "lineNumber": 1416,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 1417,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ".Component interactions for `remark 1 r/test` command"
       },
       {
         "lineNumber": 1418,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "image::PlayerDetailsDiagram.png[width\u003d\"800\"]"
       },
       {
         "lineNumber": 1419,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -10952,7 +10951,7 @@
       {
         "lineNumber": 1421,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -10980,7 +10979,7 @@
       {
         "lineNumber": 1425,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -11001,7 +11000,7 @@
       {
         "lineNumber": 1428,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -11043,42 +11042,42 @@
       {
         "lineNumber": 1434,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 1435,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    @Subscribe"
       },
       {
         "lineNumber": 1436,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    private void handlePersonDetailsChangedEvent(PersonDetailsChangedEvent event) {"
       },
       {
         "lineNumber": 1437,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        ...handlePersonDetailsChangedEvent code..."
       },
       {
         "lineNumber": 1438,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    }"
       },
       {
         "lineNumber": 1439,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -11099,7 +11098,7 @@
       {
         "lineNumber": 1442,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -11120,7 +11119,7 @@
       {
         "lineNumber": 1445,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -11176,903 +11175,903 @@
       {
         "lineNumber": 1453,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 1454,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "// end::PlayerDetails[]"
       },
       {
         "lineNumber": 1455,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 1456,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "// tag::changeThemeCommand[]"
       },
       {
         "lineNumber": 1457,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "\u003d\u003d\u003d\u003d Change Theme Command `[since v1.5]`"
       },
       {
         "lineNumber": 1458,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "\u003d\u003d\u003d\u003d\u003d Current Implementation"
       },
       {
         "lineNumber": 1459,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 1460,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "The `ChangeThemeCommand` is a new feature that allows user to change the current theme to another theme. A new css class is implemented to accommodate the new theme, LightTheme."
       },
       {
         "lineNumber": 1461,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "The `MainWindow` class is also changed to contain a handleChangeThemeRequestEvent() method which is an event handler to `setAddressBookTheme`,"
       },
       {
         "lineNumber": 1462,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "which is a method in `UserPrefs`. +"
       },
       {
         "lineNumber": 1463,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 1464,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "Below is the sequence diagram for how the `ChangeThemeCommand` works:"
       },
       {
         "lineNumber": 1465,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 1466,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ".Interactions of the Logic Component with the UI and Model Components for the `changeTheme` Command"
       },
       {
         "lineNumber": 1467,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "image::ChangeThemeDiagram.png[width\u003d\"800\"]"
       },
       {
         "lineNumber": 1468,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 1469,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 1470,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "Code snippet from \u0027ChangeThemeCommand\u0027:"
       },
       {
         "lineNumber": 1471,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 1472,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "[source, java]"
       },
       {
         "lineNumber": 1473,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "----"
       },
       {
         "lineNumber": 1474,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "public class ChangeThemeCommand extends Command {"
       },
       {
         "lineNumber": 1475,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 1476,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    public ChangeThemeCommand(String theme) {"
       },
       {
         "lineNumber": 1477,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "            this.theme \u003d theme.trim();"
       },
       {
         "lineNumber": 1478,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    }"
       },
       {
         "lineNumber": 1479,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 1480,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "   @Override"
       },
       {
         "lineNumber": 1481,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    public CommandResult execute() throws CommandException {"
       },
       {
         "lineNumber": 1482,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        //...check for valid theme code..."
       },
       {
         "lineNumber": 1483,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        EventsCenter.getInstance().post(new ChangeThemeEvent(this.theme));"
       },
       {
         "lineNumber": 1484,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        return new CommandResult(String.format(MESSAGE_THEME_SUCCESS, this.theme));"
       },
       {
         "lineNumber": 1485,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    }"
       },
       {
         "lineNumber": 1486,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "}"
       },
       {
         "lineNumber": 1487,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "----"
       },
       {
         "lineNumber": 1488,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 1489,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "\u003d\u003d\u003d\u003d\u003d Design Considerations"
       },
       {
         "lineNumber": 1490,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "\u003d\u003d\u003d\u003d\u003d\u003d Aspect: Command Syntax"
       },
       {
         "lineNumber": 1491,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 1492,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "* **Alternative 1 (current choice):** The command syntax is in the form \"changeTheme Dark\" or \"changeTheme Light\"."
       },
       {
         "lineNumber": 1493,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "** Pros: This supports future implementation of more themes, so that the developer can easily add the new themes without"
       },
       {
         "lineNumber": 1494,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "having to change the execution."
       },
       {
         "lineNumber": 1495,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "** Cons: The command is longer than it could be. (see alternative 2)"
       },
       {
         "lineNumber": 1496,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "* **Alternative 2:** The command syntax in the form \"changeTheme\", which would automatically toggle the theme."
       },
       {
         "lineNumber": 1497,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "** Pros: User does not have to type anything to change the theme, so it might be more user friendly."
       },
       {
         "lineNumber": 1498,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "** Cons: Future implementation of more themes would be harder for the developer as the toggle function would have to be"
       },
       {
         "lineNumber": 1499,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "changed quite drastically to become a command for selecting a theme out of multiple themes."
       },
       {
         "lineNumber": 1500,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 1501,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "\u003d\u003d\u003d\u003d\u003d\u003d Aspect: User Experience"
       },
       {
         "lineNumber": 1502,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 1503,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "* **Alternative 1 (current choice):** `ChangeThemeCommand` is implemented as a CLI command."
       },
       {
         "lineNumber": 1504,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "** Pros: Consistent with the rest of the application, of which all changes are made by the CLI."
       },
       {
         "lineNumber": 1505,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "** Cons: User has yet another command to remember the syntax of."
       },
       {
         "lineNumber": 1506,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "* **Alternative 2:** Change of theme is implemented as a button to change onClick."
       },
       {
         "lineNumber": 1507,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "** Pros: User does not have to type anything to change the theme, so it might be more user friendly."
       },
       {
         "lineNumber": 1508,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "** Cons: Inconsistent with the rest of the application, which is CLI-based."
       },
       {
         "lineNumber": 1509,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "// end::changeThemeCommand[]"
       },
       {
         "lineNumber": 1510,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 1511,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 1512,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "// tag::settagcolour[]"
       },
       {
         "lineNumber": 1513,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "\u003d\u003d\u003d\u003d Set Tag Colour feature `[since v1.1]`"
       },
       {
         "lineNumber": 1514,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "\u003d\u003d\u003d\u003d\u003d Current Implementation"
       },
       {
         "lineNumber": 1515,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 1516,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "The `Set` Command is an entirely new command that allows the user to assign a colour to a specific tag."
       },
       {
         "lineNumber": 1517,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "This mechanism is facilitated by the `SetCommandParser`, which creates and returns a new `SetCommand`."
       },
       {
         "lineNumber": 1518,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "In `SetCommandParser`, which implements the `Parser` interface, it parses the arguments inputted into the CLI, and checks whether the arguments are valid."
       },
       {
         "lineNumber": 1519,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 1520,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "`SetCommandParser` is implemented as such:"
       },
       {
         "lineNumber": 1521,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 1522,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "[source, java]"
       },
       {
         "lineNumber": 1523,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "----"
       },
       {
         "lineNumber": 1524,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "public class SetCommandParser implements Parser\u003cSetCommand\u003e {"
       },
       {
         "lineNumber": 1525,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 1526,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    public SetCommand parse(String args) throws ParseException {"
       },
       {
         "lineNumber": 1527,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 1528,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    // ...parse arguments and check for invalid arguments..."
       },
       {
         "lineNumber": 1529,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "  }"
       },
       {
         "lineNumber": 1530,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "}"
       },
       {
         "lineNumber": 1531,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "----"
       },
       {
         "lineNumber": 1532,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 1533,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "`SetCommand` inherits the abstract `Command` class. After `execute()` is called in `SetCommand`, the tag colour is set through the logic portions of `ModelManager` and `AddressBook`, then"
       },
       {
         "lineNumber": 1534,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "lastly changes `tagColour` attribute within the `Tag` object itself. It also posts an event in `SetCommand`, to which"
       },
       {
         "lineNumber": 1535,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "its handler in `PersonCard` responds and performs the UI update. +"
       },
       {
         "lineNumber": 1536,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 1537,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 1538,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "`SetCommand` is implemented in this way:"
       },
       {
         "lineNumber": 1539,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 1540,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "[source, java]"
       },
       {
         "lineNumber": 1541,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "----"
       },
       {
         "lineNumber": 1542,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "public class SetCommand extends Command {"
       },
       {
         "lineNumber": 1543,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 1544,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    private final Tag tagToSet;"
       },
       {
         "lineNumber": 1545,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    private final String tagColour;"
       },
       {
         "lineNumber": 1546,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 1547,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    public SetCommand(Tag tag, String colour) {"
       },
       {
         "lineNumber": 1548,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        requireNonNull(tag);"
       },
       {
         "lineNumber": 1549,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        tagToSet \u003d tag;"
       },
       {
         "lineNumber": 1550,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        tagColour \u003d colour;"
       },
       {
         "lineNumber": 1551,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    }"
       },
       {
         "lineNumber": 1552,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 1553,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    @Override"
       },
       {
         "lineNumber": 1554,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    public CommandResult execute() {"
       },
       {
         "lineNumber": 1555,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    requireNonNull(model);"
       },
       {
         "lineNumber": 1556,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        boolean isTagValid \u003d model.setTagColour(tagToSet, tagColour);"
       },
       {
         "lineNumber": 1557,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        //...check for valid tagName code...."
       },
       {
         "lineNumber": 1558,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        EventsCenter.getInstance().post(new ChangeTagColourEvent(tagToSet.getTagName(), tagColour));"
       },
       {
         "lineNumber": 1559,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        return new CommandResult(String.format(MESSAGE_SUCCESS, tagToSet.toString(), tagColour));"
       },
       {
         "lineNumber": 1560,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    }"
       },
       {
         "lineNumber": 1561,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "}"
       },
       {
         "lineNumber": 1562,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "----"
       },
       {
         "lineNumber": 1563,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 1564,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "The following sequence diagram shows how the set command operation works:"
       },
       {
         "lineNumber": 1565,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 1566,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ".Interactions of the Logic Component with the UI and Model Components for the `setTagColour` Command"
       },
       {
         "lineNumber": 1567,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "image::SetTagCommandDiagram.png[width\u003d\"800\"]"
       },
       {
         "lineNumber": 1568,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 1569,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "\u003d\u003d\u003d\u003d\u003d Design Considerations"
       },
       {
         "lineNumber": 1570,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "\u003d\u003d\u003d\u003d\u003d\u003d Aspect: Implementation of `Command` vs  `UndoableCommand`"
       },
       {
         "lineNumber": 1571,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 1572,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "* **Alternative 1 (current choice):** Inherit from `Command`."
       },
       {
         "lineNumber": 1573,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "** Pros: Does not involve complicated undo/redo tests, simple and quicker implementation,"
       },
       {
         "lineNumber": 1574,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "lessen chances of mistakes made in implementation."
       },
       {
         "lineNumber": 1575,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "** Cons: User cannot use the `undo/redo` command."
       },
       {
         "lineNumber": 1576,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "* **Alternative 2 :** Inherit from `UndoableCommand`."
       },
       {
         "lineNumber": 1577,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "** Pros: User can utilise the `undo/redo` command."
       },
       {
         "lineNumber": 1578,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "** Cons: Hard for developers to implement extra tests, not very necessary as users can just as easily type"
       },
       {
         "lineNumber": 1579,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "out the colour they would like to change their tag to; it is a short command, especially with the `stc` alias."
       },
       {
         "lineNumber": 1580,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "// end::settagcolour[]"
       },
       {
         "lineNumber": 1581,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -12303,7 +12302,7 @@
       {
         "lineNumber": 1614,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "If you are intending to develop our software further, it is highly recommended that you run tests in the ways listed below."
       },
@@ -12653,14 +12652,14 @@
       {
         "lineNumber": 1664,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "This section covers resources for you to develop this software with good practices and prepare it for release."
       },
       {
         "lineNumber": 1665,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -12898,21 +12897,21 @@
       {
         "lineNumber": 1699,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "This section tells you more details of our software, our target users, the user stories, and gives you a sneak peak into our development process."
       },
       {
         "lineNumber": 1700,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 1701,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "\u003d\u003d\u003d Target user profile:"
       },
@@ -12975,35 +12974,35 @@
       {
         "lineNumber": 1710,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "\u003d\u003d\u003d Value proposition:"
       },
       {
         "lineNumber": 1711,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "Exclusive application for management of footballers and football teams that provides an enhanced listing of footballers and convenient lookup on updated information of players."
       },
       {
         "lineNumber": 1712,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 1713,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "\u003d\u003d\u003d Feature Contribution"
       },
       {
         "lineNumber": 1714,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "* Codee +"
       },
@@ -13031,14 +13030,14 @@
       {
         "lineNumber": 1718,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 1719,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "* Jordan"
       },
@@ -13059,7 +13058,7 @@
       {
         "lineNumber": 1722,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "** Minor"
       },
@@ -13080,14 +13079,14 @@
       {
         "lineNumber": 1725,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 1726,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "* Syafiq"
       },
@@ -13115,49 +13114,49 @@
       {
         "lineNumber": 1730,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "** Minor - Autocomplete command"
       },
       {
         "lineNumber": 1731,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 1732,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "* Tianwei"
       },
       {
         "lineNumber": 1733,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "** Major - privacy"
       },
       {
         "lineNumber": 1734,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "*** Set private field and passwords"
       },
       {
         "lineNumber": 1735,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "*** Make accounts"
       },
       {
         "lineNumber": 1736,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "** Minor - Sorting players by different fields"
       },
@@ -14592,7 +14591,7 @@
       {
         "lineNumber": 1941,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ".  Should work on any mainstream OS as long as it has Java 1.8.0_60 or higher installed."
       },
@@ -14613,63 +14612,63 @@
       {
         "lineNumber": 1944,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ".  Works on both 32-bit and 64-bit machines"
       },
       {
         "lineNumber": 1945,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ".  Should respond within 1 second of query"
       },
       {
         "lineNumber": 1946,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ".  Should be intuitive and easy to use for a first-time user."
       },
       {
         "lineNumber": 1947,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ".  Should be able to handle any sort of input, i.e. should recover from invalid input."
       },
       {
         "lineNumber": 1948,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ".  Should have audience-focused user guides and developer guides."
       },
       {
         "lineNumber": 1949,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ".  Should have command names that concisely describe their function."
       },
       {
         "lineNumber": 1950,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ".  Should be an open-source project."
       },
       {
         "lineNumber": 1951,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ".  Development be cost effective or free."
       },
       {
         "lineNumber": 1952,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ".  App should be able to work offline."
       },
@@ -14683,14 +14682,14 @@
       {
         "lineNumber": 1954,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ".  Current versions must be backward compatible with older versions to support undo."
       },
       {
         "lineNumber": 1955,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ".  The user interface should be simple and minimise distractions so that user can continue with their work in a focused manner."
       },
@@ -14984,7 +14983,7 @@
       {
         "lineNumber": 1997,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "\u003d\u003d\u003d Deleting a player"
       },
@@ -14998,7 +14997,7 @@
       {
         "lineNumber": 1999,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ". Deleting a player while all players are listed"
       },
@@ -15012,7 +15011,7 @@
       {
         "lineNumber": 2001,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ".. Prerequisites: List all players using the `list` command. Multiple players in the list."
       },
@@ -15026,7 +15025,7 @@
       {
         "lineNumber": 2003,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "   Expected: First player is deleted from the list. Details of the deleted player shown in the status message. Timestamp in the status bar is updated."
       },
@@ -15957,126 +15956,126 @@
       {
         "lineNumber": 2136,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 2137,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "\u003d\u003d\u003d Appearance Related Functions"
       },
       {
         "lineNumber": 2138,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 2139,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "\u003d\u003d\u003d\u003d Changing a Theme"
       },
       {
         "lineNumber": 2140,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 2141,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ". Changing the theme that MTM is currently on"
       },
       {
         "lineNumber": 2142,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ".. Test case: `cte Dark` (if current theme is Light) or `cte Light` (if current theme is Dark) +"
       },
       {
         "lineNumber": 2143,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "Expected: MTM colour scheme will change to the respective themes as shown below:"
       },
       {
         "lineNumber": 2144,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 2145,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "image::DarkTheme.png[width\u003d\"300\"]"
       },
       {
         "lineNumber": 2146,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "image::LightTheme.png[width\u003d\"300\"]"
       },
       {
         "lineNumber": 2147,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 2148,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 2149,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "\u003d\u003d\u003d\u003d Setting Tag Colours"
       },
       {
         "lineNumber": 2150,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ". Setting the tags to colour of choice"
       },
       {
         "lineNumber": 2151,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ".. Prerequisites: Player has tags"
       },
       {
         "lineNumber": 2152,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ".. Test case:  `setTagColour t/redCard tc/blue`"
       },
       {
         "lineNumber": 2153,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "Expected: All tags with the name `redCard` would become blue"
       }
@@ -16085,8 +16084,7 @@
       "lithiumlkid": 189,
       "lohtianwei": 210,
       "jordancjq": 947,
-      "codeeong": 253,
-      "-": 554
+      "-": 807
     }
   },
   {
@@ -16319,14 +16317,14 @@
       {
         "lineNumber": 33,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "Your teams, their players, and all the relevant information is organized clearly in My Team Manager. Teams can be created and"
       },
       {
         "lineNumber": 34,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "players can be assigned to teams."
       },
@@ -16424,7 +16422,7 @@
       {
         "lineNumber": 48,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ".  Copy the file to the folder you want to use as the home folder for your MTM."
       },
@@ -17838,7 +17836,7 @@
       {
         "lineNumber": 250,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "If you accidentally call the `undo` command too many times and need a way to quickly reverse that, MTM allows you to redo the most recent `undo` command."
       },
@@ -17943,7 +17941,7 @@
       {
         "lineNumber": 265,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -17957,7 +17955,7 @@
       {
         "lineNumber": 267,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -17978,21 +17976,21 @@
       {
         "lineNumber": 270,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 271,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "[NOTE]"
       },
       {
         "lineNumber": 272,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "\u003d\u003d\u003d\u003d"
       },
@@ -18013,14 +18011,14 @@
       {
         "lineNumber": 275,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "\u003d\u003d\u003d\u003d"
       },
       {
         "lineNumber": 276,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -19112,7 +19110,7 @@
       {
         "lineNumber": 432,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "If you want to remove a player from MTM, you may use this command to delete the player."
       },
@@ -20029,14 +20027,14 @@
       {
         "lineNumber": 563,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "The details panel will display your selected player\u0027s name, phone number, address, email address,"
       },
       {
         "lineNumber": 564,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "jersey number, and remarks on the right side of the screen."
       },
@@ -20064,7 +20062,7 @@
       {
         "lineNumber": 568,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -20148,7 +20146,7 @@
       {
         "lineNumber": 580,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -20204,7 +20202,7 @@
       {
         "lineNumber": 588,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -21499,14 +21497,14 @@
       {
         "lineNumber": 773,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "[NOTE]"
       },
       {
         "lineNumber": 774,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "\u003d\u003d\u003d\u003d"
       },
@@ -21555,98 +21553,98 @@
       {
         "lineNumber": 781,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "\u003d\u003d\u003d\u003d"
       },
       {
         "lineNumber": 782,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 783,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "[IMPORTANT]"
       },
       {
         "lineNumber": 784,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ".*What to expect*"
       },
       {
         "lineNumber": 785,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "\u003d\u003d\u003d\u003d"
       },
       {
         "lineNumber": 786,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "You will see the specified tags in the left panel change to the colour of your choice."
       },
       {
         "lineNumber": 787,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "\u003d\u003d\u003d\u003d"
       },
       {
         "lineNumber": 788,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 789,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "Here is a valid example on how you can use the `setTagColour` command:"
       },
       {
         "lineNumber": 790,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 791,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "* `stc t/redCard t/red`"
       },
       {
         "lineNumber": 792,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 793,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "All the tags that say \"redCard\" in the left panel will now turn red."
       },
       {
         "lineNumber": 794,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -21660,7 +21658,7 @@
       {
         "lineNumber": 796,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -21688,14 +21686,14 @@
       {
         "lineNumber": 800,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "If you feel that the dark theme is not for you, and you prefer to work on a brighter interface,"
       },
       {
         "lineNumber": 801,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "you can change the theme from the default Dark Theme to Light Theme with the \u0027changeTheme\u0027 command."
       },
@@ -21723,7 +21721,7 @@
       {
         "lineNumber": 805,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "Alias: `cte`"
       },
@@ -21793,42 +21791,42 @@
       {
         "lineNumber": 815,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 816,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "Here is a valid example on how you can use the `changeTheme` command:"
       },
       {
         "lineNumber": 817,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 818,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "* `cte Light`"
       },
       {
         "lineNumber": 819,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 820,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "You will see the whole interface change from a dark-coloured theme to become light-coloured."
       },
@@ -22297,7 +22295,7 @@
       {
         "lineNumber": 887,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "You can easily determine the up and coming match with the team so that you never miss an important date."
       },
@@ -22374,7 +22372,7 @@
       {
         "lineNumber": 898,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "Here are a few valid examples on how you can use the `nextmatch` command:"
       },
@@ -22430,7 +22428,7 @@
       {
         "lineNumber": 906,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "// tag::showlineup[]"
       },
@@ -22444,21 +22442,21 @@
       {
         "lineNumber": 908,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 909,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "You can view the lineup for the current best 11 players."
       },
       {
         "lineNumber": 910,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -22472,70 +22470,70 @@
       {
         "lineNumber": 912,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "Alias: `sl`"
       },
       {
         "lineNumber": 913,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 914,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "[IMPORTANT]"
       },
       {
         "lineNumber": 915,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ".*What to expect*"
       },
       {
         "lineNumber": 916,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "\u003d\u003d\u003d\u003d"
       },
       {
         "lineNumber": 917,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "The panel on the right will show the avatars of the 11 players that will be playing for the next match."
       },
       {
         "lineNumber": 918,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "\u003d\u003d\u003d\u003d"
       },
       {
         "lineNumber": 919,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 920,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "Here is an valid example on how you can use the `showLineup` command:"
       },
       {
         "lineNumber": 921,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -22556,21 +22554,21 @@
       {
         "lineNumber": 924,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "Displays the 11 main players that will be playing for the next match."
       },
       {
         "lineNumber": 925,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "// end::showlineup[]"
       },
       {
         "lineNumber": 926,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -23004,7 +23002,7 @@
       {
         "lineNumber": 988,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -23039,7 +23037,7 @@
       {
         "lineNumber": 993,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -23888,8 +23886,7 @@
       "lithiumlkid": 106,
       "lohtianwei": 26,
       "jordancjq": 833,
-      "codeeong": 64,
-      "-": 84
+      "-": 148
     }
   },
   {
@@ -24326,518 +24323,6 @@
     "authorContributionMap": {
       "lithiumlkid": 60,
       "jordancjq": 1
-    }
-  },
-  {
-    "path": "docs/team/codeeong.adoc",
-    "lines": [
-      {
-        "lineNumber": 1,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "\u003d Codee Ong - Project Portfolio"
-      },
-      {
-        "lineNumber": 2,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ":imagesDir: ../images"
-      },
-      {
-        "lineNumber": 3,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ":stylesDir: ../stylesheets"
-      },
-      {
-        "lineNumber": 4,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 5,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "\u003d\u003d PROJECT: My Team Manager (MTM)"
-      },
-      {
-        "lineNumber": 6,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 7,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "---"
-      },
-      {
-        "lineNumber": 8,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 9,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "\u003d\u003d Overview"
-      },
-      {
-        "lineNumber": 10,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 11,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "My Team Manager (MTM) is a desktop application for *football team managers* to organise the information of players they are in charge of."
-      },
-      {
-        "lineNumber": 12,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "The primary usage of this application is to add and assign players to teams, and then edit and remove information related to"
-      },
-      {
-        "lineNumber": 13,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "the players as and when it is required. MTM is value added with usability features that help the team manager manage his/her"
-      },
-      {
-        "lineNumber": 14,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "teams and players efficiently."
-      },
-      {
-        "lineNumber": 15,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "The user interacts with MTM using a *Command Line Interface*, and it has a GUI created with JavaFX."
-      },
-      {
-        "lineNumber": 16,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 17,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 18,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "\u003d\u003d Summary of contributions"
-      },
-      {
-        "lineNumber": 19,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 20,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "* *Major enhancement*: Revamped the original user interface to one that suits the usage of an application for *team managers*."
-      },
-      {
-        "lineNumber": 21,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "** What it does: The change in  UI allows the user to *keep track* of which team he/she is looking at, to *view his/her players\u0027 details*,"
-      },
-      {
-        "lineNumber": 22,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "and even perform some *customisation* of the application theme."
-      },
-      {
-        "lineNumber": 23,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "** Justification: The overhaul of the UI is absolutely necessary to ensure the *best user experience* for users of My Team Manager. Previously,"
-      },
-      {
-        "lineNumber": 24,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "the existing UI components were neither sufficient nor suitable for management of sports teams."
-      },
-      {
-        "lineNumber": 25,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "** Highlights: Addition of the *team display bar*, the *player details pane* when a player is selected, addition of *MTM logo*,"
-      },
-      {
-        "lineNumber": 26,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "and *changeTheme* command."
-      },
-      {
-        "lineNumber": 27,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 28,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "* *Minor enhancement*: addition of a *setTagCommand* that allows the user to change existing tags to a colour of their choice."
-      },
-      {
-        "lineNumber": 29,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 30,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "* *Code contributed*: [https://github.com/CS2103JAN2018-F14-B1/main/blob/master/collated/functional/Codee.md[Functional code]] [https://github.com/CS2103JAN2018-F14-B1/main/blob/master/collated/test/Codee.md[Test code]]"
-      },
-      {
-        "lineNumber": 31,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 32,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "* *Other contributions*:"
-      },
-      {
-        "lineNumber": 33,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 34,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "** Project management:"
-      },
-      {
-        "lineNumber": 35,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "*** Generated release files (.jar) in `v1.4` and `v1.5rc` (2 releases), and contributed release descriptions on GitHub."
-      },
-      {
-        "lineNumber": 36,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "** Enhancements to existing features:"
-      },
-      {
-        "lineNumber": 37,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "*** changed the original GUI colour scheme [https://github.com/CS2103JAN2018-F14-B1/main/pull/89[PR #89]]"
-      },
-      {
-        "lineNumber": 38,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 39,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "** Documentation:"
-      },
-      {
-        "lineNumber": 40,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "*** changed the project name in all the relevant files so that it will be \"My Team Manager\" and not \"Address Book App\", including the data files. [https://github.com/CS2103JAN2018-F14-B1/main/pull/120[PR #120]]"
-      },
-      {
-        "lineNumber": 41,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "*** Constantly updated the README and UserGuide\u0027s application preview image. [https://github.com/CS2103JAN2018-F14-B1/main/pull/99[PR #99]][https://github.com/CS2103JAN2018-F14-B1/main/pull/160[PR #160]]"
-      },
-      {
-        "lineNumber": 42,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 43,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "** Community:"
-      },
-      {
-        "lineNumber": 44,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "*** PRs Reviewed (with non trivial comments) [https://github.com/CS2103JAN2018-F14-B1/main/pull/95[PR #95]][https://github.com/CS2103JAN2018-F14-B1/main/pull/169[PR #169]][https://github.com/CS2103JAN2018-F14-B1/main/pull/175[PR #175]]"
-      },
-      {
-        "lineNumber": 45,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 46,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "\u003d\u003d Contributions to the User Guide"
-      },
-      {
-        "lineNumber": 47,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 48,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "|\u003d\u003d\u003d"
-      },
-      {
-        "lineNumber": 49,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "|_Given below are sections I contributed to the User Guide. They showcase my ability to write documentation targeting the users of MTM._"
-      },
-      {
-        "lineNumber": 50,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "|\u003d\u003d\u003d"
-      },
-      {
-        "lineNumber": 51,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 52,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "include::../UserGuide.adoc[tag\u003dchangeTheme]"
-      },
-      {
-        "lineNumber": 53,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 54,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "include::../UserGuide.adoc[tag\u003dsetTagColour]"
-      },
-      {
-        "lineNumber": 55,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 56,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "include::../UserGuide.adoc[tag\u003dshowlineup]"
-      },
-      {
-        "lineNumber": 57,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 58,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 59,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "\u003d\u003d Contributions to the Developer Guide"
-      },
-      {
-        "lineNumber": 60,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "|\u003d\u003d\u003d"
-      },
-      {
-        "lineNumber": 61,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "|_Given below are sections I contributed to the Developer Guide. They showcase my ability to write technical documentation and the technical depth of my contributions to the project._"
-      },
-      {
-        "lineNumber": 62,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "|\u003d\u003d\u003d"
-      },
-      {
-        "lineNumber": 63,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 64,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "include::../DeveloperGuide.adoc[tag\u003dsettagcolour]"
-      },
-      {
-        "lineNumber": 65,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 66,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "include::../DeveloperGuide.adoc[tag\u003dteamDisplay]"
-      },
-      {
-        "lineNumber": 67,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 68,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "include::../DeveloperGuide.adoc[tag\u003dPlayerDetails]"
-      },
-      {
-        "lineNumber": 69,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 70,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "include::../DeveloperGuide.adoc[tag\u003dchangeThemeCommand]"
-      },
-      {
-        "lineNumber": 71,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 72,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ""
-      }
-    ],
-    "authorContributionMap": {
-      "codeeong": 72
     }
   },
   {
@@ -25838,2012 +25323,6 @@
     }
   },
   {
-    "path": "src/main/java/seedu/address/MainApp.java",
-    "lines": [
-      {
-        "lineNumber": 1,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "package seedu.address;"
-      },
-      {
-        "lineNumber": 2,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 3,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import java.io.IOException;"
-      },
-      {
-        "lineNumber": 4,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import java.util.Map;"
-      },
-      {
-        "lineNumber": 5,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import java.util.Optional;"
-      },
-      {
-        "lineNumber": 6,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import java.util.logging.Logger;"
-      },
-      {
-        "lineNumber": 7,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 8,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import com.google.common.eventbus.Subscribe;"
-      },
-      {
-        "lineNumber": 9,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 10,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import javafx.application.Application;"
-      },
-      {
-        "lineNumber": 11,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import javafx.application.Platform;"
-      },
-      {
-        "lineNumber": 12,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import javafx.stage.Stage;"
-      },
-      {
-        "lineNumber": 13,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.commons.core.Config;"
-      },
-      {
-        "lineNumber": 14,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.commons.core.EventsCenter;"
-      },
-      {
-        "lineNumber": 15,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.commons.core.LogsCenter;"
-      },
-      {
-        "lineNumber": 16,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.commons.core.Version;"
-      },
-      {
-        "lineNumber": 17,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.commons.events.ui.ExitAppRequestEvent;"
-      },
-      {
-        "lineNumber": 18,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.commons.exceptions.DataConversionException;"
-      },
-      {
-        "lineNumber": 19,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.commons.util.ConfigUtil;"
-      },
-      {
-        "lineNumber": 20,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.commons.util.StringUtil;"
-      },
-      {
-        "lineNumber": 21,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.logic.Logic;"
-      },
-      {
-        "lineNumber": 22,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.logic.LogicManager;"
-      },
-      {
-        "lineNumber": 23,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.model.AddressBook;"
-      },
-      {
-        "lineNumber": 24,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.model.Model;"
-      },
-      {
-        "lineNumber": 25,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.model.ModelManager;"
-      },
-      {
-        "lineNumber": 26,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.model.ReadOnlyAddressBook;"
-      },
-      {
-        "lineNumber": 27,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.model.UserPrefs;"
-      },
-      {
-        "lineNumber": 28,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.model.util.SampleDataUtil;"
-      },
-      {
-        "lineNumber": 29,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.storage.AddressBookStorage;"
-      },
-      {
-        "lineNumber": 30,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.storage.JsonUserPrefsStorage;"
-      },
-      {
-        "lineNumber": 31,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.storage.Storage;"
-      },
-      {
-        "lineNumber": 32,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.storage.StorageManager;"
-      },
-      {
-        "lineNumber": 33,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.storage.UserPrefsStorage;"
-      },
-      {
-        "lineNumber": 34,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.storage.XmlAddressBookStorage;"
-      },
-      {
-        "lineNumber": 35,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.ui.Ui;"
-      },
-      {
-        "lineNumber": 36,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.ui.UiManager;"
-      },
-      {
-        "lineNumber": 37,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 38,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "/**"
-      },
-      {
-        "lineNumber": 39,
-        "author": {
-          "gitId": "-"
-        },
-        "content": " * The main entry point to the application."
-      },
-      {
-        "lineNumber": 40,
-        "author": {
-          "gitId": "-"
-        },
-        "content": " */"
-      },
-      {
-        "lineNumber": 41,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "public class MainApp extends Application {"
-      },
-      {
-        "lineNumber": 42,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 43,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    public static final Version VERSION \u003d new Version(1, 1, 0, true);"
-      },
-      {
-        "lineNumber": 44,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 45,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    private static final Logger logger \u003d LogsCenter.getLogger(MainApp.class);"
-      },
-      {
-        "lineNumber": 46,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 47,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    protected Ui ui;"
-      },
-      {
-        "lineNumber": 48,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    protected Logic logic;"
-      },
-      {
-        "lineNumber": 49,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    protected Storage storage;"
-      },
-      {
-        "lineNumber": 50,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    protected Model model;"
-      },
-      {
-        "lineNumber": 51,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    protected Config config;"
-      },
-      {
-        "lineNumber": 52,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    protected UserPrefs userPrefs;"
-      },
-      {
-        "lineNumber": 53,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 54,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 55,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    @Override"
-      },
-      {
-        "lineNumber": 56,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public void init() throws Exception {"
-      },
-      {
-        "lineNumber": 57,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        logger.info(\"\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d[ Initializing AddressBook ]\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\");"
-      },
-      {
-        "lineNumber": 58,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        super.init();"
-      },
-      {
-        "lineNumber": 59,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 60,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        config \u003d initConfig(getApplicationParameter(\"config\"));"
-      },
-      {
-        "lineNumber": 61,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 62,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        UserPrefsStorage userPrefsStorage \u003d new JsonUserPrefsStorage(config.getUserPrefsFilePath());"
-      },
-      {
-        "lineNumber": 63,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        userPrefs \u003d initPrefs(userPrefsStorage);"
-      },
-      {
-        "lineNumber": 64,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        AddressBookStorage addressBookStorage \u003d new XmlAddressBookStorage(userPrefs.getAddressBookFilePath());"
-      },
-      {
-        "lineNumber": 65,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        storage \u003d new StorageManager(addressBookStorage, userPrefsStorage);"
-      },
-      {
-        "lineNumber": 66,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 67,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        initLogging(config);"
-      },
-      {
-        "lineNumber": 68,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 69,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        model \u003d initModelManager(storage, userPrefs);"
-      },
-      {
-        "lineNumber": 70,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 71,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        logic \u003d new LogicManager(model);"
-      },
-      {
-        "lineNumber": 72,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 73,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        ui \u003d new UiManager(logic, config, userPrefs);"
-      },
-      {
-        "lineNumber": 74,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 75,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        initEventsCenter();"
-      },
-      {
-        "lineNumber": 76,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 77,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 78,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    private String getApplicationParameter(String parameterName) {"
-      },
-      {
-        "lineNumber": 79,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        Map\u003cString, String\u003e applicationParameters \u003d getParameters().getNamed();"
-      },
-      {
-        "lineNumber": 80,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        return applicationParameters.get(parameterName);"
-      },
-      {
-        "lineNumber": 81,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 82,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 83,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    /**"
-      },
-      {
-        "lineNumber": 84,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     * Returns a {@code ModelManager} with the data from {@code storage}\u0027s address book and {@code userPrefs}. \u003cbr\u003e"
-      },
-      {
-        "lineNumber": 85,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     * The data from the sample address book will be used instead if {@code storage}\u0027s address book is not found,"
-      },
-      {
-        "lineNumber": 86,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     * or an empty address book will be used instead if errors occur when reading {@code storage}\u0027s address book."
-      },
-      {
-        "lineNumber": 87,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     */"
-      },
-      {
-        "lineNumber": 88,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    private Model initModelManager(Storage storage, UserPrefs userPrefs) {"
-      },
-      {
-        "lineNumber": 89,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        Optional\u003cReadOnlyAddressBook\u003e addressBookOptional;"
-      },
-      {
-        "lineNumber": 90,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        ReadOnlyAddressBook initialData;"
-      },
-      {
-        "lineNumber": 91,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        try {"
-      },
-      {
-        "lineNumber": 92,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "            addressBookOptional \u003d storage.readAddressBook();"
-      },
-      {
-        "lineNumber": 93,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "            if (!addressBookOptional.isPresent()) {"
-      },
-      {
-        "lineNumber": 94,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "                logger.info(\"Data file not found. Will be starting with a sample AddressBook\");"
-      },
-      {
-        "lineNumber": 95,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "            }"
-      },
-      {
-        "lineNumber": 96,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "            initialData \u003d addressBookOptional.orElseGet(SampleDataUtil::getSampleAddressBook);"
-      },
-      {
-        "lineNumber": 97,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        } catch (DataConversionException e) {"
-      },
-      {
-        "lineNumber": 98,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "            logger.warning(\"Data file not in the correct format. Will be starting with an empty AddressBook\");"
-      },
-      {
-        "lineNumber": 99,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "            initialData \u003d new AddressBook();"
-      },
-      {
-        "lineNumber": 100,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        } catch (IOException e) {"
-      },
-      {
-        "lineNumber": 101,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "            logger.warning(\"Problem while reading from the file. Will be starting with an empty AddressBook\");"
-      },
-      {
-        "lineNumber": 102,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "            initialData \u003d new AddressBook();"
-      },
-      {
-        "lineNumber": 103,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        }"
-      },
-      {
-        "lineNumber": 104,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 105,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        return new ModelManager(initialData, userPrefs);"
-      },
-      {
-        "lineNumber": 106,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 107,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 108,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    private void initLogging(Config config) {"
-      },
-      {
-        "lineNumber": 109,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        LogsCenter.init(config);"
-      },
-      {
-        "lineNumber": 110,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 111,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 112,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    /**"
-      },
-      {
-        "lineNumber": 113,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     * Returns a {@code Config} using the file at {@code configFilePath}. \u003cbr\u003e"
-      },
-      {
-        "lineNumber": 114,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     * The default file path {@code Config#DEFAULT_CONFIG_FILE} will be used instead"
-      },
-      {
-        "lineNumber": 115,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     * if {@code configFilePath} is null."
-      },
-      {
-        "lineNumber": 116,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     */"
-      },
-      {
-        "lineNumber": 117,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    protected Config initConfig(String configFilePath) {"
-      },
-      {
-        "lineNumber": 118,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        Config initializedConfig;"
-      },
-      {
-        "lineNumber": 119,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        String configFilePathUsed;"
-      },
-      {
-        "lineNumber": 120,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 121,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        configFilePathUsed \u003d Config.DEFAULT_CONFIG_FILE;"
-      },
-      {
-        "lineNumber": 122,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 123,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        if (configFilePath !\u003d null) {"
-      },
-      {
-        "lineNumber": 124,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "            logger.info(\"Custom Config file specified \" + configFilePath);"
-      },
-      {
-        "lineNumber": 125,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "            configFilePathUsed \u003d configFilePath;"
-      },
-      {
-        "lineNumber": 126,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        }"
-      },
-      {
-        "lineNumber": 127,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 128,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        logger.info(\"Using config file : \" + configFilePathUsed);"
-      },
-      {
-        "lineNumber": 129,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 130,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        try {"
-      },
-      {
-        "lineNumber": 131,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "            Optional\u003cConfig\u003e configOptional \u003d ConfigUtil.readConfig(configFilePathUsed);"
-      },
-      {
-        "lineNumber": 132,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "            initializedConfig \u003d configOptional.orElse(new Config());"
-      },
-      {
-        "lineNumber": 133,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        } catch (DataConversionException e) {"
-      },
-      {
-        "lineNumber": 134,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "            logger.warning(\"Config file at \" + configFilePathUsed + \" is not in the correct format. \""
-      },
-      {
-        "lineNumber": 135,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "                    + \"Using default config properties\");"
-      },
-      {
-        "lineNumber": 136,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "            initializedConfig \u003d new Config();"
-      },
-      {
-        "lineNumber": 137,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        }"
-      },
-      {
-        "lineNumber": 138,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 139,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        //Update config file in case it was missing to begin with or there are new/unused fields"
-      },
-      {
-        "lineNumber": 140,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        try {"
-      },
-      {
-        "lineNumber": 141,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "            ConfigUtil.saveConfig(initializedConfig, configFilePathUsed);"
-      },
-      {
-        "lineNumber": 142,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        } catch (IOException e) {"
-      },
-      {
-        "lineNumber": 143,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "            logger.warning(\"Failed to save config file : \" + StringUtil.getDetails(e));"
-      },
-      {
-        "lineNumber": 144,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        }"
-      },
-      {
-        "lineNumber": 145,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        return initializedConfig;"
-      },
-      {
-        "lineNumber": 146,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 147,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 148,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    /**"
-      },
-      {
-        "lineNumber": 149,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     * Returns a {@code UserPrefs} using the file at {@code storage}\u0027s user prefs file path,"
-      },
-      {
-        "lineNumber": 150,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     * or a new {@code UserPrefs} with default configuration if errors occur when"
-      },
-      {
-        "lineNumber": 151,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     * reading from the file."
-      },
-      {
-        "lineNumber": 152,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     */"
-      },
-      {
-        "lineNumber": 153,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    protected UserPrefs initPrefs(UserPrefsStorage storage) {"
-      },
-      {
-        "lineNumber": 154,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        String prefsFilePath \u003d storage.getUserPrefsFilePath();"
-      },
-      {
-        "lineNumber": 155,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        logger.info(\"Using prefs file : \" + prefsFilePath);"
-      },
-      {
-        "lineNumber": 156,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 157,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        UserPrefs initializedPrefs;"
-      },
-      {
-        "lineNumber": 158,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        try {"
-      },
-      {
-        "lineNumber": 159,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "            Optional\u003cUserPrefs\u003e prefsOptional \u003d storage.readUserPrefs();"
-      },
-      {
-        "lineNumber": 160,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "            initializedPrefs \u003d prefsOptional.orElse(new UserPrefs());"
-      },
-      {
-        "lineNumber": 161,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        } catch (DataConversionException e) {"
-      },
-      {
-        "lineNumber": 162,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "            logger.warning(\"UserPrefs file at \" + prefsFilePath + \" is not in the correct format. \""
-      },
-      {
-        "lineNumber": 163,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "                    + \"Using default user prefs\");"
-      },
-      {
-        "lineNumber": 164,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "            initializedPrefs \u003d new UserPrefs();"
-      },
-      {
-        "lineNumber": 165,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        } catch (IOException e) {"
-      },
-      {
-        "lineNumber": 166,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "            logger.warning(\"Problem while reading from the file. Will be starting with an empty AddressBook\");"
-      },
-      {
-        "lineNumber": 167,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "            initializedPrefs \u003d new UserPrefs();"
-      },
-      {
-        "lineNumber": 168,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        }"
-      },
-      {
-        "lineNumber": 169,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 170,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        //Update prefs file in case it was missing to begin with or there are new/unused fields"
-      },
-      {
-        "lineNumber": 171,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        try {"
-      },
-      {
-        "lineNumber": 172,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "            storage.saveUserPrefs(initializedPrefs);"
-      },
-      {
-        "lineNumber": 173,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        } catch (IOException e) {"
-      },
-      {
-        "lineNumber": 174,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "            logger.warning(\"Failed to save config file : \" + StringUtil.getDetails(e));"
-      },
-      {
-        "lineNumber": 175,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        }"
-      },
-      {
-        "lineNumber": 176,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 177,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        return initializedPrefs;"
-      },
-      {
-        "lineNumber": 178,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 179,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 180,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    private void initEventsCenter() {"
-      },
-      {
-        "lineNumber": 181,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        EventsCenter.getInstance().registerHandler(this);"
-      },
-      {
-        "lineNumber": 182,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 183,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 184,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    @Override"
-      },
-      {
-        "lineNumber": 185,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public void start(Stage primaryStage) {"
-      },
-      {
-        "lineNumber": 186,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        logger.info(\"Starting AddressBook \" + MainApp.VERSION);"
-      },
-      {
-        "lineNumber": 187,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        ui.start(primaryStage);"
-      },
-      {
-        "lineNumber": 188,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 189,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 190,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    @Override"
-      },
-      {
-        "lineNumber": 191,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public void stop() {"
-      },
-      {
-        "lineNumber": 192,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        logger.info(\"\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d [ Stopping Address Book ] \u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\");"
-      },
-      {
-        "lineNumber": 193,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        ui.stop();"
-      },
-      {
-        "lineNumber": 194,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        try {"
-      },
-      {
-        "lineNumber": 195,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "            storage.saveUserPrefs(userPrefs);"
-      },
-      {
-        "lineNumber": 196,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        } catch (IOException e) {"
-      },
-      {
-        "lineNumber": 197,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "            logger.severe(\"Failed to save preferences \" + StringUtil.getDetails(e));"
-      },
-      {
-        "lineNumber": 198,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        }"
-      },
-      {
-        "lineNumber": 199,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        Platform.exit();"
-      },
-      {
-        "lineNumber": 200,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        System.exit(0);"
-      },
-      {
-        "lineNumber": 201,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 202,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 203,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    @Subscribe"
-      },
-      {
-        "lineNumber": 204,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public void handleExitAppRequestEvent(ExitAppRequestEvent event) {"
-      },
-      {
-        "lineNumber": 205,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        logger.info(LogsCenter.getEventHandlingLogMessage(event));"
-      },
-      {
-        "lineNumber": 206,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        this.stop();"
-      },
-      {
-        "lineNumber": 207,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 208,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 209,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public static void main(String[] args) {"
-      },
-      {
-        "lineNumber": 210,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        launch(args);"
-      },
-      {
-        "lineNumber": 211,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 212,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "}"
-      }
-    ],
-    "authorContributionMap": {
-      "codeeong": 1,
-      "-": 211
-    }
-  },
-  {
-    "path": "src/main/java/seedu/address/commons/core/Config.java",
-    "lines": [
-      {
-        "lineNumber": 1,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "package seedu.address.commons.core;"
-      },
-      {
-        "lineNumber": 2,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 3,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import java.util.Objects;"
-      },
-      {
-        "lineNumber": 4,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import java.util.logging.Level;"
-      },
-      {
-        "lineNumber": 5,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 6,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "/**"
-      },
-      {
-        "lineNumber": 7,
-        "author": {
-          "gitId": "-"
-        },
-        "content": " * Config values used by the app"
-      },
-      {
-        "lineNumber": 8,
-        "author": {
-          "gitId": "-"
-        },
-        "content": " */"
-      },
-      {
-        "lineNumber": 9,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "public class Config {"
-      },
-      {
-        "lineNumber": 10,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 11,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public static final String DEFAULT_CONFIG_FILE \u003d \"config.json\";"
-      },
-      {
-        "lineNumber": 12,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 13,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    // Config values customizable through config file"
-      },
-      {
-        "lineNumber": 14,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    private String appTitle \u003d \"My Team Manager\";"
-      },
-      {
-        "lineNumber": 15,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    private Level logLevel \u003d Level.INFO;"
-      },
-      {
-        "lineNumber": 16,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    private String userPrefsFilePath \u003d \"preferences.json\";"
-      },
-      {
-        "lineNumber": 17,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 18,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public String getAppTitle() {"
-      },
-      {
-        "lineNumber": 19,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        return appTitle;"
-      },
-      {
-        "lineNumber": 20,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 21,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 22,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public void setAppTitle(String appTitle) {"
-      },
-      {
-        "lineNumber": 23,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        this.appTitle \u003d appTitle;"
-      },
-      {
-        "lineNumber": 24,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 25,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 26,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public Level getLogLevel() {"
-      },
-      {
-        "lineNumber": 27,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        return logLevel;"
-      },
-      {
-        "lineNumber": 28,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 29,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 30,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public void setLogLevel(Level logLevel) {"
-      },
-      {
-        "lineNumber": 31,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        this.logLevel \u003d logLevel;"
-      },
-      {
-        "lineNumber": 32,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 33,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 34,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public String getUserPrefsFilePath() {"
-      },
-      {
-        "lineNumber": 35,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        return userPrefsFilePath;"
-      },
-      {
-        "lineNumber": 36,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 37,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 38,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public void setUserPrefsFilePath(String userPrefsFilePath) {"
-      },
-      {
-        "lineNumber": 39,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        this.userPrefsFilePath \u003d userPrefsFilePath;"
-      },
-      {
-        "lineNumber": 40,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 41,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 42,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    @Override"
-      },
-      {
-        "lineNumber": 43,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public boolean equals(Object other) {"
-      },
-      {
-        "lineNumber": 44,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        if (other \u003d\u003d this) {"
-      },
-      {
-        "lineNumber": 45,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "            return true;"
-      },
-      {
-        "lineNumber": 46,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        }"
-      },
-      {
-        "lineNumber": 47,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        if (!(other instanceof Config)) { //this handles null as well."
-      },
-      {
-        "lineNumber": 48,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "            return false;"
-      },
-      {
-        "lineNumber": 49,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        }"
-      },
-      {
-        "lineNumber": 50,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 51,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        Config o \u003d (Config) other;"
-      },
-      {
-        "lineNumber": 52,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 53,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        return Objects.equals(appTitle, o.appTitle)"
-      },
-      {
-        "lineNumber": 54,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "                \u0026\u0026 Objects.equals(logLevel, o.logLevel)"
-      },
-      {
-        "lineNumber": 55,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "                \u0026\u0026 Objects.equals(userPrefsFilePath, o.userPrefsFilePath);"
-      },
-      {
-        "lineNumber": 56,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 57,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 58,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    @Override"
-      },
-      {
-        "lineNumber": 59,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public int hashCode() {"
-      },
-      {
-        "lineNumber": 60,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        return Objects.hash(appTitle, logLevel, userPrefsFilePath);"
-      },
-      {
-        "lineNumber": 61,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 62,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 63,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    @Override"
-      },
-      {
-        "lineNumber": 64,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public String toString() {"
-      },
-      {
-        "lineNumber": 65,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        StringBuilder sb \u003d new StringBuilder();"
-      },
-      {
-        "lineNumber": 66,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        sb.append(\"App title : \" + appTitle);"
-      },
-      {
-        "lineNumber": 67,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        sb.append(\"\\nCurrent log level : \" + logLevel);"
-      },
-      {
-        "lineNumber": 68,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        sb.append(\"\\nPreference file Location : \" + userPrefsFilePath);"
-      },
-      {
-        "lineNumber": 69,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        return sb.toString();"
-      },
-      {
-        "lineNumber": 70,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 71,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 72,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "}"
-      }
-    ],
-    "authorContributionMap": {
-      "codeeong": 1,
-      "-": 71
-    }
-  },
-  {
     "path": "src/main/java/seedu/address/commons/core/Messages.java",
     "lines": [
       {
@@ -27919,7 +25398,7 @@
       {
         "lineNumber": 11,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    public static final String MESSAGE_INVALID_THEME \u003d \"This theme does not exist!\\n\";"
       },
@@ -27960,9 +25439,8 @@
       }
     ],
     "authorContributionMap": {
-      "codeeong": 1,
       "jordancjq": 2,
-      "-": 13
+      "-": 14
     }
   },
   {
@@ -28127,49 +25605,49 @@
       {
         "lineNumber": 1,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "package seedu.address.commons.events.ui;"
       },
       {
         "lineNumber": 2,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 3,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import seedu.address.commons.events.BaseEvent;"
       },
       {
         "lineNumber": 4,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 5,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "/**"
       },
       {
         "lineNumber": 6,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": " * Indicates a request to change tag colour"
       },
       {
         "lineNumber": 7,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": " */"
       },
@@ -28287,7 +25765,8 @@
       }
     ],
     "authorContributionMap": {
-      "codeeong": 23
+      "codeeong": 16,
+      "-": 7
     }
   },
   {
@@ -28296,28 +25775,28 @@
       {
         "lineNumber": 1,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "package seedu.address.commons.events.ui;"
       },
       {
         "lineNumber": 2,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 3,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import seedu.address.commons.events.BaseEvent;"
       },
       {
         "lineNumber": 4,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -28442,7 +25921,8 @@
       }
     ],
     "authorContributionMap": {
-      "codeeong": 21
+      "codeeong": 17,
+      "-": 4
     }
   },
   {
@@ -28451,49 +25931,49 @@
       {
         "lineNumber": 1,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "package seedu.address.commons.events.ui;"
       },
       {
         "lineNumber": 2,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 3,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import seedu.address.commons.events.BaseEvent;"
       },
       {
         "lineNumber": 4,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 5,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "/**"
       },
       {
         "lineNumber": 6,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": " * Event handler for clearing of all teams."
       },
       {
         "lineNumber": 7,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": " */"
       },
@@ -28590,134 +26070,8 @@
       }
     ],
     "authorContributionMap": {
-      "codeeong": 20
-    }
-  },
-  {
-    "path": "src/main/java/seedu/address/commons/events/ui/DeselectTeamEvent.java",
-    "lines": [
-      {
-        "lineNumber": 1,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "package seedu.address.commons.events.ui;"
-      },
-      {
-        "lineNumber": 2,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 3,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "import seedu.address.commons.events.BaseEvent;"
-      },
-      {
-        "lineNumber": 4,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 5,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "/**"
-      },
-      {
-        "lineNumber": 6,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": " * Indicates a request to deselected selected teams."
-      },
-      {
-        "lineNumber": 7,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": " */"
-      },
-      {
-        "lineNumber": 8,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "public class DeselectTeamEvent extends BaseEvent {"
-      },
-      {
-        "lineNumber": 9,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 10,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    public DeselectTeamEvent() {"
-      },
-      {
-        "lineNumber": 11,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 12,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 13,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    @Override"
-      },
-      {
-        "lineNumber": 14,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    public String toString() {"
-      },
-      {
-        "lineNumber": 15,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        return this.getClass().getSimpleName();"
-      },
-      {
-        "lineNumber": 16,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 17,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "}"
-      }
-    ],
-    "authorContributionMap": {
-      "codeeong": 17
+      "codeeong": 13,
+      "-": 7
     }
   },
   {
@@ -28726,49 +26080,49 @@
       {
         "lineNumber": 1,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "package seedu.address.commons.events.ui;"
       },
       {
         "lineNumber": 2,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 3,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import seedu.address.commons.events.BaseEvent;"
       },
       {
         "lineNumber": 4,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 5,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "/**"
       },
       {
         "lineNumber": 6,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": " * Indicates a request to highlight selected team name."
       },
       {
         "lineNumber": 7,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": " */"
       },
@@ -28872,7 +26226,8 @@
       }
     ],
     "authorContributionMap": {
-      "codeeong": 21
+      "codeeong": 14,
+      "-": 7
     }
   },
   {
@@ -28881,63 +26236,63 @@
       {
         "lineNumber": 1,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "package seedu.address.commons.events.ui;"
       },
       {
         "lineNumber": 2,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 3,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import seedu.address.commons.core.index.Index;"
       },
       {
         "lineNumber": 4,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import seedu.address.commons.events.BaseEvent;"
       },
       {
         "lineNumber": 5,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import seedu.address.model.person.Person;"
       },
       {
         "lineNumber": 6,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 7,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "/**"
       },
       {
         "lineNumber": 8,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": " * Represents a change in the person details panel."
       },
       {
         "lineNumber": 9,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": " *"
       },
@@ -29118,7 +26473,8 @@
       }
     ],
     "authorContributionMap": {
-      "codeeong": 34
+      "codeeong": 25,
+      "-": 9
     }
   },
   {
@@ -29127,49 +26483,49 @@
       {
         "lineNumber": 1,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "package seedu.address.commons.events.ui;"
       },
       {
         "lineNumber": 2,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 3,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import seedu.address.commons.events.BaseEvent;"
       },
       {
         "lineNumber": 4,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 5,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "/**"
       },
       {
         "lineNumber": 6,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": " * Represents a change in the person details panel, but no paramaters."
       },
       {
         "lineNumber": 7,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": " *"
       },
@@ -29245,7 +26601,8 @@
       }
     ],
     "authorContributionMap": {
-      "codeeong": 17
+      "codeeong": 10,
+      "-": 7
     }
   },
   {
@@ -29416,49 +26773,49 @@
       {
         "lineNumber": 1,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "package seedu.address.commons.events.ui;"
       },
       {
         "lineNumber": 2,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 3,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import seedu.address.commons.events.BaseEvent;"
       },
       {
         "lineNumber": 4,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 5,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "/**"
       },
       {
         "lineNumber": 6,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": " * Indicates a request to show new team name."
       },
       {
         "lineNumber": 7,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": " */"
       },
@@ -29569,7 +26926,8 @@
       }
     ],
     "authorContributionMap": {
-      "codeeong": 22
+      "codeeong": 15,
+      "-": 7
     }
   },
   {
@@ -29578,49 +26936,49 @@
       {
         "lineNumber": 1,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "package seedu.address.commons.events.ui;"
       },
       {
         "lineNumber": 2,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 3,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import seedu.address.commons.events.BaseEvent;"
       },
       {
         "lineNumber": 4,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 5,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "/**"
       },
       {
         "lineNumber": 6,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": " * Event handler for undoing clearing of all teams."
       },
       {
         "lineNumber": 7,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": " */"
       },
@@ -29703,7 +27061,8 @@
       }
     ],
     "authorContributionMap": {
-      "codeeong": 18
+      "codeeong": 11,
+      "-": 7
     }
   },
   {
@@ -29768,7 +27127,7 @@
       {
         "lineNumber": 9,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import seedu.address.model.team.Team;"
       },
@@ -29894,21 +27253,21 @@
       {
         "lineNumber": 27,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    /** Returns an unmodifiable view of list of teams */"
       },
       {
         "lineNumber": 28,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    ObservableList\u003cTeam\u003e getInitTeamList();"
       },
       {
         "lineNumber": 29,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -29964,8 +27323,7 @@
     ],
     "authorContributionMap": {
       "lithiumlkid": 5,
-      "codeeong": 4,
-      "-": 27
+      "-": 31
     }
   },
   {
@@ -30079,7 +27437,7 @@
       {
         "lineNumber": 16,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import seedu.address.model.team.Team;"
       },
@@ -30366,35 +27724,35 @@
       {
         "lineNumber": 57,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    @Override"
       },
       {
         "lineNumber": 58,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    public ObservableList\u003cTeam\u003e getInitTeamList() {"
       },
       {
         "lineNumber": 59,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        return model.getInitTeamList();"
       },
       {
         "lineNumber": 60,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    }"
       },
       {
         "lineNumber": 61,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -30472,8 +27830,7 @@
     "authorContributionMap": {
       "lithiumlkid": 8,
       "lohtianwei": 1,
-      "codeeong": 6,
-      "-": 56
+      "-": 62
     }
   },
   {
@@ -32376,77 +29733,77 @@
       {
         "lineNumber": 1,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "package seedu.address.logic.commands;"
       },
       {
         "lineNumber": 2,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 3,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import seedu.address.commons.core.EventsCenter;"
       },
       {
         "lineNumber": 4,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import seedu.address.commons.core.Messages;"
       },
       {
         "lineNumber": 5,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import seedu.address.commons.events.ui.ChangeThemeEvent;"
       },
       {
         "lineNumber": 6,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import seedu.address.logic.commands.exceptions.CommandException;"
       },
       {
         "lineNumber": 7,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import seedu.address.ui.MainWindow;"
       },
       {
         "lineNumber": 8,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 9,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "/**"
       },
       {
         "lineNumber": 10,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": " * Changes the theme of the Address Book."
       },
       {
         "lineNumber": 11,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": " */"
       },
@@ -32753,7 +30110,8 @@
       }
     ],
     "authorContributionMap": {
-      "codeeong": 54
+      "codeeong": 43,
+      "-": 11
     }
   },
   {
@@ -32790,14 +30148,14 @@
       {
         "lineNumber": 5,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import seedu.address.commons.core.EventsCenter;"
       },
       {
         "lineNumber": 6,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import seedu.address.commons.events.ui.ClearTeamsEvent;"
       },
@@ -32958,8 +30316,8 @@
     ],
     "authorContributionMap": {
       "lohtianwei": 1,
-      "codeeong": 5,
-      "-": 22
+      "codeeong": 3,
+      "-": 24
     }
   },
   {
@@ -34334,14 +31692,14 @@
       {
         "lineNumber": 5,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import seedu.address.commons.core.EventsCenter;"
       },
       {
         "lineNumber": 6,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import seedu.address.commons.events.ui.ShowNewTeamNameEvent;"
       },
@@ -34726,7 +32084,7 @@
     ],
     "authorContributionMap": {
       "jordancjq": 58,
-      "codeeong": 2
+      "-": 2
     }
   },
   {
@@ -35424,7 +32782,7 @@
       {
         "lineNumber": 28,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import seedu.address.commons.events.ui.PersonDetailsChangedEvent;"
       },
@@ -37596,8 +34954,8 @@
       "lithiumlkid": 141,
       "lohtianwei": 9,
       "jordancjq": 7,
-      "codeeong": 4,
-      "-": 176
+      "codeeong": 3,
+      "-": 177
     }
   },
   {
@@ -38725,21 +36083,21 @@
       {
         "lineNumber": 5,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import seedu.address.commons.core.EventsCenter;"
       },
       {
         "lineNumber": 6,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import seedu.address.commons.events.ui.DeselectTeamEvent;"
       },
       {
         "lineNumber": 7,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -38844,7 +36202,7 @@
       {
         "lineNumber": 22,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        EventsCenter.getInstance().post(new DeselectTeamEvent());"
       },
@@ -38872,8 +36230,7 @@
     ],
     "authorContributionMap": {
       "lohtianwei": 1,
-      "codeeong": 4,
-      "-": 20
+      "-": 24
     }
   },
   {
@@ -38910,21 +36267,21 @@
       {
         "lineNumber": 5,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import seedu.address.commons.core.EventsCenter;"
       },
       {
         "lineNumber": 6,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import seedu.address.commons.events.ui.PersonDetailsChangedNoParamEvent;"
       },
       {
         "lineNumber": 7,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import seedu.address.commons.events.ui.UndoTeamsEvent;"
       },
@@ -39190,8 +36547,8 @@
     ],
     "authorContributionMap": {
       "lohtianwei": 1,
-      "codeeong": 7,
-      "-": 36
+      "codeeong": 4,
+      "-": 39
     }
   },
   {
@@ -39249,7 +36606,7 @@
       {
         "lineNumber": 8,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import seedu.address.commons.core.EventsCenter;"
       },
@@ -39270,7 +36627,7 @@
       {
         "lineNumber": 11,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import seedu.address.commons.events.ui.PersonDetailsChangedEvent;"
       },
@@ -39977,7 +37334,7 @@
     ],
     "authorContributionMap": {
       "jordancjq": 109,
-      "codeeong": 2
+      "-": 2
     }
   },
   {
@@ -41503,91 +38860,91 @@
       {
         "lineNumber": 1,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "package seedu.address.logic.commands;"
       },
       {
         "lineNumber": 2,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 3,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import static java.util.Objects.requireNonNull;"
       },
       {
         "lineNumber": 4,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;"
       },
       {
         "lineNumber": 5,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG_COLOUR;"
       },
       {
         "lineNumber": 6,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 7,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import seedu.address.commons.core.EventsCenter;"
       },
       {
         "lineNumber": 8,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import seedu.address.commons.events.ui.ChangeTagColourEvent;"
       },
       {
         "lineNumber": 9,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import seedu.address.model.tag.Tag;"
       },
       {
         "lineNumber": 10,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 11,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "/**"
       },
       {
         "lineNumber": 12,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": " * Adds a colour to a tag in address book."
       },
       {
         "lineNumber": 13,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": " */"
       },
@@ -41985,7 +39342,8 @@
       }
     ],
     "authorContributionMap": {
-      "codeeong": 69
+      "codeeong": 56,
+      "-": 13
     }
   },
   {
@@ -45574,21 +42932,21 @@
       {
         "lineNumber": 5,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import seedu.address.commons.core.EventsCenter;"
       },
       {
         "lineNumber": 6,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import seedu.address.commons.events.ui.PersonDetailsChangedNoParamEvent;"
       },
       {
         "lineNumber": 7,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import seedu.address.commons.events.ui.UndoTeamsEvent;"
       },
@@ -45854,8 +43212,8 @@
     ],
     "authorContributionMap": {
       "lohtianwei": 1,
-      "codeeong": 7,
-      "-": 36
+      "codeeong": 4,
+      "-": 39
     }
   },
   {
@@ -45892,7 +43250,7 @@
       {
         "lineNumber": 5,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import seedu.address.commons.core.EventsCenter;"
       },
@@ -45906,7 +43264,7 @@
       {
         "lineNumber": 7,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import seedu.address.commons.events.ui.HighlightSelectedTeamEvent;"
       },
@@ -46235,7 +43593,7 @@
     ],
     "authorContributionMap": {
       "jordancjq": 51,
-      "codeeong": 2
+      "-": 2
     }
   },
   {
@@ -46968,7 +44326,7 @@
       {
         "lineNumber": 11,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import seedu.address.logic.commands.ChangeThemeCommand;"
       },
@@ -47087,7 +44445,7 @@
       {
         "lineNumber": 28,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import seedu.address.logic.commands.SetCommand;"
       },
@@ -47780,28 +45138,28 @@
       {
         "lineNumber": 127,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        case SetCommand.COMMAND_WORD:"
       },
       {
         "lineNumber": 128,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        case SetCommand.COMMAND_ALIAS:"
       },
       {
         "lineNumber": 129,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "            return new SetCommandParser().parse(arguments);"
       },
       {
         "lineNumber": 130,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -48180,8 +45538,7 @@
     "authorContributionMap": {
       "lohtianwei": 87,
       "jordancjq": 26,
-      "codeeong": 6,
-      "-": 64
+      "-": 70
     }
   },
   {
@@ -48541,77 +45898,77 @@
       {
         "lineNumber": 1,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "package seedu.address.logic.parser;"
       },
       {
         "lineNumber": 2,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 3,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;"
       },
       {
         "lineNumber": 4,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import static seedu.address.logic.commands.ChangeThemeCommand.MESSAGE_USAGE;"
       },
       {
         "lineNumber": 5,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 6,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import seedu.address.logic.commands.ChangeThemeCommand;"
       },
       {
         "lineNumber": 7,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import seedu.address.logic.parser.exceptions.ParseException;"
       },
       {
         "lineNumber": 8,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 9,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "/**"
       },
       {
         "lineNumber": 10,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": " * Parses input arguments and creates a new ThemeCommand object."
       },
       {
         "lineNumber": 11,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": " */"
       },
@@ -48722,7 +46079,8 @@
       }
     ],
     "authorContributionMap": {
-      "codeeong": 26
+      "codeeong": 15,
+      "-": 11
     }
   },
   {
@@ -48829,7 +46187,7 @@
       {
         "lineNumber": 15,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    public static final Prefix PREFIX_TAG_COLOUR \u003d new Prefix(\"tc/\");"
       },
@@ -48894,8 +46252,7 @@
       "lithiumlkid": 3,
       "lohtianwei": 1,
       "jordancjq": 4,
-      "codeeong": 1,
-      "-": 14
+      "-": 15
     }
   },
   {
@@ -51750,91 +49107,91 @@
       {
         "lineNumber": 239,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "     * Parses a {@code String tagColour} into a {@code String ta}."
       },
       {
         "lineNumber": 240,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "     * Leading and trailing whitespaces will be trimmed."
       },
       {
         "lineNumber": 241,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "     *"
       },
       {
         "lineNumber": 242,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "     * @throws IllegalValueException if the given {@code tag} is invalid."
       },
       {
         "lineNumber": 243,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "     */"
       },
       {
         "lineNumber": 244,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    public static String parseTagColour(String tagColour) throws IllegalValueException {"
       },
       {
         "lineNumber": 245,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        requireNonNull(tagColour);"
       },
       {
         "lineNumber": 246,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        String trimmedTagColour \u003d tagColour.trim();"
       },
       {
         "lineNumber": 247,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        if (!trimmedTagColour.getClass().equals(String.class) ||  (trimmedTagColour.contains(\" \"))) {"
       },
       {
         "lineNumber": 248,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "            throw new IllegalValueException(Tag.MESSAGE_TAG_COLOUR_CONSTRAINTS);"
       },
       {
         "lineNumber": 249,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        }"
       },
       {
         "lineNumber": 250,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        return trimmedTagColour;"
       },
       {
         "lineNumber": 251,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    }"
       },
@@ -52542,8 +49899,7 @@
     "authorContributionMap": {
       "lithiumlkid": 103,
       "jordancjq": 67,
-      "codeeong": 13,
-      "-": 168
+      "-": 181
     }
   },
   {
@@ -53444,112 +50800,112 @@
       {
         "lineNumber": 1,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "package seedu.address.logic.parser;"
       },
       {
         "lineNumber": 2,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 3,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;"
       },
       {
         "lineNumber": 4,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;"
       },
       {
         "lineNumber": 5,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG_COLOUR;"
       },
       {
         "lineNumber": 6,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 7,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import java.util.stream.Stream;"
       },
       {
         "lineNumber": 8,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 9,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import seedu.address.commons.exceptions.IllegalValueException;"
       },
       {
         "lineNumber": 10,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import seedu.address.logic.commands.SetCommand;"
       },
       {
         "lineNumber": 11,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import seedu.address.logic.parser.exceptions.ParseException;"
       },
       {
         "lineNumber": 12,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import seedu.address.model.tag.Tag;"
       },
       {
         "lineNumber": 13,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 14,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "/**"
       },
       {
         "lineNumber": 15,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": " * This class is to check whether Set Command was input correctly"
       },
       {
         "lineNumber": 16,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": " */"
       },
@@ -53835,7 +51191,8 @@
       }
     ],
     "authorContributionMap": {
-      "codeeong": 56
+      "codeeong": 40,
+      "-": 16
     }
   },
   {
@@ -56269,28 +53626,28 @@
       {
         "lineNumber": 186,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    /**"
       },
       {
         "lineNumber": 187,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "     *"
       },
       {
         "lineNumber": 188,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "     * Sets the colour of {@code tag}."
       },
       {
         "lineNumber": 189,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "     */"
       },
@@ -58133,8 +55490,8 @@
       "lithiumlkid": 4,
       "lohtianwei": 7,
       "jordancjq": 240,
-      "codeeong": 14,
-      "-": 186
+      "codeeong": 10,
+      "-": 190
     }
   },
   {
@@ -58808,35 +56165,35 @@
       {
         "lineNumber": 96,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    /** sets the given {@code tag} to color. */"
       },
       {
         "lineNumber": 97,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    boolean setTagColour(Tag tag, String colour);"
       },
       {
         "lineNumber": 98,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 99,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    /** Returns an unmodifiable view of the team list */"
       },
       {
         "lineNumber": 100,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    ObservableList\u003cTeam\u003e getInitTeamList();"
       },
@@ -58851,8 +56208,7 @@
     "authorContributionMap": {
       "lohtianwei": 18,
       "jordancjq": 30,
-      "codeeong": 5,
-      "-": 48
+      "-": 53
     }
   },
   {
@@ -59680,7 +57036,7 @@
       {
         "lineNumber": 118,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    @Override"
       },
@@ -59701,7 +57057,7 @@
       {
         "lineNumber": 121,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        indicateAddressBookChanged();"
       },
@@ -60100,35 +57456,35 @@
       {
         "lineNumber": 178,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    @Override"
       },
       {
         "lineNumber": 179,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    public ObservableList\u003cTeam\u003e getInitTeamList() {"
       },
       {
         "lineNumber": 180,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        return addressBook.getTeamList();"
       },
       {
         "lineNumber": 181,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    }"
       },
       {
         "lineNumber": 182,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -60486,8 +57842,8 @@
     "authorContributionMap": {
       "lohtianwei": 28,
       "jordancjq": 60,
-      "codeeong": 27,
-      "-": 117
+      "codeeong": 20,
+      "-": 124
     }
   },
   {
@@ -60820,28 +58176,28 @@
       {
         "lineNumber": 16,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 17,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    private String addressBookFilePath \u003d \"data/myteammanager.xml\";"
       },
       {
         "lineNumber": 18,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    private String addressBookName \u003d \"MyTeamManager\";"
       },
       {
         "lineNumber": 19,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    private String addressBookTheme \u003d \"DarkTheme.css\";"
       },
@@ -61254,35 +58610,35 @@
       {
         "lineNumber": 78,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 79,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    public void setAddressBookTheme(String addressBookTheme) {"
       },
       {
         "lineNumber": 80,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        this.addressBookTheme \u003d addressBookTheme;"
       },
       {
         "lineNumber": 81,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    }"
       },
       {
         "lineNumber": 82,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -61534,8 +58890,8 @@
     ],
     "authorContributionMap": {
       "lohtianwei": 28,
-      "codeeong": 18,
-      "-": 71
+      "codeeong": 9,
+      "-": 80
     }
   },
   {
@@ -68929,21 +66285,21 @@
       {
         "lineNumber": 12,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    public static final String MESSAGE_TAG_CONSTRAINTS \u003d \"Tags names should be a string\";"
       },
       {
         "lineNumber": 13,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    public static final String MESSAGE_TAG_COLOUR_CONSTRAINTS \u003d \"Tag colours should be one of these colours:\""
       },
       {
         "lineNumber": 14,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        + \"teal, red, yellow, blue, orange, brown, green, pink, black, grey\";"
       },
@@ -68957,14 +66313,14 @@
       {
         "lineNumber": 16,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    private static final String[] TAG_COLOR_STYLES \u003d"
       },
       {
         "lineNumber": 17,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        { \"teal\", \"red\", \"yellow\", \"blue\", \"orange\", \"brown\", \"green\", \"pink\", \"black\", \"grey\" };"
       },
@@ -68985,7 +66341,7 @@
       {
         "lineNumber": 20,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    private String tagColour;"
       },
@@ -69062,189 +66418,189 @@
       {
         "lineNumber": 31,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        this.tagColour \u003d \"teal\";"
       },
       {
         "lineNumber": 32,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    }"
       },
       {
         "lineNumber": 33,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 34,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    /**"
       },
       {
         "lineNumber": 35,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "     * Overloaded constructor for a {@code Tag}."
       },
       {
         "lineNumber": 36,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "     *"
       },
       {
         "lineNumber": 37,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "     * @param tagName A valid tag name"
       },
       {
         "lineNumber": 38,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "     * @param tagColour A valid tag colour."
       },
       {
         "lineNumber": 39,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "     */"
       },
       {
         "lineNumber": 40,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    public Tag(String tagName, String tagColour) {"
       },
       {
         "lineNumber": 41,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        requireNonNull(tagName);"
       },
       {
         "lineNumber": 42,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        checkArgument(isValidTagName(tagName), MESSAGE_TAG_CONSTRAINTS);"
       },
       {
         "lineNumber": 43,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        this.tagName \u003d tagName;"
       },
       {
         "lineNumber": 44,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        this.tagColour \u003d tagColour;"
       },
       {
         "lineNumber": 45,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    }"
       },
       {
         "lineNumber": 46,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 47,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    public String getTagName() {"
       },
       {
         "lineNumber": 48,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        return this.tagName;"
       },
       {
         "lineNumber": 49,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    }"
       },
       {
         "lineNumber": 50,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 51,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    /**"
       },
       {
         "lineNumber": 52,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "     * Returns true if a given string is a valid tag name."
       },
       {
         "lineNumber": 53,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "     */"
       },
       {
         "lineNumber": 54,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    public static boolean isValidTagName(String test) {"
       },
       {
         "lineNumber": 55,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        return test.matches(TAG_VALIDATION_REGEX);"
       },
       {
         "lineNumber": 56,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    }"
       },
       {
         "lineNumber": 57,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -69426,7 +66782,7 @@
       {
         "lineNumber": 83,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -69572,8 +66928,8 @@
       }
     ],
     "authorContributionMap": {
-      "codeeong": 59,
-      "-": 44
+      "codeeong": 25,
+      "-": 78
     }
   },
   {
@@ -72037,7 +69393,7 @@
       {
         "lineNumber": 20,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import seedu.address.model.team.Team;"
       },
@@ -72051,7 +69407,7 @@
       {
         "lineNumber": 22,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import seedu.address.model.team.exceptions.DuplicateTeamException;"
       },
@@ -72114,21 +69470,21 @@
       {
         "lineNumber": 31,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "            new Person(new Name(\"Aaron Ramsey\"), new Phone(\"87438807\"), new Email(\"aramsey@example.com\"),"
       },
       {
         "lineNumber": 32,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "                new Address(\"Blk 30 Geylang Street 29, #06-40\"), new Remark(\"Sign him for one more year\"),"
       },
       {
         "lineNumber": 33,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "                new TeamName(\"Arsenal\"),"
       },
@@ -72149,21 +69505,21 @@
       {
         "lineNumber": 36,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "            new Person(new Name(\"Hector Moruno\"), new Phone(\"99272758\"), new Email(\"hectorm@example.com\"),"
       },
       {
         "lineNumber": 37,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "                new Address(\"Blk 30 Lorong 3 Serangoon Gardens, #07-18\"), new Remark(\"\"), new TeamName(\"Arsenal\"),"
       },
       {
         "lineNumber": 38,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "                getTagSet(\"fastRunner\", \"goodAttitude\"), new Rating(\"1\"), new Position(\"1\"), new JerseyNumber(\"2\"),"
       },
@@ -72177,14 +69533,14 @@
       {
         "lineNumber": 40,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "            new Person(new Name(\"Cesc Fabregas\"), new Phone(\"93210283\"), new Email(\"cescfabregas@example.com\"),"
       },
       {
         "lineNumber": 41,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "                new Address(\"Blk 11 Ang Mo Kio Street 74, #11-04\"), new Remark(\"\"), new TeamName(\"Chelsea\"),"
       },
@@ -72205,308 +69561,308 @@
       {
         "lineNumber": 44,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "            new Person(new Name(\"Roy Balakrishnan\"), new Phone(\"92624417\"), new Email(\"royb@example.com\"),"
       },
       {
         "lineNumber": 45,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "                    new Address(\"Blk 45 Aljunied Street 85, #11-31\"), new Remark(\"\"), new TeamName(\"Chelsea\"),"
       },
       {
         "lineNumber": 46,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "                    getTagSet(\"yellowCard\"), new Rating(\"0\"), new Position(\"1\"), new JerseyNumber(\"2\"),"
       },
       {
         "lineNumber": 47,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "                    new Avatar(\"\u003cUNSPECIFIED\u003e\")),"
       },
       {
         "lineNumber": 48,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "            new Person(new Name(\"Ospina\"), new Phone(\"99272758\"), new Email(\"Ospina@arsenal.com\"),"
       },
       {
         "lineNumber": 49,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "                    new Address(\"70 Jurong Central Circle\"), new Remark(\"\"), new TeamName(\"Arsenal\"),"
       },
       {
         "lineNumber": 50,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "                    getTagSet(\"fastRunner\", \"goodAttitude\"), new Rating(\"1\"), new Position(\"1\"), new JerseyNumber(\"22\"),"
       },
       {
         "lineNumber": 51,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "                    new Avatar(\"\u003cUNSPECIFIED\u003e\")),"
       },
       {
         "lineNumber": 52,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "            new Person(new Name(\"Cech\"), new Phone(\"93210283\"), new Email(\"cech@arsenal.com\"),"
       },
       {
         "lineNumber": 53,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "                    new Address(\"Blk 11 Ang Mo Kio Street 74, #11-04\"), new Remark(\"\"), new TeamName(\"Chelsea\"),"
       },
       {
         "lineNumber": 54,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "                    getTagSet(\"yellowCard\"), new Rating(\"4\"), new Position(\"1\"), new JerseyNumber(\"2\"),"
       },
       {
         "lineNumber": 55,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "                    new Avatar(\"\u003cUNSPECIFIED\u003e\")),"
       },
       {
         "lineNumber": 56,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "            new Person(new Name(\"Mertesacker\"), new Phone(\"95432223\"), new Email(\"mertesacker@arsenal.com\"),"
       },
       {
         "lineNumber": 57,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "                    new Address(\"Blk 430 Pasir Ris Street 33, #12-26\"), new Remark(\"\"),"
       },
       {
         "lineNumber": 58,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "                    new TeamName(\"Arsenal\"), getTagSet(\"injured\"),"
       },
       {
         "lineNumber": 59,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "                    new Rating(\"0\"), new Position(\"1\"), new JerseyNumber(\"23\"),"
       },
       {
         "lineNumber": 60,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "                    new Avatar(\"\u003cUNSPECIFIED\u003e\")),"
       },
       {
         "lineNumber": 61,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "            new Person(new Name(\"Koscielny\"), new Phone(\"92352021\"), new Email(\"koscielny@example.com\"),"
       },
       {
         "lineNumber": 62,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "                    new Address(\"Blk 47 Tampines Street 20, #17-35\"), new Remark(\"\"), new TeamName(\"Arsenal\"),"
       },
       {
         "lineNumber": 63,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "                    getTagSet(\"badAttitude\"),"
       },
       {
         "lineNumber": 64,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "                    new Rating(\"0\"), new Position(\"1\"), new JerseyNumber(\"2\"),"
       },
       {
         "lineNumber": 65,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "                    new Avatar(\"\u003cUNSPECIFIED\u003e\")),"
       },
       {
         "lineNumber": 66,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "            new Person(new Name(\"Holding\"), new Phone(\"92624417\"), new Email(\"holding@example.com\"),"
       },
       {
         "lineNumber": 67,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "                    new Address(\"Blk 45 Aljunied Street 85, #11-31\"), new Remark(\"\"), new TeamName(\"Arsenal\"),"
       },
       {
         "lineNumber": 68,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "                    getTagSet(\"fastRunner\"), new Rating(\"0\"), new Position(\"1\"), new JerseyNumber(\"7\"),"
       },
       {
         "lineNumber": 69,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "                    new Avatar(\"\u003cUNSPECIFIED\u003e\")),"
       },
       {
         "lineNumber": 70,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "            new Person(new Name(\"Monreal\"), new Phone(\"99272758\"), new Email(\"monreal@arsenal.com\"),"
       },
       {
         "lineNumber": 71,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "                    new Address(\"Blk 30 Lorong 3 Serangoon Gardens, #07-18\"), new Remark(\"\"), new TeamName(\"Arsenal\"),"
       },
       {
         "lineNumber": 72,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "                    getTagSet(\"fastRunner\", \"goodAttitude\"), new Rating(\"1\"), new Position(\"1\"), new JerseyNumber(\"2\"),"
       },
       {
         "lineNumber": 73,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "                    new Avatar(\"\u003cUNSPECIFIED\u003e\")),"
       },
       {
         "lineNumber": 74,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "            new Person(new Name(\"Mustafi\"), new Phone(\"93215483\"), new Email(\"mustafi@arsenal.com\"),"
       },
       {
         "lineNumber": 75,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "                    new Address(\"Blk 11 Ang Mo Kio Street 74, #11-04\"), new Remark(\"\"), new TeamName(\"Arsenal\"),"
       },
       {
         "lineNumber": 76,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "                    getTagSet(\"yellowCard\"), new Rating(\"4\"), new Position(\"1\"), new JerseyNumber(\"4\"),"
       },
       {
         "lineNumber": 77,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "                    new Avatar(\"\u003cUNSPECIFIED\u003e\")),"
       },
       {
         "lineNumber": 78,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "            new Person(new Name(\"Chambers\"), new Phone(\"91031282\"), new Email(\"chambers@arsenal.com\"),"
       },
       {
         "lineNumber": 79,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "                    new Address(\"Blk 436 Serangoon Gardens Street 26, #16-43\"), new Remark(\"\"),"
       },
       {
         "lineNumber": 80,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "                    new TeamName(\"Arsenal\"), getTagSet(\"injured\"),"
       },
       {
         "lineNumber": 81,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "                    new Rating(\"0\"), new Position(\"1\"), new JerseyNumber(\"2\"),"
       },
       {
         "lineNumber": 82,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "                    new Avatar(\"\u003cUNSPECIFIED\u003e\")),"
       },
       {
         "lineNumber": 83,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "            new Person(new Name(\"Chambers\"), new Phone(\"92492021\"), new Email(\"chambers@arsenal.com\"),"
       },
       {
         "lineNumber": 84,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "                    new Address(\"Blk 47 Tampines Street 20, #17-35\"), new Remark(\"\"), new TeamName(\"Arsenal\"),"
       },
       {
         "lineNumber": 85,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "                    getTagSet(\"badAttitude\"),"
       },
       {
         "lineNumber": 86,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "                    new Rating(\"0\"), new Position(\"1\"), new JerseyNumber(\"2\"),"
       },
       {
         "lineNumber": 87,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "                    new Avatar(\"\u003cUNSPECIFIED\u003e\")),"
       },
@@ -72548,21 +69904,21 @@
       {
         "lineNumber": 93,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "            new Person(new Name(\"Irfan Fandi\"), new Phone(\"92492021\"), new Email(\"irfan@example.com\"),"
       },
       {
         "lineNumber": 94,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "                new Address(\"Blk 47 Tampines Street 20, #17-35\"), new Remark(\"\"), new TeamName(\"Chelsea\"),"
       },
       {
         "lineNumber": 95,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "                getTagSet(\"badAttitude\"),"
       },
@@ -72583,189 +69939,189 @@
       {
         "lineNumber": 98,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "            new Person(new Name(\"Mavropanos\"), new Phone(\"92624417\"), new Email(\"mavropanos@arsenal.com\"),"
       },
       {
         "lineNumber": 99,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "                    new Address(\"Blk 45 Aljunied Street 85, #11-31\"), new Remark(\"\"), new TeamName(\"Chelsea\"),"
       },
       {
         "lineNumber": 100,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "                    getTagSet(\"yellowCard\"), new Rating(\"0\"), new Position(\"1\"), new JerseyNumber(\"98\"),"
       },
       {
         "lineNumber": 101,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "                    new Avatar(\"\u003cUNSPECIFIED\u003e\")),"
       },
       {
         "lineNumber": 102,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "            new Person(new Name(\"Kolasinac\"), new Phone(\"99272758\"), new Email(\"kolasinac@arsenal.com\"),"
       },
       {
         "lineNumber": 103,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "                    new Address(\"70 Jurong Central Circle\"), new Remark(\"\"), new TeamName(\"Arsenal\"),"
       },
       {
         "lineNumber": 104,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "                    getTagSet(\"fastRunner\", \"goodAttitude\"), new Rating(\"1\"), new Position(\"2\"), new JerseyNumber(\"52\"),"
       },
       {
         "lineNumber": 105,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "                    new Avatar(\"\u003cUNSPECIFIED\u003e\")),"
       },
       {
         "lineNumber": 106,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "            new Person(new Name(\"Mkhitaryan\"), new Phone(\"93210283\"), new Email(\"mkhitaryan@arsenal.com\"),"
       },
       {
         "lineNumber": 107,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "                    new Address(\"Blk 11 Ang Mo Kio Street 74, #11-04\"), new Remark(\"\"), new TeamName(\"Arsenal\"),"
       },
       {
         "lineNumber": 108,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "                    getTagSet(\"yellowCard\"), new Rating(\"4\"), new Position(\"1\"), new JerseyNumber(\"2\"),"
       },
       {
         "lineNumber": 109,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "                    new Avatar(\"\u003cUNSPECIFIED\u003e\")),"
       },
       {
         "lineNumber": 110,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "            new Person(new Name(\"Wilshere\"), new Phone(\"95432223\"), new Email(\"wilshere@arsenal.com\"),"
       },
       {
         "lineNumber": 111,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "                    new Address(\"Blk 430 Pasir Ris Street 33, #12-26\"), new Remark(\"\"),"
       },
       {
         "lineNumber": 112,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "                    new TeamName(\"Arsenal\"), getTagSet(\"injured\"),"
       },
       {
         "lineNumber": 113,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "                    new Rating(\"0\"), new Position(\"1\"), new JerseyNumber(\"23\"),"
       },
       {
         "lineNumber": 114,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "                    new Avatar(\"\u003cUNSPECIFIED\u003e\")),"
       },
       {
         "lineNumber": 115,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "            new Person(new Name(\"Ozil\"), new Phone(\"92352021\"), new Email(\"ozil@example.com\"),"
       },
       {
         "lineNumber": 116,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "                    new Address(\"Blk 47 Tampines Street 20, #17-35\"), new Remark(\"\"), new TeamName(\"Arsenal\"),"
       },
       {
         "lineNumber": 117,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "                    getTagSet(\"badAttitude\"),"
       },
       {
         "lineNumber": 118,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "                    new Rating(\"0\"), new Position(\"1\"), new JerseyNumber(\"2\"),"
       },
       {
         "lineNumber": 119,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "                    new Avatar(\"\u003cUNSPECIFIED\u003e\")),"
       },
       {
         "lineNumber": 120,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "            new Person(new Name(\"Xhaka\"), new Phone(\"92624417\"), new Email(\"xhaka@example.com\"),"
       },
       {
         "lineNumber": 121,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "                    new Address(\"Blk 45 Aljunied Street 85, #11-31\"), new Remark(\"\"), new TeamName(\"Arsenal\"),"
       },
       {
         "lineNumber": 122,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "                    getTagSet(\"fastRunner\"), new Rating(\"0\"), new Position(\"1\"), new JerseyNumber(\"7\"),"
       },
       {
         "lineNumber": 123,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "                    new Avatar(\"\u003cUNSPECIFIED\u003e\")),"
       },
       {
         "lineNumber": 124,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -72961,14 +70317,14 @@
       {
         "lineNumber": 152,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        } catch (DuplicateTeamException e) {"
       },
       {
         "lineNumber": 153,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "            throw new AssertionError(\" sample data cannot contain duplicate teams\", e);"
       },
@@ -73088,8 +70444,8 @@
     "authorContributionMap": {
       "lithiumlkid": 13,
       "jordancjq": 9,
-      "codeeong": 99,
-      "-": 48
+      "codeeong": 13,
+      "-": 134
     }
   },
   {
@@ -75843,7 +73199,7 @@
       {
         "lineNumber": 3,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import javax.xml.bind.annotation.XmlElement;"
       },
@@ -75913,7 +73269,7 @@
       {
         "lineNumber": 13,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    @XmlElement"
       },
@@ -75934,21 +73290,21 @@
       {
         "lineNumber": 16,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    @XmlElement"
       },
       {
         "lineNumber": 17,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    private String tagColour;"
       },
       {
         "lineNumber": 18,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -76011,7 +73367,7 @@
       {
         "lineNumber": 27,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -76039,42 +73395,42 @@
       {
         "lineNumber": 31,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        this.tagColour \u003d \"teal\";"
       },
       {
         "lineNumber": 32,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    }"
       },
       {
         "lineNumber": 33,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 34,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    /**"
       },
       {
         "lineNumber": 35,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "     * Constructs a {@code XmlAdaptedTag} with the given {@code tagName} and {@code tagColour}."
       },
       {
         "lineNumber": 36,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "     */"
       },
@@ -76395,8 +73751,8 @@
       }
     ],
     "authorContributionMap": {
-      "codeeong": 43,
-      "-": 38
+      "codeeong": 31,
+      "-": 50
     }
   },
   {
@@ -76405,28 +73761,28 @@
       {
         "lineNumber": 1,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "package seedu.address.storage;"
       },
       {
         "lineNumber": 2,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 3,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import java.util.ArrayList;"
       },
       {
         "lineNumber": 4,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import java.util.List;"
       },
@@ -76440,28 +73796,28 @@
       {
         "lineNumber": 6,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 7,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import javax.xml.bind.annotation.XmlElement;"
       },
       {
         "lineNumber": 8,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 9,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import seedu.address.commons.exceptions.IllegalValueException;"
       },
@@ -76475,28 +73831,28 @@
       {
         "lineNumber": 11,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import seedu.address.model.team.Team;"
       },
       {
         "lineNumber": 12,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import seedu.address.model.team.TeamName;"
       },
       {
         "lineNumber": 13,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 14,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "/**"
       },
@@ -76510,7 +73866,7 @@
       {
         "lineNumber": 16,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": " */"
       },
@@ -77055,8 +74411,9 @@
       }
     ],
     "authorContributionMap": {
-      "codeeong": 90,
-      "jordancjq": 3
+      "jordancjq": 3,
+      "codeeong": 77,
+      "-": 13
     }
   },
   {
@@ -77683,7 +75040,7 @@
       {
         "lineNumber": 1,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -78277,9 +75634,9 @@
       }
     ],
     "authorContributionMap": {
-      "codeeong": 35,
+      "codeeong": 34,
       "jordancjq": 2,
-      "-": 48
+      "-": 49
     }
   },
   {
@@ -80280,7 +77637,7 @@
       {
         "lineNumber": 9,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import javafx.scene.control.Menu;"
       },
@@ -80301,14 +77658,14 @@
       {
         "lineNumber": 12,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import javafx.scene.image.Image;"
       },
       {
         "lineNumber": 13,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import javafx.scene.image.ImageView;"
       },
@@ -80336,7 +77693,7 @@
       {
         "lineNumber": 17,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import javafx.scene.layout.VBox;"
       },
@@ -80371,7 +77728,7 @@
       {
         "lineNumber": 22,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import seedu.address.commons.events.ui.ChangeThemeEvent;"
       },
@@ -80399,7 +77756,7 @@
       {
         "lineNumber": 26,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import seedu.address.logic.commands.exceptions.CommandException;"
       },
@@ -80469,7 +77826,7 @@
       {
         "lineNumber": 36,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    private static String currentTheme \u003d \"view/DarkTheme.css\";"
       },
@@ -80560,21 +77917,21 @@
       {
         "lineNumber": 49,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    @FXML"
       },
       {
         "lineNumber": 50,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    private Menu mtmLogo;"
       },
       {
         "lineNumber": 51,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -80665,21 +78022,21 @@
       {
         "lineNumber": 64,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    @FXML"
       },
       {
         "lineNumber": 65,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    private StackPane teamDisplayPlaceholder;"
       },
       {
         "lineNumber": 66,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -80707,21 +78064,21 @@
       {
         "lineNumber": 70,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    @FXML"
       },
       {
         "lineNumber": 71,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    private VBox mainWindow;"
       },
       {
         "lineNumber": 72,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -81253,21 +78610,21 @@
       {
         "lineNumber": 148,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        TeamDisplay teamDisplay \u003d new TeamDisplay(logic.getInitTeamList());"
       },
       {
         "lineNumber": 149,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        teamDisplayPlaceholder.getChildren().add(teamDisplay.getRoot());"
       },
       {
         "lineNumber": 150,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -81582,7 +78939,7 @@
       {
         "lineNumber": 195,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -81876,8 +79233,8 @@
     ],
     "authorContributionMap": {
       "lithiumlkid": 4,
-      "codeeong": 47,
-      "-": 185
+      "codeeong": 27,
+      "-": 205
     }
   },
   {
@@ -81914,35 +79271,35 @@
       {
         "lineNumber": 5,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import java.util.Iterator;"
       },
       {
         "lineNumber": 6,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import java.util.Set;"
       },
       {
         "lineNumber": 7,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import java.util.logging.Logger;"
       },
       {
         "lineNumber": 8,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 9,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import com.google.common.eventbus.Subscribe;"
       },
@@ -81963,7 +79320,7 @@
       {
         "lineNumber": 12,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -82019,14 +79376,14 @@
       {
         "lineNumber": 20,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import seedu.address.commons.core.LogsCenter;"
       },
       {
         "lineNumber": 21,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import seedu.address.commons.events.ui.ChangeTagColourEvent;"
       },
@@ -82040,7 +79397,7 @@
       {
         "lineNumber": 23,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import seedu.address.model.tag.Tag;"
       },
@@ -82096,7 +79453,7 @@
       {
         "lineNumber": 31,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -82166,7 +79523,7 @@
       {
         "lineNumber": 41,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    private final Logger logger \u003d LogsCenter.getLogger(PersonCard.class);"
       },
@@ -82397,7 +79754,7 @@
       {
         "lineNumber": 74,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        initTags(person);"
       },
@@ -82544,84 +79901,84 @@
       {
         "lineNumber": 95,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        registerAsAnEventHandler(this);"
       },
       {
         "lineNumber": 96,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    }"
       },
       {
         "lineNumber": 97,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 98,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    /**"
       },
       {
         "lineNumber": 99,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "     * Creates the tag labels for {@code person}."
       },
       {
         "lineNumber": 100,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "     */"
       },
       {
         "lineNumber": 101,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    private void initTags(Person person) {"
       },
       {
         "lineNumber": 102,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        person.getTags().forEach(tag -\u003e {"
       },
       {
         "lineNumber": 103,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "            Label tagLabel \u003d new Label(tag.getTagName());"
       },
       {
         "lineNumber": 104,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "            tagLabel.getStyleClass().add(tag.getTagColour());"
       },
       {
         "lineNumber": 105,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "            tags.getChildren().add(tagLabel);"
       },
       {
         "lineNumber": 106,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        });"
       },
@@ -82761,7 +80118,7 @@
       {
         "lineNumber": 126,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -82895,9 +80252,9 @@
     "authorContributionMap": {
       "lithiumlkid": 36,
       "lohtianwei": 5,
-      "codeeong": 43,
       "jordancjq": 2,
-      "-": 58
+      "codeeong": 18,
+      "-": 83
     }
   },
   {
@@ -83004,7 +80361,7 @@
       {
         "lineNumber": 15,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import javafx.scene.layout.StackPane;"
       },
@@ -83025,7 +80382,7 @@
       {
         "lineNumber": 18,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import seedu.address.commons.events.ui.PersonDetailsChangedNoParamEvent;"
       },
@@ -83102,21 +80459,21 @@
       {
         "lineNumber": 29,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    private PlayerDetails playerDetails;"
       },
       {
         "lineNumber": 30,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    private Integer selectedCardIndex;"
       },
       {
         "lineNumber": 31,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -83144,21 +80501,21 @@
       {
         "lineNumber": 35,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    @FXML"
       },
       {
         "lineNumber": 36,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    private StackPane playerDetailsPlaceholder;"
       },
       {
         "lineNumber": 37,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -83291,7 +80648,7 @@
       {
         "lineNumber": 56,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "                        playerDetailsPlaceholder.getChildren().clear();"
       },
@@ -83312,14 +80669,14 @@
       {
         "lineNumber": 59,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "                        playerDetails \u003d new PlayerDetails(newValue.person);"
       },
       {
         "lineNumber": 60,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "                        playerDetailsPlaceholder.getChildren().add(playerDetails.getRoot());"
       },
@@ -83403,7 +80760,7 @@
       {
         "lineNumber": 72,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "            this.selectedCardIndex \u003d index;"
       },
@@ -83675,8 +81032,8 @@
       }
     ],
     "authorContributionMap": {
-      "codeeong": 41,
-      "-": 69
+      "codeeong": 29,
+      "-": 81
     }
   },
   {
@@ -83685,105 +81042,105 @@
       {
         "lineNumber": 1,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "package seedu.address.ui;"
       },
       {
         "lineNumber": 2,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 3,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import com.google.common.eventbus.Subscribe;"
       },
       {
         "lineNumber": 4,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 5,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import javafx.fxml.FXML;"
       },
       {
         "lineNumber": 6,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import javafx.scene.control.Label;"
       },
       {
         "lineNumber": 7,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import javafx.scene.layout.HBox;"
       },
       {
         "lineNumber": 8,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import javafx.scene.layout.Region;"
       },
       {
         "lineNumber": 9,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 10,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import seedu.address.commons.events.ui.PersonDetailsChangedEvent;"
       },
       {
         "lineNumber": 11,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import seedu.address.model.person.Person;"
       },
       {
         "lineNumber": 12,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 13,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "/**"
       },
       {
         "lineNumber": 14,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": " * The Browser Panel of the App."
       },
       {
         "lineNumber": 15,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": " */"
       },
@@ -84343,7 +81700,8 @@
     ],
     "authorContributionMap": {
       "lohtianwei": 34,
-      "codeeong": 60
+      "codeeong": 45,
+      "-": 15
     }
   },
   {
@@ -84352,21 +81710,21 @@
       {
         "lineNumber": 1,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "package seedu.address.ui;"
       },
       {
         "lineNumber": 2,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 3,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import java.util.List;"
       },
@@ -84380,70 +81738,70 @@
       {
         "lineNumber": 5,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 6,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import com.google.common.eventbus.Subscribe;"
       },
       {
         "lineNumber": 7,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 8,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import javafx.collections.FXCollections;"
       },
       {
         "lineNumber": 9,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import javafx.collections.ObservableList;"
       },
       {
         "lineNumber": 10,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import javafx.fxml.FXML;"
       },
       {
         "lineNumber": 11,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import javafx.scene.control.Label;"
       },
       {
         "lineNumber": 12,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import javafx.scene.layout.FlowPane;"
       },
       {
         "lineNumber": 13,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import javafx.scene.layout.Region;"
       },
       {
         "lineNumber": 14,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -84457,21 +81815,21 @@
       {
         "lineNumber": 16,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import seedu.address.commons.events.ui.ClearTeamsEvent;"
       },
       {
         "lineNumber": 17,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import seedu.address.commons.events.ui.DeselectTeamEvent;"
       },
       {
         "lineNumber": 18,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import seedu.address.commons.events.ui.HighlightSelectedTeamEvent;"
       },
@@ -84485,49 +81843,49 @@
       {
         "lineNumber": 20,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import seedu.address.commons.events.ui.ShowNewTeamNameEvent;"
       },
       {
         "lineNumber": 21,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import seedu.address.commons.events.ui.UndoTeamsEvent;"
       },
       {
         "lineNumber": 22,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import seedu.address.model.team.Team;"
       },
       {
         "lineNumber": 23,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 24,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "/**"
       },
       {
         "lineNumber": 25,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": " * A ui for displaying the team currently chosen"
       },
       {
         "lineNumber": 26,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": " */"
       },
@@ -85219,1195 +82577,9 @@
       }
     ],
     "authorContributionMap": {
-      "codeeong": 121,
-      "jordancjq": 3
-    }
-  },
-  {
-    "path": "src/main/java/seedu/address/ui/UiManager.java",
-    "lines": [
-      {
-        "lineNumber": 1,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "package seedu.address.ui;"
-      },
-      {
-        "lineNumber": 2,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 3,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import java.util.logging.Logger;"
-      },
-      {
-        "lineNumber": 4,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 5,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import com.google.common.eventbus.Subscribe;"
-      },
-      {
-        "lineNumber": 6,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 7,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import javafx.application.Platform;"
-      },
-      {
-        "lineNumber": 8,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import javafx.scene.control.Alert;"
-      },
-      {
-        "lineNumber": 9,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import javafx.scene.control.Alert.AlertType;"
-      },
-      {
-        "lineNumber": 10,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import javafx.scene.image.Image;"
-      },
-      {
-        "lineNumber": 11,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import javafx.stage.Stage;"
-      },
-      {
-        "lineNumber": 12,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.MainApp;"
-      },
-      {
-        "lineNumber": 13,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.commons.core.ComponentManager;"
-      },
-      {
-        "lineNumber": 14,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.commons.core.Config;"
-      },
-      {
-        "lineNumber": 15,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.commons.core.LogsCenter;"
-      },
-      {
-        "lineNumber": 16,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.commons.events.storage.DataSavingExceptionEvent;"
-      },
-      {
-        "lineNumber": 17,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.commons.util.StringUtil;"
-      },
-      {
-        "lineNumber": 18,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.logic.Logic;"
-      },
-      {
-        "lineNumber": 19,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.model.UserPrefs;"
-      },
-      {
-        "lineNumber": 20,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 21,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "/**"
-      },
-      {
-        "lineNumber": 22,
-        "author": {
-          "gitId": "-"
-        },
-        "content": " * The manager of the UI component."
-      },
-      {
-        "lineNumber": 23,
-        "author": {
-          "gitId": "-"
-        },
-        "content": " */"
-      },
-      {
-        "lineNumber": 24,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "public class UiManager extends ComponentManager implements Ui {"
-      },
-      {
-        "lineNumber": 25,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 26,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public static final String ALERT_DIALOG_PANE_FIELD_ID \u003d \"alertDialogPane\";"
-      },
-      {
-        "lineNumber": 27,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 28,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public static final String FILE_OPS_ERROR_DIALOG_STAGE_TITLE \u003d \"File Op Error\";"
-      },
-      {
-        "lineNumber": 29,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public static final String FILE_OPS_ERROR_DIALOG_HEADER_MESSAGE \u003d \"Could not save data\";"
-      },
-      {
-        "lineNumber": 30,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public static final String FILE_OPS_ERROR_DIALOG_CONTENT_MESSAGE \u003d \"Could not save data to file\";"
-      },
-      {
-        "lineNumber": 31,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 32,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    private static final Logger logger \u003d LogsCenter.getLogger(UiManager.class);"
-      },
-      {
-        "lineNumber": 33,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    private static final String ICON_APPLICATION \u003d \"/images/football.png\";"
-      },
-      {
-        "lineNumber": 34,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 35,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    private Logic logic;"
-      },
-      {
-        "lineNumber": 36,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    private Config config;"
-      },
-      {
-        "lineNumber": 37,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    private UserPrefs prefs;"
-      },
-      {
-        "lineNumber": 38,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    private MainWindow mainWindow;"
-      },
-      {
-        "lineNumber": 39,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 40,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public UiManager(Logic logic, Config config, UserPrefs prefs) {"
-      },
-      {
-        "lineNumber": 41,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        super();"
-      },
-      {
-        "lineNumber": 42,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        this.logic \u003d logic;"
-      },
-      {
-        "lineNumber": 43,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        this.config \u003d config;"
-      },
-      {
-        "lineNumber": 44,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        this.prefs \u003d prefs;"
-      },
-      {
-        "lineNumber": 45,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 46,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 47,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    @Override"
-      },
-      {
-        "lineNumber": 48,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public void start(Stage primaryStage) {"
-      },
-      {
-        "lineNumber": 49,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        logger.info(\"Starting UI...\");"
-      },
-      {
-        "lineNumber": 50,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 51,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        //Set the application icon."
-      },
-      {
-        "lineNumber": 52,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        primaryStage.getIcons().add(getImage(ICON_APPLICATION));"
-      },
-      {
-        "lineNumber": 53,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 54,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        try {"
-      },
-      {
-        "lineNumber": 55,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "            mainWindow \u003d new MainWindow(primaryStage, config, prefs, logic);"
-      },
-      {
-        "lineNumber": 56,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "            mainWindow.show(); //This should be called before creating other UI parts"
-      },
-      {
-        "lineNumber": 57,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "            mainWindow.fillInnerParts();"
-      },
-      {
-        "lineNumber": 58,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 59,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        } catch (Throwable e) {"
-      },
-      {
-        "lineNumber": 60,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "            logger.severe(StringUtil.getDetails(e));"
-      },
-      {
-        "lineNumber": 61,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "            showFatalErrorDialogAndShutdown(\"Fatal error during initializing\", e);"
-      },
-      {
-        "lineNumber": 62,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        }"
-      },
-      {
-        "lineNumber": 63,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 64,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 65,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    @Override"
-      },
-      {
-        "lineNumber": 66,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public void stop() {"
-      },
-      {
-        "lineNumber": 67,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        prefs.updateLastUsedGuiSetting(mainWindow.getCurrentGuiSetting());"
-      },
-      {
-        "lineNumber": 68,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        mainWindow.hide();"
-      },
-      {
-        "lineNumber": 69,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 70,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 71,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    private void showFileOperationAlertAndWait(String description, String details, Throwable cause) {"
-      },
-      {
-        "lineNumber": 72,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        final String content \u003d details + \":\\n\" + cause.toString();"
-      },
-      {
-        "lineNumber": 73,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        showAlertDialogAndWait(AlertType.ERROR, FILE_OPS_ERROR_DIALOG_STAGE_TITLE, description, content);"
-      },
-      {
-        "lineNumber": 74,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 75,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 76,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    private Image getImage(String imagePath) {"
-      },
-      {
-        "lineNumber": 77,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        return new Image(MainApp.class.getResourceAsStream(imagePath));"
-      },
-      {
-        "lineNumber": 78,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 79,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 80,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    void showAlertDialogAndWait(Alert.AlertType type, String title, String headerText, String contentText) {"
-      },
-      {
-        "lineNumber": 81,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        showAlertDialogAndWait(mainWindow.getPrimaryStage(), type, title, headerText, contentText);"
-      },
-      {
-        "lineNumber": 82,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 83,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 84,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    /**"
-      },
-      {
-        "lineNumber": 85,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     * Shows an alert dialog on {@code owner} with the given parameters."
-      },
-      {
-        "lineNumber": 86,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     * This method only returns after the user has closed the alert dialog."
-      },
-      {
-        "lineNumber": 87,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     */"
-      },
-      {
-        "lineNumber": 88,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    private static void showAlertDialogAndWait(Stage owner, AlertType type, String title, String headerText,"
-      },
-      {
-        "lineNumber": 89,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "                                               String contentText) {"
-      },
-      {
-        "lineNumber": 90,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        final Alert alert \u003d new Alert(type);"
-      },
-      {
-        "lineNumber": 91,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        alert.getDialogPane().getStylesheets().add(\"view/DarkTheme.css\");"
-      },
-      {
-        "lineNumber": 92,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        alert.initOwner(owner);"
-      },
-      {
-        "lineNumber": 93,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        alert.setTitle(title);"
-      },
-      {
-        "lineNumber": 94,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        alert.setHeaderText(headerText);"
-      },
-      {
-        "lineNumber": 95,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        alert.setContentText(contentText);"
-      },
-      {
-        "lineNumber": 96,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        alert.getDialogPane().setId(ALERT_DIALOG_PANE_FIELD_ID);"
-      },
-      {
-        "lineNumber": 97,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        alert.showAndWait();"
-      },
-      {
-        "lineNumber": 98,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 99,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 100,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    /**"
-      },
-      {
-        "lineNumber": 101,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     * Shows an error alert dialog with {@code title} and error message, {@code e},"
-      },
-      {
-        "lineNumber": 102,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     * and exits the application after the user has closed the alert dialog."
-      },
-      {
-        "lineNumber": 103,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     */"
-      },
-      {
-        "lineNumber": 104,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    private void showFatalErrorDialogAndShutdown(String title, Throwable e) {"
-      },
-      {
-        "lineNumber": 105,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        logger.severe(title + \" \" + e.getMessage() + StringUtil.getDetails(e));"
-      },
-      {
-        "lineNumber": 106,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        showAlertDialogAndWait(Alert.AlertType.ERROR, title, e.getMessage(), e.toString());"
-      },
-      {
-        "lineNumber": 107,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        Platform.exit();"
-      },
-      {
-        "lineNumber": 108,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        System.exit(1);"
-      },
-      {
-        "lineNumber": 109,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 110,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 111,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    //\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d Event Handling Code \u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d"
-      },
-      {
-        "lineNumber": 112,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 113,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    @Subscribe"
-      },
-      {
-        "lineNumber": 114,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    private void handleDataSavingExceptionEvent(DataSavingExceptionEvent event) {"
-      },
-      {
-        "lineNumber": 115,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        logger.info(LogsCenter.getEventHandlingLogMessage(event));"
-      },
-      {
-        "lineNumber": 116,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        showFileOperationAlertAndWait(FILE_OPS_ERROR_DIALOG_HEADER_MESSAGE, FILE_OPS_ERROR_DIALOG_CONTENT_MESSAGE,"
-      },
-      {
-        "lineNumber": 117,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "                event.exception);"
-      },
-      {
-        "lineNumber": 118,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 119,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "}"
-      }
-    ],
-    "authorContributionMap": {
-      "codeeong": 1,
-      "-": 118
-    }
-  },
-  {
-    "path": "src/test/java/guitests/guihandles/MainWindowHandle.java",
-    "lines": [
-      {
-        "lineNumber": 1,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "package guitests.guihandles;"
-      },
-      {
-        "lineNumber": 2,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 3,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import javafx.stage.Stage;"
-      },
-      {
-        "lineNumber": 4,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 5,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "/**"
-      },
-      {
-        "lineNumber": 6,
-        "author": {
-          "gitId": "-"
-        },
-        "content": " * Provides a handle for {@code MainWindow}."
-      },
-      {
-        "lineNumber": 7,
-        "author": {
-          "gitId": "-"
-        },
-        "content": " */"
-      },
-      {
-        "lineNumber": 8,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "public class MainWindowHandle extends StageHandle {"
-      },
-      {
-        "lineNumber": 9,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 10,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    private final PersonListPanelHandle personListPanel;"
-      },
-      {
-        "lineNumber": 11,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    private final ResultDisplayHandle resultDisplay;"
-      },
-      {
-        "lineNumber": 12,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    private final TeamDisplayHandle teamDisplayBar;"
-      },
-      {
-        "lineNumber": 13,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    private final CommandBoxHandle commandBox;"
-      },
-      {
-        "lineNumber": 14,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    private final StatusBarFooterHandle statusBarFooter;"
-      },
-      {
-        "lineNumber": 15,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    private final MainMenuHandle mainMenu;"
-      },
-      {
-        "lineNumber": 16,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 17,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public MainWindowHandle(Stage stage) {"
-      },
-      {
-        "lineNumber": 18,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        super(stage);"
-      },
-      {
-        "lineNumber": 19,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 20,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        personListPanel \u003d new PersonListPanelHandle(getChildNode(PersonListPanelHandle.PERSON_LIST_VIEW_ID));"
-      },
-      {
-        "lineNumber": 21,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        resultDisplay \u003d new ResultDisplayHandle(getChildNode(ResultDisplayHandle.RESULT_DISPLAY_ID));"
-      },
-      {
-        "lineNumber": 22,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        teamDisplayBar \u003d new TeamDisplayHandle(getChildNode(TeamDisplayHandle.TEAM_DISPLAY_ID));"
-      },
-      {
-        "lineNumber": 23,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        commandBox \u003d new CommandBoxHandle(getChildNode(CommandBoxHandle.COMMAND_INPUT_FIELD_ID));"
-      },
-      {
-        "lineNumber": 24,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        statusBarFooter \u003d new StatusBarFooterHandle(getChildNode(StatusBarFooterHandle.STATUS_BAR_PLACEHOLDER));"
-      },
-      {
-        "lineNumber": 25,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        mainMenu \u003d new MainMenuHandle(getChildNode(MainMenuHandle.MENU_BAR_ID));"
-      },
-      {
-        "lineNumber": 26,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 27,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 28,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public PersonListPanelHandle getPersonListPanel() {"
-      },
-      {
-        "lineNumber": 29,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        return personListPanel;"
-      },
-      {
-        "lineNumber": 30,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 31,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 32,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public ResultDisplayHandle getResultDisplay() {"
-      },
-      {
-        "lineNumber": 33,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        return resultDisplay;"
-      },
-      {
-        "lineNumber": 34,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 35,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 36,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public CommandBoxHandle getCommandBox() {"
-      },
-      {
-        "lineNumber": 37,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        return commandBox;"
-      },
-      {
-        "lineNumber": 38,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 39,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 40,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public StatusBarFooterHandle getStatusBarFooter() {"
-      },
-      {
-        "lineNumber": 41,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        return statusBarFooter;"
-      },
-      {
-        "lineNumber": 42,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 43,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 44,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public MainMenuHandle getMainMenu() {"
-      },
-      {
-        "lineNumber": 45,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        return mainMenu;"
-      },
-      {
-        "lineNumber": 46,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 47,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 48,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "}"
-      }
-    ],
-    "authorContributionMap": {
-      "codeeong": 2,
-      "-": 46
+      "jordancjq": 3,
+      "codeeong": 98,
+      "-": 23
     }
   },
   {
@@ -86528,21 +82700,21 @@
       {
         "lineNumber": 17,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    private static final String RATING_FIELD_ID \u003d \"#rating\";"
       },
       {
         "lineNumber": 18,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    private static final String POSITION_FIELD_ID \u003d \"#position\";"
       },
       {
         "lineNumber": 19,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    private static final String TEAMNAME_FIELD_ID \u003d \"#teamName\";"
       },
@@ -86570,28 +82742,28 @@
       {
         "lineNumber": 23,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    private final Label positionLabel;"
       },
       {
         "lineNumber": 24,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    private final Label ratingLabel;"
       },
       {
         "lineNumber": 25,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    private final Label teamNameLabel;"
       },
       {
         "lineNumber": 26,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -86647,21 +82819,21 @@
       {
         "lineNumber": 34,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        this.positionLabel \u003d getChildNode(POSITION_FIELD_ID);"
       },
       {
         "lineNumber": 35,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        this.ratingLabel \u003d getChildNode(RATING_FIELD_ID);"
       },
       {
         "lineNumber": 36,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        this.teamNameLabel \u003d getChildNode(TEAMNAME_FIELD_ID);"
       },
@@ -86787,14 +82959,14 @@
       {
         "lineNumber": 54,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    public String getPosition() {"
       },
       {
         "lineNumber": 55,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        return positionLabel.getText();"
       },
@@ -86815,14 +82987,14 @@
       {
         "lineNumber": 58,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    public String getRating() {"
       },
       {
         "lineNumber": 59,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        return ratingLabel.getText();"
       },
@@ -86843,14 +83015,14 @@
       {
         "lineNumber": 62,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    public String getTeamName() {"
       },
       {
         "lineNumber": 63,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        return teamNameLabel.getText();"
       },
@@ -86913,63 +83085,63 @@
       {
         "lineNumber": 72,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 73,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    public List\u003cString\u003e getTagStyleClasses(String tag) {"
       },
       {
         "lineNumber": 74,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        return tagLabels"
       },
       {
         "lineNumber": 75,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "                .stream()"
       },
       {
         "lineNumber": 76,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "                .filter(label -\u003e label.getText().equals(tag))"
       },
       {
         "lineNumber": 77,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "                .map(Label::getStyleClass)"
       },
       {
         "lineNumber": 78,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "                .findFirst()"
       },
       {
         "lineNumber": 79,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "                .orElseThrow(() -\u003e new IllegalArgumentException(\"No such tag.\"));"
       },
       {
         "lineNumber": 80,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    }"
       },
@@ -86982,9 +83154,8 @@
       }
     ],
     "authorContributionMap": {
-      "codeeong": 25,
       "jordancjq": 2,
-      "-": 54
+      "-": 79
     }
   },
   {
@@ -86993,56 +83164,56 @@
       {
         "lineNumber": 1,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "package guitests.guihandles;"
       },
       {
         "lineNumber": 2,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 3,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import javafx.scene.Node;"
       },
       {
         "lineNumber": 4,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import javafx.scene.control.Label;"
       },
       {
         "lineNumber": 5,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 6,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "/**"
       },
       {
         "lineNumber": 7,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": " * Provides a handle to a player details pane."
       },
       {
         "lineNumber": 8,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": " */"
       },
@@ -87440,7 +83611,8 @@
       }
     ],
     "authorContributionMap": {
-      "codeeong": 64
+      "codeeong": 56,
+      "-": 8
     }
   },
   {
@@ -87449,84 +83621,84 @@
       {
         "lineNumber": 1,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "package guitests.guihandles;"
       },
       {
         "lineNumber": 2,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 3,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import java.util.List;"
       },
       {
         "lineNumber": 4,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import java.util.stream.Collectors;"
       },
       {
         "lineNumber": 5,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 6,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import javafx.scene.Node;"
       },
       {
         "lineNumber": 7,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import javafx.scene.control.Label;"
       },
       {
         "lineNumber": 8,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import javafx.scene.layout.Region;"
       },
       {
         "lineNumber": 9,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 10,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "/**"
       },
       {
         "lineNumber": 11,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": " * Provides a handle for {@code TeamDisplayHandle} containing the list of {@code Teams}."
       },
       {
         "lineNumber": 12,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": " */"
       },
@@ -87707,1271 +83879,8 @@
       }
     ],
     "authorContributionMap": {
-      "codeeong": 37
-    }
-  },
-  {
-    "path": "src/test/java/seedu/address/commons/core/ConfigTest.java",
-    "lines": [
-      {
-        "lineNumber": 1,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "package seedu.address.commons.core;"
-      },
-      {
-        "lineNumber": 2,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 3,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static org.junit.Assert.assertEquals;"
-      },
-      {
-        "lineNumber": 4,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static org.junit.Assert.assertNotNull;"
-      },
-      {
-        "lineNumber": 5,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static org.junit.Assert.assertTrue;"
-      },
-      {
-        "lineNumber": 6,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 7,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import org.junit.Rule;"
-      },
-      {
-        "lineNumber": 8,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import org.junit.Test;"
-      },
-      {
-        "lineNumber": 9,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import org.junit.rules.ExpectedException;"
-      },
-      {
-        "lineNumber": 10,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 11,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "public class ConfigTest {"
-      },
-      {
-        "lineNumber": 12,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    @Rule"
-      },
-      {
-        "lineNumber": 13,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public ExpectedException thrown \u003d ExpectedException.none();"
-      },
-      {
-        "lineNumber": 14,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 15,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    @Test"
-      },
-      {
-        "lineNumber": 16,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public void toString_defaultObject_stringReturned() {"
-      },
-      {
-        "lineNumber": 17,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        String defaultConfigAsString \u003d \"App title : My Team Manager\\n\""
-      },
-      {
-        "lineNumber": 18,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "                + \"Current log level : INFO\\n\""
-      },
-      {
-        "lineNumber": 19,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "                + \"Preference file Location : preferences.json\";"
-      },
-      {
-        "lineNumber": 20,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 21,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertEquals(defaultConfigAsString, new Config().toString());"
-      },
-      {
-        "lineNumber": 22,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 23,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 24,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    @Test"
-      },
-      {
-        "lineNumber": 25,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public void equalsMethod() {"
-      },
-      {
-        "lineNumber": 26,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        Config defaultConfig \u003d new Config();"
-      },
-      {
-        "lineNumber": 27,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertNotNull(defaultConfig);"
-      },
-      {
-        "lineNumber": 28,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertTrue(defaultConfig.equals(defaultConfig));"
-      },
-      {
-        "lineNumber": 29,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 30,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 31,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 32,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "}"
-      }
-    ],
-    "authorContributionMap": {
-      "codeeong": 1,
-      "-": 31
-    }
-  },
-  {
-    "path": "src/test/java/seedu/address/commons/util/XmlUtilTest.java",
-    "lines": [
-      {
-        "lineNumber": 1,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "package seedu.address.commons.util;"
-      },
-      {
-        "lineNumber": 2,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 3,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static org.junit.Assert.assertEquals;"
-      },
-      {
-        "lineNumber": 4,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 5,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import java.io.File;"
-      },
-      {
-        "lineNumber": 6,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import java.io.FileNotFoundException;"
-      },
-      {
-        "lineNumber": 7,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import java.util.Collections;"
-      },
-      {
-        "lineNumber": 8,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import java.util.List;"
-      },
-      {
-        "lineNumber": 9,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 10,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import javax.xml.bind.JAXBException;"
-      },
-      {
-        "lineNumber": 11,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import javax.xml.bind.annotation.XmlRootElement;"
-      },
-      {
-        "lineNumber": 12,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 13,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import org.junit.Rule;"
-      },
-      {
-        "lineNumber": 14,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import org.junit.Test;"
-      },
-      {
-        "lineNumber": 15,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import org.junit.rules.ExpectedException;"
-      },
-      {
-        "lineNumber": 16,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 17,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.model.AddressBook;"
-      },
-      {
-        "lineNumber": 18,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.storage.XmlAdaptedPerson;"
-      },
-      {
-        "lineNumber": 19,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.storage.XmlAdaptedTag;"
-      },
-      {
-        "lineNumber": 20,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.storage.XmlSerializableAddressBook;"
-      },
-      {
-        "lineNumber": 21,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.testutil.AddressBookBuilder;"
-      },
-      {
-        "lineNumber": 22,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.testutil.PersonBuilder;"
-      },
-      {
-        "lineNumber": 23,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.testutil.TestUtil;"
-      },
-      {
-        "lineNumber": 24,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 25,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "public class XmlUtilTest {"
-      },
-      {
-        "lineNumber": 26,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 27,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    private static final String TEST_DATA_FOLDER \u003d FileUtil.getPath(\"src/test/data/XmlUtilTest/\");"
-      },
-      {
-        "lineNumber": 28,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    private static final File EMPTY_FILE \u003d new File(TEST_DATA_FOLDER + \"empty.xml\");"
-      },
-      {
-        "lineNumber": 29,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    private static final File MISSING_FILE \u003d new File(TEST_DATA_FOLDER + \"missing.xml\");"
-      },
-      {
-        "lineNumber": 30,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    private static final File VALID_FILE \u003d new File(TEST_DATA_FOLDER + \"validAddressBook.xml\");"
-      },
-      {
-        "lineNumber": 31,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    private static final File MISSING_PERSON_FIELD_FILE \u003d new File(TEST_DATA_FOLDER + \"missingPersonField.xml\");"
-      },
-      {
-        "lineNumber": 32,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    private static final File INVALID_PERSON_FIELD_FILE \u003d new File(TEST_DATA_FOLDER + \"invalidPersonField.xml\");"
-      },
-      {
-        "lineNumber": 33,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    private static final File VALID_PERSON_FILE \u003d new File(TEST_DATA_FOLDER + \"validPerson.xml\");"
-      },
-      {
-        "lineNumber": 34,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    private static final File TEMP_FILE \u003d new File(TestUtil.getFilePathInSandboxFolder(\"tempAddressBook.xml\"));"
-      },
-      {
-        "lineNumber": 35,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 36,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    private static final String INVALID_PHONE \u003d \"9482asf424\";"
-      },
-      {
-        "lineNumber": 37,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 38,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    private static final String VALID_NAME \u003d \"Hans Muster\";"
-      },
-      {
-        "lineNumber": 39,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    private static final String VALID_PHONE \u003d \"9482424\";"
-      },
-      {
-        "lineNumber": 40,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    private static final String VALID_EMAIL \u003d \"hans@example\";"
-      },
-      {
-        "lineNumber": 41,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    private static final String VALID_ADDRESS \u003d \"4th street\";"
-      },
-      {
-        "lineNumber": 42,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    private static final List\u003cXmlAdaptedTag\u003e VALID_TAGS \u003d Collections.singletonList(new XmlAdaptedTag(\"friends\"));"
-      },
-      {
-        "lineNumber": 43,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 44,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    @Rule"
-      },
-      {
-        "lineNumber": 45,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public ExpectedException thrown \u003d ExpectedException.none();"
-      },
-      {
-        "lineNumber": 46,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 47,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    @Test"
-      },
-      {
-        "lineNumber": 48,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public void getDataFromFile_nullFile_throwsNullPointerException() throws Exception {"
-      },
-      {
-        "lineNumber": 49,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        thrown.expect(NullPointerException.class);"
-      },
-      {
-        "lineNumber": 50,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        XmlUtil.getDataFromFile(null, AddressBook.class);"
-      },
-      {
-        "lineNumber": 51,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 52,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 53,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    @Test"
-      },
-      {
-        "lineNumber": 54,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public void getDataFromFile_nullClass_throwsNullPointerException() throws Exception {"
-      },
-      {
-        "lineNumber": 55,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        thrown.expect(NullPointerException.class);"
-      },
-      {
-        "lineNumber": 56,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        XmlUtil.getDataFromFile(VALID_FILE, null);"
-      },
-      {
-        "lineNumber": 57,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 58,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 59,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    @Test"
-      },
-      {
-        "lineNumber": 60,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public void getDataFromFile_missingFile_fileNotFoundException() throws Exception {"
-      },
-      {
-        "lineNumber": 61,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        thrown.expect(FileNotFoundException.class);"
-      },
-      {
-        "lineNumber": 62,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        XmlUtil.getDataFromFile(MISSING_FILE, AddressBook.class);"
-      },
-      {
-        "lineNumber": 63,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 64,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 65,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    @Test"
-      },
-      {
-        "lineNumber": 66,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public void getDataFromFile_emptyFile_dataFormatMismatchException() throws Exception {"
-      },
-      {
-        "lineNumber": 67,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        thrown.expect(JAXBException.class);"
-      },
-      {
-        "lineNumber": 68,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        XmlUtil.getDataFromFile(EMPTY_FILE, AddressBook.class);"
-      },
-      {
-        "lineNumber": 69,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 70,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 71,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    @Test"
-      },
-      {
-        "lineNumber": 72,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public void getDataFromFile_validFile_validResult() throws Exception {"
-      },
-      {
-        "lineNumber": 73,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        AddressBook dataFromFile \u003d XmlUtil.getDataFromFile(VALID_FILE, XmlSerializableAddressBook.class).toModelType();"
-      },
-      {
-        "lineNumber": 74,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        assertEquals(0, dataFromFile.getTeamList().size());"
-      },
-      {
-        "lineNumber": 75,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertEquals(0, dataFromFile.getTagList().size());"
-      },
-      {
-        "lineNumber": 76,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 77,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 78,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    @Test"
-      },
-      {
-        "lineNumber": 79,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public void xmlAdaptedPersonFromFile_fileWithMissingPersonField_validResult() throws Exception {"
-      },
-      {
-        "lineNumber": 80,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        XmlAdaptedPerson actualPerson \u003d XmlUtil.getDataFromFile("
-      },
-      {
-        "lineNumber": 81,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "                MISSING_PERSON_FIELD_FILE, XmlAdaptedPersonWithRootElement.class);"
-      },
-      {
-        "lineNumber": 82,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        XmlAdaptedPerson expectedPerson \u003d new XmlAdaptedPerson("
-      },
-      {
-        "lineNumber": 83,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "                null, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS);"
-      },
-      {
-        "lineNumber": 84,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertEquals(expectedPerson, actualPerson);"
-      },
-      {
-        "lineNumber": 85,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 86,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 87,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    @Test"
-      },
-      {
-        "lineNumber": 88,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public void xmlAdaptedPersonFromFile_fileWithInvalidPersonField_validResult() throws Exception {"
-      },
-      {
-        "lineNumber": 89,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        XmlAdaptedPerson actualPerson \u003d XmlUtil.getDataFromFile("
-      },
-      {
-        "lineNumber": 90,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "                INVALID_PERSON_FIELD_FILE, XmlAdaptedPersonWithRootElement.class);"
-      },
-      {
-        "lineNumber": 91,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        XmlAdaptedPerson expectedPerson \u003d new XmlAdaptedPerson("
-      },
-      {
-        "lineNumber": 92,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "                VALID_NAME, INVALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS);"
-      },
-      {
-        "lineNumber": 93,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertEquals(expectedPerson, actualPerson);"
-      },
-      {
-        "lineNumber": 94,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 95,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 96,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    @Test"
-      },
-      {
-        "lineNumber": 97,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public void xmlAdaptedPersonFromFile_fileWithValidPerson_validResult() throws Exception {"
-      },
-      {
-        "lineNumber": 98,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        XmlAdaptedPerson actualPerson \u003d XmlUtil.getDataFromFile("
-      },
-      {
-        "lineNumber": 99,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "                VALID_PERSON_FILE, XmlAdaptedPersonWithRootElement.class);"
-      },
-      {
-        "lineNumber": 100,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        XmlAdaptedPerson expectedPerson \u003d new XmlAdaptedPerson("
-      },
-      {
-        "lineNumber": 101,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "                VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS);"
-      },
-      {
-        "lineNumber": 102,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertEquals(expectedPerson, actualPerson);"
-      },
-      {
-        "lineNumber": 103,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 104,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 105,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    @Test"
-      },
-      {
-        "lineNumber": 106,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public void saveDataToFile_nullFile_throwsNullPointerException() throws Exception {"
-      },
-      {
-        "lineNumber": 107,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        thrown.expect(NullPointerException.class);"
-      },
-      {
-        "lineNumber": 108,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        XmlUtil.saveDataToFile(null, new AddressBook());"
-      },
-      {
-        "lineNumber": 109,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 110,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 111,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    @Test"
-      },
-      {
-        "lineNumber": 112,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public void saveDataToFile_nullClass_throwsNullPointerException() throws Exception {"
-      },
-      {
-        "lineNumber": 113,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        thrown.expect(NullPointerException.class);"
-      },
-      {
-        "lineNumber": 114,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        XmlUtil.saveDataToFile(VALID_FILE, null);"
-      },
-      {
-        "lineNumber": 115,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 116,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 117,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    @Test"
-      },
-      {
-        "lineNumber": 118,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public void saveDataToFile_missingFile_fileNotFoundException() throws Exception {"
-      },
-      {
-        "lineNumber": 119,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        thrown.expect(FileNotFoundException.class);"
-      },
-      {
-        "lineNumber": 120,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        XmlUtil.saveDataToFile(MISSING_FILE, new AddressBook());"
-      },
-      {
-        "lineNumber": 121,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 122,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 123,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    @Test"
-      },
-      {
-        "lineNumber": 124,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public void saveDataToFile_validFile_dataSaved() throws Exception {"
-      },
-      {
-        "lineNumber": 125,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        TEMP_FILE.createNewFile();"
-      },
-      {
-        "lineNumber": 126,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        XmlSerializableAddressBook dataToWrite \u003d new XmlSerializableAddressBook(new AddressBook());"
-      },
-      {
-        "lineNumber": 127,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        XmlUtil.saveDataToFile(TEMP_FILE, dataToWrite);"
-      },
-      {
-        "lineNumber": 128,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        XmlSerializableAddressBook dataFromFile \u003d XmlUtil.getDataFromFile(TEMP_FILE, XmlSerializableAddressBook.class);"
-      },
-      {
-        "lineNumber": 129,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertEquals(dataToWrite, dataFromFile);"
-      },
-      {
-        "lineNumber": 130,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 131,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        AddressBookBuilder builder \u003d new AddressBookBuilder(new AddressBook());"
-      },
-      {
-        "lineNumber": 132,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        dataToWrite \u003d new XmlSerializableAddressBook("
-      },
-      {
-        "lineNumber": 133,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "                builder.withPerson(new PersonBuilder().build()).withTag(\"Friends\").build());"
-      },
-      {
-        "lineNumber": 134,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 135,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        XmlUtil.saveDataToFile(TEMP_FILE, dataToWrite);"
-      },
-      {
-        "lineNumber": 136,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        dataFromFile \u003d XmlUtil.getDataFromFile(TEMP_FILE, XmlSerializableAddressBook.class);"
-      },
-      {
-        "lineNumber": 137,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertEquals(dataToWrite, dataFromFile);"
-      },
-      {
-        "lineNumber": 138,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 139,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 140,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    /**"
-      },
-      {
-        "lineNumber": 141,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     * Test class annotated with {@code XmlRootElement} to allow unmarshalling of .xml data to {@code XmlAdaptedPerson}"
-      },
-      {
-        "lineNumber": 142,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     * objects."
-      },
-      {
-        "lineNumber": 143,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     */"
-      },
-      {
-        "lineNumber": 144,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    @XmlRootElement(name \u003d \"person\")"
-      },
-      {
-        "lineNumber": 145,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    private static class XmlAdaptedPersonWithRootElement extends XmlAdaptedPerson {}"
-      },
-      {
-        "lineNumber": 146,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "}"
-      }
-    ],
-    "authorContributionMap": {
-      "codeeong": 1,
-      "-": 145
+      "codeeong": 25,
+      "-": 12
     }
   },
   {
@@ -90782,42 +85691,42 @@
       {
         "lineNumber": 165,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        @Override"
       },
       {
         "lineNumber": 166,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        public ObservableList\u003cTeam\u003e getInitTeamList() {"
       },
       {
         "lineNumber": 167,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "            fail(\"This method should not be called.\");"
       },
       {
         "lineNumber": 168,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "            return null;"
       },
       {
         "lineNumber": 169,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        }"
       },
       {
         "lineNumber": 170,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -90922,7 +85831,7 @@
       {
         "lineNumber": 185,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -91104,35 +86013,35 @@
       {
         "lineNumber": 211,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        @Override"
       },
       {
         "lineNumber": 212,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        public boolean setTagColour(Tag tag, String colour) {"
       },
       {
         "lineNumber": 213,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "            fail(\"This method should not be called.\");"
       },
       {
         "lineNumber": 214,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "            return false;"
       },
       {
         "lineNumber": 215,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        }"
       },
@@ -91434,8 +86343,7 @@
     "authorContributionMap": {
       "lohtianwei": 29,
       "jordancjq": 45,
-      "codeeong": 12,
-      "-": 171
+      "-": 183
     }
   },
   {
@@ -93013,84 +87921,84 @@
       {
         "lineNumber": 1,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "package seedu.address.logic.commands;"
       },
       {
         "lineNumber": 2,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 3,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import static org.junit.Assert.assertEquals;"
       },
       {
         "lineNumber": 4,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import static org.junit.Assert.assertFalse;"
       },
       {
         "lineNumber": 5,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import static org.junit.Assert.assertTrue;"
       },
       {
         "lineNumber": 6,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import static org.junit.Assert.fail;"
       },
       {
         "lineNumber": 7,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 8,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import org.junit.Test;"
       },
       {
         "lineNumber": 9,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 10,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import seedu.address.commons.core.Messages;"
       },
       {
         "lineNumber": 11,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import seedu.address.logic.commands.exceptions.CommandException;"
       },
       {
         "lineNumber": 12,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -93635,7 +88543,8 @@
       }
     ],
     "authorContributionMap": {
-      "codeeong": 89
+      "codeeong": 77,
+      "-": 12
     }
   },
   {
@@ -101650,175 +96559,175 @@
       {
         "lineNumber": 1,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "package seedu.address.logic.commands;"
       },
       {
         "lineNumber": 2,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 3,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import static org.junit.Assert.assertFalse;"
       },
       {
         "lineNumber": 4,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import static org.junit.Assert.assertTrue;"
       },
       {
         "lineNumber": 5,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import static seedu.address.logic.commands.CommandTestUtil.DESC_AMY;"
       },
       {
         "lineNumber": 6,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;"
       },
       {
         "lineNumber": 7,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import static seedu.address.testutil.TypicalPersons.CARL;"
       },
       {
         "lineNumber": 8,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;"
       },
       {
         "lineNumber": 9,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 10,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import org.junit.Before;"
       },
       {
         "lineNumber": 11,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import org.junit.Test;"
       },
       {
         "lineNumber": 12,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 13,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import javafx.collections.ObservableList;"
       },
       {
         "lineNumber": 14,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 15,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import seedu.address.logic.CommandHistory;"
       },
       {
         "lineNumber": 16,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import seedu.address.logic.UndoRedoStack;"
       },
       {
         "lineNumber": 17,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import seedu.address.logic.commands.exceptions.CommandException;"
       },
       {
         "lineNumber": 18,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import seedu.address.model.Model;"
       },
       {
         "lineNumber": 19,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import seedu.address.model.ModelManager;"
       },
       {
         "lineNumber": 20,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import seedu.address.model.UserPrefs;"
       },
       {
         "lineNumber": 21,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import seedu.address.model.tag.Tag;"
       },
       {
         "lineNumber": 22,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 23,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "/**"
       },
       {
         "lineNumber": 24,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": " * This is the unit test for {@code SetCommand}."
       },
       {
         "lineNumber": 25,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": " */"
       },
@@ -102349,7 +97258,8 @@
       }
     ],
     "authorContributionMap": {
-      "codeeong": 100
+      "codeeong": 75,
+      "-": 25
     }
   },
   {
@@ -106221,7 +101131,7 @@
       {
         "lineNumber": 22,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import seedu.address.logic.commands.ChangeThemeCommand;"
       },
@@ -108125,7 +103035,7 @@
       {
         "lineNumber": 294,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -108230,49 +103140,49 @@
       {
         "lineNumber": 309,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    /** @@Codee */"
       },
       {
         "lineNumber": 310,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    @Test"
       },
       {
         "lineNumber": 311,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    public void parseCommand_theme() throws Exception {"
       },
       {
         "lineNumber": 312,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        String[] listThemes \u003d { \"Light\", \"Dark\" };"
       },
       {
         "lineNumber": 313,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 314,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        for (int i \u003d 0; i \u003c 2; i++) {"
       },
       {
         "lineNumber": 315,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "            ChangeThemeCommand command \u003d (ChangeThemeCommand) parser.parseCommand("
       },
@@ -108286,21 +103196,21 @@
       {
         "lineNumber": 317,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "            assertEquals(new ChangeThemeCommand(listThemes[i]), command);"
       },
       {
         "lineNumber": 318,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        }"
       },
       {
         "lineNumber": 319,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    }"
       },
@@ -108320,8 +103230,7 @@
       "null": 1,
       "lohtianwei": 150,
       "jordancjq": 36,
-      "codeeong": 12,
-      "-": 122
+      "-": 134
     }
   },
   {
@@ -108842,70 +103751,70 @@
       {
         "lineNumber": 1,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "package seedu.address.logic.parser;"
       },
       {
         "lineNumber": 2,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 3,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;"
       },
       {
         "lineNumber": 4,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;"
       },
       {
         "lineNumber": 5,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;"
       },
       {
         "lineNumber": 6,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 7,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import org.junit.Test;"
       },
       {
         "lineNumber": 8,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 9,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import seedu.address.logic.commands.ChangeThemeCommand;"
       },
       {
         "lineNumber": 10,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -109051,7 +103960,8 @@
       }
     ],
     "authorContributionMap": {
-      "codeeong": 30
+      "codeeong": 20,
+      "-": 10
     }
   },
   {
@@ -114213,77 +109123,77 @@
       {
         "lineNumber": 1,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "package seedu.address.logic.parser;"
       },
       {
         "lineNumber": 2,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 3,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;"
       },
       {
         "lineNumber": 4,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG_COLOUR;"
       },
       {
         "lineNumber": 5,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;"
       },
       {
         "lineNumber": 6,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import static seedu.address.testutil.TypicalTags.FRIEND;"
       },
       {
         "lineNumber": 7,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 8,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import org.junit.Test;"
       },
       {
         "lineNumber": 9,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 10,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import seedu.address.logic.commands.SetCommand;"
       },
       {
         "lineNumber": 11,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -114373,7 +109283,8 @@
       }
     ],
     "authorContributionMap": {
-      "codeeong": 23
+      "codeeong": 12,
+      "-": 11
     }
   },
   {
@@ -121223,281 +116134,6 @@
     }
   },
   {
-    "path": "src/test/java/seedu/address/model/tag/TagTest.java",
-    "lines": [
-      {
-        "lineNumber": 1,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "package seedu.address.model.tag;"
-      },
-      {
-        "lineNumber": 2,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 3,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import org.junit.Test;"
-      },
-      {
-        "lineNumber": 4,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 5,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.testutil.Assert;"
-      },
-      {
-        "lineNumber": 6,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 7,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "public class TagTest {"
-      },
-      {
-        "lineNumber": 8,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 9,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    @Test"
-      },
-      {
-        "lineNumber": 10,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public void constructor_null_throwsNullPointerException() {"
-      },
-      {
-        "lineNumber": 11,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        Assert.assertThrows(NullPointerException.class, () -\u003e new Tag(null));"
-      },
-      {
-        "lineNumber": 12,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 13,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 14,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    @Test"
-      },
-      {
-        "lineNumber": 15,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public void constructor_invalidTagName_throwsIllegalArgumentException() {"
-      },
-      {
-        "lineNumber": 16,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        String invalidTagName \u003d \"\";"
-      },
-      {
-        "lineNumber": 17,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        Assert.assertThrows(IllegalArgumentException.class, () -\u003e new Tag(invalidTagName));"
-      },
-      {
-        "lineNumber": 18,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 19,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 20,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    @Test"
-      },
-      {
-        "lineNumber": 21,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    public void constructor_invalidTagColourName_throwsIllegalArgumentException() {"
-      },
-      {
-        "lineNumber": 22,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        String invalidTagColourName \u003d \"\";"
-      },
-      {
-        "lineNumber": 23,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        Assert.assertThrows(IllegalArgumentException.class, () -\u003e new Tag(invalidTagColourName));"
-      },
-      {
-        "lineNumber": 24,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 25,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 26,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    @Test"
-      },
-      {
-        "lineNumber": 27,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public void isValidTagName() {"
-      },
-      {
-        "lineNumber": 28,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        // null tag name"
-      },
-      {
-        "lineNumber": 29,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        Assert.assertThrows(NullPointerException.class, () -\u003e Tag.isValidTagName(null));"
-      },
-      {
-        "lineNumber": 30,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 31,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 32,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    @Test"
-      },
-      {
-        "lineNumber": 33,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    public void isValidTagColour() {"
-      },
-      {
-        "lineNumber": 34,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        // null tag name"
-      },
-      {
-        "lineNumber": 35,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        Assert.assertThrows(NullPointerException.class, () -\u003e Tag.isValidTagColour(null));"
-      },
-      {
-        "lineNumber": 36,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 37,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 38,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "}"
-      }
-    ],
-    "authorContributionMap": {
-      "codeeong": 12,
-      "-": 26
-    }
-  },
-  {
     "path": "src/test/java/seedu/address/model/team/TeamNameTest.java",
     "lines": [
       {
@@ -121797,960 +116433,6 @@
     ],
     "authorContributionMap": {
       "jordancjq": 42
-    }
-  },
-  {
-    "path": "src/test/java/seedu/address/storage/JsonUserPrefsStorageTest.java",
-    "lines": [
-      {
-        "lineNumber": 1,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "package seedu.address.storage;"
-      },
-      {
-        "lineNumber": 2,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 3,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static org.junit.Assert.assertEquals;"
-      },
-      {
-        "lineNumber": 4,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static org.junit.Assert.assertFalse;"
-      },
-      {
-        "lineNumber": 5,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 6,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import java.io.File;"
-      },
-      {
-        "lineNumber": 7,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import java.io.IOException;"
-      },
-      {
-        "lineNumber": 8,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import java.util.Optional;"
-      },
-      {
-        "lineNumber": 9,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 10,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import org.junit.Rule;"
-      },
-      {
-        "lineNumber": 11,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import org.junit.Test;"
-      },
-      {
-        "lineNumber": 12,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import org.junit.rules.ExpectedException;"
-      },
-      {
-        "lineNumber": 13,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import org.junit.rules.TemporaryFolder;"
-      },
-      {
-        "lineNumber": 14,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 15,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.commons.exceptions.DataConversionException;"
-      },
-      {
-        "lineNumber": 16,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.commons.util.FileUtil;"
-      },
-      {
-        "lineNumber": 17,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.model.UserPrefs;"
-      },
-      {
-        "lineNumber": 18,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 19,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "public class JsonUserPrefsStorageTest {"
-      },
-      {
-        "lineNumber": 20,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 21,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    private static final String TEST_DATA_FOLDER \u003d FileUtil.getPath(\"./src/test/data/JsonUserPrefsStorageTest/\");"
-      },
-      {
-        "lineNumber": 22,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 23,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    @Rule"
-      },
-      {
-        "lineNumber": 24,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public ExpectedException thrown \u003d ExpectedException.none();"
-      },
-      {
-        "lineNumber": 25,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 26,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    @Rule"
-      },
-      {
-        "lineNumber": 27,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public TemporaryFolder testFolder \u003d new TemporaryFolder();"
-      },
-      {
-        "lineNumber": 28,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 29,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    @Test"
-      },
-      {
-        "lineNumber": 30,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public void readUserPrefs_nullFilePath_throwsNullPointerException() throws DataConversionException {"
-      },
-      {
-        "lineNumber": 31,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        thrown.expect(NullPointerException.class);"
-      },
-      {
-        "lineNumber": 32,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        readUserPrefs(null);"
-      },
-      {
-        "lineNumber": 33,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 34,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 35,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    private Optional\u003cUserPrefs\u003e readUserPrefs(String userPrefsFileInTestDataFolder) throws DataConversionException {"
-      },
-      {
-        "lineNumber": 36,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        String prefsFilePath \u003d addToTestDataPathIfNotNull(userPrefsFileInTestDataFolder);"
-      },
-      {
-        "lineNumber": 37,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        return new JsonUserPrefsStorage(prefsFilePath).readUserPrefs(prefsFilePath);"
-      },
-      {
-        "lineNumber": 38,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 39,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 40,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    @Test"
-      },
-      {
-        "lineNumber": 41,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public void readUserPrefs_missingFile_emptyResult() throws DataConversionException {"
-      },
-      {
-        "lineNumber": 42,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertFalse(readUserPrefs(\"NonExistentFile.json\").isPresent());"
-      },
-      {
-        "lineNumber": 43,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 44,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 45,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    @Test"
-      },
-      {
-        "lineNumber": 46,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public void readUserPrefs_notJsonFormat_exceptionThrown() throws DataConversionException {"
-      },
-      {
-        "lineNumber": 47,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        thrown.expect(DataConversionException.class);"
-      },
-      {
-        "lineNumber": 48,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        readUserPrefs(\"NotJsonFormatUserPrefs.json\");"
-      },
-      {
-        "lineNumber": 49,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 50,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        /* IMPORTANT: Any code below an exception-throwing line (like the one above) will be ignored."
-      },
-      {
-        "lineNumber": 51,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "         * That means you should not have more than one exception test in one method"
-      },
-      {
-        "lineNumber": 52,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "         */"
-      },
-      {
-        "lineNumber": 53,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 54,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 55,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    private String addToTestDataPathIfNotNull(String userPrefsFileInTestDataFolder) {"
-      },
-      {
-        "lineNumber": 56,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        return userPrefsFileInTestDataFolder !\u003d null"
-      },
-      {
-        "lineNumber": 57,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "                ? TEST_DATA_FOLDER + userPrefsFileInTestDataFolder"
-      },
-      {
-        "lineNumber": 58,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "                : null;"
-      },
-      {
-        "lineNumber": 59,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 60,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 61,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    @Test"
-      },
-      {
-        "lineNumber": 62,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public void readUserPrefs_fileInOrder_successfullyRead() throws DataConversionException {"
-      },
-      {
-        "lineNumber": 63,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        UserPrefs expected \u003d getTypicalUserPrefs();"
-      },
-      {
-        "lineNumber": 64,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        UserPrefs actual \u003d readUserPrefs(\"TypicalUserPref.json\").get();"
-      },
-      {
-        "lineNumber": 65,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertEquals(expected, actual);"
-      },
-      {
-        "lineNumber": 66,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 67,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 68,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    @Test"
-      },
-      {
-        "lineNumber": 69,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public void readUserPrefs_valuesMissingFromFile_defaultValuesUsed() throws DataConversionException {"
-      },
-      {
-        "lineNumber": 70,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        UserPrefs actual \u003d readUserPrefs(\"EmptyUserPrefs.json\").get();"
-      },
-      {
-        "lineNumber": 71,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertEquals(new UserPrefs(), actual);"
-      },
-      {
-        "lineNumber": 72,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 73,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 74,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    @Test"
-      },
-      {
-        "lineNumber": 75,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public void readUserPrefs_extraValuesInFile_extraValuesIgnored() throws DataConversionException {"
-      },
-      {
-        "lineNumber": 76,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        UserPrefs expected \u003d getTypicalUserPrefs();"
-      },
-      {
-        "lineNumber": 77,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        UserPrefs actual \u003d readUserPrefs(\"ExtraValuesUserPref.json\").get();"
-      },
-      {
-        "lineNumber": 78,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 79,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertEquals(expected, actual);"
-      },
-      {
-        "lineNumber": 80,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 81,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 82,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    private UserPrefs getTypicalUserPrefs() {"
-      },
-      {
-        "lineNumber": 83,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        UserPrefs userPrefs \u003d new UserPrefs();"
-      },
-      {
-        "lineNumber": 84,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        userPrefs.setGuiSettings(1000, 500, 300, 100);"
-      },
-      {
-        "lineNumber": 85,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        userPrefs.setAddressBookFilePath(\"myteammanager.xml\");"
-      },
-      {
-        "lineNumber": 86,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        userPrefs.setAddressBookName(\"TypicalAddressBookName\");"
-      },
-      {
-        "lineNumber": 87,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        return userPrefs;"
-      },
-      {
-        "lineNumber": 88,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 89,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 90,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    @Test"
-      },
-      {
-        "lineNumber": 91,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public void savePrefs_nullPrefs_throwsNullPointerException() {"
-      },
-      {
-        "lineNumber": 92,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        thrown.expect(NullPointerException.class);"
-      },
-      {
-        "lineNumber": 93,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        saveUserPrefs(null, \"SomeFile.json\");"
-      },
-      {
-        "lineNumber": 94,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 95,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 96,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    @Test"
-      },
-      {
-        "lineNumber": 97,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public void saveUserPrefs_nullFilePath_throwsNullPointerException() {"
-      },
-      {
-        "lineNumber": 98,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        thrown.expect(NullPointerException.class);"
-      },
-      {
-        "lineNumber": 99,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        saveUserPrefs(new UserPrefs(), null);"
-      },
-      {
-        "lineNumber": 100,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 101,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 102,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    /**"
-      },
-      {
-        "lineNumber": 103,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     * Saves {@code userPrefs} at the specified {@code prefsFileInTestDataFolder} filepath."
-      },
-      {
-        "lineNumber": 104,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     */"
-      },
-      {
-        "lineNumber": 105,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    private void saveUserPrefs(UserPrefs userPrefs, String prefsFileInTestDataFolder) {"
-      },
-      {
-        "lineNumber": 106,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        try {"
-      },
-      {
-        "lineNumber": 107,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "            new JsonUserPrefsStorage(addToTestDataPathIfNotNull(prefsFileInTestDataFolder))"
-      },
-      {
-        "lineNumber": 108,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "                    .saveUserPrefs(userPrefs);"
-      },
-      {
-        "lineNumber": 109,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        } catch (IOException ioe) {"
-      },
-      {
-        "lineNumber": 110,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "            throw new AssertionError(\"There should not be an error writing to the file\", ioe);"
-      },
-      {
-        "lineNumber": 111,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        }"
-      },
-      {
-        "lineNumber": 112,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 113,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 114,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    @Test"
-      },
-      {
-        "lineNumber": 115,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public void saveUserPrefs_allInOrder_success() throws DataConversionException, IOException {"
-      },
-      {
-        "lineNumber": 116,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 117,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        UserPrefs original \u003d new UserPrefs();"
-      },
-      {
-        "lineNumber": 118,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        original.setGuiSettings(1200, 200, 0, 2);"
-      },
-      {
-        "lineNumber": 119,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 120,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        String pefsFilePath \u003d testFolder.getRoot() + File.separator + \"TempPrefs.json\";"
-      },
-      {
-        "lineNumber": 121,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        JsonUserPrefsStorage jsonUserPrefsStorage \u003d new JsonUserPrefsStorage(pefsFilePath);"
-      },
-      {
-        "lineNumber": 122,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 123,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        //Try writing when the file doesn\u0027t exist"
-      },
-      {
-        "lineNumber": 124,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        jsonUserPrefsStorage.saveUserPrefs(original);"
-      },
-      {
-        "lineNumber": 125,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        UserPrefs readBack \u003d jsonUserPrefsStorage.readUserPrefs().get();"
-      },
-      {
-        "lineNumber": 126,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertEquals(original, readBack);"
-      },
-      {
-        "lineNumber": 127,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 128,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        //Try saving when the file exists"
-      },
-      {
-        "lineNumber": 129,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        original.setGuiSettings(5, 5, 5, 5);"
-      },
-      {
-        "lineNumber": 130,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        jsonUserPrefsStorage.saveUserPrefs(original);"
-      },
-      {
-        "lineNumber": 131,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        readBack \u003d jsonUserPrefsStorage.readUserPrefs().get();"
-      },
-      {
-        "lineNumber": 132,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertEquals(original, readBack);"
-      },
-      {
-        "lineNumber": 133,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 134,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 135,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "}"
-      }
-    ],
-    "authorContributionMap": {
-      "codeeong": 1,
-      "-": 134
     }
   },
   {
@@ -125910,56 +119592,56 @@
       {
         "lineNumber": 1,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "package seedu.address.testutil;"
       },
       {
         "lineNumber": 2,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 3,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import seedu.address.model.team.Team;"
       },
       {
         "lineNumber": 4,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import seedu.address.model.team.TeamName;"
       },
       {
         "lineNumber": 5,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 6,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "/**"
       },
       {
         "lineNumber": 7,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": " * A utility class to help with building a TeamList."
       },
       {
         "lineNumber": 8,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": " */"
       },
@@ -126182,7 +119864,8 @@
       }
     ],
     "authorContributionMap": {
-      "codeeong": 39
+      "codeeong": 31,
+      "-": 8
     }
   },
   {
@@ -127365,98 +121048,98 @@
       {
         "lineNumber": 1,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "package seedu.address.testutil;"
       },
       {
         "lineNumber": 2,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 3,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import java.util.ArrayList;"
       },
       {
         "lineNumber": 4,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import java.util.Arrays;"
       },
       {
         "lineNumber": 5,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import java.util.List;"
       },
       {
         "lineNumber": 6,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 7,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import seedu.address.model.AddressBook;"
       },
       {
         "lineNumber": 8,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import seedu.address.model.tag.Tag;"
       },
       {
         "lineNumber": 9,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import seedu.address.model.tag.UniqueTagList;"
       },
       {
         "lineNumber": 10,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 11,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 12,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "/**"
       },
       {
         "lineNumber": 13,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": " * A utility class containing a list of {@code Tag} objects to be used in tests."
       },
       {
         "lineNumber": 14,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": " */"
       },
@@ -127665,7 +121348,8 @@
       }
     ],
     "authorContributionMap": {
-      "codeeong": 43
+      "codeeong": 29,
+      "-": 14
     }
   },
   {
@@ -129420,91 +123104,91 @@
       {
         "lineNumber": 1,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "package seedu.address.ui;"
       },
       {
         "lineNumber": 2,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 3,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import static org.junit.Assert.assertFalse;"
       },
       {
         "lineNumber": 4,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import static org.junit.Assert.assertTrue;"
       },
       {
         "lineNumber": 5,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import static seedu.address.ui.testutil.GuiTestAssert.assertPlayerDetailsDisplaysPerson;"
       },
       {
         "lineNumber": 6,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 7,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import org.junit.Test;"
       },
       {
         "lineNumber": 8,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 9,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import guitests.guihandles.PlayerDetailsHandle;"
       },
       {
         "lineNumber": 10,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 11,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import seedu.address.model.person.Person;"
       },
       {
         "lineNumber": 12,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import seedu.address.testutil.PersonBuilder;"
       },
       {
         "lineNumber": 13,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -129818,7 +123502,8 @@
       }
     ],
     "authorContributionMap": {
-      "codeeong": 57
+      "codeeong": 44,
+      "-": 13
     }
   },
   {
@@ -129827,63 +123512,63 @@
       {
         "lineNumber": 1,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "package seedu.address.ui;"
       },
       {
         "lineNumber": 2,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 3,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import static seedu.address.testutil.EventsUtil.postNow;"
       },
       {
         "lineNumber": 4,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import static seedu.address.ui.testutil.GuiTestAssert.assertTeamDisplayEquals;"
       },
       {
         "lineNumber": 5,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 6,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import org.junit.Before;"
       },
       {
         "lineNumber": 7,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import org.junit.Test;"
       },
       {
         "lineNumber": 8,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 9,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import guitests.guihandles.TeamDisplayHandle;"
       },
@@ -129897,70 +123582,70 @@
       {
         "lineNumber": 11,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import javafx.collections.ObservableList;"
       },
       {
         "lineNumber": 12,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import seedu.address.commons.events.ui.ShowNewTeamNameEvent;"
       },
       {
         "lineNumber": 13,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import seedu.address.model.team.Team;"
       },
       {
         "lineNumber": 14,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import seedu.address.model.team.TeamName;"
       },
       {
         "lineNumber": 15,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import seedu.address.testutil.TeamBuilder;"
       },
       {
         "lineNumber": 16,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 17,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "/**"
       },
       {
         "lineNumber": 18,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": " * tests for TeamDisplay UI Component."
       },
       {
         "lineNumber": 19,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": " */"
       },
       {
         "lineNumber": 20,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -130309,850 +123994,9 @@
       }
     ],
     "authorContributionMap": {
-      "codeeong": 68,
-      "jordancjq": 1
-    }
-  },
-  {
-    "path": "src/test/java/seedu/address/ui/UiPartTest.java",
-    "lines": [
-      {
-        "lineNumber": 1,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "package seedu.address.ui;"
-      },
-      {
-        "lineNumber": 2,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 3,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static org.junit.Assert.assertEquals;"
-      },
-      {
-        "lineNumber": 4,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static org.junit.Assert.assertNotNull;"
-      },
-      {
-        "lineNumber": 5,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 6,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import java.net.URL;"
-      },
-      {
-        "lineNumber": 7,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 8,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import org.junit.Rule;"
-      },
-      {
-        "lineNumber": 9,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import org.junit.Test;"
-      },
-      {
-        "lineNumber": 10,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import org.junit.rules.ExpectedException;"
-      },
-      {
-        "lineNumber": 11,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import org.junit.rules.TemporaryFolder;"
-      },
-      {
-        "lineNumber": 12,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 13,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import javafx.fxml.FXML;"
-      },
-      {
-        "lineNumber": 14,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.MainApp;"
-      },
-      {
-        "lineNumber": 15,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.testutil.Assert;"
-      },
-      {
-        "lineNumber": 16,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 17,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "public class UiPartTest {"
-      },
-      {
-        "lineNumber": 18,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 19,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    private static final String MISSING_FILE_PATH \u003d \"UiPartTest/missingFile.fxml\";"
-      },
-      {
-        "lineNumber": 20,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    private static final String INVALID_FILE_PATH \u003d \"UiPartTest/invalidFile.fxml\";"
-      },
-      {
-        "lineNumber": 21,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    private static final String VALID_FILE_PATH \u003d \"UiPartTest/validFile.fxml\";"
-      },
-      {
-        "lineNumber": 22,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    private static final String VALID_FILE_WITH_FX_ROOT_PATH \u003d \"UiPartTest/validFileWithFxRoot.fxml\";"
-      },
-      {
-        "lineNumber": 23,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    private static final TestFxmlObject VALID_FILE_ROOT \u003d new TestFxmlObject(\"Hello World!\");"
-      },
-      {
-        "lineNumber": 24,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 25,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    @Rule"
-      },
-      {
-        "lineNumber": 26,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public ExpectedException thrown \u003d ExpectedException.none();"
-      },
-      {
-        "lineNumber": 27,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 28,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    @Rule"
-      },
-      {
-        "lineNumber": 29,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public TemporaryFolder testFolder \u003d new TemporaryFolder();"
-      },
-      {
-        "lineNumber": 30,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 31,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    @Test"
-      },
-      {
-        "lineNumber": 32,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public void constructor_nullFileUrl_throwsNullPointerException() {"
-      },
-      {
-        "lineNumber": 33,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        Assert.assertThrows(NullPointerException.class, () -\u003e new TestUiPart\u003cObject\u003e((URL) null));"
-      },
-      {
-        "lineNumber": 34,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        Assert.assertThrows(NullPointerException.class, () -\u003e new TestUiPart\u003cObject\u003e((URL) null, new Object()));"
-      },
-      {
-        "lineNumber": 35,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 36,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 37,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    @Test"
-      },
-      {
-        "lineNumber": 38,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public void constructor_missingFileUrl_throwsAssertionError() throws Exception {"
-      },
-      {
-        "lineNumber": 39,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        URL missingFileUrl \u003d new URL(testFolder.getRoot().toURI().toURL(), MISSING_FILE_PATH);"
-      },
-      {
-        "lineNumber": 40,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        Assert.assertThrows(AssertionError.class, () -\u003e new TestUiPart\u003cObject\u003e(missingFileUrl));"
-      },
-      {
-        "lineNumber": 41,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        Assert.assertThrows(AssertionError.class, () -\u003e new TestUiPart\u003cObject\u003e(missingFileUrl, new Object()));"
-      },
-      {
-        "lineNumber": 42,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 43,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 44,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    @Test"
-      },
-      {
-        "lineNumber": 45,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public void constructor_invalidFileUrl_throwsAssertionError() {"
-      },
-      {
-        "lineNumber": 46,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        URL invalidFileUrl \u003d getTestFileUrl(INVALID_FILE_PATH);"
-      },
-      {
-        "lineNumber": 47,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        Assert.assertThrows(AssertionError.class, () -\u003e new TestUiPart\u003cObject\u003e(invalidFileUrl));"
-      },
-      {
-        "lineNumber": 48,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        Assert.assertThrows(AssertionError.class, () -\u003e new TestUiPart\u003cObject\u003e(invalidFileUrl, new Object()));"
-      },
-      {
-        "lineNumber": 49,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 50,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 51,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    @Test"
-      },
-      {
-        "lineNumber": 52,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public void constructor_validFileUrl_loadsFile() {"
-      },
-      {
-        "lineNumber": 53,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        URL validFileUrl \u003d getTestFileUrl(VALID_FILE_PATH);"
-      },
-      {
-        "lineNumber": 54,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertEquals(VALID_FILE_ROOT, new TestUiPart\u003cTestFxmlObject\u003e(validFileUrl).getRoot());"
-      },
-      {
-        "lineNumber": 55,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 56,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 57,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    @Test"
-      },
-      {
-        "lineNumber": 58,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public void constructor_validFileWithFxRootUrl_loadsFile() {"
-      },
-      {
-        "lineNumber": 59,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        URL validFileUrl \u003d getTestFileUrl(VALID_FILE_WITH_FX_ROOT_PATH);"
-      },
-      {
-        "lineNumber": 60,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        TestFxmlObject root \u003d new TestFxmlObject();"
-      },
-      {
-        "lineNumber": 61,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertEquals(VALID_FILE_ROOT, new TestUiPart\u003cTestFxmlObject\u003e(validFileUrl, root).getRoot());"
-      },
-      {
-        "lineNumber": 62,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 63,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 64,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    @Test"
-      },
-      {
-        "lineNumber": 65,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public void constructor_nullFileName_throwsNullPointerException() {"
-      },
-      {
-        "lineNumber": 66,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        Assert.assertThrows(NullPointerException.class, () -\u003e new TestUiPart\u003cObject\u003e((String) null));"
-      },
-      {
-        "lineNumber": 67,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        Assert.assertThrows(NullPointerException.class, () -\u003e new TestUiPart\u003cObject\u003e((String) null, new Object()));"
-      },
-      {
-        "lineNumber": 68,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 69,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 70,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    @Test"
-      },
-      {
-        "lineNumber": 71,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public void constructor_missingFileName_throwsNullPointerException() {"
-      },
-      {
-        "lineNumber": 72,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        Assert.assertThrows(NullPointerException.class, () -\u003e new TestUiPart\u003cObject\u003e(MISSING_FILE_PATH));"
-      },
-      {
-        "lineNumber": 73,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        Assert.assertThrows(NullPointerException.class, () -\u003e new TestUiPart\u003cObject\u003e(MISSING_FILE_PATH, new Object()));"
-      },
-      {
-        "lineNumber": 74,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 75,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 76,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    @Test"
-      },
-      {
-        "lineNumber": 77,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public void constructor_invalidFileName_throwsAssertionError() {"
-      },
-      {
-        "lineNumber": 78,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        Assert.assertThrows(AssertionError.class, () -\u003e new TestUiPart\u003cObject\u003e(INVALID_FILE_PATH));"
-      },
-      {
-        "lineNumber": 79,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        Assert.assertThrows(AssertionError.class, () -\u003e new TestUiPart\u003cObject\u003e(INVALID_FILE_PATH, new Object()));"
-      },
-      {
-        "lineNumber": 80,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 81,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 82,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    private URL getTestFileUrl(String testFilePath) {"
-      },
-      {
-        "lineNumber": 83,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        String testFilePathInView \u003d \"/view/\" + testFilePath;"
-      },
-      {
-        "lineNumber": 84,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        URL testFileUrl \u003d MainApp.class.getResource(testFilePathInView);"
-      },
-      {
-        "lineNumber": 85,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertNotNull(testFilePathInView + \" does not exist.\", testFileUrl);"
-      },
-      {
-        "lineNumber": 86,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        return testFileUrl;"
-      },
-      {
-        "lineNumber": 87,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 88,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 89,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    /**"
-      },
-      {
-        "lineNumber": 90,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     * UiPart used for testing."
-      },
-      {
-        "lineNumber": 91,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     * It should only be used with invalid FXML files or the valid file located at {@link VALID_FILE_PATH}."
-      },
-      {
-        "lineNumber": 92,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     */"
-      },
-      {
-        "lineNumber": 93,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    private static class TestUiPart\u003cT\u003e extends UiPart\u003cT\u003e {"
-      },
-      {
-        "lineNumber": 94,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 95,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        @FXML"
-      },
-      {
-        "lineNumber": 96,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        private TestFxmlObject validFileRoot; // Check that @FXML annotations work"
-      },
-      {
-        "lineNumber": 97,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 98,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        TestUiPart(URL fxmlFileUrl, T root) {"
-      },
-      {
-        "lineNumber": 99,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "            super(fxmlFileUrl, root);"
-      },
-      {
-        "lineNumber": 100,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        }"
-      },
-      {
-        "lineNumber": 101,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 102,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        TestUiPart(String fxmlFileName, T root) {"
-      },
-      {
-        "lineNumber": 103,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "            super(fxmlFileName, root);"
-      },
-      {
-        "lineNumber": 104,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        }"
-      },
-      {
-        "lineNumber": 105,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 106,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        TestUiPart(URL fxmlFileUrl) {"
-      },
-      {
-        "lineNumber": 107,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "            super(fxmlFileUrl);"
-      },
-      {
-        "lineNumber": 108,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "            assertEquals(VALID_FILE_ROOT, validFileRoot);"
-      },
-      {
-        "lineNumber": 109,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        }"
-      },
-      {
-        "lineNumber": 110,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 111,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        TestUiPart(String fxmlFileName) {"
-      },
-      {
-        "lineNumber": 112,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "            super(fxmlFileName);"
-      },
-      {
-        "lineNumber": 113,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "            assertEquals(VALID_FILE_ROOT, validFileRoot);"
-      },
-      {
-        "lineNumber": 114,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        }"
-      },
-      {
-        "lineNumber": 115,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 116,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 117,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 118,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "}"
-      },
-      {
-        "lineNumber": 119,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ""
-      }
-    ],
-    "authorContributionMap": {
-      "codeeong": 1,
-      "-": 118
+      "jordancjq": 1,
+      "codeeong": 49,
+      "-": 19
     }
   },
   {
@@ -131182,7 +124026,7 @@
       {
         "lineNumber": 4,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import static org.junit.Assert.fail;"
       },
@@ -131196,7 +124040,7 @@
       {
         "lineNumber": 6,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import java.util.Arrays;"
       },
@@ -131238,7 +124082,7 @@
       {
         "lineNumber": 12,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import guitests.guihandles.PlayerDetailsHandle;"
       },
@@ -131252,7 +124096,7 @@
       {
         "lineNumber": 14,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import guitests.guihandles.TeamDisplayHandle;"
       },
@@ -131266,14 +124110,14 @@
       {
         "lineNumber": 16,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import seedu.address.ui.PersonCard;"
       },
       {
         "lineNumber": 17,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import seedu.address.ui.TeamDisplay;"
       },
@@ -131315,14 +124159,14 @@
       {
         "lineNumber": 23,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    private static final String LABEL_DEFAULT_STYLE \u003d \"label\";"
       },
       {
         "lineNumber": 24,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -131364,14 +124208,14 @@
       {
         "lineNumber": 30,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        assertEquals(expectedCard.getPosition(), actualCard.getPosition());"
       },
       {
         "lineNumber": 31,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        assertEquals(expectedCard.getRating(), actualCard.getRating());"
       },
@@ -131385,7 +124229,7 @@
       {
         "lineNumber": 33,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        assertEquals(expectedCard.getTeamName(), actualCard.getTeamName());"
       },
@@ -131399,21 +124243,21 @@
       {
         "lineNumber": 35,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 36,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        expectedCard.getTags().forEach(tag -\u003e"
       },
       {
         "lineNumber": 37,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "                assertEquals(expectedCard.getTagStyleClasses(tag), actualCard.getTagStyleClasses(tag)));"
       },
@@ -131434,21 +124278,21 @@
       {
         "lineNumber": 40,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    /**"
       },
       {
         "lineNumber": 41,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "     * Asserts that {@code actualTeamDisplay} displays the details of {@code expectedTeamDisplay}."
       },
       {
         "lineNumber": 42,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "     */"
       },
@@ -131497,7 +124341,7 @@
       {
         "lineNumber": 49,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -131539,70 +124383,70 @@
       {
         "lineNumber": 55,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        assertEquals(expectedPerson.getTeamName().toString(), actualCard.getTeamName());"
       },
       {
         "lineNumber": 56,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        assertEquals(expectedPerson.getRating().value, actualCard.getRating());"
       },
       {
         "lineNumber": 57,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        assertEquals(expectedPerson.getPosition().getPositionName(), actualCard.getPosition());"
       },
       {
         "lineNumber": 58,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 59,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        assertTagsEqual(expectedPerson, actualCard);"
       },
       {
         "lineNumber": 60,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    }"
       },
       {
         "lineNumber": 61,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 62,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    /**"
       },
       {
         "lineNumber": 63,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "     * Asserts that {@code actualPlayerDetails} displays the details of {@code expectedPerson}."
       },
       {
         "lineNumber": 64,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "     */"
       },
@@ -131679,294 +124523,294 @@
       {
         "lineNumber": 75,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 76,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    /**"
       },
       {
         "lineNumber": 77,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "     * Returns the color style for {@code tagName}\u0027s label. The tag\u0027s color is determined by looking up the color"
       },
       {
         "lineNumber": 78,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "     * of {@tagColour}"
       },
       {
         "lineNumber": 79,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "     *"
       },
       {
         "lineNumber": 80,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "     * @see PersonCard getTagColorStyleFor(String)"
       },
       {
         "lineNumber": 81,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "     */"
       },
       {
         "lineNumber": 82,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    private static String getTagColorStyleFor(String tagName) {"
       },
       {
         "lineNumber": 83,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        switch (tagName) {"
       },
       {
         "lineNumber": 84,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        case \"classmates\":"
       },
       {
         "lineNumber": 85,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        case \"owesMoney\":"
       },
       {
         "lineNumber": 86,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        case \"colleagues\":"
       },
       {
         "lineNumber": 87,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        case \"neighbours\":"
       },
       {
         "lineNumber": 88,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        case \"family\":"
       },
       {
         "lineNumber": 89,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        case \"friend\":"
       },
       {
         "lineNumber": 90,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        case \"friends\":"
       },
       {
         "lineNumber": 91,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        case \"husband\":"
       },
       {
         "lineNumber": 92,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        case \"redCard\":"
       },
       {
         "lineNumber": 93,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        case \"yellowCard\":"
       },
       {
         "lineNumber": 94,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        case \"goodAttitude\":"
       },
       {
         "lineNumber": 95,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        case \"badAttitude\":"
       },
       {
         "lineNumber": 96,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        case \"injured\":"
       },
       {
         "lineNumber": 97,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        case \"fastRunner\":"
       },
       {
         "lineNumber": 98,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "            return \"teal\";"
       },
       {
         "lineNumber": 99,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 100,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        default:"
       },
       {
         "lineNumber": 101,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "            fail(tagName + \" does not have a color assigned.\");"
       },
       {
         "lineNumber": 102,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "            return \"\";"
       },
       {
         "lineNumber": 103,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        }"
       },
       {
         "lineNumber": 104,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    }"
       },
       {
         "lineNumber": 105,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 106,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    /**"
       },
       {
         "lineNumber": 107,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "     * Asserts that the tags in {@code actualCard} matches all the tags in {@code expectedPerson} with the correct"
       },
       {
         "lineNumber": 108,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "     * color."
       },
       {
         "lineNumber": 109,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "     */"
       },
       {
         "lineNumber": 110,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    private static void assertTagsEqual(Person expectedPerson, PersonCardHandle actualCard) {"
       },
       {
         "lineNumber": 111,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        List\u003cString\u003e expectedTags \u003d expectedPerson.getTags().stream()"
       },
       {
         "lineNumber": 112,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "                .map(tag -\u003e tag.tagName).collect(Collectors.toList());"
       },
       {
         "lineNumber": 113,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        assertEquals(expectedTags, actualCard.getTags());"
       },
       {
         "lineNumber": 114,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        expectedTags.forEach(tag -\u003e"
       },
       {
         "lineNumber": 115,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "                assertEquals(Arrays.asList(LABEL_DEFAULT_STYLE, getTagColorStyleFor(tag)),"
       },
       {
         "lineNumber": 116,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "                        actualCard.getTagStyleClasses(tag)));"
       },
@@ -132217,8 +125061,8 @@
       }
     ],
     "authorContributionMap": {
-      "codeeong": 86,
-      "-": 65
+      "codeeong": 16,
+      "-": 135
     }
   },
   {
@@ -132360,7 +125204,7 @@
       {
         "lineNumber": 20,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import static seedu.address.logic.commands.CommandTestUtil.JERSEY_NUMBER_DESC_17;"
       },
@@ -132402,7 +125246,7 @@
       {
         "lineNumber": 26,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import static seedu.address.logic.commands.CommandTestUtil.POSITION_DESC_MIDFILED;"
       },
@@ -132423,7 +125267,7 @@
       {
         "lineNumber": 29,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import static seedu.address.logic.commands.CommandTestUtil.RATING_DESC_1;"
       },
@@ -133081,7 +125925,7 @@
       {
         "lineNumber": 123,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "                + TAG_DESC_FRIEND + RATING_DESC_0 + POSITION_DESC_STRIKER + JERSEY_NUMBER_DESC_2;"
       },
@@ -133277,7 +126121,7 @@
       {
         "lineNumber": 151,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "                + TAG_DESC_HUSBAND + EMAIL_DESC_BOB + POSITION_DESC_MIDFILED + JERSEY_NUMBER_DESC_17 + RATING_DESC_1;"
       },
@@ -134775,1880 +127619,8 @@
     ],
     "authorContributionMap": {
       "lithiumlkid": 189,
-      "codeeong": 5,
       "jordancjq": 9,
-      "-": 161
-    }
-  },
-  {
-    "path": "src/test/java/systemtests/AddressBookSystemTest.java",
-    "lines": [
-      {
-        "lineNumber": 1,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "package systemtests;"
-      },
-      {
-        "lineNumber": 2,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 3,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static org.junit.Assert.assertEquals;"
-      },
-      {
-        "lineNumber": 4,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static org.junit.Assert.assertFalse;"
-      },
-      {
-        "lineNumber": 5,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static org.junit.Assert.assertTrue;"
-      },
-      {
-        "lineNumber": 6,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static seedu.address.ui.StatusBarFooter.SYNC_STATUS_INITIAL;"
-      },
-      {
-        "lineNumber": 7,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static seedu.address.ui.StatusBarFooter.SYNC_STATUS_UPDATED;"
-      },
-      {
-        "lineNumber": 8,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static seedu.address.ui.testutil.GuiTestAssert.assertListMatching;"
-      },
-      {
-        "lineNumber": 9,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 10,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import java.util.Arrays;"
-      },
-      {
-        "lineNumber": 11,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import java.util.Date;"
-      },
-      {
-        "lineNumber": 12,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import java.util.List;"
-      },
-      {
-        "lineNumber": 13,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 14,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import org.junit.After;"
-      },
-      {
-        "lineNumber": 15,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import org.junit.Before;"
-      },
-      {
-        "lineNumber": 16,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import org.junit.BeforeClass;"
-      },
-      {
-        "lineNumber": 17,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import org.junit.ClassRule;"
-      },
-      {
-        "lineNumber": 18,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 19,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import guitests.guihandles.CommandBoxHandle;"
-      },
-      {
-        "lineNumber": 20,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import guitests.guihandles.MainMenuHandle;"
-      },
-      {
-        "lineNumber": 21,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import guitests.guihandles.MainWindowHandle;"
-      },
-      {
-        "lineNumber": 22,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import guitests.guihandles.PersonListPanelHandle;"
-      },
-      {
-        "lineNumber": 23,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import guitests.guihandles.ResultDisplayHandle;"
-      },
-      {
-        "lineNumber": 24,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import guitests.guihandles.StatusBarFooterHandle;"
-      },
-      {
-        "lineNumber": 25,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 26,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.TestApp;"
-      },
-      {
-        "lineNumber": 27,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.commons.core.EventsCenter;"
-      },
-      {
-        "lineNumber": 28,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.commons.core.index.Index;"
-      },
-      {
-        "lineNumber": 29,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.logic.commands.ClearCommand;"
-      },
-      {
-        "lineNumber": 30,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.logic.commands.FindCommand;"
-      },
-      {
-        "lineNumber": 31,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.logic.commands.ListCommand;"
-      },
-      {
-        "lineNumber": 32,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.logic.commands.SelectCommand;"
-      },
-      {
-        "lineNumber": 33,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.model.AddressBook;"
-      },
-      {
-        "lineNumber": 34,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.model.Model;"
-      },
-      {
-        "lineNumber": 35,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.testutil.TypicalPersons;"
-      },
-      {
-        "lineNumber": 36,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.ui.CommandBox;"
-      },
-      {
-        "lineNumber": 37,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 38,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "/**"
-      },
-      {
-        "lineNumber": 39,
-        "author": {
-          "gitId": "-"
-        },
-        "content": " * A system test class for AddressBook, which provides access to handles of GUI components and helper methods"
-      },
-      {
-        "lineNumber": 40,
-        "author": {
-          "gitId": "-"
-        },
-        "content": " * for test verification."
-      },
-      {
-        "lineNumber": 41,
-        "author": {
-          "gitId": "-"
-        },
-        "content": " */"
-      },
-      {
-        "lineNumber": 42,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "public abstract class AddressBookSystemTest {"
-      },
-      {
-        "lineNumber": 43,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    @ClassRule"
-      },
-      {
-        "lineNumber": 44,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public static ClockRule clockRule \u003d new ClockRule();"
-      },
-      {
-        "lineNumber": 45,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 46,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    private static final List\u003cString\u003e COMMAND_BOX_DEFAULT_STYLE \u003d Arrays.asList(\"text-input\", \"text-field\");"
-      },
-      {
-        "lineNumber": 47,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    private static final List\u003cString\u003e COMMAND_BOX_ERROR_STYLE \u003d"
-      },
-      {
-        "lineNumber": 48,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "            Arrays.asList(\"text-input\", \"text-field\", CommandBox.ERROR_STYLE_CLASS);"
-      },
-      {
-        "lineNumber": 49,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 50,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    private MainWindowHandle mainWindowHandle;"
-      },
-      {
-        "lineNumber": 51,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    private TestApp testApp;"
-      },
-      {
-        "lineNumber": 52,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    private SystemTestSetupHelper setupHelper;"
-      },
-      {
-        "lineNumber": 53,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 54,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    @BeforeClass"
-      },
-      {
-        "lineNumber": 55,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public static void setupBeforeClass() {"
-      },
-      {
-        "lineNumber": 56,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        SystemTestSetupHelper.initialize();"
-      },
-      {
-        "lineNumber": 57,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 58,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 59,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    @Before"
-      },
-      {
-        "lineNumber": 60,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public void setUp() {"
-      },
-      {
-        "lineNumber": 61,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        setupHelper \u003d new SystemTestSetupHelper();"
-      },
-      {
-        "lineNumber": 62,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        testApp \u003d setupHelper.setupApplication(this::getInitialData, getDataFileLocation());"
-      },
-      {
-        "lineNumber": 63,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        mainWindowHandle \u003d setupHelper.setupMainWindowHandle();"
-      },
-      {
-        "lineNumber": 64,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 65,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertApplicationStartingStateIsCorrect();"
-      },
-      {
-        "lineNumber": 66,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 67,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 68,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    @After"
-      },
-      {
-        "lineNumber": 69,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public void tearDown() throws Exception {"
-      },
-      {
-        "lineNumber": 70,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        setupHelper.tearDownStage();"
-      },
-      {
-        "lineNumber": 71,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        EventsCenter.clearSubscribers();"
-      },
-      {
-        "lineNumber": 72,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 73,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 74,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    /**"
-      },
-      {
-        "lineNumber": 75,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     * Returns the data to be loaded into the file in {@link #getDataFileLocation()}."
-      },
-      {
-        "lineNumber": 76,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     */"
-      },
-      {
-        "lineNumber": 77,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    protected AddressBook getInitialData() {"
-      },
-      {
-        "lineNumber": 78,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        return TypicalPersons.getTypicalAddressBook();"
-      },
-      {
-        "lineNumber": 79,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 80,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 81,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    /**"
-      },
-      {
-        "lineNumber": 82,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     * Returns the directory of the data file."
-      },
-      {
-        "lineNumber": 83,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     */"
-      },
-      {
-        "lineNumber": 84,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    protected String getDataFileLocation() {"
-      },
-      {
-        "lineNumber": 85,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        return TestApp.SAVE_LOCATION_FOR_TESTING;"
-      },
-      {
-        "lineNumber": 86,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 87,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 88,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public MainWindowHandle getMainWindowHandle() {"
-      },
-      {
-        "lineNumber": 89,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        return mainWindowHandle;"
-      },
-      {
-        "lineNumber": 90,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 91,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 92,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public CommandBoxHandle getCommandBox() {"
-      },
-      {
-        "lineNumber": 93,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        return mainWindowHandle.getCommandBox();"
-      },
-      {
-        "lineNumber": 94,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 95,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 96,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public PersonListPanelHandle getPersonListPanel() {"
-      },
-      {
-        "lineNumber": 97,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        return mainWindowHandle.getPersonListPanel();"
-      },
-      {
-        "lineNumber": 98,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 99,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 100,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public MainMenuHandle getMainMenu() {"
-      },
-      {
-        "lineNumber": 101,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        return mainWindowHandle.getMainMenu();"
-      },
-      {
-        "lineNumber": 102,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 103,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 104,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public StatusBarFooterHandle getStatusBarFooter() {"
-      },
-      {
-        "lineNumber": 105,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        return mainWindowHandle.getStatusBarFooter();"
-      },
-      {
-        "lineNumber": 106,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 107,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 108,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public ResultDisplayHandle getResultDisplay() {"
-      },
-      {
-        "lineNumber": 109,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        return mainWindowHandle.getResultDisplay();"
-      },
-      {
-        "lineNumber": 110,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 111,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 112,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    /**"
-      },
-      {
-        "lineNumber": 113,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     * Executes {@code command} in the application\u0027s {@code CommandBox}."
-      },
-      {
-        "lineNumber": 114,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     * Method returns after UI components have been updated."
-      },
-      {
-        "lineNumber": 115,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     */"
-      },
-      {
-        "lineNumber": 116,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    protected void executeCommand(String command) {"
-      },
-      {
-        "lineNumber": 117,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        rememberStates();"
-      },
-      {
-        "lineNumber": 118,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        // Injects a fixed clock before executing a command so that the time stamp shown in the status bar"
-      },
-      {
-        "lineNumber": 119,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        // after each command is predictable and also different from the previous command."
-      },
-      {
-        "lineNumber": 120,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        clockRule.setInjectedClockToCurrentTime();"
-      },
-      {
-        "lineNumber": 121,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 122,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        mainWindowHandle.getCommandBox().run(command);"
-      },
-      {
-        "lineNumber": 123,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 124,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 125,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 126,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    /**"
-      },
-      {
-        "lineNumber": 127,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     * Displays all persons in the address book."
-      },
-      {
-        "lineNumber": 128,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     */"
-      },
-      {
-        "lineNumber": 129,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    protected void showAllPersons() {"
-      },
-      {
-        "lineNumber": 130,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        executeCommand(ListCommand.COMMAND_WORD);"
-      },
-      {
-        "lineNumber": 131,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertEquals(getModel().getAddressBook().getPersonList().size(), getModel().getFilteredPersonList().size());"
-      },
-      {
-        "lineNumber": 132,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 133,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 134,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    /**"
-      },
-      {
-        "lineNumber": 135,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     * Displays all persons with any parts of their names matching {@code keyword} (case-insensitive)."
-      },
-      {
-        "lineNumber": 136,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     */"
-      },
-      {
-        "lineNumber": 137,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    protected void showPersonsWithName(String keyword) {"
-      },
-      {
-        "lineNumber": 138,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        executeCommand(FindCommand.COMMAND_WORD + \" \" + keyword);"
-      },
-      {
-        "lineNumber": 139,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertTrue(getModel().getFilteredPersonList().size() \u003c getModel().getAddressBook().getPersonList().size());"
-      },
-      {
-        "lineNumber": 140,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 141,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 142,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    /**"
-      },
-      {
-        "lineNumber": 143,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     * Selects the person at {@code index} of the displayed list."
-      },
-      {
-        "lineNumber": 144,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     */"
-      },
-      {
-        "lineNumber": 145,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    protected void selectPerson(Index index) {"
-      },
-      {
-        "lineNumber": 146,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        executeCommand(SelectCommand.COMMAND_WORD + \" \" + index.getOneBased());"
-      },
-      {
-        "lineNumber": 147,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertEquals(index.getZeroBased(), getPersonListPanel().getSelectedCardIndex());"
-      },
-      {
-        "lineNumber": 148,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 149,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 150,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    /**"
-      },
-      {
-        "lineNumber": 151,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     * Deletes all persons in the address book."
-      },
-      {
-        "lineNumber": 152,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     */"
-      },
-      {
-        "lineNumber": 153,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    protected void deleteAllPersons() {"
-      },
-      {
-        "lineNumber": 154,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        executeCommand(ClearCommand.COMMAND_WORD);"
-      },
-      {
-        "lineNumber": 155,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertEquals(0, getModel().getAddressBook().getPersonList().size());"
-      },
-      {
-        "lineNumber": 156,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 157,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 158,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    /**"
-      },
-      {
-        "lineNumber": 159,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     * Asserts that the {@code CommandBox} displays {@code expectedCommandInput}, the {@code ResultDisplay} displays"
-      },
-      {
-        "lineNumber": 160,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     * {@code expectedResultMessage}, the model and storage contains the same person objects as {@code expectedModel}"
-      },
-      {
-        "lineNumber": 161,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     * and the person list panel displays the persons in the model correctly."
-      },
-      {
-        "lineNumber": 162,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     */"
-      },
-      {
-        "lineNumber": 163,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    protected void assertApplicationDisplaysExpected(String expectedCommandInput, String expectedResultMessage,"
-      },
-      {
-        "lineNumber": 164,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "            Model expectedModel) {"
-      },
-      {
-        "lineNumber": 165,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertEquals(expectedCommandInput, getCommandBox().getInput());"
-      },
-      {
-        "lineNumber": 166,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertEquals(expectedResultMessage, getResultDisplay().getText());"
-      },
-      {
-        "lineNumber": 167,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertEquals(expectedModel, getModel());"
-      },
-      {
-        "lineNumber": 168,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertEquals(expectedModel.getAddressBook(), testApp.readStorageAddressBook());"
-      },
-      {
-        "lineNumber": 169,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertListMatching(getPersonListPanel(), expectedModel.getFilteredPersonList());"
-      },
-      {
-        "lineNumber": 170,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 171,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 172,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    /**"
-      },
-      {
-        "lineNumber": 173,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     * Calls {@code BrowserPanelHandle}, {@code PersonListPanelHandle} and {@code StatusBarFooterHandle} to remember"
-      },
-      {
-        "lineNumber": 174,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     * their current state."
-      },
-      {
-        "lineNumber": 175,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     */"
-      },
-      {
-        "lineNumber": 176,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    private void rememberStates() {"
-      },
-      {
-        "lineNumber": 177,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        StatusBarFooterHandle statusBarFooterHandle \u003d getStatusBarFooter();"
-      },
-      {
-        "lineNumber": 178,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        statusBarFooterHandle.rememberSaveLocation();"
-      },
-      {
-        "lineNumber": 179,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        statusBarFooterHandle.rememberSyncStatus();"
-      },
-      {
-        "lineNumber": 180,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        getPersonListPanel().rememberSelectedPersonCard();"
-      },
-      {
-        "lineNumber": 181,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 182,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 183,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    /**"
-      },
-      {
-        "lineNumber": 184,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     * Asserts that the previously selected card is now deselected and the browser\u0027s url remains displaying the details"
-      },
-      {
-        "lineNumber": 185,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     * of the previously selected person."
-      },
-      {
-        "lineNumber": 186,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     */"
-      },
-      {
-        "lineNumber": 187,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    protected void assertSelectedCardDeselected() {"
-      },
-      {
-        "lineNumber": 188,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertFalse(getPersonListPanel().isAnyCardSelected());"
-      },
-      {
-        "lineNumber": 189,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 190,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 191,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    /**"
-      },
-      {
-        "lineNumber": 192,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     * Asserts that the browser\u0027s url is changed to display the details of the person in the person list panel at"
-      },
-      {
-        "lineNumber": 193,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     * {@code expectedSelectedCardIndex}, and only the card at {@code expectedSelectedCardIndex} is selected."
-      },
-      {
-        "lineNumber": 194,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     * @see PersonListPanelHandle#isSelectedPersonCardChanged()"
-      },
-      {
-        "lineNumber": 195,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     */"
-      },
-      {
-        "lineNumber": 196,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    protected void assertSelectedCardChanged(Index expectedSelectedCardIndex) {"
-      },
-      {
-        "lineNumber": 197,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 198,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertEquals(expectedSelectedCardIndex.getZeroBased(), getPersonListPanel().getSelectedCardIndex());"
-      },
-      {
-        "lineNumber": 199,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 200,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 201,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    /**"
-      },
-      {
-        "lineNumber": 202,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     * Asserts that the browser\u0027s url and the selected card in the person list panel remain unchanged."
-      },
-      {
-        "lineNumber": 203,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     * @see PersonListPanelHandle#isSelectedPersonCardChanged()"
-      },
-      {
-        "lineNumber": 204,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     */"
-      },
-      {
-        "lineNumber": 205,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    protected void assertSelectedCardUnchanged() {"
-      },
-      {
-        "lineNumber": 206,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertFalse(getPersonListPanel().isSelectedPersonCardChanged());"
-      },
-      {
-        "lineNumber": 207,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 208,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 209,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    /**"
-      },
-      {
-        "lineNumber": 210,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     * Asserts that the command box\u0027s shows the default style."
-      },
-      {
-        "lineNumber": 211,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     */"
-      },
-      {
-        "lineNumber": 212,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    protected void assertCommandBoxShowsDefaultStyle() {"
-      },
-      {
-        "lineNumber": 213,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertEquals(COMMAND_BOX_DEFAULT_STYLE, getCommandBox().getStyleClass());"
-      },
-      {
-        "lineNumber": 214,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 215,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 216,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    /**"
-      },
-      {
-        "lineNumber": 217,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     * Asserts that the command box\u0027s shows the error style."
-      },
-      {
-        "lineNumber": 218,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     */"
-      },
-      {
-        "lineNumber": 219,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    protected void assertCommandBoxShowsErrorStyle() {"
-      },
-      {
-        "lineNumber": 220,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertEquals(COMMAND_BOX_ERROR_STYLE, getCommandBox().getStyleClass());"
-      },
-      {
-        "lineNumber": 221,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 222,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 223,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    /**"
-      },
-      {
-        "lineNumber": 224,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     * Asserts that the entire status bar remains the same."
-      },
-      {
-        "lineNumber": 225,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     */"
-      },
-      {
-        "lineNumber": 226,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    protected void assertStatusBarUnchanged() {"
-      },
-      {
-        "lineNumber": 227,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        StatusBarFooterHandle handle \u003d getStatusBarFooter();"
-      },
-      {
-        "lineNumber": 228,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertFalse(handle.isSaveLocationChanged());"
-      },
-      {
-        "lineNumber": 229,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertFalse(handle.isSyncStatusChanged());"
-      },
-      {
-        "lineNumber": 230,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 231,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 232,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    /**"
-      },
-      {
-        "lineNumber": 233,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     * Asserts that only the sync status in the status bar was changed to the timing of"
-      },
-      {
-        "lineNumber": 234,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     * {@code ClockRule#getInjectedClock()}, while the save location remains the same."
-      },
-      {
-        "lineNumber": 235,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     */"
-      },
-      {
-        "lineNumber": 236,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    protected void assertStatusBarUnchangedExceptSyncStatus() {"
-      },
-      {
-        "lineNumber": 237,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        StatusBarFooterHandle handle \u003d getStatusBarFooter();"
-      },
-      {
-        "lineNumber": 238,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        String timestamp \u003d new Date(clockRule.getInjectedClock().millis()).toString();"
-      },
-      {
-        "lineNumber": 239,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        String expectedSyncStatus \u003d String.format(SYNC_STATUS_UPDATED, timestamp);"
-      },
-      {
-        "lineNumber": 240,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertEquals(expectedSyncStatus, handle.getSyncStatus());"
-      },
-      {
-        "lineNumber": 241,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertFalse(handle.isSaveLocationChanged());"
-      },
-      {
-        "lineNumber": 242,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 243,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 244,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    /**"
-      },
-      {
-        "lineNumber": 245,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     * Asserts that the starting state of the application is correct."
-      },
-      {
-        "lineNumber": 246,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     */"
-      },
-      {
-        "lineNumber": 247,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    private void assertApplicationStartingStateIsCorrect() {"
-      },
-      {
-        "lineNumber": 248,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        try {"
-      },
-      {
-        "lineNumber": 249,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "            assertEquals(\"\", getCommandBox().getInput());"
-      },
-      {
-        "lineNumber": 250,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "            assertEquals(\"\", getResultDisplay().getText());"
-      },
-      {
-        "lineNumber": 251,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "            assertListMatching(getPersonListPanel(), getModel().getFilteredPersonList());"
-      },
-      {
-        "lineNumber": 252,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "            //assertEquals that the detail card is correct"
-      },
-      {
-        "lineNumber": 253,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "            assertEquals(\"./\" + testApp.getStorageSaveLocation(), getStatusBarFooter().getSaveLocation());"
-      },
-      {
-        "lineNumber": 254,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "            assertEquals(SYNC_STATUS_INITIAL, getStatusBarFooter().getSyncStatus());"
-      },
-      {
-        "lineNumber": 255,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        } catch (Exception e) {"
-      },
-      {
-        "lineNumber": 256,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "            throw new AssertionError(\"Starting state is wrong.\", e);"
-      },
-      {
-        "lineNumber": 257,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        }"
-      },
-      {
-        "lineNumber": 258,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 259,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 260,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    /**"
-      },
-      {
-        "lineNumber": 261,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     * Returns a defensive copy of the current model."
-      },
-      {
-        "lineNumber": 262,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     */"
-      },
-      {
-        "lineNumber": 263,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    protected Model getModel() {"
-      },
-      {
-        "lineNumber": 264,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        return testApp.getModel();"
-      },
-      {
-        "lineNumber": 265,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 266,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "}"
-      }
-    ],
-    "authorContributionMap": {
-      "codeeong": 2,
-      "-": 264
+      "-": 166
     }
   },
   {
@@ -136685,7 +127657,7 @@
       {
         "lineNumber": 5,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -136811,28 +127783,28 @@
       {
         "lineNumber": 23,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import static seedu.address.logic.commands.CommandTestUtil.POSITION_DESC_MIDFILED;"
       },
       {
         "lineNumber": 24,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import static seedu.address.logic.commands.CommandTestUtil.POSITION_DESC_STRIKER;"
       },
       {
         "lineNumber": 25,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import static seedu.address.logic.commands.CommandTestUtil.RATING_DESC_0;"
       },
       {
         "lineNumber": 26,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "import static seedu.address.logic.commands.CommandTestUtil.RATING_DESC_1;"
       },
@@ -137217,7 +128189,7 @@
       {
         "lineNumber": 81,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "                .withEmail(VALID_EMAIL_BOB).withAddress(VALID_ADDRESS_BOB).withTags(VALID_TAG_HUSBAND)"
       },
@@ -138813,640 +129785,7 @@
     ],
     "authorContributionMap": {
       "lithiumlkid": 25,
-      "codeeong": 6,
-      "-": 277
-    }
-  },
-  {
-    "path": "src/test/java/systemtests/HelpCommandSystemTest.java",
-    "lines": [
-      {
-        "lineNumber": 1,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "package systemtests;"
-      },
-      {
-        "lineNumber": 2,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 3,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static org.junit.Assert.assertEquals;"
-      },
-      {
-        "lineNumber": 4,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static org.junit.Assert.assertFalse;"
-      },
-      {
-        "lineNumber": 5,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static org.junit.Assert.assertNotEquals;"
-      },
-      {
-        "lineNumber": 6,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static org.junit.Assert.assertTrue;"
-      },
-      {
-        "lineNumber": 7,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;"
-      },
-      {
-        "lineNumber": 8,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static seedu.address.ui.testutil.GuiTestAssert.assertListMatching;"
-      },
-      {
-        "lineNumber": 9,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 10,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import org.junit.Test;"
-      },
-      {
-        "lineNumber": 11,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 12,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import guitests.GuiRobot;"
-      },
-      {
-        "lineNumber": 13,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import guitests.guihandles.HelpWindowHandle;"
-      },
-      {
-        "lineNumber": 14,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.logic.commands.DeleteCommand;"
-      },
-      {
-        "lineNumber": 15,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.logic.commands.HelpCommand;"
-      },
-      {
-        "lineNumber": 16,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.logic.commands.SelectCommand;"
-      },
-      {
-        "lineNumber": 17,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.ui.StatusBarFooter;"
-      },
-      {
-        "lineNumber": 18,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 19,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "/**"
-      },
-      {
-        "lineNumber": 20,
-        "author": {
-          "gitId": "-"
-        },
-        "content": " * A system test class for the help window, which contains interaction with other UI components."
-      },
-      {
-        "lineNumber": 21,
-        "author": {
-          "gitId": "-"
-        },
-        "content": " */"
-      },
-      {
-        "lineNumber": 22,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "public class HelpCommandSystemTest extends AddressBookSystemTest {"
-      },
-      {
-        "lineNumber": 23,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    private static final String ERROR_MESSAGE \u003d \"ATTENTION!!!! : On some computers, this test may fail when run on \""
-      },
-      {
-        "lineNumber": 24,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "            + \"non-headless mode as FxRobot#clickOn(Node, MouseButton...) clicks on the wrong location. We suspect \""
-      },
-      {
-        "lineNumber": 25,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "            + \"that this is a bug with TestFX library that we are using. If this test fails, you have to run your \""
-      },
-      {
-        "lineNumber": 26,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "            + \"tests on headless mode. See UsingGradle.adoc on how to do so.\";"
-      },
-      {
-        "lineNumber": 27,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 28,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    private final GuiRobot guiRobot \u003d new GuiRobot();"
-      },
-      {
-        "lineNumber": 29,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 30,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    @Test"
-      },
-      {
-        "lineNumber": 31,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public void openHelpWindow() {"
-      },
-      {
-        "lineNumber": 32,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        //use accelerator"
-      },
-      {
-        "lineNumber": 33,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        getCommandBox().click();"
-      },
-      {
-        "lineNumber": 34,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        getMainMenu().openHelpWindowUsingAccelerator();"
-      },
-      {
-        "lineNumber": 35,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertHelpWindowOpen();"
-      },
-      {
-        "lineNumber": 36,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 37,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        getResultDisplay().click();"
-      },
-      {
-        "lineNumber": 38,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        getMainMenu().openHelpWindowUsingAccelerator();"
-      },
-      {
-        "lineNumber": 39,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertHelpWindowOpen();"
-      },
-      {
-        "lineNumber": 40,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 41,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        getPersonListPanel().click();"
-      },
-      {
-        "lineNumber": 42,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        getMainMenu().openHelpWindowUsingAccelerator();"
-      },
-      {
-        "lineNumber": 43,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertHelpWindowOpen();"
-      },
-      {
-        "lineNumber": 44,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 45,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        //use menu button"
-      },
-      {
-        "lineNumber": 46,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        getMainMenu().openHelpWindowUsingMenu();"
-      },
-      {
-        "lineNumber": 47,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertHelpWindowOpen();"
-      },
-      {
-        "lineNumber": 48,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 49,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        //use command box"
-      },
-      {
-        "lineNumber": 50,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        executeCommand(HelpCommand.COMMAND_WORD);"
-      },
-      {
-        "lineNumber": 51,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertHelpWindowOpen();"
-      },
-      {
-        "lineNumber": 52,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 53,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        // open help window and give it focus"
-      },
-      {
-        "lineNumber": 54,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        executeCommand(HelpCommand.COMMAND_WORD);"
-      },
-      {
-        "lineNumber": 55,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        getMainWindowHandle().focus();"
-      },
-      {
-        "lineNumber": 56,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 57,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        // assert that while the help window is open the UI updates correctly for a command execution"
-      },
-      {
-        "lineNumber": 58,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        executeCommand(SelectCommand.COMMAND_WORD + \" \" + INDEX_FIRST_PERSON.getOneBased());"
-      },
-      {
-        "lineNumber": 59,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertEquals(\"\", getCommandBox().getInput());"
-      },
-      {
-        "lineNumber": 60,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertCommandBoxShowsDefaultStyle();"
-      },
-      {
-        "lineNumber": 61,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertNotEquals(HelpCommand.SHOWING_HELP_MESSAGE, getResultDisplay().getText());"
-      },
-      {
-        "lineNumber": 62,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        //assertNotEquals(BrowserPanel.DEFAULT_PAGE, getBrowserPanel().getLoadedUrl());"
-      },
-      {
-        "lineNumber": 63,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertListMatching(getPersonListPanel(), getModel().getFilteredPersonList());"
-      },
-      {
-        "lineNumber": 64,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 65,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        // assert that the status bar too is updated correctly while the help window is open"
-      },
-      {
-        "lineNumber": 66,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        // note: the select command tested above does not update the status bar"
-      },
-      {
-        "lineNumber": 67,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        executeCommand(DeleteCommand.COMMAND_WORD + \" \" + INDEX_FIRST_PERSON.getOneBased());"
-      },
-      {
-        "lineNumber": 68,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertNotEquals(StatusBarFooter.SYNC_STATUS_INITIAL, getStatusBarFooter().getSyncStatus());"
-      },
-      {
-        "lineNumber": 69,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 70,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 71,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    /**"
-      },
-      {
-        "lineNumber": 72,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     * Asserts that the help window is open, and closes it after checking."
-      },
-      {
-        "lineNumber": 73,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     */"
-      },
-      {
-        "lineNumber": 74,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    private void assertHelpWindowOpen() {"
-      },
-      {
-        "lineNumber": 75,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertTrue(ERROR_MESSAGE, HelpWindowHandle.isWindowPresent());"
-      },
-      {
-        "lineNumber": 76,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        guiRobot.pauseForHuman();"
-      },
-      {
-        "lineNumber": 77,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 78,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        new HelpWindowHandle(guiRobot.getStage(HelpWindowHandle.HELP_WINDOW_TITLE)).close();"
-      },
-      {
-        "lineNumber": 79,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        getMainWindowHandle().focus();"
-      },
-      {
-        "lineNumber": 80,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 81,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 82,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    /**"
-      },
-      {
-        "lineNumber": 83,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     * Asserts that the help window isn\u0027t open."
-      },
-      {
-        "lineNumber": 84,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     */"
-      },
-      {
-        "lineNumber": 85,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    private void assertHelpWindowNotOpen() {"
-      },
-      {
-        "lineNumber": 86,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertFalse(ERROR_MESSAGE, HelpWindowHandle.isWindowPresent());"
-      },
-      {
-        "lineNumber": 87,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 88,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 89,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "}"
-      }
-    ],
-    "authorContributionMap": {
-      "codeeong": 1,
-      "-": 88
+      "-": 283
     }
   }
 ]

--- a/src/functional/resources/noDateRange/expected/reposense_testrepo-Delta_master/authorship.json
+++ b/src/functional/resources/noDateRange/expected/reposense_testrepo-Delta_master/authorship.json
@@ -27066,267 +27066,6 @@
     }
   },
   {
-    "path": "src/main/java/seedu/address/logic/Logic.java",
-    "lines": [
-      {
-        "lineNumber": 1,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "package seedu.address.logic;"
-      },
-      {
-        "lineNumber": 2,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 3,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import javafx.collections.ObservableList;"
-      },
-      {
-        "lineNumber": 4,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.logic.commands.CommandResult;"
-      },
-      {
-        "lineNumber": 5,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "import seedu.address.logic.commands.CommandTrie;"
-      },
-      {
-        "lineNumber": 6,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.logic.commands.exceptions.CommandException;"
-      },
-      {
-        "lineNumber": 7,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.logic.parser.exceptions.ParseException;"
-      },
-      {
-        "lineNumber": 8,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.model.person.Person;"
-      },
-      {
-        "lineNumber": 9,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.model.team.Team;"
-      },
-      {
-        "lineNumber": 10,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 11,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "/**"
-      },
-      {
-        "lineNumber": 12,
-        "author": {
-          "gitId": "-"
-        },
-        "content": " * API of the Logic component"
-      },
-      {
-        "lineNumber": 13,
-        "author": {
-          "gitId": "-"
-        },
-        "content": " */"
-      },
-      {
-        "lineNumber": 14,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "public interface Logic {"
-      },
-      {
-        "lineNumber": 15,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    /**"
-      },
-      {
-        "lineNumber": 16,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     * Executes the command and returns the result."
-      },
-      {
-        "lineNumber": 17,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     * @param commandText The command as entered by the user."
-      },
-      {
-        "lineNumber": 18,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     * @return the result of the command execution."
-      },
-      {
-        "lineNumber": 19,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     * @throws CommandException If an error occurs during command execution."
-      },
-      {
-        "lineNumber": 20,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     * @throws ParseException If an error occurs during parsing."
-      },
-      {
-        "lineNumber": 21,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     */"
-      },
-      {
-        "lineNumber": 22,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    CommandResult execute(String commandText) throws CommandException, ParseException;"
-      },
-      {
-        "lineNumber": 23,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 24,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    /** Returns an unmodifiable view of the filtered list of persons */"
-      },
-      {
-        "lineNumber": 25,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    ObservableList\u003cPerson\u003e getFilteredPersonList();"
-      },
-      {
-        "lineNumber": 26,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 27,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    /** Returns an unmodifiable view of list of teams */"
-      },
-      {
-        "lineNumber": 28,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    ObservableList\u003cTeam\u003e getInitTeamList();"
-      },
-      {
-        "lineNumber": 29,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 30,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    /** Returns the list of input entered by the user, encapsulated in a {@code ListElementPointer} object */"
-      },
-      {
-        "lineNumber": 31,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    ListElementPointer getHistorySnapshot();"
-      },
-      {
-        "lineNumber": 32,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 33,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    /** Returns the command trie. */"
-      },
-      {
-        "lineNumber": 34,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    CommandTrie getCommandTrie();"
-      },
-      {
-        "lineNumber": 35,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 36,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "}"
-      }
-    ],
-    "authorContributionMap": {
-      "lithiumlkid": 5,
-      "-": 31
-    }
-  },
-  {
     "path": "src/main/java/seedu/address/logic/LogicManager.java",
     "lines": [
       {
@@ -27395,7 +27134,7 @@
       {
         "lineNumber": 10,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "import seedu.address.logic.commands.CommandTrie;"
       },
@@ -27521,7 +27260,7 @@
       {
         "lineNumber": 28,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    private final CommandTrie commandTrie;"
       },
@@ -27570,7 +27309,7 @@
       {
         "lineNumber": 35,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        commandTrie \u003d new CommandTrie();"
       },
@@ -27787,35 +27526,35 @@
       {
         "lineNumber": 66,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 67,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    @Override"
       },
       {
         "lineNumber": 68,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    public CommandTrie getCommandTrie() {"
       },
       {
         "lineNumber": 69,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        return commandTrie;"
       },
       {
         "lineNumber": 70,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    }"
       },
@@ -27828,9 +27567,8 @@
       }
     ],
     "authorContributionMap": {
-      "lithiumlkid": 8,
       "lohtianwei": 1,
-      "-": 62
+      "-": 70
     }
   },
   {
@@ -27867,21 +27605,21 @@
       {
         "lineNumber": 5,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "import static seedu.address.logic.parser.CliSyntax.PREFIX_AVATAR;"
       },
       {
         "lineNumber": 6,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;"
       },
       {
         "lineNumber": 7,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "import static seedu.address.logic.parser.CliSyntax.PREFIX_JERSEY_NUMBER;"
       },
@@ -27902,14 +27640,14 @@
       {
         "lineNumber": 10,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "import static seedu.address.logic.parser.CliSyntax.PREFIX_POSITION;"
       },
       {
         "lineNumber": 11,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "import static seedu.address.logic.parser.CliSyntax.PREFIX_RATING;"
       },
@@ -27944,14 +27682,14 @@
       {
         "lineNumber": 16,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "import java.io.IOException;"
       },
       {
         "lineNumber": 17,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -28706,9 +28444,9 @@
       }
     ],
     "authorContributionMap": {
-      "lithiumlkid": 104,
+      "lithiumlkid": 97,
       "jordancjq": 8,
-      "-": 12
+      "-": 19
     }
   },
   {
@@ -30326,70 +30064,70 @@
       {
         "lineNumber": 1,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "package seedu.address.logic.commands;"
       },
       {
         "lineNumber": 2,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 3,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "import java.util.ArrayList;"
       },
       {
         "lineNumber": 4,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "import java.util.HashMap;"
       },
       {
         "lineNumber": 5,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "import java.util.List;"
       },
       {
         "lineNumber": 6,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "import java.util.Map;"
       },
       {
         "lineNumber": 7,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "import java.util.Set;"
       },
       {
         "lineNumber": 8,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "import java.util.stream.Collectors;"
       },
       {
         "lineNumber": 9,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "import java.util.stream.Stream;"
       },
       {
         "lineNumber": 10,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -31655,7 +31393,8 @@
       }
     ],
     "authorContributionMap": {
-      "lithiumlkid": 190
+      "lithiumlkid": 180,
+      "-": 10
     }
   },
   {
@@ -32275,14 +32014,14 @@
       {
         "lineNumber": 27,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    public static final String MESSAGE_PARAMETERS \u003d \"INDEX\";"
       },
       {
         "lineNumber": 28,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -32582,9 +32321,8 @@
       }
     ],
     "authorContributionMap": {
-      "lithiumlkid": 2,
       "lohtianwei": 1,
-      "-": 67
+      "-": 69
     }
   },
   {
@@ -32621,21 +32359,21 @@
       {
         "lineNumber": 5,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "import static seedu.address.logic.parser.CliSyntax.PREFIX_AVATAR;"
       },
       {
         "lineNumber": 6,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;"
       },
       {
         "lineNumber": 7,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "import static seedu.address.logic.parser.CliSyntax.PREFIX_JERSEY_NUMBER;"
       },
@@ -32656,14 +32394,14 @@
       {
         "lineNumber": 10,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "import static seedu.address.logic.parser.CliSyntax.PREFIX_POSITION;"
       },
       {
         "lineNumber": 11,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "import static seedu.address.logic.parser.CliSyntax.PREFIX_RATING;"
       },
@@ -32677,7 +32415,7 @@
       {
         "lineNumber": 13,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "import static seedu.address.logic.parser.ParserUtil.UNSPECIFIED_FIELD;"
       },
@@ -32698,7 +32436,7 @@
       {
         "lineNumber": 16,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "import java.io.IOException;"
       },
@@ -32810,7 +32548,7 @@
       {
         "lineNumber": 32,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "import seedu.address.model.person.Avatar;"
       },
@@ -32824,7 +32562,7 @@
       {
         "lineNumber": 34,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "import seedu.address.model.person.JerseyNumber;"
       },
@@ -32852,14 +32590,14 @@
       {
         "lineNumber": 38,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "import seedu.address.model.person.Position;"
       },
       {
         "lineNumber": 39,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "import seedu.address.model.person.Rating;"
       },
@@ -33699,42 +33437,42 @@
       {
         "lineNumber": 159,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        Rating updatedRating \u003d editPersonDescriptor.getRating().orElse(personToEdit.getRating());"
       },
       {
         "lineNumber": 160,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        JerseyNumber updatedJerseyNumber \u003d editPersonDescriptor.getJerseyNumber()"
       },
       {
         "lineNumber": 161,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "                .orElse(personToEdit.getJerseyNumber());"
       },
       {
         "lineNumber": 162,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        Position updatedPosition \u003d editPersonDescriptor.getPosition().orElse(personToEdit.getPosition());"
       },
       {
         "lineNumber": 163,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        Avatar updatedAvatar \u003d editPersonDescriptor.getAvatar().orElse(personToEdit.getAvatar());"
       },
       {
         "lineNumber": 164,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -33755,7 +33493,7 @@
       {
         "lineNumber": 167,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "                updatedTeamName, updatedTags, updatedRating, updatedPosition, updatedJerseyNumber, updatedAvatar);"
       },
@@ -33916,14 +33654,14 @@
       {
         "lineNumber": 190,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "     * Stores the details to edit the player with. Each non-empty field value will replace the"
       },
       {
         "lineNumber": 191,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "     * corresponding field value of the player."
       },
@@ -33979,28 +33717,28 @@
       {
         "lineNumber": 199,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        private Rating rating;"
       },
       {
         "lineNumber": 200,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        private Position position;"
       },
       {
         "lineNumber": 201,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        private JerseyNumber jerseyNumber;"
       },
       {
         "lineNumber": 202,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        private Avatar avatar;"
       },
@@ -34098,28 +33836,28 @@
       {
         "lineNumber": 216,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "            setRating(toCopy.rating);"
       },
       {
         "lineNumber": 217,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "            setPosition(toCopy.position);"
       },
       {
         "lineNumber": 218,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "            setJerseyNumber(toCopy.jerseyNumber);"
       },
       {
         "lineNumber": 219,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "            setAvatar(toCopy.avatar);"
       },
@@ -34168,14 +33906,14 @@
       {
         "lineNumber": 226,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "            return CollectionUtil.isAnyNonNull(this.name, this.phone, this.email, this.address, this.tags,"
       },
       {
         "lineNumber": 227,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "                    this.rating, this.position, this.jerseyNumber, this.avatar);"
       },
@@ -34539,224 +34277,224 @@
       {
         "lineNumber": 279,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        public void setRating(Rating rating) {"
       },
       {
         "lineNumber": 280,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "            this.rating \u003d rating;"
       },
       {
         "lineNumber": 281,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        }"
       },
       {
         "lineNumber": 282,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 283,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        public Optional\u003cRating\u003e getRating() {"
       },
       {
         "lineNumber": 284,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "            return Optional.ofNullable(rating);"
       },
       {
         "lineNumber": 285,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        }"
       },
       {
         "lineNumber": 286,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 287,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        public void setPosition(Position position) {"
       },
       {
         "lineNumber": 288,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "            this.position \u003d position;"
       },
       {
         "lineNumber": 289,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        }"
       },
       {
         "lineNumber": 290,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 291,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        public Optional\u003cPosition\u003e getPosition() {"
       },
       {
         "lineNumber": 292,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "            return Optional.ofNullable(position);"
       },
       {
         "lineNumber": 293,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        }"
       },
       {
         "lineNumber": 294,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 295,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        public void setJerseyNumber(JerseyNumber jerseyNumber) {"
       },
       {
         "lineNumber": 296,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "            this.jerseyNumber \u003d jerseyNumber;"
       },
       {
         "lineNumber": 297,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        }"
       },
       {
         "lineNumber": 298,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 299,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        public Optional\u003cJerseyNumber\u003e getJerseyNumber() {"
       },
       {
         "lineNumber": 300,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "            return Optional.ofNullable(jerseyNumber);"
       },
       {
         "lineNumber": 301,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        }"
       },
       {
         "lineNumber": 302,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 303,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        public void setAvatar(Avatar avatar) {"
       },
       {
         "lineNumber": 304,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "            this.avatar \u003d avatar;"
       },
       {
         "lineNumber": 305,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        }"
       },
       {
         "lineNumber": 306,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 307,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        public Optional\u003cAvatar\u003e getAvatar() {"
       },
       {
         "lineNumber": 308,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "            return Optional.ofNullable(avatar);"
       },
       {
         "lineNumber": 309,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        }"
       },
       {
         "lineNumber": 310,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -34896,35 +34634,35 @@
       {
         "lineNumber": 330,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "                    \u0026\u0026 getTags().equals(e.getTags())"
       },
       {
         "lineNumber": 331,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "                    \u0026\u0026 getRating().equals(e.getRating())"
       },
       {
         "lineNumber": 332,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "                    \u0026\u0026 getPosition().equals(e.getPosition())"
       },
       {
         "lineNumber": 333,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "                    \u0026\u0026 getJerseyNumber().equals(e.getJerseyNumber())"
       },
       {
         "lineNumber": 334,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "                    \u0026\u0026 getAvatar().equals(e.getAvatar());"
       },
@@ -34951,11 +34689,11 @@
       }
     ],
     "authorContributionMap": {
-      "lithiumlkid": 141,
+      "lithiumlkid": 74,
       "lohtianwei": 9,
       "jordancjq": 7,
       "codeeong": 3,
-      "-": 177
+      "-": 244
     }
   },
   {
@@ -35090,14 +34828,14 @@
       {
         "lineNumber": 19,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    public static final String MESSAGE_PARAMETERS \u003d \"KEYWORD [MORE KEYWORD]\";"
       },
       {
         "lineNumber": 20,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -35236,9 +34974,8 @@
       }
     ],
     "authorContributionMap": {
-      "lithiumlkid": 2,
       "lohtianwei": 1,
-      "-": 36
+      "-": 38
     }
   },
   {
@@ -38633,14 +38370,14 @@
       {
         "lineNumber": 25,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    public static final String MESSAGE_PARAMETERS \u003d \"INDEX\";"
       },
       {
         "lineNumber": 26,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -38849,9 +38586,8 @@
       }
     ],
     "authorContributionMap": {
-      "lithiumlkid": 2,
       "lohtianwei": 1,
-      "-": 52
+      "-": 54
     }
   },
   {
@@ -42574,14 +42310,14 @@
       {
         "lineNumber": 1,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "package seedu.address.logic.commands;"
       },
       {
         "lineNumber": 2,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -42895,7 +42631,8 @@
       }
     ],
     "authorContributionMap": {
-      "lithiumlkid": 46
+      "lithiumlkid": 44,
+      "-": 2
     }
   },
   {
@@ -43630,7 +43367,7 @@
       {
         "lineNumber": 5,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "import static seedu.address.logic.parser.CliSyntax.PREFIX_AVATAR;"
       },
@@ -43644,7 +43381,7 @@
       {
         "lineNumber": 7,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "import static seedu.address.logic.parser.CliSyntax.PREFIX_JERSEY_NUMBER;"
       },
@@ -43665,14 +43402,14 @@
       {
         "lineNumber": 10,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "import static seedu.address.logic.parser.CliSyntax.PREFIX_POSITION;"
       },
       {
         "lineNumber": 11,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "import static seedu.address.logic.parser.CliSyntax.PREFIX_RATING;"
       },
@@ -43749,7 +43486,7 @@
       {
         "lineNumber": 22,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "import seedu.address.model.person.Avatar;"
       },
@@ -43763,7 +43500,7 @@
       {
         "lineNumber": 24,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "import seedu.address.model.person.JerseyNumber;"
       },
@@ -43791,14 +43528,14 @@
       {
         "lineNumber": 28,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "import seedu.address.model.person.Position;"
       },
       {
         "lineNumber": 29,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "import seedu.address.model.person.Rating;"
       },
@@ -44245,9 +43982,9 @@
       }
     ],
     "authorContributionMap": {
-      "lithiumlkid": 67,
+      "lithiumlkid": 59,
       "jordancjq": 3,
-      "-": 22
+      "-": 30
     }
   },
   {
@@ -46208,21 +45945,21 @@
       {
         "lineNumber": 18,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    public static final Prefix PREFIX_RATING \u003d new Prefix(\"ra/\");"
       },
       {
         "lineNumber": 19,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    public static final Prefix PREFIX_JERSEY_NUMBER \u003d new Prefix(\"j/\");"
       },
       {
         "lineNumber": 20,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    public static final Prefix PREFIX_POSITION \u003d new Prefix(\"po/\");"
       },
@@ -46249,10 +45986,9 @@
       }
     ],
     "authorContributionMap": {
-      "lithiumlkid": 3,
       "lohtianwei": 1,
       "jordancjq": 4,
-      "-": 15
+      "-": 18
     }
   },
   {
@@ -46598,7 +46334,7 @@
       {
         "lineNumber": 6,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "import static seedu.address.logic.parser.CliSyntax.PREFIX_AVATAR;"
       },
@@ -46612,7 +46348,7 @@
       {
         "lineNumber": 8,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "import static seedu.address.logic.parser.CliSyntax.PREFIX_JERSEY_NUMBER;"
       },
@@ -46633,14 +46369,14 @@
       {
         "lineNumber": 11,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "import static seedu.address.logic.parser.CliSyntax.PREFIX_POSITION;"
       },
       {
         "lineNumber": 12,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "import static seedu.address.logic.parser.CliSyntax.PREFIX_RATING;"
       },
@@ -47206,8 +46942,8 @@
       }
     ],
     "authorContributionMap": {
-      "lithiumlkid": 70,
-      "-": 22
+      "lithiumlkid": 66,
+      "-": 26
     }
   },
   {
@@ -47553,7 +47289,7 @@
       {
         "lineNumber": 17,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "import seedu.address.model.person.Avatar;"
       },
@@ -47567,7 +47303,7 @@
       {
         "lineNumber": 19,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "import seedu.address.model.person.JerseyNumber;"
       },
@@ -47588,14 +47324,14 @@
       {
         "lineNumber": 22,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "import seedu.address.model.person.Position;"
       },
       {
         "lineNumber": 23,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "import seedu.address.model.person.Rating;"
       },
@@ -49198,693 +48934,693 @@
       {
         "lineNumber": 252,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 253,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    /**"
       },
       {
         "lineNumber": 254,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "     * Parses a {@code String rating} into a {@code Phone}."
       },
       {
         "lineNumber": 255,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "     * Leading and trailing whitespaces will be trimmed."
       },
       {
         "lineNumber": 256,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "     *"
       },
       {
         "lineNumber": 257,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "     * @throws IllegalValueException if the given {@code rating} is invalid."
       },
       {
         "lineNumber": 258,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "     */"
       },
       {
         "lineNumber": 259,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    public static Rating parseRating(String rating) throws IllegalValueException {"
       },
       {
         "lineNumber": 260,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        requireNonNull(rating);"
       },
       {
         "lineNumber": 261,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        String trimmedRating \u003d rating.trim();"
       },
       {
         "lineNumber": 262,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        if (!Rating.isValidRating(trimmedRating)) {"
       },
       {
         "lineNumber": 263,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "            throw new IllegalValueException(Rating.MESSAGE_RATING_CONSTRAINTS);"
       },
       {
         "lineNumber": 264,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        }"
       },
       {
         "lineNumber": 265,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        return new Rating(trimmedRating);"
       },
       {
         "lineNumber": 266,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    }"
       },
       {
         "lineNumber": 267,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 268,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    /**"
       },
       {
         "lineNumber": 269,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "     * Parses a {@code Optional\u003cString\u003e rating} into an {@code Optional\u003cRating\u003e} if {@code rating} is present."
       },
       {
         "lineNumber": 270,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "     * See header comment of this class regarding the use of {@code Optional} parameters."
       },
       {
         "lineNumber": 271,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "     */"
       },
       {
         "lineNumber": 272,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    public static Optional\u003cRating\u003e parseRating(Optional\u003cString\u003e rating) throws IllegalValueException {"
       },
       {
         "lineNumber": 273,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        requireNonNull(rating);"
       },
       {
         "lineNumber": 274,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        return rating.isPresent() ? Optional.of(parseRating(rating.get())) : Optional.empty();"
       },
       {
         "lineNumber": 275,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    }"
       },
       {
         "lineNumber": 276,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 277,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    /**"
       },
       {
         "lineNumber": 278,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "     * Parses a {@code String position} into a {@code Position}."
       },
       {
         "lineNumber": 279,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "     * Leading and trailing whitespaces will be trimmed."
       },
       {
         "lineNumber": 280,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "     *"
       },
       {
         "lineNumber": 281,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "     * @throws IllegalValueException if the given {@code position} is invalid."
       },
       {
         "lineNumber": 282,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "     */"
       },
       {
         "lineNumber": 283,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    public static Position parsePosition(String position) throws IllegalValueException {"
       },
       {
         "lineNumber": 284,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        requireNonNull(position);"
       },
       {
         "lineNumber": 285,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        String trimmedPosition \u003d position.trim();"
       },
       {
         "lineNumber": 286,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        if (!Position.isValidPosition(trimmedPosition)) {"
       },
       {
         "lineNumber": 287,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "            throw new IllegalValueException(Position.MESSAGE_POSITION_CONSTRAINTS);"
       },
       {
         "lineNumber": 288,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        }"
       },
       {
         "lineNumber": 289,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        return new Position(trimmedPosition);"
       },
       {
         "lineNumber": 290,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    }"
       },
       {
         "lineNumber": 291,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 292,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    /**"
       },
       {
         "lineNumber": 293,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "     * Parses a {@code Optional\u003cString\u003e position} into an {@code Optional\u003cPosition\u003e} if {@code position} is present."
       },
       {
         "lineNumber": 294,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "     * See header comment of this class regarding the use of {@code Optional} parameters."
       },
       {
         "lineNumber": 295,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "     */"
       },
       {
         "lineNumber": 296,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    public static Optional\u003cPosition\u003e parsePosition(Optional\u003cString\u003e position) throws IllegalValueException {"
       },
       {
         "lineNumber": 297,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        requireNonNull(position);"
       },
       {
         "lineNumber": 298,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        return position.isPresent() ? Optional.of(parsePosition(position.get())) : Optional.empty();"
       },
       {
         "lineNumber": 299,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    }"
       },
       {
         "lineNumber": 300,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 301,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    /**"
       },
       {
         "lineNumber": 302,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "     * Parses a {@code String jerseyNumber} into a {@code JerseyNumber}."
       },
       {
         "lineNumber": 303,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "     * Leading and trailing whitespaces will be trimmed."
       },
       {
         "lineNumber": 304,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "     *"
       },
       {
         "lineNumber": 305,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "     * @throws IllegalValueException if the given {@code jerseyNumber} is invalid."
       },
       {
         "lineNumber": 306,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "     */"
       },
       {
         "lineNumber": 307,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    public static JerseyNumber parseJerseyNumber(String jerseyNumber) throws IllegalValueException {"
       },
       {
         "lineNumber": 308,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        requireNonNull(jerseyNumber);"
       },
       {
         "lineNumber": 309,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        String trimmedJerseyNumber \u003d jerseyNumber.trim();"
       },
       {
         "lineNumber": 310,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        if (!JerseyNumber.isValidJerseyNumber(trimmedJerseyNumber)) {"
       },
       {
         "lineNumber": 311,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "            throw new IllegalValueException(JerseyNumber.MESSAGE_JERSEY_NUMBER_CONSTRAINTS);"
       },
       {
         "lineNumber": 312,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        }"
       },
       {
         "lineNumber": 313,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        return new JerseyNumber(trimmedJerseyNumber);"
       },
       {
         "lineNumber": 314,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    }"
       },
       {
         "lineNumber": 315,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 316,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    /**"
       },
       {
         "lineNumber": 317,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "     * Parses a {@code Optional\u003cString\u003e jerseyNumber} into an {@code Optional\u003cJerseyNumber\u003e}"
       },
       {
         "lineNumber": 318,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "     * if {@code jerseyNumber} is present."
       },
       {
         "lineNumber": 319,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "     * See header comment of this class regarding the use of {@code Optional} parameters."
       },
       {
         "lineNumber": 320,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "     */"
       },
       {
         "lineNumber": 321,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    public static Optional\u003cJerseyNumber\u003e parseJerseyNumber(Optional\u003cString\u003e jerseyNumber) throws IllegalValueException {"
       },
       {
         "lineNumber": 322,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        requireNonNull(jerseyNumber);"
       },
       {
         "lineNumber": 323,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        return jerseyNumber.isPresent() ? Optional.of(parseJerseyNumber(jerseyNumber.get())) : Optional.empty();"
       },
       {
         "lineNumber": 324,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    }"
       },
       {
         "lineNumber": 325,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 326,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    /**"
       },
       {
         "lineNumber": 327,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "     * Parses a {@code String jerseyNumber} into a {@code JerseyNumber}."
       },
       {
         "lineNumber": 328,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "     * Leading and trailing whitespaces will be trimmed."
       },
       {
         "lineNumber": 329,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "     *"
       },
       {
         "lineNumber": 330,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "     * @throws IllegalValueException if the given {@code jerseyNumber} is invalid."
       },
       {
         "lineNumber": 331,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "     */"
       },
       {
         "lineNumber": 332,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 333,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    public static Avatar parseAvatar(String avatar) throws IllegalValueException {"
       },
       {
         "lineNumber": 334,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        requireNonNull(avatar);"
       },
       {
         "lineNumber": 335,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        String trimmedAvatar \u003d avatar.trim();"
       },
       {
         "lineNumber": 336,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        if (!Avatar.isValidAvatar(trimmedAvatar)) {"
       },
       {
         "lineNumber": 337,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "            throw new IllegalValueException(Avatar.MESSAGE_AVATAR_CONSTRAINTS);"
       },
       {
         "lineNumber": 338,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        }"
       },
       {
         "lineNumber": 339,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        return new Avatar(trimmedAvatar);"
       },
       {
         "lineNumber": 340,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    }"
       },
       {
         "lineNumber": 341,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 342,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    /**"
       },
       {
         "lineNumber": 343,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "     * Parses a {@code Optional\u003cString\u003e avatar} into an {@code Optional\u003cAvatar\u003e}"
       },
       {
         "lineNumber": 344,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "     * if {@code avatar} is present."
       },
       {
         "lineNumber": 345,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "     * See header comment of this class regarding the use of {@code Optional} parameters."
       },
       {
         "lineNumber": 346,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "     */"
       },
       {
         "lineNumber": 347,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    public static Optional\u003cAvatar\u003e parseAvatar(Optional\u003cString\u003e avatar) throws IllegalValueException {"
       },
       {
         "lineNumber": 348,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        requireNonNull(avatar);"
       },
       {
         "lineNumber": 349,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        return avatar.isPresent() ? Optional.of(parseAvatar(avatar.get())) : Optional.empty();"
       },
       {
         "lineNumber": 350,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    }"
       },
@@ -49897,9 +49633,8 @@
       }
     ],
     "authorContributionMap": {
-      "lithiumlkid": 103,
       "jordancjq": 67,
-      "-": 181
+      "-": 284
     }
   },
   {
@@ -53472,14 +53207,14 @@
       {
         "lineNumber": 164,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "                person.getTeamName(), correctTagReferences, person.getRating(), person.getPosition(),"
       },
       {
         "lineNumber": 165,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "                person.getJerseyNumber(), person.getAvatar());"
       },
@@ -53913,14 +53648,14 @@
       {
         "lineNumber": 227,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "                        person.getRemark(), person.getTeamName(), newTags, person.getRating(), person.getPosition(),"
       },
       {
         "lineNumber": 228,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "                        person.getJerseyNumber(), person.getAvatar());"
       },
@@ -55487,11 +55222,10 @@
       }
     ],
     "authorContributionMap": {
-      "lithiumlkid": 4,
       "lohtianwei": 7,
       "jordancjq": 240,
       "codeeong": 10,
-      "-": 190
+      "-": 194
     }
   },
   {
@@ -59477,119 +59211,119 @@
       {
         "lineNumber": 1,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "package seedu.address.model.person;"
       },
       {
         "lineNumber": 2,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 3,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "import static java.util.Objects.requireNonNull;"
       },
       {
         "lineNumber": 4,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "import static seedu.address.commons.util.AppUtil.checkArgument;"
       },
       {
         "lineNumber": 5,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "import static seedu.address.logic.parser.ParserUtil.UNSPECIFIED_FIELD;"
       },
       {
         "lineNumber": 6,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 7,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "import java.io.File;"
       },
       {
         "lineNumber": 8,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "import java.io.IOException;"
       },
       {
         "lineNumber": 9,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "import java.nio.file.Files;"
       },
       {
         "lineNumber": 10,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "import java.nio.file.Path;"
       },
       {
         "lineNumber": 11,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "import java.nio.file.Paths;"
       },
       {
         "lineNumber": 12,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "import java.nio.file.StandardCopyOption;"
       },
       {
         "lineNumber": 13,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "import java.util.regex.Matcher;"
       },
       {
         "lineNumber": 14,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "import java.util.regex.Pattern;"
       },
       {
         "lineNumber": 15,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 16,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "import seedu.address.commons.core.LogsCenter;"
       },
       {
         "lineNumber": 17,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -60246,7 +59980,8 @@
       }
     ],
     "authorContributionMap": {
-      "lithiumlkid": 110
+      "lithiumlkid": 93,
+      "-": 17
     }
   },
   {
@@ -60887,42 +60622,42 @@
       {
         "lineNumber": 1,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "package seedu.address.model.person;"
       },
       {
         "lineNumber": 2,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 3,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "import static java.util.Objects.requireNonNull;"
       },
       {
         "lineNumber": 4,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "import static seedu.address.commons.util.AppUtil.checkArgument;"
       },
       {
         "lineNumber": 5,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "import static seedu.address.logic.parser.ParserUtil.UNSPECIFIED_FIELD;"
       },
       {
         "lineNumber": 6,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -61285,7 +61020,8 @@
       }
     ],
     "authorContributionMap": {
-      "lithiumlkid": 57
+      "lithiumlkid": 51,
+      "-": 6
     }
   },
   {
@@ -61462,28 +61198,28 @@
       {
         "lineNumber": 25,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    private final JerseyNumber jerseyNumber;"
       },
       {
         "lineNumber": 26,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    private final Rating rating;"
       },
       {
         "lineNumber": 27,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    private final Position position;"
       },
       {
         "lineNumber": 28,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    private final Avatar avatar;"
       },
@@ -61539,7 +61275,7 @@
       {
         "lineNumber": 36,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "                  Set\u003cTag\u003e tags, Rating rating, Position position, JerseyNumber jerseyNumber, Avatar avatar) {"
       },
@@ -61609,28 +61345,28 @@
       {
         "lineNumber": 46,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        this.rating \u003d rating;"
       },
       {
         "lineNumber": 47,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        this.position \u003d position;"
       },
       {
         "lineNumber": 48,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        this.jerseyNumber \u003d jerseyNumber;"
       },
       {
         "lineNumber": 49,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        this.avatar \u003d avatar;"
       },
@@ -61819,112 +61555,112 @@
       {
         "lineNumber": 76,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    public JerseyNumber getJerseyNumber() {"
       },
       {
         "lineNumber": 77,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        return jerseyNumber;"
       },
       {
         "lineNumber": 78,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    }"
       },
       {
         "lineNumber": 79,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 80,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    public Rating getRating() {"
       },
       {
         "lineNumber": 81,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        return rating;"
       },
       {
         "lineNumber": 82,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    }"
       },
       {
         "lineNumber": 83,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 84,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    public Position getPosition() {"
       },
       {
         "lineNumber": 85,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        return position;"
       },
       {
         "lineNumber": 86,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    }"
       },
       {
         "lineNumber": 87,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 88,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    public Avatar getAvatar() {"
       },
       {
         "lineNumber": 89,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        return avatar;"
       },
       {
         "lineNumber": 90,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    }"
       },
       {
         "lineNumber": 91,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -62134,14 +61870,14 @@
       {
         "lineNumber": 121,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        return Objects.hash(name, phone, email, address, remark, teamName, tags, rating, position, jerseyNumber,"
       },
       {
         "lineNumber": 122,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "                avatar);"
       },
@@ -62246,56 +61982,56 @@
       {
         "lineNumber": 137,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "                .append(\" Jersey Number: \")"
       },
       {
         "lineNumber": 138,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "                .append(getJerseyNumber())"
       },
       {
         "lineNumber": 139,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "                .append(\" Rating: \")"
       },
       {
         "lineNumber": 140,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "                .append(getRating())"
       },
       {
         "lineNumber": 141,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "                .append(\" Position: \")"
       },
       {
         "lineNumber": 142,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "                .append(getPosition())"
       },
       {
         "lineNumber": 143,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "                .append(\" Avatar File Path: \")"
       },
       {
         "lineNumber": 144,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "                .append(getAvatar())"
       },
@@ -62350,9 +62086,8 @@
       }
     ],
     "authorContributionMap": {
-      "lithiumlkid": 35,
       "jordancjq": 19,
-      "-": 97
+      "-": 132
     }
   },
   {
@@ -62903,70 +62638,70 @@
       {
         "lineNumber": 1,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "package seedu.address.model.person;"
       },
       {
         "lineNumber": 2,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 3,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "import static java.util.Objects.requireNonNull;"
       },
       {
         "lineNumber": 4,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "import static seedu.address.commons.util.AppUtil.checkArgument;"
       },
       {
         "lineNumber": 5,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "import static seedu.address.logic.parser.ParserUtil.UNSPECIFIED_FIELD;"
       },
       {
         "lineNumber": 6,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 7,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "import java.util.Collections;"
       },
       {
         "lineNumber": 8,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "import java.util.HashMap;"
       },
       {
         "lineNumber": 9,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "import java.util.Map;"
       },
       {
         "lineNumber": 10,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -63434,7 +63169,8 @@
       }
     ],
     "authorContributionMap": {
-      "lithiumlkid": 76
+      "lithiumlkid": 66,
+      "-": 10
     }
   },
   {
@@ -63443,42 +63179,42 @@
       {
         "lineNumber": 1,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "package seedu.address.model.person;"
       },
       {
         "lineNumber": 2,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 3,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "import static java.util.Objects.requireNonNull;"
       },
       {
         "lineNumber": 4,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "import static seedu.address.commons.util.AppUtil.checkArgument;"
       },
       {
         "lineNumber": 5,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "import static seedu.address.logic.parser.ParserUtil.UNSPECIFIED_FIELD;"
       },
       {
         "lineNumber": 6,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -63981,7 +63717,8 @@
       }
     ],
     "authorContributionMap": {
-      "lithiumlkid": 77
+      "lithiumlkid": 71,
+      "-": 6
     }
   },
   {
@@ -69316,7 +69053,7 @@
       {
         "lineNumber": 9,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "import seedu.address.model.person.Avatar;"
       },
@@ -69330,7 +69067,7 @@
       {
         "lineNumber": 11,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "import seedu.address.model.person.JerseyNumber;"
       },
@@ -69358,14 +69095,14 @@
       {
         "lineNumber": 15,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "import seedu.address.model.person.Position;"
       },
       {
         "lineNumber": 16,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "import seedu.address.model.person.Rating;"
       },
@@ -69491,14 +69228,14 @@
       {
         "lineNumber": 34,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "                getTagSet(\"redCard\"), new Rating(\"3\"), new Position(\"1\"), new JerseyNumber(\"2\"),"
       },
       {
         "lineNumber": 35,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "                    new Avatar(\"\u003cUNSPECIFIED\u003e\")),"
       },
@@ -69526,7 +69263,7 @@
       {
         "lineNumber": 39,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "                    new Avatar(\"\u003cUNSPECIFIED\u003e\")),"
       },
@@ -69547,14 +69284,14 @@
       {
         "lineNumber": 42,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "                getTagSet(\"yellowCard\"), new Rating(\"4\"), new Position(\"1\"), new JerseyNumber(\"2\"),"
       },
       {
         "lineNumber": 43,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "                    new Avatar(\"\u003cUNSPECIFIED\u003e\")),"
       },
@@ -69890,14 +69627,14 @@
       {
         "lineNumber": 91,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "                    new Rating(\"0\"), new Position(\"1\"), new JerseyNumber(\"2\"),"
       },
       {
         "lineNumber": 92,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "                    new Avatar(\"\u003cUNSPECIFIED\u003e\")),"
       },
@@ -69925,14 +69662,14 @@
       {
         "lineNumber": 96,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "                    new Rating(\"0\"), new Position(\"1\"), new JerseyNumber(\"2\"),"
       },
       {
         "lineNumber": 97,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "                    new Avatar(\"\u003cUNSPECIFIED\u003e\")),"
       },
@@ -70442,1029 +70179,9 @@
       }
     ],
     "authorContributionMap": {
-      "lithiumlkid": 13,
       "jordancjq": 9,
       "codeeong": 13,
-      "-": 134
-    }
-  },
-  {
-    "path": "src/main/java/seedu/address/storage/AddressBookStorage.java",
-    "lines": [
-      {
-        "lineNumber": 1,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "package seedu.address.storage;"
-      },
-      {
-        "lineNumber": 2,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 3,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import java.io.IOException;"
-      },
-      {
-        "lineNumber": 4,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import java.util.Optional;"
-      },
-      {
-        "lineNumber": 5,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 6,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.commons.exceptions.DataConversionException;"
-      },
-      {
-        "lineNumber": 7,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.model.ReadOnlyAddressBook;"
-      },
-      {
-        "lineNumber": 8,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 9,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "/**"
-      },
-      {
-        "lineNumber": 10,
-        "author": {
-          "gitId": "-"
-        },
-        "content": " * Represents a storage for {@link seedu.address.model.AddressBook}."
-      },
-      {
-        "lineNumber": 11,
-        "author": {
-          "gitId": "-"
-        },
-        "content": " */"
-      },
-      {
-        "lineNumber": 12,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "public interface AddressBookStorage {"
-      },
-      {
-        "lineNumber": 13,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 14,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    /**"
-      },
-      {
-        "lineNumber": 15,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     * Returns the file path of the data file."
-      },
-      {
-        "lineNumber": 16,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     */"
-      },
-      {
-        "lineNumber": 17,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    String getAddressBookFilePath();"
-      },
-      {
-        "lineNumber": 18,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 19,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    /**"
-      },
-      {
-        "lineNumber": 20,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     * Returns AddressBook data as a {@link ReadOnlyAddressBook}."
-      },
-      {
-        "lineNumber": 21,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     *   Returns {@code Optional.empty()} if storage file is not found."
-      },
-      {
-        "lineNumber": 22,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     * @throws DataConversionException if the data in storage is not in the expected format."
-      },
-      {
-        "lineNumber": 23,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     * @throws IOException if there was any problem when reading from the storage."
-      },
-      {
-        "lineNumber": 24,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     */"
-      },
-      {
-        "lineNumber": 25,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    Optional\u003cReadOnlyAddressBook\u003e readAddressBook() throws DataConversionException, IOException;"
-      },
-      {
-        "lineNumber": 26,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 27,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    /**"
-      },
-      {
-        "lineNumber": 28,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     * @see #getAddressBookFilePath()"
-      },
-      {
-        "lineNumber": 29,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     */"
-      },
-      {
-        "lineNumber": 30,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    Optional\u003cReadOnlyAddressBook\u003e readAddressBook(String filePath) throws DataConversionException, IOException;"
-      },
-      {
-        "lineNumber": 31,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 32,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    /**"
-      },
-      {
-        "lineNumber": 33,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     * Saves the given {@link ReadOnlyAddressBook} to the storage."
-      },
-      {
-        "lineNumber": 34,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     * @param addressBook cannot be null."
-      },
-      {
-        "lineNumber": 35,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     * @throws IOException if there was any problem writing to the file."
-      },
-      {
-        "lineNumber": 36,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     */"
-      },
-      {
-        "lineNumber": 37,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    void saveAddressBook(ReadOnlyAddressBook addressBook) throws IOException;"
-      },
-      {
-        "lineNumber": 38,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 39,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    /**"
-      },
-      {
-        "lineNumber": 40,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     * @see #saveAddressBook(ReadOnlyAddressBook)"
-      },
-      {
-        "lineNumber": 41,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     */"
-      },
-      {
-        "lineNumber": 42,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    void saveAddressBook(ReadOnlyAddressBook addressBook, String filePath) throws IOException;"
-      },
-      {
-        "lineNumber": 43,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 44,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    void backupAddressBook(ReadOnlyAddressBook addressBook) throws IOException;"
-      },
-      {
-        "lineNumber": 45,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 46,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "}"
-      }
-    ],
-    "authorContributionMap": {
-      "lithiumlkid": 2,
-      "-": 44
-    }
-  },
-  {
-    "path": "src/main/java/seedu/address/storage/StorageManager.java",
-    "lines": [
-      {
-        "lineNumber": 1,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "package seedu.address.storage;"
-      },
-      {
-        "lineNumber": 2,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 3,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import java.io.IOException;"
-      },
-      {
-        "lineNumber": 4,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import java.util.Optional;"
-      },
-      {
-        "lineNumber": 5,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import java.util.logging.Logger;"
-      },
-      {
-        "lineNumber": 6,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 7,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import com.google.common.eventbus.Subscribe;"
-      },
-      {
-        "lineNumber": 8,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 9,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.commons.core.ComponentManager;"
-      },
-      {
-        "lineNumber": 10,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.commons.core.LogsCenter;"
-      },
-      {
-        "lineNumber": 11,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.commons.events.model.AddressBookChangedEvent;"
-      },
-      {
-        "lineNumber": 12,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.commons.events.storage.DataSavingExceptionEvent;"
-      },
-      {
-        "lineNumber": 13,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.commons.exceptions.DataConversionException;"
-      },
-      {
-        "lineNumber": 14,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.model.ReadOnlyAddressBook;"
-      },
-      {
-        "lineNumber": 15,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.model.UserPrefs;"
-      },
-      {
-        "lineNumber": 16,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 17,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "/**"
-      },
-      {
-        "lineNumber": 18,
-        "author": {
-          "gitId": "-"
-        },
-        "content": " * Manages storage of AddressBook data in local storage."
-      },
-      {
-        "lineNumber": 19,
-        "author": {
-          "gitId": "-"
-        },
-        "content": " */"
-      },
-      {
-        "lineNumber": 20,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "public class StorageManager extends ComponentManager implements Storage {"
-      },
-      {
-        "lineNumber": 21,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 22,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    private static final Logger logger \u003d LogsCenter.getLogger(StorageManager.class);"
-      },
-      {
-        "lineNumber": 23,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    private AddressBookStorage addressBookStorage;"
-      },
-      {
-        "lineNumber": 24,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    private UserPrefsStorage userPrefsStorage;"
-      },
-      {
-        "lineNumber": 25,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 26,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 27,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public StorageManager(AddressBookStorage addressBookStorage, UserPrefsStorage userPrefsStorage) {"
-      },
-      {
-        "lineNumber": 28,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        super();"
-      },
-      {
-        "lineNumber": 29,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        this.addressBookStorage \u003d addressBookStorage;"
-      },
-      {
-        "lineNumber": 30,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        this.userPrefsStorage \u003d userPrefsStorage;"
-      },
-      {
-        "lineNumber": 31,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 32,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 33,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    // \u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d UserPrefs methods \u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d"
-      },
-      {
-        "lineNumber": 34,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 35,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    @Override"
-      },
-      {
-        "lineNumber": 36,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public String getUserPrefsFilePath() {"
-      },
-      {
-        "lineNumber": 37,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        return userPrefsStorage.getUserPrefsFilePath();"
-      },
-      {
-        "lineNumber": 38,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 39,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 40,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    @Override"
-      },
-      {
-        "lineNumber": 41,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public Optional\u003cUserPrefs\u003e readUserPrefs() throws DataConversionException, IOException {"
-      },
-      {
-        "lineNumber": 42,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        return userPrefsStorage.readUserPrefs();"
-      },
-      {
-        "lineNumber": 43,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 44,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 45,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    @Override"
-      },
-      {
-        "lineNumber": 46,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public void saveUserPrefs(UserPrefs userPrefs) throws IOException {"
-      },
-      {
-        "lineNumber": 47,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        userPrefsStorage.saveUserPrefs(userPrefs);"
-      },
-      {
-        "lineNumber": 48,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 49,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 50,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 51,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    // \u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d AddressBook methods \u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d\u003d"
-      },
-      {
-        "lineNumber": 52,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 53,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    @Override"
-      },
-      {
-        "lineNumber": 54,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public String getAddressBookFilePath() {"
-      },
-      {
-        "lineNumber": 55,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        return addressBookStorage.getAddressBookFilePath();"
-      },
-      {
-        "lineNumber": 56,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 57,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 58,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    @Override"
-      },
-      {
-        "lineNumber": 59,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public Optional\u003cReadOnlyAddressBook\u003e readAddressBook() throws DataConversionException, IOException {"
-      },
-      {
-        "lineNumber": 60,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        return readAddressBook(addressBookStorage.getAddressBookFilePath());"
-      },
-      {
-        "lineNumber": 61,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 62,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 63,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    @Override"
-      },
-      {
-        "lineNumber": 64,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public Optional\u003cReadOnlyAddressBook\u003e readAddressBook(String filePath) throws DataConversionException, IOException {"
-      },
-      {
-        "lineNumber": 65,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        logger.fine(\"Attempting to read data from file: \" + filePath);"
-      },
-      {
-        "lineNumber": 66,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        return addressBookStorage.readAddressBook(filePath);"
-      },
-      {
-        "lineNumber": 67,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 68,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 69,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    @Override"
-      },
-      {
-        "lineNumber": 70,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public void saveAddressBook(ReadOnlyAddressBook addressBook) throws IOException {"
-      },
-      {
-        "lineNumber": 71,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        saveAddressBook(addressBook, addressBookStorage.getAddressBookFilePath());"
-      },
-      {
-        "lineNumber": 72,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 73,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 74,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    @Override"
-      },
-      {
-        "lineNumber": 75,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public void saveAddressBook(ReadOnlyAddressBook addressBook, String filePath) throws IOException {"
-      },
-      {
-        "lineNumber": 76,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        logger.fine(\"Attempting to write to data file: \" + filePath);"
-      },
-      {
-        "lineNumber": 77,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        addressBookStorage.saveAddressBook(addressBook, filePath);"
-      },
-      {
-        "lineNumber": 78,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 79,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 80,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    @Override"
-      },
-      {
-        "lineNumber": 81,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    public void backupAddressBook(ReadOnlyAddressBook addressBook) throws IOException {"
-      },
-      {
-        "lineNumber": 82,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        addressBookStorage.backupAddressBook(addressBook);"
-      },
-      {
-        "lineNumber": 83,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 84,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 85,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 86,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    @Override"
-      },
-      {
-        "lineNumber": 87,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    @Subscribe"
-      },
-      {
-        "lineNumber": 88,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public void handleAddressBookChangedEvent(AddressBookChangedEvent event) {"
-      },
-      {
-        "lineNumber": 89,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        logger.info(LogsCenter.getEventHandlingLogMessage(event, \"Local data changed, saving to file\"));"
-      },
-      {
-        "lineNumber": 90,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        try {"
-      },
-      {
-        "lineNumber": 91,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "            saveAddressBook(event.data);"
-      },
-      {
-        "lineNumber": 92,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        } catch (IOException e) {"
-      },
-      {
-        "lineNumber": 93,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "            raise(new DataSavingExceptionEvent(e));"
-      },
-      {
-        "lineNumber": 94,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        }"
-      },
-      {
-        "lineNumber": 95,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 96,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 97,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "}"
-      }
-    ],
-    "authorContributionMap": {
-      "lithiumlkid": 5,
-      "-": 92
+      "-": 147
     }
   },
   {
@@ -71557,7 +70274,7 @@
       {
         "lineNumber": 13,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "import seedu.address.model.person.Avatar;"
       },
@@ -71571,7 +70288,7 @@
       {
         "lineNumber": 15,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "import seedu.address.model.person.JerseyNumber;"
       },
@@ -71599,14 +70316,14 @@
       {
         "lineNumber": 19,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "import seedu.address.model.person.Position;"
       },
       {
         "lineNumber": 20,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "import seedu.address.model.person.Rating;"
       },
@@ -71830,21 +70547,21 @@
       {
         "lineNumber": 52,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    @XmlElement(required \u003d true)"
       },
       {
         "lineNumber": 53,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    private String rating;"
       },
       {
         "lineNumber": 54,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    @XmlElement(required \u003d true)"
       },
@@ -71865,35 +70582,35 @@
       {
         "lineNumber": 57,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    private String position;"
       },
       {
         "lineNumber": 58,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    @XmlElement(required \u003d true)"
       },
       {
         "lineNumber": 59,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    private String jerseyNumber;"
       },
       {
         "lineNumber": 60,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    @XmlElement(required \u003d true)"
       },
       {
         "lineNumber": 61,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    private String avatar;"
       },
@@ -72243,35 +70960,35 @@
       {
         "lineNumber": 111,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        rating \u003d source.getRating().value;"
       },
       {
         "lineNumber": 112,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        position \u003d source.getPosition().value;"
       },
       {
         "lineNumber": 113,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        jerseyNumber \u003d source.getJerseyNumber().value;"
       },
       {
         "lineNumber": 114,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        avatar \u003d source.getAvatar().getValue();"
       },
       {
         "lineNumber": 115,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -72782,49 +71499,49 @@
       {
         "lineNumber": 188,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 189,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        if (this.rating \u003d\u003d null) {"
       },
       {
         "lineNumber": 190,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, Rating.class.getSimpleName()));"
       },
       {
         "lineNumber": 191,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        }"
       },
       {
         "lineNumber": 192,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        if (!Rating.isValidRating(this.rating)) {"
       },
       {
         "lineNumber": 193,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "            throw new IllegalValueException(Rating.MESSAGE_RATING_CONSTRAINTS);"
       },
       {
         "lineNumber": 194,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        }"
       },
@@ -72838,196 +71555,196 @@
       {
         "lineNumber": 196,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 197,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        if (this.position \u003d\u003d null) {"
       },
       {
         "lineNumber": 198,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT,"
       },
       {
         "lineNumber": 199,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "                    Position.class.getSimpleName()));"
       },
       {
         "lineNumber": 200,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        }"
       },
       {
         "lineNumber": 201,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        if (!Position.isValidPosition(this.position)) {"
       },
       {
         "lineNumber": 202,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "            throw new IllegalValueException(Position.MESSAGE_POSITION_CONSTRAINTS);"
       },
       {
         "lineNumber": 203,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        }"
       },
       {
         "lineNumber": 204,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        final Position position \u003d new Position(this.position);"
       },
       {
         "lineNumber": 205,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 206,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        if (this.jerseyNumber \u003d\u003d null) {"
       },
       {
         "lineNumber": 207,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT,"
       },
       {
         "lineNumber": 208,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "                    JerseyNumber.class.getSimpleName()));"
       },
       {
         "lineNumber": 209,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        }"
       },
       {
         "lineNumber": 210,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        if (!JerseyNumber.isValidJerseyNumber(this.jerseyNumber)) {"
       },
       {
         "lineNumber": 211,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "            throw new IllegalValueException(JerseyNumber.MESSAGE_JERSEY_NUMBER_CONSTRAINTS);"
       },
       {
         "lineNumber": 212,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        }"
       },
       {
         "lineNumber": 213,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        final JerseyNumber jerseyNumber \u003d new JerseyNumber(this.jerseyNumber);"
       },
       {
         "lineNumber": 214,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 215,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        if (this.avatar \u003d\u003d null) {"
       },
       {
         "lineNumber": 216,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT,"
       },
       {
         "lineNumber": 217,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "                    Avatar.class.getSimpleName()));"
       },
       {
         "lineNumber": 218,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        }"
       },
       {
         "lineNumber": 219,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        if (!Avatar.isValidAvatar(this.avatar)) {"
       },
       {
         "lineNumber": 220,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "            throw new IllegalValueException(Avatar.MESSAGE_AVATAR_CONSTRAINTS);"
       },
       {
         "lineNumber": 221,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        }"
       },
       {
         "lineNumber": 222,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        final Avatar avatar \u003d new Avatar(this.avatar);"
       },
       {
         "lineNumber": 223,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        return new Person(name, phone, email, address, remark, teamName, tags, rating, position, jerseyNumber, avatar);"
       },
@@ -73173,10 +71890,9 @@
       }
     ],
     "authorContributionMap": {
-      "lithiumlkid": 52,
       "lohtianwei": 48,
       "jordancjq": 11,
-      "-": 132
+      "-": 184
     }
   },
   {
@@ -74417,624 +73133,6 @@
     }
   },
   {
-    "path": "src/main/java/seedu/address/storage/XmlAddressBookStorage.java",
-    "lines": [
-      {
-        "lineNumber": 1,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "package seedu.address.storage;"
-      },
-      {
-        "lineNumber": 2,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 3,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static java.util.Objects.requireNonNull;"
-      },
-      {
-        "lineNumber": 4,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 5,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import java.io.File;"
-      },
-      {
-        "lineNumber": 6,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import java.io.FileNotFoundException;"
-      },
-      {
-        "lineNumber": 7,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import java.io.IOException;"
-      },
-      {
-        "lineNumber": 8,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import java.util.Optional;"
-      },
-      {
-        "lineNumber": 9,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import java.util.logging.Logger;"
-      },
-      {
-        "lineNumber": 10,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 11,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.commons.core.LogsCenter;"
-      },
-      {
-        "lineNumber": 12,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.commons.exceptions.DataConversionException;"
-      },
-      {
-        "lineNumber": 13,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.commons.exceptions.IllegalValueException;"
-      },
-      {
-        "lineNumber": 14,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.commons.util.FileUtil;"
-      },
-      {
-        "lineNumber": 15,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.model.ReadOnlyAddressBook;"
-      },
-      {
-        "lineNumber": 16,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 17,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "/**"
-      },
-      {
-        "lineNumber": 18,
-        "author": {
-          "gitId": "-"
-        },
-        "content": " * A class to access AddressBook data stored as an xml file on the hard disk."
-      },
-      {
-        "lineNumber": 19,
-        "author": {
-          "gitId": "-"
-        },
-        "content": " */"
-      },
-      {
-        "lineNumber": 20,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "public class XmlAddressBookStorage implements AddressBookStorage {"
-      },
-      {
-        "lineNumber": 21,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 22,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    private static final Logger logger \u003d LogsCenter.getLogger(XmlAddressBookStorage.class);"
-      },
-      {
-        "lineNumber": 23,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 24,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    private String filePath;"
-      },
-      {
-        "lineNumber": 25,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 26,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public XmlAddressBookStorage(String filePath) {"
-      },
-      {
-        "lineNumber": 27,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        this.filePath \u003d filePath;"
-      },
-      {
-        "lineNumber": 28,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 29,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 30,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public String getAddressBookFilePath() {"
-      },
-      {
-        "lineNumber": 31,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        return filePath;"
-      },
-      {
-        "lineNumber": 32,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 33,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 34,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    @Override"
-      },
-      {
-        "lineNumber": 35,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public Optional\u003cReadOnlyAddressBook\u003e readAddressBook() throws DataConversionException, IOException {"
-      },
-      {
-        "lineNumber": 36,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        return readAddressBook(filePath);"
-      },
-      {
-        "lineNumber": 37,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 38,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 39,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    /**"
-      },
-      {
-        "lineNumber": 40,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     * Similar to {@link #readAddressBook()}"
-      },
-      {
-        "lineNumber": 41,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     * @param filePath location of the data. Cannot be null"
-      },
-      {
-        "lineNumber": 42,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     * @throws DataConversionException if the file is not in the correct format."
-      },
-      {
-        "lineNumber": 43,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     */"
-      },
-      {
-        "lineNumber": 44,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public Optional\u003cReadOnlyAddressBook\u003e readAddressBook(String filePath) throws DataConversionException,"
-      },
-      {
-        "lineNumber": 45,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "                                                                                 FileNotFoundException {"
-      },
-      {
-        "lineNumber": 46,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        requireNonNull(filePath);"
-      },
-      {
-        "lineNumber": 47,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 48,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        File addressBookFile \u003d new File(filePath);"
-      },
-      {
-        "lineNumber": 49,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 50,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        if (!addressBookFile.exists()) {"
-      },
-      {
-        "lineNumber": 51,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "            logger.info(\"AddressBook file \"  + addressBookFile + \" not found\");"
-      },
-      {
-        "lineNumber": 52,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "            return Optional.empty();"
-      },
-      {
-        "lineNumber": 53,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        }"
-      },
-      {
-        "lineNumber": 54,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 55,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        XmlSerializableAddressBook xmlAddressBook \u003d XmlFileStorage.loadDataFromSaveFile(new File(filePath));"
-      },
-      {
-        "lineNumber": 56,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        try {"
-      },
-      {
-        "lineNumber": 57,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "            return Optional.of(xmlAddressBook.toModelType());"
-      },
-      {
-        "lineNumber": 58,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        } catch (IllegalValueException ive) {"
-      },
-      {
-        "lineNumber": 59,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "            logger.info(\"Illegal values found in \" + addressBookFile + \": \" + ive.getMessage());"
-      },
-      {
-        "lineNumber": 60,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "            throw new DataConversionException(ive);"
-      },
-      {
-        "lineNumber": 61,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        }"
-      },
-      {
-        "lineNumber": 62,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 63,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 64,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    @Override"
-      },
-      {
-        "lineNumber": 65,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    public void backupAddressBook(ReadOnlyAddressBook addressBook) throws IOException {"
-      },
-      {
-        "lineNumber": 66,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        saveAddressBook(addressBook, filePath + \".backup\");"
-      },
-      {
-        "lineNumber": 67,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 68,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 69,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    @Override"
-      },
-      {
-        "lineNumber": 70,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public void saveAddressBook(ReadOnlyAddressBook addressBook) throws IOException {"
-      },
-      {
-        "lineNumber": 71,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        saveAddressBook(addressBook, filePath);"
-      },
-      {
-        "lineNumber": 72,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 73,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 74,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    /**"
-      },
-      {
-        "lineNumber": 75,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     * Similar to {@link #saveAddressBook(ReadOnlyAddressBook)}"
-      },
-      {
-        "lineNumber": 76,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     * @param filePath location of the data. Cannot be null"
-      },
-      {
-        "lineNumber": 77,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     */"
-      },
-      {
-        "lineNumber": 78,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public void saveAddressBook(ReadOnlyAddressBook addressBook, String filePath) throws IOException {"
-      },
-      {
-        "lineNumber": 79,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        requireNonNull(addressBook);"
-      },
-      {
-        "lineNumber": 80,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        requireNonNull(filePath);"
-      },
-      {
-        "lineNumber": 81,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 82,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        File file \u003d new File(filePath);"
-      },
-      {
-        "lineNumber": 83,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        FileUtil.createIfMissing(file);"
-      },
-      {
-        "lineNumber": 84,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        XmlFileStorage.saveDataToFile(file, new XmlSerializableAddressBook(addressBook));"
-      },
-      {
-        "lineNumber": 85,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 86,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 87,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "}"
-      }
-    ],
-    "authorContributionMap": {
-      "lithiumlkid": 5,
-      "-": 82
-    }
-  },
-  {
     "path": "src/main/java/seedu/address/storage/XmlSerializableAddressBook.java",
     "lines": [
       {
@@ -75659,14 +73757,14 @@
       {
         "lineNumber": 3,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "import java.util.List;"
       },
       {
         "lineNumber": 4,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "import java.util.Set;"
       },
@@ -75701,21 +73799,21 @@
       {
         "lineNumber": 9,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "import javafx.geometry.Side;"
       },
       {
         "lineNumber": 10,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "import javafx.scene.control.ContextMenu;"
       },
       {
         "lineNumber": 11,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "import javafx.scene.control.MenuItem;"
       },
@@ -75778,7 +73876,7 @@
       {
         "lineNumber": 20,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "import seedu.address.logic.commands.CommandTrie;"
       },
@@ -75862,14 +73960,14 @@
       {
         "lineNumber": 32,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    private CommandTrie commandTrie;"
       },
       {
         "lineNumber": 33,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    private Set\u003cString\u003e commandSet;"
       },
@@ -75897,14 +73995,14 @@
       {
         "lineNumber": 37,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    private final ContextMenu suggestions;"
       },
       {
         "lineNumber": 38,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -77107,472 +75205,8 @@
       }
     ],
     "authorContributionMap": {
-      "lithiumlkid": 177,
-      "-": 32
-    }
-  },
-  {
-    "path": "src/main/java/seedu/address/ui/HelpWindow.java",
-    "lines": [
-      {
-        "lineNumber": 1,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "package seedu.address.ui;"
-      },
-      {
-        "lineNumber": 2,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 3,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import java.util.logging.Logger;"
-      },
-      {
-        "lineNumber": 4,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 5,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import javafx.fxml.FXML;"
-      },
-      {
-        "lineNumber": 6,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import javafx.scene.web.WebView;"
-      },
-      {
-        "lineNumber": 7,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import javafx.stage.Stage;"
-      },
-      {
-        "lineNumber": 8,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.commons.core.LogsCenter;"
-      },
-      {
-        "lineNumber": 9,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 10,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "/**"
-      },
-      {
-        "lineNumber": 11,
-        "author": {
-          "gitId": "-"
-        },
-        "content": " * Controller for a help page"
-      },
-      {
-        "lineNumber": 12,
-        "author": {
-          "gitId": "-"
-        },
-        "content": " */"
-      },
-      {
-        "lineNumber": 13,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "public class HelpWindow extends UiPart\u003cStage\u003e {"
-      },
-      {
-        "lineNumber": 14,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 15,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public static final String USERGUIDE_FILE_PATH \u003d \"/docs/UserGuide.html\";"
-      },
-      {
-        "lineNumber": 16,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 17,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    private static final Logger logger \u003d LogsCenter.getLogger(HelpWindow.class);"
-      },
-      {
-        "lineNumber": 18,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    private static final String FXML \u003d \"HelpWindow.fxml\";"
-      },
-      {
-        "lineNumber": 19,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 20,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    @FXML"
-      },
-      {
-        "lineNumber": 21,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    private WebView browser;"
-      },
-      {
-        "lineNumber": 22,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 23,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    /**"
-      },
-      {
-        "lineNumber": 24,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     * Creates a new HelpWindow."
-      },
-      {
-        "lineNumber": 25,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     *"
-      },
-      {
-        "lineNumber": 26,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     * @param root Stage to use as the root of the HelpWindow."
-      },
-      {
-        "lineNumber": 27,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     */"
-      },
-      {
-        "lineNumber": 28,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public HelpWindow(Stage root) {"
-      },
-      {
-        "lineNumber": 29,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        super(FXML, root);"
-      },
-      {
-        "lineNumber": 30,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 31,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        String userGuideUrl \u003d getClass().getResource(USERGUIDE_FILE_PATH).toString();"
-      },
-      {
-        "lineNumber": 32,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        browser.getEngine().load(userGuideUrl);"
-      },
-      {
-        "lineNumber": 33,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 34,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 35,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    /**"
-      },
-      {
-        "lineNumber": 36,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     * Creates a new HelpWindow."
-      },
-      {
-        "lineNumber": 37,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     */"
-      },
-      {
-        "lineNumber": 38,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public HelpWindow() {"
-      },
-      {
-        "lineNumber": 39,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        this(new Stage());"
-      },
-      {
-        "lineNumber": 40,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 41,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 42,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    /**"
-      },
-      {
-        "lineNumber": 43,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     * Shows the help window."
-      },
-      {
-        "lineNumber": 44,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     * @throws IllegalStateException"
-      },
-      {
-        "lineNumber": 45,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     * \u003cul\u003e"
-      },
-      {
-        "lineNumber": 46,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     *     \u003cli\u003e"
-      },
-      {
-        "lineNumber": 47,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     *         if this method is called on a thread other than the JavaFX Application Thread."
-      },
-      {
-        "lineNumber": 48,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     *     \u003c/li\u003e"
-      },
-      {
-        "lineNumber": 49,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     *     \u003cli\u003e"
-      },
-      {
-        "lineNumber": 50,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     *         if this method is called during animation or layout processing."
-      },
-      {
-        "lineNumber": 51,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     *     \u003c/li\u003e"
-      },
-      {
-        "lineNumber": 52,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     *     \u003cli\u003e"
-      },
-      {
-        "lineNumber": 53,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     *         if this method is called on the primary stage."
-      },
-      {
-        "lineNumber": 54,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     *     \u003c/li\u003e"
-      },
-      {
-        "lineNumber": 55,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     *     \u003cli\u003e"
-      },
-      {
-        "lineNumber": 56,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     *         if {@code dialogStage} is already showing."
-      },
-      {
-        "lineNumber": 57,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     *     \u003c/li\u003e"
-      },
-      {
-        "lineNumber": 58,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     * \u003c/ul\u003e"
-      },
-      {
-        "lineNumber": 59,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     */"
-      },
-      {
-        "lineNumber": 60,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public void show() {"
-      },
-      {
-        "lineNumber": 61,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        logger.fine(\"Showing help page about the application.\");"
-      },
-      {
-        "lineNumber": 62,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        getRoot().show();"
-      },
-      {
-        "lineNumber": 63,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        getRoot().toFront();"
-      },
-      {
-        "lineNumber": 64,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 65,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "}"
-      }
-    ],
-    "authorContributionMap": {
-      "lithiumlkid": 1,
-      "-": 64
+      "lithiumlkid": 167,
+      "-": 42
     }
   },
   {
@@ -77903,7 +75537,7 @@
       {
         "lineNumber": 47,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    private HelpWindow helpWindow;"
       },
@@ -79037,21 +76671,21 @@
       {
         "lineNumber": 209,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        if (helpWindow \u003d\u003d null) {"
       },
       {
         "lineNumber": 210,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "            helpWindow \u003d new HelpWindow();"
       },
       {
         "lineNumber": 211,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        }"
       },
@@ -79232,9 +76866,8 @@
       }
     ],
     "authorContributionMap": {
-      "lithiumlkid": 4,
       "codeeong": 27,
-      "-": 205
+      "-": 209
     }
   },
   {
@@ -79257,14 +76890,14 @@
       {
         "lineNumber": 3,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "import java.io.File;"
       },
       {
         "lineNumber": 4,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "import java.net.MalformedURLException;"
       },
@@ -79306,7 +76939,7 @@
       {
         "lineNumber": 10,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -79334,7 +76967,7 @@
       {
         "lineNumber": 14,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "import javafx.scene.image.Image;"
       },
@@ -79362,14 +76995,14 @@
       {
         "lineNumber": 18,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "import javafx.scene.paint.ImagePattern;"
       },
       {
         "lineNumber": 19,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "import javafx.scene.shape.Circle;"
       },
@@ -79607,56 +77240,56 @@
       {
         "lineNumber": 53,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    @FXML"
       },
       {
         "lineNumber": 54,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    private Label rating;"
       },
       {
         "lineNumber": 55,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    @FXML"
       },
       {
         "lineNumber": 56,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    private Label position;"
       },
       {
         "lineNumber": 57,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    @FXML"
       },
       {
         "lineNumber": 58,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    private Label jerseyNumber;"
       },
       {
         "lineNumber": 59,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    @FXML"
       },
       {
         "lineNumber": 60,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    private Circle avatar;"
       },
@@ -79726,7 +77359,7 @@
       {
         "lineNumber": 70,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "            rating.setText(person.getRating().value);"
       },
@@ -79747,7 +77380,7 @@
       {
         "lineNumber": 73,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        position.setText(person.getPosition().getPositionName());"
       },
@@ -79761,140 +77394,140 @@
       {
         "lineNumber": 75,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        setContactImage(person.getAvatar().getValue());"
       },
       {
         "lineNumber": 76,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    }"
       },
       {
         "lineNumber": 77,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 78,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 79,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    private void setContactImage(String path) {"
       },
       {
         "lineNumber": 80,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 81,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        Image img \u003d null;"
       },
       {
         "lineNumber": 82,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 83,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        try {"
       },
       {
         "lineNumber": 84,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "            if (new File(path).isFile()) {"
       },
       {
         "lineNumber": 85,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "                img \u003d new Image(new File(path).toURI().toURL().toString());"
       },
       {
         "lineNumber": 86,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "            } else {"
       },
       {
         "lineNumber": 87,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "                img \u003d new Image(getClass().getResource(\"/images/placeholder_test.png\").toString());"
       },
       {
         "lineNumber": 88,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "            }"
       },
       {
         "lineNumber": 89,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        } catch (MalformedURLException e) {"
       },
       {
         "lineNumber": 90,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "            img \u003d new Image(getClass().getResource(\"/images/placeholder_test.png\").toString());"
       },
       {
         "lineNumber": 91,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        }"
       },
       {
         "lineNumber": 92,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        avatar.setVisible(true);"
       },
       {
         "lineNumber": 93,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        avatar.setFill(new ImagePattern(img));"
       },
       {
         "lineNumber": 94,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        avatar.setVisible(true);"
       },
@@ -80250,11 +77883,10 @@
       }
     ],
     "authorContributionMap": {
-      "lithiumlkid": 36,
       "lohtianwei": 5,
       "jordancjq": 2,
       "codeeong": 18,
-      "-": 83
+      "-": 119
     }
   },
   {
@@ -83889,14 +81521,14 @@
       {
         "lineNumber": 1,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "package seedu.address.logic;"
       },
       {
         "lineNumber": 2,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -84133,7 +81765,8 @@
       }
     ],
     "authorContributionMap": {
-      "lithiumlkid": 35
+      "lithiumlkid": 33,
+      "-": 2
     }
   },
   {
@@ -88595,7 +86228,7 @@
       {
         "lineNumber": 7,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "import static seedu.address.logic.parser.CliSyntax.PREFIX_AVATAR;"
       },
@@ -88616,7 +86249,7 @@
       {
         "lineNumber": 10,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "import static seedu.address.logic.parser.CliSyntax.PREFIX_JERSEY_NUMBER;"
       },
@@ -88637,14 +86270,14 @@
       {
         "lineNumber": 13,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "import static seedu.address.logic.parser.CliSyntax.PREFIX_POSITION;"
       },
       {
         "lineNumber": 14,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "import static seedu.address.logic.parser.CliSyntax.PREFIX_RATING;"
       },
@@ -88924,56 +86557,56 @@
       {
         "lineNumber": 54,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    public static final String VALID_RATING_0 \u003d \"0\";"
       },
       {
         "lineNumber": 55,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    public static final String VALID_RATING_1 \u003d \"1\";"
       },
       {
         "lineNumber": 56,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    public static final String VALID_POSITION_STRIKER \u003d \"1\";"
       },
       {
         "lineNumber": 57,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    public static final String VALID_POSITION_MIDFIELD \u003d \"2\";"
       },
       {
         "lineNumber": 58,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    public static final String VALID_JERSEY_NUMBER_2 \u003d \"2\";"
       },
       {
         "lineNumber": 59,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    public static final String VALID_JERSEY_NUMBER_17 \u003d \"17\";"
       },
       {
         "lineNumber": 60,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    public static final String VALID_AVATAR_WINDOWS \u003d System.getProperty(\"user.dir\") + \"\\\\images\\\\placeholder_test.png\";"
       },
       {
         "lineNumber": 61,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    public static final String VALID_AVATAR_MAC_LINUX \u003d System.getProperty(\"user.dir\") + \"/images/placeholder_test.png\";"
       },
@@ -89064,56 +86697,56 @@
       {
         "lineNumber": 74,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    public static final String RATING_DESC_0 \u003d \" \" + PREFIX_RATING + VALID_RATING_0;"
       },
       {
         "lineNumber": 75,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    public static final String RATING_DESC_1 \u003d \" \" + PREFIX_RATING + VALID_RATING_1;"
       },
       {
         "lineNumber": 76,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    public static final String POSITION_DESC_STRIKER \u003d \" \" + PREFIX_POSITION + VALID_POSITION_STRIKER;"
       },
       {
         "lineNumber": 77,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    public static final String POSITION_DESC_MIDFILED \u003d \" \" + PREFIX_POSITION + VALID_POSITION_MIDFIELD;"
       },
       {
         "lineNumber": 78,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    public static final String JERSEY_NUMBER_DESC_2 \u003d \" \" + PREFIX_JERSEY_NUMBER + VALID_JERSEY_NUMBER_2;"
       },
       {
         "lineNumber": 79,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    public static final String JERSEY_NUMBER_DESC_17 \u003d \" \" + PREFIX_JERSEY_NUMBER + VALID_JERSEY_NUMBER_17;"
       },
       {
         "lineNumber": 80,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    public static final String AVATAR_WINDOWS \u003d \" \" + PREFIX_AVATAR + VALID_AVATAR_WINDOWS;"
       },
       {
         "lineNumber": 81,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    public static final String AVATAR_MAC_LINUX \u003d \" \" + PREFIX_AVATAR + VALID_AVATAR_MAC_LINUX;"
       },
@@ -89183,56 +86816,56 @@
       {
         "lineNumber": 91,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    public static final String INVALID_RATING_DESC \u003d \" \" + PREFIX_RATING + \"06\"; // only integer 0 to 5 allowed"
       },
       {
         "lineNumber": 92,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    public static final String INVALID_POSITION_DESC \u003d \" \" + PREFIX_POSITION + \"10\"; // only integer 1 to 4 allowed"
       },
       {
         "lineNumber": 93,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    // only integer 0 to 99 not allowed"
       },
       {
         "lineNumber": 94,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    public static final String INVALID_JERSEY_NUMBER_DESC \u003d \" \" + PREFIX_JERSEY_NUMBER + \"100\";"
       },
       {
         "lineNumber": 95,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    //only jpg and png file type allowed"
       },
       {
         "lineNumber": 96,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    public static final String INVALID_AVATAR_TYPE \u003d \" \" + PREFIX_AVATAR + \"images.gif\";"
       },
       {
         "lineNumber": 97,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    //only jpg and png file type allowed"
       },
       {
         "lineNumber": 98,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    public static final String INVALID_AVATAR_NO_FILE \u003d \" \" + PREFIX_AVATAR + \"file.png\";"
       },
@@ -89337,21 +86970,21 @@
       {
         "lineNumber": 113,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "                .withTags(VALID_TAG_FRIEND).withRating(VALID_RATING_0)"
       },
       {
         "lineNumber": 114,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "                .withPosition(VALID_POSITION_STRIKER).withJerseyNumber(VALID_JERSEY_NUMBER_2)"
       },
       {
         "lineNumber": 115,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "                .build();"
       },
@@ -89372,14 +87005,14 @@
       {
         "lineNumber": 118,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "                .withTags(VALID_TAG_HUSBAND, VALID_TAG_FRIEND).withRating(VALID_RATING_1)"
       },
       {
         "lineNumber": 119,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "                .withPosition(VALID_POSITION_MIDFIELD).withJerseyNumber(VALID_JERSEY_NUMBER_17).build();"
       },
@@ -89973,9 +87606,8 @@
       }
     ],
     "authorContributionMap": {
-      "lithiumlkid": 33,
       "jordancjq": 17,
-      "-": 153
+      "-": 186
     }
   },
   {
@@ -90768,2404 +88400,6 @@
     ],
     "authorContributionMap": {
       "jordancjq": 112
-    }
-  },
-  {
-    "path": "src/test/java/seedu/address/logic/commands/EditCommandTest.java",
-    "lines": [
-      {
-        "lineNumber": 1,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "package seedu.address.logic.commands;"
-      },
-      {
-        "lineNumber": 2,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 3,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static org.junit.Assert.assertFalse;"
-      },
-      {
-        "lineNumber": 4,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static org.junit.Assert.assertNotEquals;"
-      },
-      {
-        "lineNumber": 5,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static org.junit.Assert.assertTrue;"
-      },
-      {
-        "lineNumber": 6,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static seedu.address.logic.commands.CommandTestUtil.DESC_AMY;"
-      },
-      {
-        "lineNumber": 7,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static seedu.address.logic.commands.CommandTestUtil.DESC_BOB;"
-      },
-      {
-        "lineNumber": 8,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "import static seedu.address.logic.commands.CommandTestUtil.VALID_JERSEY_NUMBER_2;"
-      },
-      {
-        "lineNumber": 9,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;"
-      },
-      {
-        "lineNumber": 10,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_BOB;"
-      },
-      {
-        "lineNumber": 11,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "import static seedu.address.logic.commands.CommandTestUtil.VALID_POSITION_STRIKER;"
-      },
-      {
-        "lineNumber": 12,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "import static seedu.address.logic.commands.CommandTestUtil.VALID_RATING_0;"
-      },
-      {
-        "lineNumber": 13,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;"
-      },
-      {
-        "lineNumber": 14,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;"
-      },
-      {
-        "lineNumber": 15,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;"
-      },
-      {
-        "lineNumber": 16,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static seedu.address.logic.commands.CommandTestUtil.prepareRedoCommand;"
-      },
-      {
-        "lineNumber": 17,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static seedu.address.logic.commands.CommandTestUtil.prepareUndoCommand;"
-      },
-      {
-        "lineNumber": 18,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static seedu.address.logic.commands.CommandTestUtil.showPersonAtIndex;"
-      },
-      {
-        "lineNumber": 19,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;"
-      },
-      {
-        "lineNumber": 20,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;"
-      },
-      {
-        "lineNumber": 21,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;"
-      },
-      {
-        "lineNumber": 22,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 23,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import org.junit.Test;"
-      },
-      {
-        "lineNumber": 24,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 25,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.commons.core.Messages;"
-      },
-      {
-        "lineNumber": 26,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.commons.core.index.Index;"
-      },
-      {
-        "lineNumber": 27,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.logic.CommandHistory;"
-      },
-      {
-        "lineNumber": 28,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.logic.UndoRedoStack;"
-      },
-      {
-        "lineNumber": 29,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.logic.commands.EditCommand.EditPersonDescriptor;"
-      },
-      {
-        "lineNumber": 30,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.model.AddressBook;"
-      },
-      {
-        "lineNumber": 31,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.model.Model;"
-      },
-      {
-        "lineNumber": 32,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.model.ModelManager;"
-      },
-      {
-        "lineNumber": 33,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.model.UserPrefs;"
-      },
-      {
-        "lineNumber": 34,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.model.person.Person;"
-      },
-      {
-        "lineNumber": 35,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.testutil.EditPersonDescriptorBuilder;"
-      },
-      {
-        "lineNumber": 36,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.testutil.PersonBuilder;"
-      },
-      {
-        "lineNumber": 37,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 38,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "/**"
-      },
-      {
-        "lineNumber": 39,
-        "author": {
-          "gitId": "-"
-        },
-        "content": " * Contains integration tests (interaction with the Model, UndoCommand and RedoCommand) and unit tests for EditCommand."
-      },
-      {
-        "lineNumber": 40,
-        "author": {
-          "gitId": "-"
-        },
-        "content": " */"
-      },
-      {
-        "lineNumber": 41,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "public class EditCommandTest {"
-      },
-      {
-        "lineNumber": 42,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 43,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    private Model model \u003d new ModelManager(getTypicalAddressBook(), new UserPrefs());"
-      },
-      {
-        "lineNumber": 44,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 45,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    @Test"
-      },
-      {
-        "lineNumber": 46,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public void execute_allFieldsSpecifiedUnfilteredList_success() throws Exception {"
-      },
-      {
-        "lineNumber": 47,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        Person editedPerson \u003d new PersonBuilder().build();"
-      },
-      {
-        "lineNumber": 48,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        EditPersonDescriptor descriptor \u003d new EditPersonDescriptorBuilder(editedPerson).build();"
-      },
-      {
-        "lineNumber": 49,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        EditCommand editCommand \u003d prepareCommand(INDEX_FIRST_PERSON, descriptor);"
-      },
-      {
-        "lineNumber": 50,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 51,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        String expectedMessage \u003d String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS, editedPerson);"
-      },
-      {
-        "lineNumber": 52,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 53,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        Model expectedModel \u003d new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());"
-      },
-      {
-        "lineNumber": 54,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        expectedModel.updatePerson(model.getFilteredPersonList().get(0), editedPerson);"
-      },
-      {
-        "lineNumber": 55,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 56,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);"
-      },
-      {
-        "lineNumber": 57,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 58,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 59,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    @Test"
-      },
-      {
-        "lineNumber": 60,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public void execute_someFieldsSpecifiedUnfilteredList_success() throws Exception {"
-      },
-      {
-        "lineNumber": 61,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        Index indexLastPerson \u003d Index.fromOneBased(model.getFilteredPersonList().size());"
-      },
-      {
-        "lineNumber": 62,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        Person lastPerson \u003d model.getFilteredPersonList().get(indexLastPerson.getZeroBased());"
-      },
-      {
-        "lineNumber": 63,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 64,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        PersonBuilder personInList \u003d new PersonBuilder(lastPerson);"
-      },
-      {
-        "lineNumber": 65,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        Person editedPerson \u003d personInList.withName(VALID_NAME_BOB).withPhone(VALID_PHONE_BOB)"
-      },
-      {
-        "lineNumber": 66,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "                .withRating(VALID_RATING_0).withPosition(VALID_POSITION_STRIKER)"
-      },
-      {
-        "lineNumber": 67,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "                .withJerseyNumber(VALID_JERSEY_NUMBER_2).withTags(VALID_TAG_HUSBAND).build();"
-      },
-      {
-        "lineNumber": 68,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 69,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        EditPersonDescriptor descriptor \u003d new EditPersonDescriptorBuilder().withName(VALID_NAME_BOB)"
-      },
-      {
-        "lineNumber": 70,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "                .withPhone(VALID_PHONE_BOB).withRating(VALID_RATING_0).withPosition(VALID_POSITION_STRIKER)"
-      },
-      {
-        "lineNumber": 71,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "                .withJerseyNumber(VALID_JERSEY_NUMBER_2).withTags(VALID_TAG_HUSBAND).build();"
-      },
-      {
-        "lineNumber": 72,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        EditCommand editCommand \u003d prepareCommand(indexLastPerson, descriptor);"
-      },
-      {
-        "lineNumber": 73,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 74,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        String expectedMessage \u003d String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS, editedPerson);"
-      },
-      {
-        "lineNumber": 75,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 76,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        Model expectedModel \u003d new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());"
-      },
-      {
-        "lineNumber": 77,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        expectedModel.updatePerson(lastPerson, editedPerson);"
-      },
-      {
-        "lineNumber": 78,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 79,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);"
-      },
-      {
-        "lineNumber": 80,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 81,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 82,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    @Test"
-      },
-      {
-        "lineNumber": 83,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public void execute_noFieldSpecifiedUnfilteredList_success() {"
-      },
-      {
-        "lineNumber": 84,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        EditCommand editCommand \u003d prepareCommand(INDEX_FIRST_PERSON, new EditPersonDescriptor());"
-      },
-      {
-        "lineNumber": 85,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        Person editedPerson \u003d model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());"
-      },
-      {
-        "lineNumber": 86,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 87,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        String expectedMessage \u003d String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS, editedPerson);"
-      },
-      {
-        "lineNumber": 88,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 89,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        Model expectedModel \u003d new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());"
-      },
-      {
-        "lineNumber": 90,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 91,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);"
-      },
-      {
-        "lineNumber": 92,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 93,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 94,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    @Test"
-      },
-      {
-        "lineNumber": 95,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public void execute_filteredList_success() throws Exception {"
-      },
-      {
-        "lineNumber": 96,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        showPersonAtIndex(model, INDEX_FIRST_PERSON);"
-      },
-      {
-        "lineNumber": 97,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 98,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        Person personInFilteredList \u003d model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());"
-      },
-      {
-        "lineNumber": 99,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        Person editedPerson \u003d new PersonBuilder(personInFilteredList).withName(VALID_NAME_BOB).build();"
-      },
-      {
-        "lineNumber": 100,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        EditCommand editCommand \u003d prepareCommand(INDEX_FIRST_PERSON,"
-      },
-      {
-        "lineNumber": 101,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "                new EditPersonDescriptorBuilder().withName(VALID_NAME_BOB).build());"
-      },
-      {
-        "lineNumber": 102,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 103,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        String expectedMessage \u003d String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS, editedPerson);"
-      },
-      {
-        "lineNumber": 104,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 105,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        Model expectedModel \u003d new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());"
-      },
-      {
-        "lineNumber": 106,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        expectedModel.updatePerson(model.getFilteredPersonList().get(0), editedPerson);"
-      },
-      {
-        "lineNumber": 107,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 108,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);"
-      },
-      {
-        "lineNumber": 109,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 110,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 111,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    @Test"
-      },
-      {
-        "lineNumber": 112,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public void execute_duplicatePersonUnfilteredList_failure() {"
-      },
-      {
-        "lineNumber": 113,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        Person firstPerson \u003d model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());"
-      },
-      {
-        "lineNumber": 114,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        EditPersonDescriptor descriptor \u003d new EditPersonDescriptorBuilder(firstPerson).build();"
-      },
-      {
-        "lineNumber": 115,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        EditCommand editCommand \u003d prepareCommand(INDEX_SECOND_PERSON, descriptor);"
-      },
-      {
-        "lineNumber": 116,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 117,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertCommandFailure(editCommand, model, EditCommand.MESSAGE_DUPLICATE_PERSON);"
-      },
-      {
-        "lineNumber": 118,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 119,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 120,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    @Test"
-      },
-      {
-        "lineNumber": 121,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public void execute_duplicatePersonFilteredList_failure() {"
-      },
-      {
-        "lineNumber": 122,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        showPersonAtIndex(model, INDEX_FIRST_PERSON);"
-      },
-      {
-        "lineNumber": 123,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 124,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        // edit person in filtered list into a duplicate in address book"
-      },
-      {
-        "lineNumber": 125,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        Person personInList \u003d model.getAddressBook().getPersonList().get(INDEX_SECOND_PERSON.getZeroBased());"
-      },
-      {
-        "lineNumber": 126,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        EditCommand editCommand \u003d prepareCommand(INDEX_FIRST_PERSON,"
-      },
-      {
-        "lineNumber": 127,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "                new EditPersonDescriptorBuilder(personInList).build());"
-      },
-      {
-        "lineNumber": 128,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 129,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertCommandFailure(editCommand, model, EditCommand.MESSAGE_DUPLICATE_PERSON);"
-      },
-      {
-        "lineNumber": 130,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 131,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 132,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    @Test"
-      },
-      {
-        "lineNumber": 133,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public void execute_invalidPersonIndexUnfilteredList_failure() {"
-      },
-      {
-        "lineNumber": 134,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        Index outOfBoundIndex \u003d Index.fromOneBased(model.getFilteredPersonList().size() + 1);"
-      },
-      {
-        "lineNumber": 135,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        EditPersonDescriptor descriptor \u003d new EditPersonDescriptorBuilder().withName(VALID_NAME_BOB).build();"
-      },
-      {
-        "lineNumber": 136,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        EditCommand editCommand \u003d prepareCommand(outOfBoundIndex, descriptor);"
-      },
-      {
-        "lineNumber": 137,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 138,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertCommandFailure(editCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);"
-      },
-      {
-        "lineNumber": 139,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 140,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 141,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    /**"
-      },
-      {
-        "lineNumber": 142,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     * Edit filtered list where index is larger than size of filtered list,"
-      },
-      {
-        "lineNumber": 143,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     * but smaller than size of address book"
-      },
-      {
-        "lineNumber": 144,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     */"
-      },
-      {
-        "lineNumber": 145,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    @Test"
-      },
-      {
-        "lineNumber": 146,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public void execute_invalidPersonIndexFilteredList_failure() {"
-      },
-      {
-        "lineNumber": 147,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        showPersonAtIndex(model, INDEX_FIRST_PERSON);"
-      },
-      {
-        "lineNumber": 148,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        Index outOfBoundIndex \u003d INDEX_SECOND_PERSON;"
-      },
-      {
-        "lineNumber": 149,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        // ensures that outOfBoundIndex is still in bounds of address book list"
-      },
-      {
-        "lineNumber": 150,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertTrue(outOfBoundIndex.getZeroBased() \u003c model.getAddressBook().getPersonList().size());"
-      },
-      {
-        "lineNumber": 151,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 152,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        EditCommand editCommand \u003d prepareCommand(outOfBoundIndex,"
-      },
-      {
-        "lineNumber": 153,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "                new EditPersonDescriptorBuilder().withName(VALID_NAME_BOB).build());"
-      },
-      {
-        "lineNumber": 154,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 155,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertCommandFailure(editCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);"
-      },
-      {
-        "lineNumber": 156,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 157,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 158,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    @Test"
-      },
-      {
-        "lineNumber": 159,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public void executeUndoRedo_validIndexUnfilteredList_success() throws Exception {"
-      },
-      {
-        "lineNumber": 160,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        UndoRedoStack undoRedoStack \u003d new UndoRedoStack();"
-      },
-      {
-        "lineNumber": 161,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        UndoCommand undoCommand \u003d prepareUndoCommand(model, undoRedoStack);"
-      },
-      {
-        "lineNumber": 162,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        RedoCommand redoCommand \u003d prepareRedoCommand(model, undoRedoStack);"
-      },
-      {
-        "lineNumber": 163,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        Person editedPerson \u003d new PersonBuilder().build();"
-      },
-      {
-        "lineNumber": 164,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        Person personToEdit \u003d model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());"
-      },
-      {
-        "lineNumber": 165,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        EditPersonDescriptor descriptor \u003d new EditPersonDescriptorBuilder(editedPerson).build();"
-      },
-      {
-        "lineNumber": 166,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        EditCommand editCommand \u003d prepareCommand(INDEX_FIRST_PERSON, descriptor);"
-      },
-      {
-        "lineNumber": 167,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        Model expectedModel \u003d new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());"
-      },
-      {
-        "lineNumber": 168,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 169,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        // edit -\u003e first person edited"
-      },
-      {
-        "lineNumber": 170,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        editCommand.execute();"
-      },
-      {
-        "lineNumber": 171,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        undoRedoStack.push(editCommand);"
-      },
-      {
-        "lineNumber": 172,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 173,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        // undo -\u003e reverts addressbook back to previous state and filtered person list to show all persons"
-      },
-      {
-        "lineNumber": 174,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertCommandSuccess(undoCommand, model, UndoCommand.MESSAGE_SUCCESS, expectedModel);"
-      },
-      {
-        "lineNumber": 175,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 176,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        // redo -\u003e same first person edited again"
-      },
-      {
-        "lineNumber": 177,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        expectedModel.updatePerson(personToEdit, editedPerson);"
-      },
-      {
-        "lineNumber": 178,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertCommandSuccess(redoCommand, model, RedoCommand.MESSAGE_SUCCESS, expectedModel);"
-      },
-      {
-        "lineNumber": 179,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 180,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 181,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    @Test"
-      },
-      {
-        "lineNumber": 182,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public void executeUndoRedo_invalidIndexUnfilteredList_failure() {"
-      },
-      {
-        "lineNumber": 183,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        UndoRedoStack undoRedoStack \u003d new UndoRedoStack();"
-      },
-      {
-        "lineNumber": 184,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        UndoCommand undoCommand \u003d prepareUndoCommand(model, undoRedoStack);"
-      },
-      {
-        "lineNumber": 185,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        RedoCommand redoCommand \u003d prepareRedoCommand(model, undoRedoStack);"
-      },
-      {
-        "lineNumber": 186,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        Index outOfBoundIndex \u003d Index.fromOneBased(model.getFilteredPersonList().size() + 1);"
-      },
-      {
-        "lineNumber": 187,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        EditPersonDescriptor descriptor \u003d new EditPersonDescriptorBuilder().withName(VALID_NAME_BOB).build();"
-      },
-      {
-        "lineNumber": 188,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        EditCommand editCommand \u003d prepareCommand(outOfBoundIndex, descriptor);"
-      },
-      {
-        "lineNumber": 189,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 190,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        // execution failed -\u003e editCommand not pushed into undoRedoStack"
-      },
-      {
-        "lineNumber": 191,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertCommandFailure(editCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);"
-      },
-      {
-        "lineNumber": 192,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 193,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        // no commands in undoRedoStack -\u003e undoCommand and redoCommand fail"
-      },
-      {
-        "lineNumber": 194,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertCommandFailure(undoCommand, model, UndoCommand.MESSAGE_FAILURE);"
-      },
-      {
-        "lineNumber": 195,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertCommandFailure(redoCommand, model, RedoCommand.MESSAGE_FAILURE);"
-      },
-      {
-        "lineNumber": 196,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 197,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 198,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    /**"
-      },
-      {
-        "lineNumber": 199,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     * 1. Edits a {@code Person} from a filtered list."
-      },
-      {
-        "lineNumber": 200,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     * 2. Undo the edit."
-      },
-      {
-        "lineNumber": 201,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     * 3. The unfiltered list should be shown now. Verify that the index of the previously edited person in the"
-      },
-      {
-        "lineNumber": 202,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     * unfiltered list is different from the index at the filtered list."
-      },
-      {
-        "lineNumber": 203,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     * 4. Redo the edit. This ensures {@code RedoCommand} edits the person object regardless of indexing."
-      },
-      {
-        "lineNumber": 204,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     */"
-      },
-      {
-        "lineNumber": 205,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    @Test"
-      },
-      {
-        "lineNumber": 206,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public void executeUndoRedo_validIndexFilteredList_samePersonEdited() throws Exception {"
-      },
-      {
-        "lineNumber": 207,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        UndoRedoStack undoRedoStack \u003d new UndoRedoStack();"
-      },
-      {
-        "lineNumber": 208,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        UndoCommand undoCommand \u003d prepareUndoCommand(model, undoRedoStack);"
-      },
-      {
-        "lineNumber": 209,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        RedoCommand redoCommand \u003d prepareRedoCommand(model, undoRedoStack);"
-      },
-      {
-        "lineNumber": 210,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        Person editedPerson \u003d new PersonBuilder().build();"
-      },
-      {
-        "lineNumber": 211,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        EditPersonDescriptor descriptor \u003d new EditPersonDescriptorBuilder(editedPerson).build();"
-      },
-      {
-        "lineNumber": 212,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        EditCommand editCommand \u003d prepareCommand(INDEX_FIRST_PERSON, descriptor);"
-      },
-      {
-        "lineNumber": 213,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        Model expectedModel \u003d new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());"
-      },
-      {
-        "lineNumber": 214,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 215,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        showPersonAtIndex(model, INDEX_SECOND_PERSON);"
-      },
-      {
-        "lineNumber": 216,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        Person personToEdit \u003d model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());"
-      },
-      {
-        "lineNumber": 217,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        // edit -\u003e edits second person in unfiltered person list / first person in filtered person list"
-      },
-      {
-        "lineNumber": 218,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        editCommand.execute();"
-      },
-      {
-        "lineNumber": 219,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        undoRedoStack.push(editCommand);"
-      },
-      {
-        "lineNumber": 220,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 221,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        // undo -\u003e reverts addressbook back to previous state and filtered person list to show all persons"
-      },
-      {
-        "lineNumber": 222,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertCommandSuccess(undoCommand, model, UndoCommand.MESSAGE_SUCCESS, expectedModel);"
-      },
-      {
-        "lineNumber": 223,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 224,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        expectedModel.updatePerson(personToEdit, editedPerson);"
-      },
-      {
-        "lineNumber": 225,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertNotEquals(model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased()), personToEdit);"
-      },
-      {
-        "lineNumber": 226,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        // redo -\u003e edits same second person in unfiltered person list"
-      },
-      {
-        "lineNumber": 227,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertCommandSuccess(redoCommand, model, RedoCommand.MESSAGE_SUCCESS, expectedModel);"
-      },
-      {
-        "lineNumber": 228,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 229,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 230,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    @Test"
-      },
-      {
-        "lineNumber": 231,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public void equals() throws Exception {"
-      },
-      {
-        "lineNumber": 232,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        final EditCommand standardCommand \u003d prepareCommand(INDEX_FIRST_PERSON, DESC_AMY);"
-      },
-      {
-        "lineNumber": 233,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 234,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        // same values -\u003e returns true"
-      },
-      {
-        "lineNumber": 235,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        EditPersonDescriptor copyDescriptor \u003d new EditPersonDescriptor(DESC_AMY);"
-      },
-      {
-        "lineNumber": 236,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        EditCommand commandWithSameValues \u003d prepareCommand(INDEX_FIRST_PERSON, copyDescriptor);"
-      },
-      {
-        "lineNumber": 237,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertTrue(standardCommand.equals(commandWithSameValues));"
-      },
-      {
-        "lineNumber": 238,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 239,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        // same object -\u003e returns true"
-      },
-      {
-        "lineNumber": 240,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertTrue(standardCommand.equals(standardCommand));"
-      },
-      {
-        "lineNumber": 241,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 242,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        // one command preprocessed when previously equal -\u003e returns false"
-      },
-      {
-        "lineNumber": 243,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        commandWithSameValues.preprocessUndoableCommand();"
-      },
-      {
-        "lineNumber": 244,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertFalse(standardCommand.equals(commandWithSameValues));"
-      },
-      {
-        "lineNumber": 245,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 246,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        // null -\u003e returns false"
-      },
-      {
-        "lineNumber": 247,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertFalse(standardCommand.equals(null));"
-      },
-      {
-        "lineNumber": 248,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 249,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        // different types -\u003e returns false"
-      },
-      {
-        "lineNumber": 250,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertFalse(standardCommand.equals(new ClearCommand()));"
-      },
-      {
-        "lineNumber": 251,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 252,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        // different index -\u003e returns false"
-      },
-      {
-        "lineNumber": 253,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertFalse(standardCommand.equals(new EditCommand(INDEX_SECOND_PERSON, DESC_AMY)));"
-      },
-      {
-        "lineNumber": 254,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 255,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        // different descriptor -\u003e returns false"
-      },
-      {
-        "lineNumber": 256,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertFalse(standardCommand.equals(new EditCommand(INDEX_FIRST_PERSON, DESC_BOB)));"
-      },
-      {
-        "lineNumber": 257,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 258,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 259,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    /**"
-      },
-      {
-        "lineNumber": 260,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     * Returns an {@code EditCommand} with parameters {@code index} and {@code descriptor}"
-      },
-      {
-        "lineNumber": 261,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     */"
-      },
-      {
-        "lineNumber": 262,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    private EditCommand prepareCommand(Index index, EditPersonDescriptor descriptor) {"
-      },
-      {
-        "lineNumber": 263,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        EditCommand editCommand \u003d new EditCommand(index, descriptor);"
-      },
-      {
-        "lineNumber": 264,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        editCommand.setData(model, new CommandHistory(), new UndoRedoStack());"
-      },
-      {
-        "lineNumber": 265,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        return editCommand;"
-      },
-      {
-        "lineNumber": 266,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 267,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "}"
-      }
-    ],
-    "authorContributionMap": {
-      "lithiumlkid": 7,
-      "-": 260
-    }
-  },
-  {
-    "path": "src/test/java/seedu/address/logic/commands/EditPersonDescriptorTest.java",
-    "lines": [
-      {
-        "lineNumber": 1,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "package seedu.address.logic.commands;"
-      },
-      {
-        "lineNumber": 2,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 3,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static org.junit.Assert.assertFalse;"
-      },
-      {
-        "lineNumber": 4,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static org.junit.Assert.assertTrue;"
-      },
-      {
-        "lineNumber": 5,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static seedu.address.logic.commands.CommandTestUtil.DESC_AMY;"
-      },
-      {
-        "lineNumber": 6,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static seedu.address.logic.commands.CommandTestUtil.DESC_BOB;"
-      },
-      {
-        "lineNumber": 7,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static seedu.address.logic.commands.CommandTestUtil.VALID_ADDRESS_BOB;"
-      },
-      {
-        "lineNumber": 8,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static seedu.address.logic.commands.CommandTestUtil.VALID_EMAIL_BOB;"
-      },
-      {
-        "lineNumber": 9,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "import static seedu.address.logic.commands.CommandTestUtil.VALID_JERSEY_NUMBER_17;"
-      },
-      {
-        "lineNumber": 10,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;"
-      },
-      {
-        "lineNumber": 11,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_BOB;"
-      },
-      {
-        "lineNumber": 12,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "import static seedu.address.logic.commands.CommandTestUtil.VALID_POSITION_MIDFIELD;"
-      },
-      {
-        "lineNumber": 13,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "import static seedu.address.logic.commands.CommandTestUtil.VALID_RATING_1;"
-      },
-      {
-        "lineNumber": 14,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;"
-      },
-      {
-        "lineNumber": 15,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 16,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import org.junit.Test;"
-      },
-      {
-        "lineNumber": 17,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 18,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.logic.commands.EditCommand.EditPersonDescriptor;"
-      },
-      {
-        "lineNumber": 19,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.testutil.EditPersonDescriptorBuilder;"
-      },
-      {
-        "lineNumber": 20,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 21,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "public class EditPersonDescriptorTest {"
-      },
-      {
-        "lineNumber": 22,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 23,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    @Test"
-      },
-      {
-        "lineNumber": 24,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public void equals() {"
-      },
-      {
-        "lineNumber": 25,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        // same values -\u003e returns true"
-      },
-      {
-        "lineNumber": 26,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        EditPersonDescriptor descriptorWithSameValues \u003d new EditPersonDescriptor(DESC_AMY);"
-      },
-      {
-        "lineNumber": 27,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertTrue(DESC_AMY.equals(descriptorWithSameValues));"
-      },
-      {
-        "lineNumber": 28,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 29,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        // same object -\u003e returns true"
-      },
-      {
-        "lineNumber": 30,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertTrue(DESC_AMY.equals(DESC_AMY));"
-      },
-      {
-        "lineNumber": 31,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 32,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        // null -\u003e returns false"
-      },
-      {
-        "lineNumber": 33,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertFalse(DESC_AMY.equals(null));"
-      },
-      {
-        "lineNumber": 34,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 35,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        // different types -\u003e returns false"
-      },
-      {
-        "lineNumber": 36,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertFalse(DESC_AMY.equals(5));"
-      },
-      {
-        "lineNumber": 37,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 38,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        // different values -\u003e returns false"
-      },
-      {
-        "lineNumber": 39,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertFalse(DESC_AMY.equals(DESC_BOB));"
-      },
-      {
-        "lineNumber": 40,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 41,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        // different name -\u003e returns false"
-      },
-      {
-        "lineNumber": 42,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        EditPersonDescriptor editedAmy \u003d new EditPersonDescriptorBuilder(DESC_AMY).withName(VALID_NAME_BOB).build();"
-      },
-      {
-        "lineNumber": 43,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertFalse(DESC_AMY.equals(editedAmy));"
-      },
-      {
-        "lineNumber": 44,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 45,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        // different phone -\u003e returns false"
-      },
-      {
-        "lineNumber": 46,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        editedAmy \u003d new EditPersonDescriptorBuilder(DESC_AMY).withPhone(VALID_PHONE_BOB).build();"
-      },
-      {
-        "lineNumber": 47,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertFalse(DESC_AMY.equals(editedAmy));"
-      },
-      {
-        "lineNumber": 48,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 49,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        // different email -\u003e returns false"
-      },
-      {
-        "lineNumber": 50,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        editedAmy \u003d new EditPersonDescriptorBuilder(DESC_AMY).withEmail(VALID_EMAIL_BOB).build();"
-      },
-      {
-        "lineNumber": 51,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertFalse(DESC_AMY.equals(editedAmy));"
-      },
-      {
-        "lineNumber": 52,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 53,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        // different address -\u003e returns false"
-      },
-      {
-        "lineNumber": 54,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        editedAmy \u003d new EditPersonDescriptorBuilder(DESC_AMY).withAddress(VALID_ADDRESS_BOB).build();"
-      },
-      {
-        "lineNumber": 55,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertFalse(DESC_AMY.equals(editedAmy));"
-      },
-      {
-        "lineNumber": 56,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 57,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        // different tags -\u003e returns false"
-      },
-      {
-        "lineNumber": 58,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        editedAmy \u003d new EditPersonDescriptorBuilder(DESC_AMY).withTags(VALID_TAG_HUSBAND).build();"
-      },
-      {
-        "lineNumber": 59,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertFalse(DESC_AMY.equals(editedAmy));"
-      },
-      {
-        "lineNumber": 60,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 61,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        // different rating -\u003e returns false"
-      },
-      {
-        "lineNumber": 62,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        editedAmy \u003d new EditPersonDescriptorBuilder(DESC_AMY).withRating(VALID_RATING_1).build();"
-      },
-      {
-        "lineNumber": 63,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        assertFalse(DESC_AMY.equals(editedAmy));"
-      },
-      {
-        "lineNumber": 64,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 65,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        // different position -\u003e returns false"
-      },
-      {
-        "lineNumber": 66,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        editedAmy \u003d new EditPersonDescriptorBuilder(DESC_AMY).withPosition(VALID_POSITION_MIDFIELD).build();"
-      },
-      {
-        "lineNumber": 67,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        assertFalse(DESC_AMY.equals(editedAmy));"
-      },
-      {
-        "lineNumber": 68,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 69,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        // different jersey number -\u003e returns false"
-      },
-      {
-        "lineNumber": 70,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        editedAmy \u003d new EditPersonDescriptorBuilder(DESC_AMY).withJerseyNumber(VALID_JERSEY_NUMBER_17).build();"
-      },
-      {
-        "lineNumber": 71,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        assertFalse(DESC_AMY.equals(editedAmy));"
-      },
-      {
-        "lineNumber": 72,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 73,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "}"
-      }
-    ],
-    "authorContributionMap": {
-      "lithiumlkid": 15,
-      "-": 58
     }
   },
   {
@@ -99231,7 +94465,7 @@
       {
         "lineNumber": 10,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "import static seedu.address.logic.commands.CommandTestUtil.INVALID_JERSEY_NUMBER_DESC;"
       },
@@ -99252,14 +94486,14 @@
       {
         "lineNumber": 13,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "import static seedu.address.logic.commands.CommandTestUtil.INVALID_POSITION_DESC;"
       },
       {
         "lineNumber": 14,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "import static seedu.address.logic.commands.CommandTestUtil.INVALID_RATING_DESC;"
       },
@@ -99273,14 +94507,14 @@
       {
         "lineNumber": 16,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "import static seedu.address.logic.commands.CommandTestUtil.JERSEY_NUMBER_DESC_17;"
       },
       {
         "lineNumber": 17,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "import static seedu.address.logic.commands.CommandTestUtil.JERSEY_NUMBER_DESC_2;"
       },
@@ -99315,14 +94549,14 @@
       {
         "lineNumber": 22,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "import static seedu.address.logic.commands.CommandTestUtil.POSITION_DESC_MIDFILED;"
       },
       {
         "lineNumber": 23,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "import static seedu.address.logic.commands.CommandTestUtil.POSITION_DESC_STRIKER;"
       },
@@ -99343,14 +94577,14 @@
       {
         "lineNumber": 26,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "import static seedu.address.logic.commands.CommandTestUtil.RATING_DESC_0;"
       },
       {
         "lineNumber": 27,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "import static seedu.address.logic.commands.CommandTestUtil.RATING_DESC_1;"
       },
@@ -99399,14 +94633,14 @@
       {
         "lineNumber": 34,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "import static seedu.address.logic.commands.CommandTestUtil.VALID_JERSEY_NUMBER_17;"
       },
       {
         "lineNumber": 35,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "import static seedu.address.logic.commands.CommandTestUtil.VALID_JERSEY_NUMBER_2;"
       },
@@ -99441,28 +94675,28 @@
       {
         "lineNumber": 40,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "import static seedu.address.logic.commands.CommandTestUtil.VALID_POSITION_MIDFIELD;"
       },
       {
         "lineNumber": 41,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "import static seedu.address.logic.commands.CommandTestUtil.VALID_POSITION_STRIKER;"
       },
       {
         "lineNumber": 42,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "import static seedu.address.logic.commands.CommandTestUtil.VALID_RATING_0;"
       },
       {
         "lineNumber": 43,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "import static seedu.address.logic.commands.CommandTestUtil.VALID_RATING_1;"
       },
@@ -99546,7 +94780,7 @@
       {
         "lineNumber": 55,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "import seedu.address.model.person.JerseyNumber;"
       },
@@ -99574,14 +94808,14 @@
       {
         "lineNumber": 59,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "import seedu.address.model.person.Position;"
       },
       {
         "lineNumber": 60,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "import seedu.address.model.person.Rating;"
       },
@@ -99651,21 +94885,21 @@
       {
         "lineNumber": 70,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "                .withEmail(VALID_EMAIL_BOB).withAddress(VALID_ADDRESS_BOB).withTags(VALID_TAG_FRIEND)"
       },
       {
         "lineNumber": 71,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "                .withRating(VALID_RATING_0).withPosition(VALID_POSITION_STRIKER)"
       },
       {
         "lineNumber": 72,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "                .withJerseyNumber(VALID_JERSEY_NUMBER_2).build();"
       },
@@ -99693,14 +94927,14 @@
       {
         "lineNumber": 76,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "                + ADDRESS_DESC_BOB + RATING_DESC_0 + POSITION_DESC_STRIKER + JERSEY_NUMBER_DESC_2"
       },
       {
         "lineNumber": 77,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "                + TAG_DESC_FRIEND, new AddCommand(expectedPerson));"
       },
@@ -99728,14 +94962,14 @@
       {
         "lineNumber": 81,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "                + ADDRESS_DESC_BOB + RATING_DESC_0 + POSITION_DESC_STRIKER + JERSEY_NUMBER_DESC_2"
       },
       {
         "lineNumber": 82,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "                + TAG_DESC_FRIEND, new AddCommand(expectedPerson));"
       },
@@ -99763,14 +94997,14 @@
       {
         "lineNumber": 86,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "                + ADDRESS_DESC_BOB + RATING_DESC_0 + POSITION_DESC_STRIKER + JERSEY_NUMBER_DESC_2"
       },
       {
         "lineNumber": 87,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "                + TAG_DESC_FRIEND, new AddCommand(expectedPerson));"
       },
@@ -99798,14 +95032,14 @@
       {
         "lineNumber": 91,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "                + ADDRESS_DESC_BOB + RATING_DESC_0 + POSITION_DESC_STRIKER + JERSEY_NUMBER_DESC_2"
       },
       {
         "lineNumber": 92,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "                + TAG_DESC_FRIEND, new AddCommand(expectedPerson));"
       },
@@ -99833,119 +95067,119 @@
       {
         "lineNumber": 96,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "                + ADDRESS_DESC_BOB + RATING_DESC_0 + POSITION_DESC_STRIKER + JERSEY_NUMBER_DESC_2"
       },
       {
         "lineNumber": 97,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "                + TAG_DESC_FRIEND, new AddCommand(expectedPerson));"
       },
       {
         "lineNumber": 98,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 99,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        //multiple rating - last rating accepted"
       },
       {
         "lineNumber": 100,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        assertParseSuccess(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB"
       },
       {
         "lineNumber": 101,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "                + RATING_DESC_1 + RATING_DESC_0 + POSITION_DESC_STRIKER + JERSEY_NUMBER_DESC_2"
       },
       {
         "lineNumber": 102,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "                + TAG_DESC_FRIEND, new AddCommand(expectedPerson));"
       },
       {
         "lineNumber": 103,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 104,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        //multiple position - last position accepted"
       },
       {
         "lineNumber": 105,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        assertParseSuccess(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB"
       },
       {
         "lineNumber": 106,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "                + RATING_DESC_0 + POSITION_DESC_MIDFILED + POSITION_DESC_STRIKER + JERSEY_NUMBER_DESC_2"
       },
       {
         "lineNumber": 107,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "                + TAG_DESC_FRIEND, new AddCommand(expectedPerson));"
       },
       {
         "lineNumber": 108,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 109,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        //multiple jersey number - last jersey number accepted"
       },
       {
         "lineNumber": 110,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        assertParseSuccess(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB"
       },
       {
         "lineNumber": 111,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "                + RATING_DESC_0 + POSITION_DESC_STRIKER + JERSEY_NUMBER_DESC_17 + JERSEY_NUMBER_DESC_2"
       },
       {
         "lineNumber": 112,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "                + TAG_DESC_FRIEND, new AddCommand(expectedPerson));"
       },
@@ -99980,21 +95214,21 @@
       {
         "lineNumber": 117,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "                .withTags(VALID_TAG_FRIEND, VALID_TAG_HUSBAND)"
       },
       {
         "lineNumber": 118,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "                .withRating(VALID_RATING_0).withPosition(VALID_POSITION_STRIKER)"
       },
       {
         "lineNumber": 119,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "                .withJerseyNumber(VALID_JERSEY_NUMBER_2).build();"
       },
@@ -100008,7 +95242,7 @@
       {
         "lineNumber": 121,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "                + RATING_DESC_0 + POSITION_DESC_MIDFILED + JERSEY_NUMBER_DESC_2"
       },
@@ -100064,35 +95298,35 @@
       {
         "lineNumber": 129,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "                .withEmail(VALID_EMAIL_AMY).withAddress(VALID_ADDRESS_AMY).withTags()"
       },
       {
         "lineNumber": 130,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "                .withRating(VALID_RATING_1).withPosition(VALID_POSITION_MIDFIELD)"
       },
       {
         "lineNumber": 131,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "                .withJerseyNumber(VALID_JERSEY_NUMBER_17).build();"
       },
       {
         "lineNumber": 132,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        assertParseSuccess(parser, NAME_DESC_AMY + PHONE_DESC_AMY + EMAIL_DESC_AMY + ADDRESS_DESC_AMY"
       },
       {
         "lineNumber": 133,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "                + RATING_DESC_1 + POSITION_DESC_MIDFILED + JERSEY_NUMBER_DESC_17,"
       },
@@ -100169,35 +95403,35 @@
       {
         "lineNumber": 144,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "                .withEmail(VALID_EMAIL_AMY).withAddress(UNSPECIFIED_FIELD).withRating(VALID_RATING_1)"
       },
       {
         "lineNumber": 145,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "                .withPosition(VALID_POSITION_MIDFIELD)"
       },
       {
         "lineNumber": 146,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "                .withJerseyNumber(VALID_JERSEY_NUMBER_17).withTags().build();"
       },
       {
         "lineNumber": 147,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        assertParseSuccess(parser, NAME_DESC_AMY + EMAIL_DESC_AMY + PHONE_DESC_AMY"
       },
       {
         "lineNumber": 148,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "                        + RATING_DESC_1 + POSITION_DESC_MIDFILED + JERSEY_NUMBER_DESC_17,"
       },
@@ -100232,224 +95466,224 @@
       {
         "lineNumber": 153,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "                .withEmail(VALID_EMAIL_AMY).withAddress(VALID_ADDRESS_AMY)"
       },
       {
         "lineNumber": 154,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "                .withRating(VALID_RATING_1).withPosition(VALID_POSITION_MIDFIELD)"
       },
       {
         "lineNumber": 155,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "                .withJerseyNumber(VALID_JERSEY_NUMBER_17).withTags().build();"
       },
       {
         "lineNumber": 156,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        assertParseSuccess(parser, NAME_DESC_AMY + EMAIL_DESC_AMY + ADDRESS_DESC_AMY"
       },
       {
         "lineNumber": 157,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "                        + RATING_DESC_1 + POSITION_DESC_MIDFILED + JERSEY_NUMBER_DESC_17,"
       },
       {
         "lineNumber": 158,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "                new AddCommand((expectedPerson)));"
       },
       {
         "lineNumber": 159,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 160,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        // missing rating"
       },
       {
         "lineNumber": 161,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        expectedPerson \u003d new PersonBuilder().withName(VALID_NAME_AMY).withPhone(UNSPECIFIED_FIELD)"
       },
       {
         "lineNumber": 162,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "                .withEmail(VALID_EMAIL_AMY).withAddress(VALID_ADDRESS_AMY)"
       },
       {
         "lineNumber": 163,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "                .withPosition(VALID_POSITION_MIDFIELD)"
       },
       {
         "lineNumber": 164,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "                .withJerseyNumber(VALID_JERSEY_NUMBER_17).withTags().build();"
       },
       {
         "lineNumber": 165,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        assertParseSuccess(parser, NAME_DESC_AMY + EMAIL_DESC_AMY + ADDRESS_DESC_AMY"
       },
       {
         "lineNumber": 166,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "                        + POSITION_DESC_MIDFILED + JERSEY_NUMBER_DESC_17,"
       },
       {
         "lineNumber": 167,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "                new AddCommand((expectedPerson)));"
       },
       {
         "lineNumber": 168,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 169,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        // missing position"
       },
       {
         "lineNumber": 170,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        expectedPerson \u003d new PersonBuilder().withName(VALID_NAME_AMY).withPhone(UNSPECIFIED_FIELD)"
       },
       {
         "lineNumber": 171,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "                .withEmail(VALID_EMAIL_AMY).withAddress(VALID_ADDRESS_AMY)"
       },
       {
         "lineNumber": 172,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "                .withRating(VALID_RATING_1)"
       },
       {
         "lineNumber": 173,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "                .withJerseyNumber(VALID_JERSEY_NUMBER_17).withTags().build();"
       },
       {
         "lineNumber": 174,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        assertParseSuccess(parser, NAME_DESC_AMY + EMAIL_DESC_AMY + ADDRESS_DESC_AMY"
       },
       {
         "lineNumber": 175,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "                        + RATING_DESC_1 + JERSEY_NUMBER_DESC_17,"
       },
       {
         "lineNumber": 176,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "                new AddCommand((expectedPerson)));"
       },
       {
         "lineNumber": 177,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 178,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        // missing jersey number"
       },
       {
         "lineNumber": 179,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        expectedPerson \u003d new PersonBuilder().withName(VALID_NAME_AMY).withPhone(UNSPECIFIED_FIELD)"
       },
       {
         "lineNumber": 180,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "                .withEmail(VALID_EMAIL_AMY).withAddress(VALID_ADDRESS_AMY)"
       },
       {
         "lineNumber": 181,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "                .withRating(VALID_RATING_1).withPosition(VALID_POSITION_MIDFIELD)"
       },
       {
         "lineNumber": 182,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "                .withTags().build();"
       },
       {
         "lineNumber": 183,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        assertParseSuccess(parser, NAME_DESC_AMY + EMAIL_DESC_AMY + ADDRESS_DESC_AMY"
       },
       {
         "lineNumber": 184,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "                        + RATING_DESC_1 + POSITION_DESC_MIDFILED,"
       },
@@ -100624,7 +95858,7 @@
       {
         "lineNumber": 209,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "                + RATING_DESC_1 + POSITION_DESC_MIDFILED + JERSEY_NUMBER_DESC_17"
       },
@@ -100659,7 +95893,7 @@
       {
         "lineNumber": 214,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "                + RATING_DESC_1 + POSITION_DESC_MIDFILED + JERSEY_NUMBER_DESC_17"
       },
@@ -100694,7 +95928,7 @@
       {
         "lineNumber": 219,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "                + RATING_DESC_1 + POSITION_DESC_MIDFILED + JERSEY_NUMBER_DESC_17"
       },
@@ -100729,7 +95963,7 @@
       {
         "lineNumber": 224,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "                + RATING_DESC_1 + POSITION_DESC_MIDFILED + JERSEY_NUMBER_DESC_17"
       },
@@ -100764,7 +95998,7 @@
       {
         "lineNumber": 229,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "                + RATING_DESC_1 + POSITION_DESC_MIDFILED + JERSEY_NUMBER_DESC_17"
       },
@@ -100785,105 +96019,105 @@
       {
         "lineNumber": 232,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        // invalid rating"
       },
       {
         "lineNumber": 233,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB"
       },
       {
         "lineNumber": 234,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "                + INVALID_RATING_DESC + POSITION_DESC_MIDFILED + JERSEY_NUMBER_DESC_17"
       },
       {
         "lineNumber": 235,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "                 + VALID_TAG_FRIEND, Rating.MESSAGE_RATING_CONSTRAINTS);"
       },
       {
         "lineNumber": 236,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 237,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        // invalid position"
       },
       {
         "lineNumber": 238,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB"
       },
       {
         "lineNumber": 239,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "                + RATING_DESC_1 + INVALID_POSITION_DESC + JERSEY_NUMBER_DESC_17"
       },
       {
         "lineNumber": 240,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "                + VALID_TAG_FRIEND, Position.MESSAGE_POSITION_CONSTRAINTS);"
       },
       {
         "lineNumber": 241,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 242,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        // invalid jersey number"
       },
       {
         "lineNumber": 243,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB"
       },
       {
         "lineNumber": 244,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "                + RATING_DESC_1 + POSITION_DESC_MIDFILED + INVALID_JERSEY_NUMBER_DESC"
       },
       {
         "lineNumber": 245,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "                + VALID_TAG_FRIEND, JerseyNumber.MESSAGE_JERSEY_NUMBER_CONSTRAINTS);"
       },
       {
         "lineNumber": 246,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -100897,14 +96131,14 @@
       {
         "lineNumber": 248,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        assertParseFailure(parser, INVALID_NAME_DESC + PHONE_DESC_BOB + EMAIL_DESC_BOB"
       },
       {
         "lineNumber": 249,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "                + RATING_DESC_1 + POSITION_DESC_MIDFILED + JERSEY_NUMBER_DESC_17 + INVALID_ADDRESS_DESC,"
       },
@@ -100939,7 +96173,7 @@
       {
         "lineNumber": 254,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "                + RATING_DESC_1 + POSITION_DESC_MIDFILED + JERSEY_NUMBER_DESC_17"
       },
@@ -100973,9 +96207,8 @@
       }
     ],
     "authorContributionMap": {
-      "lithiumlkid": 115,
       "jordancjq": 15,
-      "-": 128
+      "-": 243
     }
   },
   {
@@ -104271,1492 +99504,6 @@
     ],
     "authorContributionMap": {
       "jordancjq": 43
-    }
-  },
-  {
-    "path": "src/test/java/seedu/address/logic/parser/EditCommandParserTest.java",
-    "lines": [
-      {
-        "lineNumber": 1,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "package seedu.address.logic.parser;"
-      },
-      {
-        "lineNumber": 2,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 3,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;"
-      },
-      {
-        "lineNumber": 4,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static seedu.address.logic.commands.CommandTestUtil.ADDRESS_DESC_AMY;"
-      },
-      {
-        "lineNumber": 5,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static seedu.address.logic.commands.CommandTestUtil.ADDRESS_DESC_BOB;"
-      },
-      {
-        "lineNumber": 6,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static seedu.address.logic.commands.CommandTestUtil.EMAIL_DESC_AMY;"
-      },
-      {
-        "lineNumber": 7,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static seedu.address.logic.commands.CommandTestUtil.EMAIL_DESC_BOB;"
-      },
-      {
-        "lineNumber": 8,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static seedu.address.logic.commands.CommandTestUtil.INVALID_ADDRESS_DESC;"
-      },
-      {
-        "lineNumber": 9,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static seedu.address.logic.commands.CommandTestUtil.INVALID_EMAIL_DESC;"
-      },
-      {
-        "lineNumber": 10,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static seedu.address.logic.commands.CommandTestUtil.INVALID_NAME_DESC;"
-      },
-      {
-        "lineNumber": 11,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static seedu.address.logic.commands.CommandTestUtil.INVALID_PHONE_DESC;"
-      },
-      {
-        "lineNumber": 12,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static seedu.address.logic.commands.CommandTestUtil.INVALID_TAG_DESC;"
-      },
-      {
-        "lineNumber": 13,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static seedu.address.logic.commands.CommandTestUtil.NAME_DESC_AMY;"
-      },
-      {
-        "lineNumber": 14,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static seedu.address.logic.commands.CommandTestUtil.PHONE_DESC_AMY;"
-      },
-      {
-        "lineNumber": 15,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static seedu.address.logic.commands.CommandTestUtil.PHONE_DESC_BOB;"
-      },
-      {
-        "lineNumber": 16,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static seedu.address.logic.commands.CommandTestUtil.TAG_DESC_FRIEND;"
-      },
-      {
-        "lineNumber": 17,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static seedu.address.logic.commands.CommandTestUtil.TAG_DESC_HUSBAND;"
-      },
-      {
-        "lineNumber": 18,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static seedu.address.logic.commands.CommandTestUtil.VALID_ADDRESS_AMY;"
-      },
-      {
-        "lineNumber": 19,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static seedu.address.logic.commands.CommandTestUtil.VALID_ADDRESS_BOB;"
-      },
-      {
-        "lineNumber": 20,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static seedu.address.logic.commands.CommandTestUtil.VALID_EMAIL_AMY;"
-      },
-      {
-        "lineNumber": 21,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static seedu.address.logic.commands.CommandTestUtil.VALID_EMAIL_BOB;"
-      },
-      {
-        "lineNumber": 22,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_AMY;"
-      },
-      {
-        "lineNumber": 23,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_AMY;"
-      },
-      {
-        "lineNumber": 24,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_BOB;"
-      },
-      {
-        "lineNumber": 25,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_FRIEND;"
-      },
-      {
-        "lineNumber": 26,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;"
-      },
-      {
-        "lineNumber": 27,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;"
-      },
-      {
-        "lineNumber": 28,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;"
-      },
-      {
-        "lineNumber": 29,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;"
-      },
-      {
-        "lineNumber": 30,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;"
-      },
-      {
-        "lineNumber": 31,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;"
-      },
-      {
-        "lineNumber": 32,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static seedu.address.testutil.TypicalIndexes.INDEX_THIRD_PERSON;"
-      },
-      {
-        "lineNumber": 33,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 34,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import org.junit.Test;"
-      },
-      {
-        "lineNumber": 35,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 36,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.commons.core.index.Index;"
-      },
-      {
-        "lineNumber": 37,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.logic.commands.EditCommand;"
-      },
-      {
-        "lineNumber": 38,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.logic.commands.EditCommand.EditPersonDescriptor;"
-      },
-      {
-        "lineNumber": 39,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.model.person.Address;"
-      },
-      {
-        "lineNumber": 40,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.model.person.Email;"
-      },
-      {
-        "lineNumber": 41,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.model.person.Name;"
-      },
-      {
-        "lineNumber": 42,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.model.person.Phone;"
-      },
-      {
-        "lineNumber": 43,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.model.tag.Tag;"
-      },
-      {
-        "lineNumber": 44,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.testutil.EditPersonDescriptorBuilder;"
-      },
-      {
-        "lineNumber": 45,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 46,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "public class EditCommandParserTest {"
-      },
-      {
-        "lineNumber": 47,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 48,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    private static final String TAG_EMPTY \u003d \" \" + PREFIX_TAG;"
-      },
-      {
-        "lineNumber": 49,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 50,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    private static final String MESSAGE_INVALID_FORMAT \u003d"
-      },
-      {
-        "lineNumber": 51,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "            String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE);"
-      },
-      {
-        "lineNumber": 52,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 53,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    private EditCommandParser parser \u003d new EditCommandParser();"
-      },
-      {
-        "lineNumber": 54,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 55,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    @Test"
-      },
-      {
-        "lineNumber": 56,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public void parse_missingParts_failure() {"
-      },
-      {
-        "lineNumber": 57,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        // no index specified"
-      },
-      {
-        "lineNumber": 58,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertParseFailure(parser, VALID_NAME_AMY, MESSAGE_INVALID_FORMAT);"
-      },
-      {
-        "lineNumber": 59,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 60,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        // no field specified"
-      },
-      {
-        "lineNumber": 61,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertParseFailure(parser, \"1\", EditCommand.MESSAGE_NOT_EDITED);"
-      },
-      {
-        "lineNumber": 62,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 63,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        // no index and no field specified"
-      },
-      {
-        "lineNumber": 64,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertParseFailure(parser, \"\", MESSAGE_INVALID_FORMAT);"
-      },
-      {
-        "lineNumber": 65,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 66,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 67,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    @Test"
-      },
-      {
-        "lineNumber": 68,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public void parse_invalidPreamble_failure() {"
-      },
-      {
-        "lineNumber": 69,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        // negative index"
-      },
-      {
-        "lineNumber": 70,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertParseFailure(parser, \"-5\" + NAME_DESC_AMY, MESSAGE_INVALID_FORMAT);"
-      },
-      {
-        "lineNumber": 71,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 72,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        // zero index"
-      },
-      {
-        "lineNumber": 73,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertParseFailure(parser, \"0\" + NAME_DESC_AMY, MESSAGE_INVALID_FORMAT);"
-      },
-      {
-        "lineNumber": 74,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 75,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        // invalid arguments being parsed as preamble"
-      },
-      {
-        "lineNumber": 76,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertParseFailure(parser, \"1 some random string\", MESSAGE_INVALID_FORMAT);"
-      },
-      {
-        "lineNumber": 77,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 78,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        // invalid prefix being parsed as preamble"
-      },
-      {
-        "lineNumber": 79,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        assertParseFailure(parser, \"1 x/ string\", MESSAGE_INVALID_FORMAT);"
-      },
-      {
-        "lineNumber": 80,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 81,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 82,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    @Test"
-      },
-      {
-        "lineNumber": 83,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public void parse_invalidValue_failure() {"
-      },
-      {
-        "lineNumber": 84,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertParseFailure(parser, \"1\" + INVALID_NAME_DESC, Name.MESSAGE_NAME_CONSTRAINTS); // invalid name"
-      },
-      {
-        "lineNumber": 85,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertParseFailure(parser, \"1\" + INVALID_PHONE_DESC, Phone.MESSAGE_PHONE_CONSTRAINTS); // invalid phone"
-      },
-      {
-        "lineNumber": 86,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertParseFailure(parser, \"1\" + INVALID_EMAIL_DESC, Email.MESSAGE_EMAIL_CONSTRAINTS); // invalid email"
-      },
-      {
-        "lineNumber": 87,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertParseFailure(parser, \"1\" + INVALID_ADDRESS_DESC, Address.MESSAGE_ADDRESS_CONSTRAINTS); // invalid address"
-      },
-      {
-        "lineNumber": 88,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertParseFailure(parser, \"1\" + INVALID_TAG_DESC, Tag.MESSAGE_TAG_CONSTRAINTS); // invalid tag"
-      },
-      {
-        "lineNumber": 89,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 90,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        // invalid phone followed by valid email"
-      },
-      {
-        "lineNumber": 91,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertParseFailure(parser, \"1\" + INVALID_PHONE_DESC + EMAIL_DESC_AMY, Phone.MESSAGE_PHONE_CONSTRAINTS);"
-      },
-      {
-        "lineNumber": 92,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 93,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        // valid phone followed by invalid phone. The test case for invalid phone followed by valid phone"
-      },
-      {
-        "lineNumber": 94,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        // is tested at {@code parse_invalidValueFollowedByValidValue_success()}"
-      },
-      {
-        "lineNumber": 95,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertParseFailure(parser, \"1\" + PHONE_DESC_BOB + INVALID_PHONE_DESC, Phone.MESSAGE_PHONE_CONSTRAINTS);"
-      },
-      {
-        "lineNumber": 96,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 97,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        // while parsing {@code PREFIX_TAG} alone will reset the tags of the {@code Person} being edited,"
-      },
-      {
-        "lineNumber": 98,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        // parsing it together with a valid tag results in error"
-      },
-      {
-        "lineNumber": 99,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertParseFailure(parser, \"1\" + TAG_DESC_FRIEND + TAG_DESC_HUSBAND + TAG_EMPTY, Tag.MESSAGE_TAG_CONSTRAINTS);"
-      },
-      {
-        "lineNumber": 100,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertParseFailure(parser, \"1\" + TAG_DESC_FRIEND + TAG_EMPTY + TAG_DESC_HUSBAND, Tag.MESSAGE_TAG_CONSTRAINTS);"
-      },
-      {
-        "lineNumber": 101,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertParseFailure(parser, \"1\" + TAG_EMPTY + TAG_DESC_FRIEND + TAG_DESC_HUSBAND, Tag.MESSAGE_TAG_CONSTRAINTS);"
-      },
-      {
-        "lineNumber": 102,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 103,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        // multiple invalid values, but only the first invalid value is captured"
-      },
-      {
-        "lineNumber": 104,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertParseFailure(parser, \"1\" + INVALID_NAME_DESC + INVALID_EMAIL_DESC + VALID_ADDRESS_AMY + VALID_PHONE_AMY,"
-      },
-      {
-        "lineNumber": 105,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "                Name.MESSAGE_NAME_CONSTRAINTS);"
-      },
-      {
-        "lineNumber": 106,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 107,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 108,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    @Test"
-      },
-      {
-        "lineNumber": 109,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public void parse_allFieldsSpecified_success() {"
-      },
-      {
-        "lineNumber": 110,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        Index targetIndex \u003d INDEX_SECOND_PERSON;"
-      },
-      {
-        "lineNumber": 111,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        String userInput \u003d targetIndex.getOneBased() + PHONE_DESC_BOB + TAG_DESC_HUSBAND"
-      },
-      {
-        "lineNumber": 112,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "                + EMAIL_DESC_AMY + ADDRESS_DESC_AMY + NAME_DESC_AMY + TAG_DESC_FRIEND;"
-      },
-      {
-        "lineNumber": 113,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 114,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        EditPersonDescriptor descriptor \u003d new EditPersonDescriptorBuilder().withName(VALID_NAME_AMY)"
-      },
-      {
-        "lineNumber": 115,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "                .withPhone(VALID_PHONE_BOB).withEmail(VALID_EMAIL_AMY).withAddress(VALID_ADDRESS_AMY)"
-      },
-      {
-        "lineNumber": 116,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "                .withTags(VALID_TAG_HUSBAND, VALID_TAG_FRIEND).build();"
-      },
-      {
-        "lineNumber": 117,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        EditCommand expectedCommand \u003d new EditCommand(targetIndex, descriptor);"
-      },
-      {
-        "lineNumber": 118,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 119,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertParseSuccess(parser, userInput, expectedCommand);"
-      },
-      {
-        "lineNumber": 120,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 121,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 122,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    @Test"
-      },
-      {
-        "lineNumber": 123,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public void parse_someFieldsSpecified_success() {"
-      },
-      {
-        "lineNumber": 124,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        Index targetIndex \u003d INDEX_FIRST_PERSON;"
-      },
-      {
-        "lineNumber": 125,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        String userInput \u003d targetIndex.getOneBased() + PHONE_DESC_BOB + EMAIL_DESC_AMY;"
-      },
-      {
-        "lineNumber": 126,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 127,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        EditPersonDescriptor descriptor \u003d new EditPersonDescriptorBuilder().withPhone(VALID_PHONE_BOB)"
-      },
-      {
-        "lineNumber": 128,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "                .withEmail(VALID_EMAIL_AMY).build();"
-      },
-      {
-        "lineNumber": 129,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        EditCommand expectedCommand \u003d new EditCommand(targetIndex, descriptor);"
-      },
-      {
-        "lineNumber": 130,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 131,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertParseSuccess(parser, userInput, expectedCommand);"
-      },
-      {
-        "lineNumber": 132,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 133,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 134,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    @Test"
-      },
-      {
-        "lineNumber": 135,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public void parse_oneFieldSpecified_success() {"
-      },
-      {
-        "lineNumber": 136,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        // name"
-      },
-      {
-        "lineNumber": 137,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        Index targetIndex \u003d INDEX_THIRD_PERSON;"
-      },
-      {
-        "lineNumber": 138,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        String userInput \u003d targetIndex.getOneBased() + NAME_DESC_AMY;"
-      },
-      {
-        "lineNumber": 139,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        EditPersonDescriptor descriptor \u003d new EditPersonDescriptorBuilder().withName(VALID_NAME_AMY).build();"
-      },
-      {
-        "lineNumber": 140,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        EditCommand expectedCommand \u003d new EditCommand(targetIndex, descriptor);"
-      },
-      {
-        "lineNumber": 141,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertParseSuccess(parser, userInput, expectedCommand);"
-      },
-      {
-        "lineNumber": 142,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 143,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        // phone"
-      },
-      {
-        "lineNumber": 144,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        userInput \u003d targetIndex.getOneBased() + PHONE_DESC_AMY;"
-      },
-      {
-        "lineNumber": 145,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        descriptor \u003d new EditPersonDescriptorBuilder().withPhone(VALID_PHONE_AMY).build();"
-      },
-      {
-        "lineNumber": 146,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        expectedCommand \u003d new EditCommand(targetIndex, descriptor);"
-      },
-      {
-        "lineNumber": 147,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertParseSuccess(parser, userInput, expectedCommand);"
-      },
-      {
-        "lineNumber": 148,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 149,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        // email"
-      },
-      {
-        "lineNumber": 150,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        userInput \u003d targetIndex.getOneBased() + EMAIL_DESC_AMY;"
-      },
-      {
-        "lineNumber": 151,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        descriptor \u003d new EditPersonDescriptorBuilder().withEmail(VALID_EMAIL_AMY).build();"
-      },
-      {
-        "lineNumber": 152,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        expectedCommand \u003d new EditCommand(targetIndex, descriptor);"
-      },
-      {
-        "lineNumber": 153,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertParseSuccess(parser, userInput, expectedCommand);"
-      },
-      {
-        "lineNumber": 154,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 155,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        // address"
-      },
-      {
-        "lineNumber": 156,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        userInput \u003d targetIndex.getOneBased() + ADDRESS_DESC_AMY;"
-      },
-      {
-        "lineNumber": 157,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        descriptor \u003d new EditPersonDescriptorBuilder().withAddress(VALID_ADDRESS_AMY).build();"
-      },
-      {
-        "lineNumber": 158,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        expectedCommand \u003d new EditCommand(targetIndex, descriptor);"
-      },
-      {
-        "lineNumber": 159,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertParseSuccess(parser, userInput, expectedCommand);"
-      },
-      {
-        "lineNumber": 160,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 161,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        // tags"
-      },
-      {
-        "lineNumber": 162,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        userInput \u003d targetIndex.getOneBased() + TAG_DESC_FRIEND;"
-      },
-      {
-        "lineNumber": 163,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        descriptor \u003d new EditPersonDescriptorBuilder().withTags(VALID_TAG_FRIEND).build();"
-      },
-      {
-        "lineNumber": 164,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        expectedCommand \u003d new EditCommand(targetIndex, descriptor);"
-      },
-      {
-        "lineNumber": 165,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertParseSuccess(parser, userInput, expectedCommand);"
-      },
-      {
-        "lineNumber": 166,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 167,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 168,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    @Test"
-      },
-      {
-        "lineNumber": 169,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public void parse_multipleRepeatedFields_acceptsLast() {"
-      },
-      {
-        "lineNumber": 170,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        Index targetIndex \u003d INDEX_FIRST_PERSON;"
-      },
-      {
-        "lineNumber": 171,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        String userInput \u003d targetIndex.getOneBased()  + PHONE_DESC_AMY + ADDRESS_DESC_AMY + EMAIL_DESC_AMY"
-      },
-      {
-        "lineNumber": 172,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "                + TAG_DESC_FRIEND + PHONE_DESC_AMY + ADDRESS_DESC_AMY + EMAIL_DESC_AMY + TAG_DESC_FRIEND"
-      },
-      {
-        "lineNumber": 173,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "                + PHONE_DESC_BOB + ADDRESS_DESC_BOB + EMAIL_DESC_BOB + TAG_DESC_HUSBAND;"
-      },
-      {
-        "lineNumber": 174,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 175,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        EditPersonDescriptor descriptor \u003d new EditPersonDescriptorBuilder().withPhone(VALID_PHONE_BOB)"
-      },
-      {
-        "lineNumber": 176,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "                .withEmail(VALID_EMAIL_BOB).withAddress(VALID_ADDRESS_BOB).withTags(VALID_TAG_FRIEND, VALID_TAG_HUSBAND)"
-      },
-      {
-        "lineNumber": 177,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "                .build();"
-      },
-      {
-        "lineNumber": 178,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        EditCommand expectedCommand \u003d new EditCommand(targetIndex, descriptor);"
-      },
-      {
-        "lineNumber": 179,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 180,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertParseSuccess(parser, userInput, expectedCommand);"
-      },
-      {
-        "lineNumber": 181,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 182,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 183,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    @Test"
-      },
-      {
-        "lineNumber": 184,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public void parse_invalidValueFollowedByValidValue_success() {"
-      },
-      {
-        "lineNumber": 185,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        // no other valid values specified"
-      },
-      {
-        "lineNumber": 186,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        Index targetIndex \u003d INDEX_FIRST_PERSON;"
-      },
-      {
-        "lineNumber": 187,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        String userInput \u003d targetIndex.getOneBased() + INVALID_PHONE_DESC + PHONE_DESC_BOB;"
-      },
-      {
-        "lineNumber": 188,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        EditPersonDescriptor descriptor \u003d new EditPersonDescriptorBuilder().withPhone(VALID_PHONE_BOB).build();"
-      },
-      {
-        "lineNumber": 189,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        EditCommand expectedCommand \u003d new EditCommand(targetIndex, descriptor);"
-      },
-      {
-        "lineNumber": 190,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertParseSuccess(parser, userInput, expectedCommand);"
-      },
-      {
-        "lineNumber": 191,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 192,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        // other valid values specified"
-      },
-      {
-        "lineNumber": 193,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        userInput \u003d targetIndex.getOneBased() + EMAIL_DESC_BOB + INVALID_PHONE_DESC + ADDRESS_DESC_BOB"
-      },
-      {
-        "lineNumber": 194,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "                + PHONE_DESC_BOB;"
-      },
-      {
-        "lineNumber": 195,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        descriptor \u003d new EditPersonDescriptorBuilder().withPhone(VALID_PHONE_BOB).withEmail(VALID_EMAIL_BOB)"
-      },
-      {
-        "lineNumber": 196,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "                .withAddress(VALID_ADDRESS_BOB).build();"
-      },
-      {
-        "lineNumber": 197,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        expectedCommand \u003d new EditCommand(targetIndex, descriptor);"
-      },
-      {
-        "lineNumber": 198,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertParseSuccess(parser, userInput, expectedCommand);"
-      },
-      {
-        "lineNumber": 199,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 200,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 201,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    @Test"
-      },
-      {
-        "lineNumber": 202,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public void parse_resetTags_success() {"
-      },
-      {
-        "lineNumber": 203,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        Index targetIndex \u003d INDEX_THIRD_PERSON;"
-      },
-      {
-        "lineNumber": 204,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        String userInput \u003d targetIndex.getOneBased() + TAG_EMPTY;"
-      },
-      {
-        "lineNumber": 205,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 206,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        EditPersonDescriptor descriptor \u003d new EditPersonDescriptorBuilder().withTags().build();"
-      },
-      {
-        "lineNumber": 207,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        EditCommand expectedCommand \u003d new EditCommand(targetIndex, descriptor);"
-      },
-      {
-        "lineNumber": 208,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 209,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertParseSuccess(parser, userInput, expectedCommand);"
-      },
-      {
-        "lineNumber": 210,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 211,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "}"
-      }
-    ],
-    "authorContributionMap": {
-      "lithiumlkid": 1,
-      "-": 210
     }
   },
   {
@@ -112887,392 +106634,68 @@
     }
   },
   {
-    "path": "src/test/java/seedu/address/model/person/AddressTest.java",
-    "lines": [
-      {
-        "lineNumber": 1,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "package seedu.address.model.person;"
-      },
-      {
-        "lineNumber": 2,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 3,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static org.junit.Assert.assertFalse;"
-      },
-      {
-        "lineNumber": 4,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static org.junit.Assert.assertTrue;"
-      },
-      {
-        "lineNumber": 5,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 6,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import org.junit.Test;"
-      },
-      {
-        "lineNumber": 7,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 8,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.testutil.Assert;"
-      },
-      {
-        "lineNumber": 9,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 10,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "public class AddressTest {"
-      },
-      {
-        "lineNumber": 11,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 12,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    @Test"
-      },
-      {
-        "lineNumber": 13,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public void constructor_null_throwsNullPointerException() {"
-      },
-      {
-        "lineNumber": 14,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        Assert.assertThrows(NullPointerException.class, () -\u003e new Address(null));"
-      },
-      {
-        "lineNumber": 15,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 16,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 17,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    @Test"
-      },
-      {
-        "lineNumber": 18,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public void constructor_invalidAddress_throwsIllegalArgumentException() {"
-      },
-      {
-        "lineNumber": 19,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        String invalidAddress \u003d \"\";"
-      },
-      {
-        "lineNumber": 20,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        Assert.assertThrows(IllegalArgumentException.class, () -\u003e new Address(invalidAddress));"
-      },
-      {
-        "lineNumber": 21,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 22,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 23,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    @Test"
-      },
-      {
-        "lineNumber": 24,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public void isValidAddress() {"
-      },
-      {
-        "lineNumber": 25,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        // null address"
-      },
-      {
-        "lineNumber": 26,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        Assert.assertThrows(NullPointerException.class, () -\u003e Address.isValidAddress(null));"
-      },
-      {
-        "lineNumber": 27,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 28,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        // invalid addresses"
-      },
-      {
-        "lineNumber": 29,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertFalse(Address.isValidAddress(\"\")); // empty string"
-      },
-      {
-        "lineNumber": 30,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertFalse(Address.isValidAddress(\" \")); // spaces only"
-      },
-      {
-        "lineNumber": 31,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 32,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        // valid addresses"
-      },
-      {
-        "lineNumber": 33,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertTrue(Address.isValidAddress(\"Blk 456, Den Road, #01-355\"));"
-      },
-      {
-        "lineNumber": 34,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertTrue(Address.isValidAddress(\"-\")); // one character"
-      },
-      {
-        "lineNumber": 35,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertTrue(Address.isValidAddress(\"Leng Inc; 1234 Market St; San Francisco CA 2349879; USA\")); // long address"
-      },
-      {
-        "lineNumber": 36,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 37,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 38,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    @Test"
-      },
-      {
-        "lineNumber": 39,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    public void isEqualAddress() {"
-      },
-      {
-        "lineNumber": 40,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        Address x  \u003d new Address(\"Blk 456, Den Road, #01-355\");"
-      },
-      {
-        "lineNumber": 41,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        Address y \u003d new Address(\"Blk 456, Den Road, #01-355\");"
-      },
-      {
-        "lineNumber": 42,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        assertTrue(x.equals(y) \u0026\u0026 y.equals(x));"
-      },
-      {
-        "lineNumber": 43,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        assertTrue(x.hashCode() \u003d\u003d y.hashCode());"
-      },
-      {
-        "lineNumber": 44,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 45,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "}"
-      }
-    ],
-    "authorContributionMap": {
-      "lithiumlkid": 8,
-      "-": 37
-    }
-  },
-  {
     "path": "src/test/java/seedu/address/model/person/AvatarTest.java",
     "lines": [
       {
         "lineNumber": 1,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "package seedu.address.model.person;"
       },
       {
         "lineNumber": 2,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 3,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "import static org.junit.Assert.assertFalse;"
       },
       {
         "lineNumber": 4,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "import static org.junit.Assert.assertTrue;"
       },
       {
         "lineNumber": 5,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 6,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "import org.junit.Test;"
       },
       {
         "lineNumber": 7,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 8,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "import seedu.address.testutil.Assert;"
       },
       {
         "lineNumber": 9,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -113565,506 +106988,8 @@
       }
     ],
     "authorContributionMap": {
-      "lithiumlkid": 50
-    }
-  },
-  {
-    "path": "src/test/java/seedu/address/model/person/EmailTest.java",
-    "lines": [
-      {
-        "lineNumber": 1,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "package seedu.address.model.person;"
-      },
-      {
-        "lineNumber": 2,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 3,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static org.junit.Assert.assertFalse;"
-      },
-      {
-        "lineNumber": 4,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static org.junit.Assert.assertTrue;"
-      },
-      {
-        "lineNumber": 5,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 6,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import org.junit.Test;"
-      },
-      {
-        "lineNumber": 7,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 8,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.testutil.Assert;"
-      },
-      {
-        "lineNumber": 9,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 10,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "public class EmailTest {"
-      },
-      {
-        "lineNumber": 11,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 12,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    @Test"
-      },
-      {
-        "lineNumber": 13,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public void constructor_null_throwsNullPointerException() {"
-      },
-      {
-        "lineNumber": 14,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        Assert.assertThrows(NullPointerException.class, () -\u003e new Email(null));"
-      },
-      {
-        "lineNumber": 15,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 16,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 17,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    @Test"
-      },
-      {
-        "lineNumber": 18,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public void constructor_invalidEmail_throwsIllegalArgumentException() {"
-      },
-      {
-        "lineNumber": 19,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        String invalidEmail \u003d \"\";"
-      },
-      {
-        "lineNumber": 20,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        Assert.assertThrows(IllegalArgumentException.class, () -\u003e new Email(invalidEmail));"
-      },
-      {
-        "lineNumber": 21,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 22,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 23,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    @Test"
-      },
-      {
-        "lineNumber": 24,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public void isValidEmail() {"
-      },
-      {
-        "lineNumber": 25,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        // null email"
-      },
-      {
-        "lineNumber": 26,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        Assert.assertThrows(NullPointerException.class, () -\u003e Email.isValidEmail(null));"
-      },
-      {
-        "lineNumber": 27,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 28,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        // blank email"
-      },
-      {
-        "lineNumber": 29,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertFalse(Email.isValidEmail(\"\")); // empty string"
-      },
-      {
-        "lineNumber": 30,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertFalse(Email.isValidEmail(\" \")); // spaces only"
-      },
-      {
-        "lineNumber": 31,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 32,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        // missing parts"
-      },
-      {
-        "lineNumber": 33,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertFalse(Email.isValidEmail(\"@example.com\")); // missing local part"
-      },
-      {
-        "lineNumber": 34,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertFalse(Email.isValidEmail(\"peterjackexample.com\")); // missing \u0027@\u0027 symbol"
-      },
-      {
-        "lineNumber": 35,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertFalse(Email.isValidEmail(\"peterjack@\")); // missing domain name"
-      },
-      {
-        "lineNumber": 36,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 37,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        // invalid parts"
-      },
-      {
-        "lineNumber": 38,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertFalse(Email.isValidEmail(\"peterjack@-\")); // invalid domain name"
-      },
-      {
-        "lineNumber": 39,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertFalse(Email.isValidEmail(\"peterjack@exam_ple.com\")); // underscore in domain name"
-      },
-      {
-        "lineNumber": 40,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertFalse(Email.isValidEmail(\"peter jack@example.com\")); // spaces in local part"
-      },
-      {
-        "lineNumber": 41,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertFalse(Email.isValidEmail(\"peterjack@exam ple.com\")); // spaces in domain name"
-      },
-      {
-        "lineNumber": 42,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertFalse(Email.isValidEmail(\" peterjack@example.com\")); // leading space"
-      },
-      {
-        "lineNumber": 43,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertFalse(Email.isValidEmail(\"peterjack@example.com \")); // trailing space"
-      },
-      {
-        "lineNumber": 44,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertFalse(Email.isValidEmail(\"peterjack@@example.com\")); // double \u0027@\u0027 symbol"
-      },
-      {
-        "lineNumber": 45,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertFalse(Email.isValidEmail(\"peter@jack@example.com\")); // \u0027@\u0027 symbol in local part"
-      },
-      {
-        "lineNumber": 46,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertFalse(Email.isValidEmail(\"peterjack@example@com\")); // \u0027@\u0027 symbol in domain name"
-      },
-      {
-        "lineNumber": 47,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertFalse(Email.isValidEmail(\"peterjack@.example.com\")); // domain name starts with a period"
-      },
-      {
-        "lineNumber": 48,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertFalse(Email.isValidEmail(\"peterjack@example.com.\")); // domain name ends with a period"
-      },
-      {
-        "lineNumber": 49,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertFalse(Email.isValidEmail(\"peterjack@-example.com\")); // domain name starts with a hyphen"
-      },
-      {
-        "lineNumber": 50,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertFalse(Email.isValidEmail(\"peterjack@example.com-\")); // domain name ends with a hyphen"
-      },
-      {
-        "lineNumber": 51,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 52,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        // valid email"
-      },
-      {
-        "lineNumber": 53,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertTrue(Email.isValidEmail(\"PeterJack_1190@example.com\"));"
-      },
-      {
-        "lineNumber": 54,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertTrue(Email.isValidEmail(\"a@bc\"));  // minimal"
-      },
-      {
-        "lineNumber": 55,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertTrue(Email.isValidEmail(\"test@localhost\"));   // alphabets only"
-      },
-      {
-        "lineNumber": 56,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertTrue(Email.isValidEmail(\"!#$%\u0026\u0027*+/\u003d?`{|}~^.-@example.org\")); // special characters local part"
-      },
-      {
-        "lineNumber": 57,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertTrue(Email.isValidEmail(\"123@145\"));  // numeric local part and domain name"
-      },
-      {
-        "lineNumber": 58,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertTrue(Email.isValidEmail(\"a1+be!@example1.com\")); // mixture of alphanumeric and special characters"
-      },
-      {
-        "lineNumber": 59,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertTrue(Email.isValidEmail(\"peter_jack@very-very-very-long-example.com\"));   // long domain name"
-      },
-      {
-        "lineNumber": 60,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertTrue(Email.isValidEmail(\"if.you.dream.it_you.can.do.it@example.com\"));    // long local part"
-      },
-      {
-        "lineNumber": 61,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 62,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 63,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    @Test"
-      },
-      {
-        "lineNumber": 64,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    public void isEqualEmail() {"
-      },
-      {
-        "lineNumber": 65,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        Email x  \u003d new Email(\"PeterJack_1190@example.com\");"
-      },
-      {
-        "lineNumber": 66,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        Email y \u003d new Email(\"PeterJack_1190@example.com\");"
-      },
-      {
-        "lineNumber": 67,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        assertTrue(x.equals(y) \u0026\u0026 y.equals(x));"
-      },
-      {
-        "lineNumber": 68,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        assertTrue(x.hashCode() \u003d\u003d y.hashCode());"
-      },
-      {
-        "lineNumber": 69,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 70,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "}"
-      }
-    ],
-    "authorContributionMap": {
-      "lithiumlkid": 8,
-      "-": 62
+      "lithiumlkid": 41,
+      "-": 9
     }
   },
   {
@@ -114073,63 +106998,63 @@
       {
         "lineNumber": 1,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "package seedu.address.model.person;"
       },
       {
         "lineNumber": 2,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 3,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "import static org.junit.Assert.assertFalse;"
       },
       {
         "lineNumber": 4,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "import static org.junit.Assert.assertTrue;"
       },
       {
         "lineNumber": 5,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 6,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "import org.junit.Test;"
       },
       {
         "lineNumber": 7,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 8,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "import seedu.address.testutil.Assert;"
       },
       {
         "lineNumber": 9,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -114422,711 +107347,8 @@
       }
     ],
     "authorContributionMap": {
-      "lithiumlkid": 50
-    }
-  },
-  {
-    "path": "src/test/java/seedu/address/model/person/NameTest.java",
-    "lines": [
-      {
-        "lineNumber": 1,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "package seedu.address.model.person;"
-      },
-      {
-        "lineNumber": 2,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 3,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static org.junit.Assert.assertFalse;"
-      },
-      {
-        "lineNumber": 4,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static org.junit.Assert.assertTrue;"
-      },
-      {
-        "lineNumber": 5,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 6,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import org.junit.Test;"
-      },
-      {
-        "lineNumber": 7,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 8,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.testutil.Assert;"
-      },
-      {
-        "lineNumber": 9,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 10,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "public class NameTest {"
-      },
-      {
-        "lineNumber": 11,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 12,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    @Test"
-      },
-      {
-        "lineNumber": 13,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public void constructor_null_throwsNullPointerException() {"
-      },
-      {
-        "lineNumber": 14,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        Assert.assertThrows(NullPointerException.class, () -\u003e new Name(null));"
-      },
-      {
-        "lineNumber": 15,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 16,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 17,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    @Test"
-      },
-      {
-        "lineNumber": 18,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public void constructor_invalidName_throwsIllegalArgumentException() {"
-      },
-      {
-        "lineNumber": 19,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        String invalidName \u003d \"\";"
-      },
-      {
-        "lineNumber": 20,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        Assert.assertThrows(IllegalArgumentException.class, () -\u003e new Name(invalidName));"
-      },
-      {
-        "lineNumber": 21,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 22,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 23,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    @Test"
-      },
-      {
-        "lineNumber": 24,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public void isValidName() {"
-      },
-      {
-        "lineNumber": 25,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        // null name"
-      },
-      {
-        "lineNumber": 26,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        Assert.assertThrows(NullPointerException.class, () -\u003e Name.isValidName(null));"
-      },
-      {
-        "lineNumber": 27,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 28,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        // invalid name"
-      },
-      {
-        "lineNumber": 29,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertFalse(Name.isValidName(\"\")); // empty string"
-      },
-      {
-        "lineNumber": 30,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertFalse(Name.isValidName(\" \")); // spaces only"
-      },
-      {
-        "lineNumber": 31,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertFalse(Name.isValidName(\"^\")); // only non-alphanumeric characters"
-      },
-      {
-        "lineNumber": 32,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertFalse(Name.isValidName(\"peter*\")); // contains non-alphanumeric characters"
-      },
-      {
-        "lineNumber": 33,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 34,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        // valid name"
-      },
-      {
-        "lineNumber": 35,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertTrue(Name.isValidName(\"peter jack\")); // alphabets only"
-      },
-      {
-        "lineNumber": 36,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertTrue(Name.isValidName(\"12345\")); // numbers only"
-      },
-      {
-        "lineNumber": 37,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertTrue(Name.isValidName(\"peter the 2nd\")); // alphanumeric characters"
-      },
-      {
-        "lineNumber": 38,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertTrue(Name.isValidName(\"Capital Tan\")); // with capital letters"
-      },
-      {
-        "lineNumber": 39,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertTrue(Name.isValidName(\"David Roger Jackson Ray Jr 2nd\")); // long names"
-      },
-      {
-        "lineNumber": 40,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 41,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 42,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    @Test"
-      },
-      {
-        "lineNumber": 43,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    public void isEqualName() {"
-      },
-      {
-        "lineNumber": 44,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        Name x  \u003d new Name(\"peter\");"
-      },
-      {
-        "lineNumber": 45,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        Name y \u003d new Name(\"peter\");"
-      },
-      {
-        "lineNumber": 46,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        assertTrue(x.equals(y) \u0026\u0026 y.equals(x));"
-      },
-      {
-        "lineNumber": 47,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        assertTrue(x.hashCode() \u003d\u003d y.hashCode());"
-      },
-      {
-        "lineNumber": 48,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 49,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "}"
-      }
-    ],
-    "authorContributionMap": {
-      "lithiumlkid": 8,
-      "-": 41
-    }
-  },
-  {
-    "path": "src/test/java/seedu/address/model/person/PhoneTest.java",
-    "lines": [
-      {
-        "lineNumber": 1,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "package seedu.address.model.person;"
-      },
-      {
-        "lineNumber": 2,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 3,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static org.junit.Assert.assertFalse;"
-      },
-      {
-        "lineNumber": 4,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static org.junit.Assert.assertTrue;"
-      },
-      {
-        "lineNumber": 5,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 6,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import org.junit.Test;"
-      },
-      {
-        "lineNumber": 7,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 8,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.testutil.Assert;"
-      },
-      {
-        "lineNumber": 9,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 10,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "public class PhoneTest {"
-      },
-      {
-        "lineNumber": 11,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 12,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    @Test"
-      },
-      {
-        "lineNumber": 13,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public void constructor_null_throwsNullPointerException() {"
-      },
-      {
-        "lineNumber": 14,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        Assert.assertThrows(NullPointerException.class, () -\u003e new Phone(null));"
-      },
-      {
-        "lineNumber": 15,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 16,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 17,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    @Test"
-      },
-      {
-        "lineNumber": 18,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public void constructor_invalidPhone_throwsIllegalArgumentException() {"
-      },
-      {
-        "lineNumber": 19,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        String invalidPhone \u003d \"\";"
-      },
-      {
-        "lineNumber": 20,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        Assert.assertThrows(IllegalArgumentException.class, () -\u003e new Phone(invalidPhone));"
-      },
-      {
-        "lineNumber": 21,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 22,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 23,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    @Test"
-      },
-      {
-        "lineNumber": 24,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public void isValidPhone() {"
-      },
-      {
-        "lineNumber": 25,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        // null phone number"
-      },
-      {
-        "lineNumber": 26,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        Assert.assertThrows(NullPointerException.class, () -\u003e Phone.isValidPhone(null));"
-      },
-      {
-        "lineNumber": 27,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 28,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        // invalid phone numbers"
-      },
-      {
-        "lineNumber": 29,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertFalse(Phone.isValidPhone(\"\")); // empty string"
-      },
-      {
-        "lineNumber": 30,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertFalse(Phone.isValidPhone(\" \")); // spaces only"
-      },
-      {
-        "lineNumber": 31,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertFalse(Phone.isValidPhone(\"91\")); // less than 3 numbers"
-      },
-      {
-        "lineNumber": 32,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertFalse(Phone.isValidPhone(\"phone\")); // non-numeric"
-      },
-      {
-        "lineNumber": 33,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertFalse(Phone.isValidPhone(\"9011p041\")); // alphabets within digits"
-      },
-      {
-        "lineNumber": 34,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertFalse(Phone.isValidPhone(\"9312 1534\")); // spaces within digits"
-      },
-      {
-        "lineNumber": 35,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 36,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        // valid phone numbers"
-      },
-      {
-        "lineNumber": 37,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertTrue(Phone.isValidPhone(\"911\")); // exactly 3 numbers"
-      },
-      {
-        "lineNumber": 38,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertTrue(Phone.isValidPhone(\"93121534\"));"
-      },
-      {
-        "lineNumber": 39,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertTrue(Phone.isValidPhone(\"124293842033123\")); // long phone numbers"
-      },
-      {
-        "lineNumber": 40,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 41,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 42,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    @Test"
-      },
-      {
-        "lineNumber": 43,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    public void isEqualPhone() {"
-      },
-      {
-        "lineNumber": 44,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        Phone x  \u003d new Phone(\"911\");"
-      },
-      {
-        "lineNumber": 45,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        Phone y \u003d new Phone(\"911\");"
-      },
-      {
-        "lineNumber": 46,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        assertTrue(x.equals(y) \u0026\u0026 y.equals(x));"
-      },
-      {
-        "lineNumber": 47,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        assertTrue(x.hashCode() \u003d\u003d y.hashCode());"
-      },
-      {
-        "lineNumber": 48,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 49,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "}"
-      }
-    ],
-    "authorContributionMap": {
-      "lithiumlkid": 8,
-      "-": 41
+      "lithiumlkid": 41,
+      "-": 9
     }
   },
   {
@@ -115135,63 +107357,63 @@
       {
         "lineNumber": 1,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "package seedu.address.model.person;"
       },
       {
         "lineNumber": 2,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 3,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "import static org.junit.Assert.assertFalse;"
       },
       {
         "lineNumber": 4,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "import static org.junit.Assert.assertTrue;"
       },
       {
         "lineNumber": 5,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 6,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "import org.junit.Test;"
       },
       {
         "lineNumber": 7,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 8,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "import seedu.address.testutil.Assert;"
       },
       {
         "lineNumber": 9,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -115484,7 +107706,8 @@
       }
     ],
     "authorContributionMap": {
-      "lithiumlkid": 50
+      "lithiumlkid": 41,
+      "-": 9
     }
   },
   {
@@ -115493,63 +107716,63 @@
       {
         "lineNumber": 1,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "package seedu.address.model.person;"
       },
       {
         "lineNumber": 2,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 3,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "import static org.junit.Assert.assertFalse;"
       },
       {
         "lineNumber": 4,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "import static org.junit.Assert.assertTrue;"
       },
       {
         "lineNumber": 5,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 6,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "import org.junit.Test;"
       },
       {
         "lineNumber": 7,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 8,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "import seedu.address.testutil.Assert;"
       },
       {
         "lineNumber": 9,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -115835,7 +108058,8 @@
       }
     ],
     "authorContributionMap": {
-      "lithiumlkid": 49
+      "lithiumlkid": 40,
+      "-": 9
     }
   },
   {
@@ -116433,897 +108657,6 @@
     ],
     "authorContributionMap": {
       "jordancjq": 42
-    }
-  },
-  {
-    "path": "src/test/java/seedu/address/testutil/EditPersonDescriptorBuilder.java",
-    "lines": [
-      {
-        "lineNumber": 1,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "package seedu.address.testutil;"
-      },
-      {
-        "lineNumber": 2,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 3,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import java.util.Set;"
-      },
-      {
-        "lineNumber": 4,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import java.util.stream.Collectors;"
-      },
-      {
-        "lineNumber": 5,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import java.util.stream.Stream;"
-      },
-      {
-        "lineNumber": 6,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 7,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.logic.commands.EditCommand.EditPersonDescriptor;"
-      },
-      {
-        "lineNumber": 8,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.model.person.Address;"
-      },
-      {
-        "lineNumber": 9,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "import seedu.address.model.person.Avatar;"
-      },
-      {
-        "lineNumber": 10,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.model.person.Email;"
-      },
-      {
-        "lineNumber": 11,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "import seedu.address.model.person.JerseyNumber;"
-      },
-      {
-        "lineNumber": 12,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.model.person.Name;"
-      },
-      {
-        "lineNumber": 13,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.model.person.Person;"
-      },
-      {
-        "lineNumber": 14,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.model.person.Phone;"
-      },
-      {
-        "lineNumber": 15,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "import seedu.address.model.person.Position;"
-      },
-      {
-        "lineNumber": 16,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "import seedu.address.model.person.Rating;"
-      },
-      {
-        "lineNumber": 17,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.model.tag.Tag;"
-      },
-      {
-        "lineNumber": 18,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 19,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "/**"
-      },
-      {
-        "lineNumber": 20,
-        "author": {
-          "gitId": "-"
-        },
-        "content": " * A utility class to help with building EditPersonDescriptor objects."
-      },
-      {
-        "lineNumber": 21,
-        "author": {
-          "gitId": "-"
-        },
-        "content": " */"
-      },
-      {
-        "lineNumber": 22,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "public class EditPersonDescriptorBuilder {"
-      },
-      {
-        "lineNumber": 23,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 24,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    private EditPersonDescriptor descriptor;"
-      },
-      {
-        "lineNumber": 25,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 26,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public EditPersonDescriptorBuilder() {"
-      },
-      {
-        "lineNumber": 27,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        descriptor \u003d new EditPersonDescriptor();"
-      },
-      {
-        "lineNumber": 28,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 29,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 30,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public EditPersonDescriptorBuilder(EditPersonDescriptor descriptor) {"
-      },
-      {
-        "lineNumber": 31,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        this.descriptor \u003d new EditPersonDescriptor(descriptor);"
-      },
-      {
-        "lineNumber": 32,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 33,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 34,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    /**"
-      },
-      {
-        "lineNumber": 35,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     * Returns an {@code EditPersonDescriptor} with fields containing {@code person}\u0027s details"
-      },
-      {
-        "lineNumber": 36,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     */"
-      },
-      {
-        "lineNumber": 37,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public EditPersonDescriptorBuilder(Person person) {"
-      },
-      {
-        "lineNumber": 38,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        descriptor \u003d new EditPersonDescriptor();"
-      },
-      {
-        "lineNumber": 39,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        descriptor.setName(person.getName());"
-      },
-      {
-        "lineNumber": 40,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        descriptor.setPhone(person.getPhone());"
-      },
-      {
-        "lineNumber": 41,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        descriptor.setEmail(person.getEmail());"
-      },
-      {
-        "lineNumber": 42,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        descriptor.setAddress(person.getAddress());"
-      },
-      {
-        "lineNumber": 43,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        descriptor.setTags(person.getTags());"
-      },
-      {
-        "lineNumber": 44,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        descriptor.setRating(person.getRating());"
-      },
-      {
-        "lineNumber": 45,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        descriptor.setPosition(person.getPosition());"
-      },
-      {
-        "lineNumber": 46,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        descriptor.setJerseyNumber(person.getJerseyNumber());"
-      },
-      {
-        "lineNumber": 47,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 48,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 49,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    /**"
-      },
-      {
-        "lineNumber": 50,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     * Sets the {@code Name} of the {@code EditPersonDescriptor} that we are building."
-      },
-      {
-        "lineNumber": 51,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     */"
-      },
-      {
-        "lineNumber": 52,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public EditPersonDescriptorBuilder withName(String name) {"
-      },
-      {
-        "lineNumber": 53,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        descriptor.setName(new Name(name));"
-      },
-      {
-        "lineNumber": 54,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        return this;"
-      },
-      {
-        "lineNumber": 55,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 56,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 57,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    /**"
-      },
-      {
-        "lineNumber": 58,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     * Sets the {@code Phone} of the {@code EditPersonDescriptor} that we are building."
-      },
-      {
-        "lineNumber": 59,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     */"
-      },
-      {
-        "lineNumber": 60,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public EditPersonDescriptorBuilder withPhone(String phone) {"
-      },
-      {
-        "lineNumber": 61,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        descriptor.setPhone(new Phone(phone));"
-      },
-      {
-        "lineNumber": 62,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        return this;"
-      },
-      {
-        "lineNumber": 63,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 64,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 65,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    /**"
-      },
-      {
-        "lineNumber": 66,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     * Sets the {@code Email} of the {@code EditPersonDescriptor} that we are building."
-      },
-      {
-        "lineNumber": 67,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     */"
-      },
-      {
-        "lineNumber": 68,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public EditPersonDescriptorBuilder withEmail(String email) {"
-      },
-      {
-        "lineNumber": 69,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        descriptor.setEmail(new Email(email));"
-      },
-      {
-        "lineNumber": 70,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        return this;"
-      },
-      {
-        "lineNumber": 71,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 72,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 73,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    /**"
-      },
-      {
-        "lineNumber": 74,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     * Sets the {@code Address} of the {@code EditPersonDescriptor} that we are building."
-      },
-      {
-        "lineNumber": 75,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     */"
-      },
-      {
-        "lineNumber": 76,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public EditPersonDescriptorBuilder withAddress(String address) {"
-      },
-      {
-        "lineNumber": 77,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        descriptor.setAddress(new Address(address));"
-      },
-      {
-        "lineNumber": 78,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        return this;"
-      },
-      {
-        "lineNumber": 79,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 80,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 81,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    /**"
-      },
-      {
-        "lineNumber": 82,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     * Parses the {@code tags} into a {@code Set\u003cTag\u003e} and set it to the {@code EditPersonDescriptor}"
-      },
-      {
-        "lineNumber": 83,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     * that we are building."
-      },
-      {
-        "lineNumber": 84,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     */"
-      },
-      {
-        "lineNumber": 85,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public EditPersonDescriptorBuilder withTags(String... tags) {"
-      },
-      {
-        "lineNumber": 86,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        Set\u003cTag\u003e tagSet \u003d Stream.of(tags).map(Tag::new).collect(Collectors.toSet());"
-      },
-      {
-        "lineNumber": 87,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        descriptor.setTags(tagSet);"
-      },
-      {
-        "lineNumber": 88,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        return this;"
-      },
-      {
-        "lineNumber": 89,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 90,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 91,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    /**"
-      },
-      {
-        "lineNumber": 92,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "     * Sets the {@code Rating} of the {@code EditPersonDescriptor} that we are building."
-      },
-      {
-        "lineNumber": 93,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "     */"
-      },
-      {
-        "lineNumber": 94,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    public EditPersonDescriptorBuilder withRating(String rating) {"
-      },
-      {
-        "lineNumber": 95,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        descriptor.setRating(new Rating(rating));"
-      },
-      {
-        "lineNumber": 96,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        return this;"
-      },
-      {
-        "lineNumber": 97,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 98,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 99,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    /**"
-      },
-      {
-        "lineNumber": 100,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "     * Sets the {@code Position} of the {@code EditPersonDescriptor} that we are building."
-      },
-      {
-        "lineNumber": 101,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "     */"
-      },
-      {
-        "lineNumber": 102,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    public EditPersonDescriptorBuilder withPosition(String position) {"
-      },
-      {
-        "lineNumber": 103,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        descriptor.setPosition(new Position(position));"
-      },
-      {
-        "lineNumber": 104,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        return this;"
-      },
-      {
-        "lineNumber": 105,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 106,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 107,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    /**"
-      },
-      {
-        "lineNumber": 108,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "     * Sets the {@code JerseyNumber} of the {@code EditPersonDescriptor} that we are building."
-      },
-      {
-        "lineNumber": 109,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "     */"
-      },
-      {
-        "lineNumber": 110,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    public EditPersonDescriptorBuilder withJerseyNumber(String jerseyNumber) {"
-      },
-      {
-        "lineNumber": 111,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        descriptor.setJerseyNumber(new JerseyNumber(jerseyNumber));"
-      },
-      {
-        "lineNumber": 112,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        return this;"
-      },
-      {
-        "lineNumber": 113,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 114,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 115,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    /**"
-      },
-      {
-        "lineNumber": 116,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "     * Sets the {@code Avatar} of the {@code EditPersonDescriptor} that we are building."
-      },
-      {
-        "lineNumber": 117,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "     */"
-      },
-      {
-        "lineNumber": 118,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    public EditPersonDescriptorBuilder withAvatar(String avatar) {"
-      },
-      {
-        "lineNumber": 119,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        descriptor.setAvatar(new Avatar(avatar));"
-      },
-      {
-        "lineNumber": 120,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        return this;"
-      },
-      {
-        "lineNumber": 121,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 122,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 123,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public EditPersonDescriptor build() {"
-      },
-      {
-        "lineNumber": 124,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        return descriptor;"
-      },
-      {
-        "lineNumber": 125,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 126,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "}"
-      }
-    ],
-    "authorContributionMap": {
-      "lithiumlkid": 39,
-      "-": 87
     }
   },
   {
@@ -117991,7 +109324,7 @@
       {
         "lineNumber": 3,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "import java.io.IOException;"
       },
@@ -118019,7 +109352,7 @@
       {
         "lineNumber": 7,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "import seedu.address.commons.core.LogsCenter;"
       },
@@ -118033,7 +109366,7 @@
       {
         "lineNumber": 9,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "import seedu.address.model.person.Avatar;"
       },
@@ -118047,7 +109380,7 @@
       {
         "lineNumber": 11,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "import seedu.address.model.person.JerseyNumber;"
       },
@@ -118075,14 +109408,14 @@
       {
         "lineNumber": 15,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "import seedu.address.model.person.Position;"
       },
       {
         "lineNumber": 16,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "import seedu.address.model.person.Rating;"
       },
@@ -118208,28 +109541,28 @@
       {
         "lineNumber": 34,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    public static final String DEFAULT_RATING \u003d \"1\";"
       },
       {
         "lineNumber": 35,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    public static final String DEFAULT_POSITION \u003d \"1\";"
       },
       {
         "lineNumber": 36,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    public static final String DEFAULT_JERSEY_NUMBER \u003d \"1\";"
       },
       {
         "lineNumber": 37,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    public static final String DEFAULT_AVATAR \u003d \"\u003cUNSPECIFIED\u003e\";"
       },
@@ -118292,28 +109625,28 @@
       {
         "lineNumber": 46,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    private Rating rating;"
       },
       {
         "lineNumber": 47,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    private Position position;"
       },
       {
         "lineNumber": 48,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    private JerseyNumber jerseyNumber;"
       },
       {
         "lineNumber": 49,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    private Avatar avatar;"
       },
@@ -118383,35 +109716,35 @@
       {
         "lineNumber": 59,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        rating \u003d new Rating(DEFAULT_RATING);"
       },
       {
         "lineNumber": 60,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        position \u003d new Position(DEFAULT_POSITION);"
       },
       {
         "lineNumber": 61,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        jerseyNumber \u003d new JerseyNumber(DEFAULT_JERSEY_NUMBER);"
       },
       {
         "lineNumber": 62,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        avatar \u003d new Avatar(DEFAULT_AVATAR);"
       },
       {
         "lineNumber": 63,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        setFilePath();"
       },
@@ -118509,91 +109842,91 @@
       {
         "lineNumber": 77,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        rating \u003d personToCopy.getRating();"
       },
       {
         "lineNumber": 78,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        position \u003d personToCopy.getPosition();"
       },
       {
         "lineNumber": 79,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        jerseyNumber \u003d personToCopy.getJerseyNumber();"
       },
       {
         "lineNumber": 80,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        avatar \u003d personToCopy.getAvatar();"
       },
       {
         "lineNumber": 81,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        setFilePath();"
       },
       {
         "lineNumber": 82,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    }"
       },
       {
         "lineNumber": 83,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 84,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    private void setFilePath() {"
       },
       {
         "lineNumber": 85,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        try {"
       },
       {
         "lineNumber": 86,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "            avatar.setFilePath(name.fullName);"
       },
       {
         "lineNumber": 87,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        } catch (IOException e) {"
       },
       {
         "lineNumber": 88,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "            LogsCenter.getLogger(Avatar.class).warning(\"image file missing\");"
       },
       {
         "lineNumber": 89,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        }"
       },
@@ -119006,217 +110339,217 @@
       {
         "lineNumber": 148,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    /**"
       },
       {
         "lineNumber": 149,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "     * Sets the {@code Rating} of the {@code Person} that we are building."
       },
       {
         "lineNumber": 150,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "     */"
       },
       {
         "lineNumber": 151,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    public PersonBuilder withRating(String rating) {"
       },
       {
         "lineNumber": 152,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        this.rating \u003d new Rating(rating);"
       },
       {
         "lineNumber": 153,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        return this;"
       },
       {
         "lineNumber": 154,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    }"
       },
       {
         "lineNumber": 155,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 156,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    /**"
       },
       {
         "lineNumber": 157,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "     * Sets the {@code Position} of the {@code Person} that we are building."
       },
       {
         "lineNumber": 158,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "     */"
       },
       {
         "lineNumber": 159,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    public PersonBuilder withPosition(String position) {"
       },
       {
         "lineNumber": 160,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        this.position \u003d new Position(position);"
       },
       {
         "lineNumber": 161,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        return this;"
       },
       {
         "lineNumber": 162,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    }"
       },
       {
         "lineNumber": 163,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 164,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    /**"
       },
       {
         "lineNumber": 165,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "     * Sets the {@code JerseyNumber} of the {@code Person} that we are building."
       },
       {
         "lineNumber": 166,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "     */"
       },
       {
         "lineNumber": 167,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    public PersonBuilder withJerseyNumber(String jerseyNumber) {"
       },
       {
         "lineNumber": 168,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        this.jerseyNumber \u003d new JerseyNumber(jerseyNumber);"
       },
       {
         "lineNumber": 169,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        return this;"
       },
       {
         "lineNumber": 170,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    }"
       },
       {
         "lineNumber": 171,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 172,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    /**"
       },
       {
         "lineNumber": 173,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "     * Sets the {@code JerseyNumber} of the {@code Person} that we are building."
       },
       {
         "lineNumber": 174,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "     */"
       },
       {
         "lineNumber": 175,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    public PersonBuilder withAvatar(String avatar) {"
       },
       {
         "lineNumber": 176,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        this.avatar \u003d new Avatar(avatar);"
       },
       {
         "lineNumber": 177,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        setFilePath();"
       },
       {
         "lineNumber": 178,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        return this;"
       },
@@ -119237,21 +110570,21 @@
       {
         "lineNumber": 181,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    public Person build() {"
       },
       {
         "lineNumber": 182,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        return new Person(name, phone, email, address, remark, teamName, tags, rating, position, jerseyNumber, avatar);"
       },
       {
         "lineNumber": 183,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    }"
       },
@@ -119264,326 +110597,8 @@
       }
     ],
     "authorContributionMap": {
-      "lithiumlkid": 66,
       "jordancjq": 26,
-      "-": 92
-    }
-  },
-  {
-    "path": "src/test/java/seedu/address/testutil/PersonUtil.java",
-    "lines": [
-      {
-        "lineNumber": 1,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "package seedu.address.testutil;"
-      },
-      {
-        "lineNumber": 2,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 3,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;"
-      },
-      {
-        "lineNumber": 4,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;"
-      },
-      {
-        "lineNumber": 5,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "import static seedu.address.logic.parser.CliSyntax.PREFIX_JERSEY_NUMBER;"
-      },
-      {
-        "lineNumber": 6,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;"
-      },
-      {
-        "lineNumber": 7,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;"
-      },
-      {
-        "lineNumber": 8,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "import static seedu.address.logic.parser.CliSyntax.PREFIX_POSITION;"
-      },
-      {
-        "lineNumber": 9,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "import static seedu.address.logic.parser.CliSyntax.PREFIX_RATING;"
-      },
-      {
-        "lineNumber": 10,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;"
-      },
-      {
-        "lineNumber": 11,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 12,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.logic.commands.AddCommand;"
-      },
-      {
-        "lineNumber": 13,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.model.person.Person;"
-      },
-      {
-        "lineNumber": 14,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 15,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "/**"
-      },
-      {
-        "lineNumber": 16,
-        "author": {
-          "gitId": "-"
-        },
-        "content": " * A utility class for Person."
-      },
-      {
-        "lineNumber": 17,
-        "author": {
-          "gitId": "-"
-        },
-        "content": " */"
-      },
-      {
-        "lineNumber": 18,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "public class PersonUtil {"
-      },
-      {
-        "lineNumber": 19,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 20,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    /**"
-      },
-      {
-        "lineNumber": 21,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     * Returns an add command string for adding the {@code person}."
-      },
-      {
-        "lineNumber": 22,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     */"
-      },
-      {
-        "lineNumber": 23,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public static String getAddCommand(Person person) {"
-      },
-      {
-        "lineNumber": 24,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        return AddCommand.COMMAND_WORD + \" \" + getPersonDetails(person);"
-      },
-      {
-        "lineNumber": 25,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 26,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 27,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    /**"
-      },
-      {
-        "lineNumber": 28,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     * Returns the part of command string for the given {@code person}\u0027s details."
-      },
-      {
-        "lineNumber": 29,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     */"
-      },
-      {
-        "lineNumber": 30,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public static String getPersonDetails(Person person) {"
-      },
-      {
-        "lineNumber": 31,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        StringBuilder sb \u003d new StringBuilder();"
-      },
-      {
-        "lineNumber": 32,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        sb.append(PREFIX_NAME + person.getName().fullName + \" \");"
-      },
-      {
-        "lineNumber": 33,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        sb.append(PREFIX_PHONE + person.getPhone().value + \" \");"
-      },
-      {
-        "lineNumber": 34,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        sb.append(PREFIX_EMAIL + person.getEmail().value + \" \");"
-      },
-      {
-        "lineNumber": 35,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        sb.append(PREFIX_ADDRESS + person.getAddress().value + \" \");"
-      },
-      {
-        "lineNumber": 36,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        sb.append(PREFIX_RATING + person.getRating().value + \" \");"
-      },
-      {
-        "lineNumber": 37,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        sb.append(PREFIX_POSITION + person.getPosition().value + \" \");"
-      },
-      {
-        "lineNumber": 38,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        sb.append(PREFIX_JERSEY_NUMBER + person.getJerseyNumber().value + \" \");"
-      },
-      {
-        "lineNumber": 39,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        person.getTags().stream().forEach("
-      },
-      {
-        "lineNumber": 40,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "            s -\u003e sb.append(PREFIX_TAG + s.tagName + \" \")"
-      },
-      {
-        "lineNumber": 41,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        );"
-      },
-      {
-        "lineNumber": 42,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        return sb.toString();"
-      },
-      {
-        "lineNumber": 43,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 44,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "}"
-      }
-    ],
-    "authorContributionMap": {
-      "lithiumlkid": 6,
-      "-": 38
+      "-": 158
     }
   },
   {
@@ -120030,14 +111045,14 @@
       {
         "lineNumber": 7,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "import static seedu.address.logic.commands.CommandTestUtil.VALID_JERSEY_NUMBER_17;"
       },
       {
         "lineNumber": 8,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "import static seedu.address.logic.commands.CommandTestUtil.VALID_JERSEY_NUMBER_2;"
       },
@@ -120072,28 +111087,28 @@
       {
         "lineNumber": 13,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "import static seedu.address.logic.commands.CommandTestUtil.VALID_POSITION_MIDFIELD;"
       },
       {
         "lineNumber": 14,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "import static seedu.address.logic.commands.CommandTestUtil.VALID_POSITION_STRIKER;"
       },
       {
         "lineNumber": 15,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "import static seedu.address.logic.commands.CommandTestUtil.VALID_RATING_0;"
       },
       {
         "lineNumber": 16,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "import static seedu.address.logic.commands.CommandTestUtil.VALID_RATING_1;"
       },
@@ -120233,14 +111248,14 @@
       {
         "lineNumber": 36,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "            .withPhone(\"85355255\").withTags(\"friends\").withRating(\"0\")"
       },
       {
         "lineNumber": 37,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "            .withPosition(\"1\").withJerseyNumber(\"1\").build();"
       },
@@ -120268,14 +111283,14 @@
       {
         "lineNumber": 41,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "            .withTags(\"owesMoney\", \"friends\").withRating(\"1\")"
       },
       {
         "lineNumber": 42,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "            .withPosition(\"2\").withJerseyNumber(\"2\").build();"
       },
@@ -120289,14 +111304,14 @@
       {
         "lineNumber": 44,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "            .withEmail(\"heinz@example.com\").withAddress(\"wall street\").withRating(\"2\")"
       },
       {
         "lineNumber": 45,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "            .withPosition(\"3\").withJerseyNumber(\"3\").build();"
       },
@@ -120310,14 +111325,14 @@
       {
         "lineNumber": 47,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "            .withEmail(\"cornelia@example.com\").withAddress(\"10th street\").withRating(\"3\")"
       },
       {
         "lineNumber": 48,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "            .withPosition(\"4\").withJerseyNumber(\"4\").build();"
       },
@@ -120331,14 +111346,14 @@
       {
         "lineNumber": 50,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "            .withEmail(\"werner@example.com\").withAddress(\"michegan ave\").withRating(\"4\")"
       },
       {
         "lineNumber": 51,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "            .withPosition(\"1\").withJerseyNumber(\"5\").build();"
       },
@@ -120352,14 +111367,14 @@
       {
         "lineNumber": 53,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "            .withEmail(\"lydia@example.com\").withAddress(\"little tokyo\").withRating(\"5\")"
       },
       {
         "lineNumber": 54,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "            .withPosition(\"2\").withJerseyNumber(\"6\").build();"
       },
@@ -120373,14 +111388,14 @@
       {
         "lineNumber": 56,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "            .withEmail(\"anna@example.com\").withAddress(\"4th street\").withRemark(\"Could be famous\").withRating(\"0\")"
       },
       {
         "lineNumber": 57,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "            .withPosition(\"3\").withJerseyNumber(\"7\").build();"
       },
@@ -120450,21 +111465,21 @@
       {
         "lineNumber": 67,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "            .withEmail(VALID_EMAIL_AMY).withAddress(VALID_ADDRESS_AMY).withRating(VALID_RATING_0)"
       },
       {
         "lineNumber": 68,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "            .withPosition(VALID_POSITION_STRIKER).withJerseyNumber(VALID_JERSEY_NUMBER_2)"
       },
       {
         "lineNumber": 69,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "            .withTags(VALID_TAG_FRIEND).build();"
       },
@@ -120478,21 +111493,21 @@
       {
         "lineNumber": 71,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "            .withEmail(VALID_EMAIL_BOB).withAddress(VALID_ADDRESS_BOB).withRating(VALID_RATING_1)"
       },
       {
         "lineNumber": 72,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "            .withPosition(VALID_POSITION_MIDFIELD).withJerseyNumber(VALID_JERSEY_NUMBER_17)"
       },
       {
         "lineNumber": 73,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "            .withTags(VALID_TAG_HUSBAND, VALID_TAG_FRIEND).build();"
       },
@@ -121037,9 +112052,8 @@
       }
     ],
     "authorContributionMap": {
-      "lithiumlkid": 26,
       "lohtianwei": 59,
-      "-": 65
+      "-": 91
     }
   },
   {
@@ -121947,7 +112961,7 @@
       {
         "lineNumber": 14,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "import seedu.address.logic.commands.ExitCommand;"
       },
@@ -121961,7 +112975,7 @@
       {
         "lineNumber": 16,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "import seedu.address.logic.commands.ViewCommand;"
       },
@@ -123094,8 +114108,8 @@
       }
     ],
     "authorContributionMap": {
-      "lithiumlkid": 160,
-      "-": 17
+      "lithiumlkid": 158,
+      "-": 19
     }
   },
   {
@@ -125106,14 +116120,14 @@
       {
         "lineNumber": 6,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "import static seedu.address.logic.commands.CommandTestUtil.AVATAR_MAC_LINUX;"
       },
       {
         "lineNumber": 7,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "import static seedu.address.logic.commands.CommandTestUtil.AVATAR_WINDOWS;"
       },
@@ -125141,14 +116155,14 @@
       {
         "lineNumber": 11,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "import static seedu.address.logic.commands.CommandTestUtil.INVALID_AVATAR_NO_FILE;"
       },
       {
         "lineNumber": 12,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "import static seedu.address.logic.commands.CommandTestUtil.INVALID_AVATAR_TYPE;"
       },
@@ -125162,7 +116176,7 @@
       {
         "lineNumber": 14,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "import static seedu.address.logic.commands.CommandTestUtil.INVALID_JERSEY_NUMBER_DESC;"
       },
@@ -125183,14 +116197,14 @@
       {
         "lineNumber": 17,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "import static seedu.address.logic.commands.CommandTestUtil.INVALID_POSITION_DESC;"
       },
       {
         "lineNumber": 18,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "import static seedu.address.logic.commands.CommandTestUtil.INVALID_RATING_DESC;"
       },
@@ -125211,7 +116225,7 @@
       {
         "lineNumber": 21,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "import static seedu.address.logic.commands.CommandTestUtil.JERSEY_NUMBER_DESC_2;"
       },
@@ -125253,14 +116267,14 @@
       {
         "lineNumber": 27,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "import static seedu.address.logic.commands.CommandTestUtil.POSITION_DESC_STRIKER;"
       },
       {
         "lineNumber": 28,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "import static seedu.address.logic.commands.CommandTestUtil.RATING_DESC_0;"
       },
@@ -125302,14 +116316,14 @@
       {
         "lineNumber": 34,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "import static seedu.address.logic.commands.CommandTestUtil.VALID_AVATAR_MAC_LINUX;"
       },
       {
         "lineNumber": 35,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "import static seedu.address.logic.commands.CommandTestUtil.VALID_AVATAR_WINDOWS;"
       },
@@ -125330,14 +116344,14 @@
       {
         "lineNumber": 38,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "import static seedu.address.logic.commands.CommandTestUtil.VALID_JERSEY_NUMBER_17;"
       },
       {
         "lineNumber": 39,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "import static seedu.address.logic.commands.CommandTestUtil.VALID_JERSEY_NUMBER_2;"
       },
@@ -125372,14 +116386,14 @@
       {
         "lineNumber": 44,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "import static seedu.address.logic.commands.CommandTestUtil.VALID_POSITION_STRIKER;"
       },
       {
         "lineNumber": 45,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "import static seedu.address.logic.commands.CommandTestUtil.VALID_RATING_0;"
       },
@@ -125477,14 +116491,14 @@
       {
         "lineNumber": 59,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "import com.sun.javafx.PlatformUtil;"
       },
       {
         "lineNumber": 60,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -125540,7 +116554,7 @@
       {
         "lineNumber": 68,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "import seedu.address.model.person.Avatar;"
       },
@@ -125554,7 +116568,7 @@
       {
         "lineNumber": 70,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "import seedu.address.model.person.JerseyNumber;"
       },
@@ -125582,14 +116596,14 @@
       {
         "lineNumber": 74,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "import seedu.address.model.person.Position;"
       },
       {
         "lineNumber": 75,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "import seedu.address.model.person.Rating;"
       },
@@ -125708,7 +116722,7 @@
       {
         "lineNumber": 92,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        Avatar.setUpPlaceholderForTest();"
       },
@@ -125722,14 +116736,14 @@
       {
         "lineNumber": 94,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        String command \u003d AddCommand.COMMAND_WORD + NAME_DESC_AMY + PHONE_DESC_AMY + EMAIL_DESC_AMY + ADDRESS_DESC_AMY"
       },
       {
         "lineNumber": 95,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "                + TAG_DESC_FRIEND + RATING_DESC_0 + POSITION_DESC_STRIKER + JERSEY_NUMBER_DESC_2;"
       },
@@ -125841,14 +116855,14 @@
       {
         "lineNumber": 111,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "                .withAddress(VALID_ADDRESS_AMY).withTags(VALID_TAG_FRIEND).withRating(VALID_RATING_0)"
       },
       {
         "lineNumber": 112,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "                .withPosition(VALID_POSITION_STRIKER).withJerseyNumber(VALID_JERSEY_NUMBER_2).build();"
       },
@@ -125862,14 +116876,14 @@
       {
         "lineNumber": 114,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "                + TAG_DESC_FRIEND  + \" \" + RATING_DESC_0 + \"   \" + POSITION_DESC_STRIKER + \"   \""
       },
       {
         "lineNumber": 115,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "                + JERSEY_NUMBER_DESC_2;"
       },
@@ -125904,14 +116918,14 @@
       {
         "lineNumber": 120,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "                .withAddress(VALID_ADDRESS_AMY).withTags(VALID_TAG_FRIEND).withRating(VALID_RATING_0)"
       },
       {
         "lineNumber": 121,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "                .withPosition(VALID_POSITION_STRIKER).withJerseyNumber(VALID_JERSEY_NUMBER_2).build();"
       },
@@ -125960,14 +116974,14 @@
       {
         "lineNumber": 128,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "                .withAddress(VALID_ADDRESS_AMY).withTags(VALID_TAG_FRIEND).withRating(VALID_RATING_0)"
       },
       {
         "lineNumber": 129,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "                .withPosition(VALID_POSITION_STRIKER).withJerseyNumber(VALID_JERSEY_NUMBER_2).build();"
       },
@@ -125981,14 +116995,14 @@
       {
         "lineNumber": 131,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "                + TAG_DESC_FRIEND  + \" \" + RATING_DESC_0 + \"   \" + POSITION_DESC_STRIKER + \"   \""
       },
       {
         "lineNumber": 132,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "                + JERSEY_NUMBER_DESC_2;"
       },
@@ -126023,14 +117037,14 @@
       {
         "lineNumber": 137,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "                .withAddress(VALID_ADDRESS_BOB).withTags(VALID_TAG_FRIEND).withRating(VALID_RATING_0)"
       },
       {
         "lineNumber": 138,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "                .withPosition(VALID_POSITION_STRIKER).withJerseyNumber(VALID_JERSEY_NUMBER_2).build();"
       },
@@ -126044,14 +117058,14 @@
       {
         "lineNumber": 140,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "                + TAG_DESC_FRIEND  + \" \" + RATING_DESC_0 + \"   \" + POSITION_DESC_STRIKER + \"   \""
       },
       {
         "lineNumber": 141,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "                + JERSEY_NUMBER_DESC_2;"
       },
@@ -126177,28 +117191,28 @@
       {
         "lineNumber": 159,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "                .withPhone(UNSPECIFIED_FIELD).withTags().withRating(VALID_RATING_0)"
       },
       {
         "lineNumber": 160,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "                .withPosition(VALID_POSITION_STRIKER).withJerseyNumber(VALID_JERSEY_NUMBER_2).build();"
       },
       {
         "lineNumber": 161,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        command \u003d AddCommand.COMMAND_WORD + NAME_DESC_AMY + EMAIL_DESC_AMY + ADDRESS_DESC_AMY + RATING_DESC_0"
       },
       {
         "lineNumber": 162,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "                + POSITION_DESC_STRIKER + JERSEY_NUMBER_DESC_2;"
       },
@@ -126233,84 +117247,84 @@
       {
         "lineNumber": 167,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "                .withAddress(UNSPECIFIED_FIELD).withTags().withRating(VALID_RATING_0)"
       },
       {
         "lineNumber": 168,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "                .withPosition(VALID_POSITION_STRIKER).withJerseyNumber(VALID_JERSEY_NUMBER_2).build();"
       },
       {
         "lineNumber": 169,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        command \u003d AddCommand.COMMAND_WORD + NAME_DESC_AMY + PHONE_DESC_AMY + EMAIL_DESC_AMY + RATING_DESC_0"
       },
       {
         "lineNumber": 170,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "                + POSITION_DESC_STRIKER + JERSEY_NUMBER_DESC_2;"
       },
       {
         "lineNumber": 171,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        assertCommandSuccess(command, toAdd);"
       },
       {
         "lineNumber": 172,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 173,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        /* Case: missing rating -\u003e added */"
       },
       {
         "lineNumber": 174,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        toAdd \u003d new PersonBuilder().withName(VALID_NAME_AMY).withPhone(VALID_PHONE_AMY).withEmail(VALID_EMAIL_AMY)"
       },
       {
         "lineNumber": 175,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "                .withAddress(VALID_ADDRESS_AMY).withTags().withRating(UNSPECIFIED_FIELD)"
       },
       {
         "lineNumber": 176,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "                .withPosition(VALID_POSITION_STRIKER).withJerseyNumber(VALID_JERSEY_NUMBER_2).build();"
       },
       {
         "lineNumber": 177,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        command \u003d AddCommand.COMMAND_WORD + NAME_DESC_AMY + PHONE_DESC_AMY + EMAIL_DESC_AMY + ADDRESS_DESC_AMY"
       },
       {
         "lineNumber": 178,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "                + POSITION_DESC_STRIKER + JERSEY_NUMBER_DESC_2;"
       },
@@ -126331,140 +117345,140 @@
       {
         "lineNumber": 181,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        if (PlatformUtil.isWindows()) {"
       },
       {
         "lineNumber": 182,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "            toAdd \u003d new PersonBuilder().withName(VALID_NAME_BOB).withEmail(VALID_EMAIL_BOB)"
       },
       {
         "lineNumber": 183,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "                    .withPhone(VALID_PHONE_AMY).withAddress(VALID_ADDRESS_AMY).withAvatar(VALID_AVATAR_WINDOWS)"
       },
       {
         "lineNumber": 184,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "                    .withTags(VALID_TAG_FRIEND).withRating(VALID_RATING_0).withJerseyNumber(VALID_JERSEY_NUMBER_17)"
       },
       {
         "lineNumber": 185,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "                            .build();"
       },
       {
         "lineNumber": 186,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "            command \u003d AddCommand.COMMAND_WORD + NAME_DESC_BOB + EMAIL_DESC_BOB + AVATAR_WINDOWS"
       },
       {
         "lineNumber": 187,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "                    + PHONE_DESC_AMY + ADDRESS_DESC_AMY + RATING_DESC_0 + JERSEY_NUMBER_DESC_17 + POSITION_DESC_STRIKER"
       },
       {
         "lineNumber": 188,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "                    + TAG_DESC_FRIEND;"
       },
       {
         "lineNumber": 189,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "            assertCommandSuccess(command, toAdd);"
       },
       {
         "lineNumber": 190,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        } else if (PlatformUtil.isMac() || PlatformUtil.isLinux()) {"
       },
       {
         "lineNumber": 191,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "            toAdd \u003d new PersonBuilder().withName(VALID_NAME_BOB).withEmail(VALID_EMAIL_BOB)"
       },
       {
         "lineNumber": 192,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "                    .withPhone(VALID_PHONE_AMY).withAddress(VALID_ADDRESS_AMY).withAvatar(VALID_AVATAR_MAC_LINUX)"
       },
       {
         "lineNumber": 193,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "                    .withTags(VALID_TAG_FRIEND).withRating(VALID_RATING_0).withJerseyNumber(VALID_JERSEY_NUMBER_17)"
       },
       {
         "lineNumber": 194,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "                    .build();"
       },
       {
         "lineNumber": 195,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "            command \u003d AddCommand.COMMAND_WORD + NAME_DESC_BOB + EMAIL_DESC_BOB + AVATAR_MAC_LINUX"
       },
       {
         "lineNumber": 196,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "                    + PHONE_DESC_AMY + ADDRESS_DESC_AMY + RATING_DESC_0 + JERSEY_NUMBER_DESC_17 + POSITION_DESC_STRIKER"
       },
       {
         "lineNumber": 197,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "                    + TAG_DESC_FRIEND;"
       },
       {
         "lineNumber": 198,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "            assertCommandSuccess(command, toAdd);"
       },
       {
         "lineNumber": 199,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        }"
       },
       {
         "lineNumber": 200,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -126653,14 +117667,14 @@
       {
         "lineNumber": 227,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        command \u003d AddCommand.COMMAND_WORD + PHONE_DESC_AMY + EMAIL_DESC_AMY + ADDRESS_DESC_AMY + RATING_DESC_0"
       },
       {
         "lineNumber": 228,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "                + POSITION_DESC_STRIKER + JERSEY_NUMBER_DESC_2;"
       },
@@ -126688,14 +117702,14 @@
       {
         "lineNumber": 232,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        command \u003d AddCommand.COMMAND_WORD + NAME_DESC_AMY + PHONE_DESC_AMY + ADDRESS_DESC_AMY + RATING_DESC_0"
       },
       {
         "lineNumber": 233,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "                + POSITION_DESC_STRIKER + JERSEY_NUMBER_DESC_2;"
       },
@@ -126751,14 +117765,14 @@
       {
         "lineNumber": 241,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        command \u003d AddCommand.COMMAND_WORD + INVALID_NAME_DESC + PHONE_DESC_AMY + EMAIL_DESC_AMY + ADDRESS_DESC_AMY"
       },
       {
         "lineNumber": 242,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "                + RATING_DESC_0 + POSITION_DESC_STRIKER + JERSEY_NUMBER_DESC_2;"
       },
@@ -126786,14 +117800,14 @@
       {
         "lineNumber": 246,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        command \u003d AddCommand.COMMAND_WORD + NAME_DESC_AMY + INVALID_PHONE_DESC + EMAIL_DESC_AMY + ADDRESS_DESC_AMY"
       },
       {
         "lineNumber": 247,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "                + RATING_DESC_0 + POSITION_DESC_STRIKER + JERSEY_NUMBER_DESC_2;"
       },
@@ -126821,14 +117835,14 @@
       {
         "lineNumber": 251,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        command \u003d AddCommand.COMMAND_WORD + NAME_DESC_AMY + PHONE_DESC_AMY + INVALID_EMAIL_DESC + ADDRESS_DESC_AMY"
       },
       {
         "lineNumber": 252,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "                + RATING_DESC_0 + POSITION_DESC_STRIKER + JERSEY_NUMBER_DESC_2;"
       },
@@ -126856,14 +117870,14 @@
       {
         "lineNumber": 256,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        command \u003d AddCommand.COMMAND_WORD + NAME_DESC_AMY + PHONE_DESC_AMY + EMAIL_DESC_AMY + INVALID_ADDRESS_DESC"
       },
       {
         "lineNumber": 257,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "                + RATING_DESC_0 + POSITION_DESC_STRIKER + JERSEY_NUMBER_DESC_2;"
       },
@@ -126898,7 +117912,7 @@
       {
         "lineNumber": 262,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "                + INVALID_TAG_DESC + RATING_DESC_0 + POSITION_DESC_STRIKER + JERSEY_NUMBER_DESC_2;"
       },
@@ -126912,7 +117926,7 @@
       {
         "lineNumber": 264,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -127618,2174 +118632,9 @@
       }
     ],
     "authorContributionMap": {
-      "lithiumlkid": 189,
+      "lithiumlkid": 100,
       "jordancjq": 9,
-      "-": 166
-    }
-  },
-  {
-    "path": "src/test/java/systemtests/EditCommandSystemTest.java",
-    "lines": [
-      {
-        "lineNumber": 1,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "package systemtests;"
-      },
-      {
-        "lineNumber": 2,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 3,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static org.junit.Assert.assertFalse;"
-      },
-      {
-        "lineNumber": 4,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static org.junit.Assert.assertTrue;"
-      },
-      {
-        "lineNumber": 5,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 6,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static seedu.address.logic.commands.CommandTestUtil.ADDRESS_DESC_AMY;"
-      },
-      {
-        "lineNumber": 7,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static seedu.address.logic.commands.CommandTestUtil.ADDRESS_DESC_BOB;"
-      },
-      {
-        "lineNumber": 8,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static seedu.address.logic.commands.CommandTestUtil.EMAIL_DESC_AMY;"
-      },
-      {
-        "lineNumber": 9,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static seedu.address.logic.commands.CommandTestUtil.EMAIL_DESC_BOB;"
-      },
-      {
-        "lineNumber": 10,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static seedu.address.logic.commands.CommandTestUtil.INVALID_ADDRESS_DESC;"
-      },
-      {
-        "lineNumber": 11,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "import static seedu.address.logic.commands.CommandTestUtil.INVALID_AVATAR_NO_FILE;"
-      },
-      {
-        "lineNumber": 12,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "import static seedu.address.logic.commands.CommandTestUtil.INVALID_AVATAR_TYPE;"
-      },
-      {
-        "lineNumber": 13,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static seedu.address.logic.commands.CommandTestUtil.INVALID_EMAIL_DESC;"
-      },
-      {
-        "lineNumber": 14,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static seedu.address.logic.commands.CommandTestUtil.INVALID_NAME_DESC;"
-      },
-      {
-        "lineNumber": 15,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static seedu.address.logic.commands.CommandTestUtil.INVALID_PHONE_DESC;"
-      },
-      {
-        "lineNumber": 16,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static seedu.address.logic.commands.CommandTestUtil.INVALID_TAG_DESC;"
-      },
-      {
-        "lineNumber": 17,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "import static seedu.address.logic.commands.CommandTestUtil.JERSEY_NUMBER_DESC_17;"
-      },
-      {
-        "lineNumber": 18,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "import static seedu.address.logic.commands.CommandTestUtil.JERSEY_NUMBER_DESC_2;"
-      },
-      {
-        "lineNumber": 19,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static seedu.address.logic.commands.CommandTestUtil.NAME_DESC_AMY;"
-      },
-      {
-        "lineNumber": 20,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static seedu.address.logic.commands.CommandTestUtil.NAME_DESC_BOB;"
-      },
-      {
-        "lineNumber": 21,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static seedu.address.logic.commands.CommandTestUtil.PHONE_DESC_AMY;"
-      },
-      {
-        "lineNumber": 22,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static seedu.address.logic.commands.CommandTestUtil.PHONE_DESC_BOB;"
-      },
-      {
-        "lineNumber": 23,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static seedu.address.logic.commands.CommandTestUtil.POSITION_DESC_MIDFILED;"
-      },
-      {
-        "lineNumber": 24,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static seedu.address.logic.commands.CommandTestUtil.POSITION_DESC_STRIKER;"
-      },
-      {
-        "lineNumber": 25,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static seedu.address.logic.commands.CommandTestUtil.RATING_DESC_0;"
-      },
-      {
-        "lineNumber": 26,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static seedu.address.logic.commands.CommandTestUtil.RATING_DESC_1;"
-      },
-      {
-        "lineNumber": 27,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static seedu.address.logic.commands.CommandTestUtil.TAG_DESC_FRIEND;"
-      },
-      {
-        "lineNumber": 28,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static seedu.address.logic.commands.CommandTestUtil.TAG_DESC_HUSBAND;"
-      },
-      {
-        "lineNumber": 29,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static seedu.address.logic.commands.CommandTestUtil.VALID_ADDRESS_BOB;"
-      },
-      {
-        "lineNumber": 30,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static seedu.address.logic.commands.CommandTestUtil.VALID_EMAIL_BOB;"
-      },
-      {
-        "lineNumber": 31,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "import static seedu.address.logic.commands.CommandTestUtil.VALID_JERSEY_NUMBER_2;"
-      },
-      {
-        "lineNumber": 32,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;"
-      },
-      {
-        "lineNumber": 33,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_BOB;"
-      },
-      {
-        "lineNumber": 34,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "import static seedu.address.logic.commands.CommandTestUtil.VALID_POSITION_MIDFIELD;"
-      },
-      {
-        "lineNumber": 35,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "import static seedu.address.logic.commands.CommandTestUtil.VALID_RATING_1;"
-      },
-      {
-        "lineNumber": 36,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_FRIEND;"
-      },
-      {
-        "lineNumber": 37,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;"
-      },
-      {
-        "lineNumber": 38,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;"
-      },
-      {
-        "lineNumber": 39,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;"
-      },
-      {
-        "lineNumber": 40,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;"
-      },
-      {
-        "lineNumber": 41,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static seedu.address.testutil.TypicalPersons.AMY;"
-      },
-      {
-        "lineNumber": 42,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static seedu.address.testutil.TypicalPersons.BOB;"
-      },
-      {
-        "lineNumber": 43,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static seedu.address.testutil.TypicalPersons.KEYWORD_MATCHING_MEIER;"
-      },
-      {
-        "lineNumber": 44,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 45,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import org.junit.Test;"
-      },
-      {
-        "lineNumber": 46,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 47,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.commons.core.Messages;"
-      },
-      {
-        "lineNumber": 48,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.commons.core.index.Index;"
-      },
-      {
-        "lineNumber": 49,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.logic.commands.EditCommand;"
-      },
-      {
-        "lineNumber": 50,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.logic.commands.RedoCommand;"
-      },
-      {
-        "lineNumber": 51,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.logic.commands.UndoCommand;"
-      },
-      {
-        "lineNumber": 52,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.model.Model;"
-      },
-      {
-        "lineNumber": 53,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.model.person.Address;"
-      },
-      {
-        "lineNumber": 54,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "import seedu.address.model.person.Avatar;"
-      },
-      {
-        "lineNumber": 55,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.model.person.Email;"
-      },
-      {
-        "lineNumber": 56,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.model.person.Name;"
-      },
-      {
-        "lineNumber": 57,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.model.person.Person;"
-      },
-      {
-        "lineNumber": 58,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.model.person.Phone;"
-      },
-      {
-        "lineNumber": 59,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.model.person.exceptions.DuplicatePersonException;"
-      },
-      {
-        "lineNumber": 60,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.model.person.exceptions.PersonNotFoundException;"
-      },
-      {
-        "lineNumber": 61,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.model.tag.Tag;"
-      },
-      {
-        "lineNumber": 62,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.testutil.PersonBuilder;"
-      },
-      {
-        "lineNumber": 63,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.testutil.PersonUtil;"
-      },
-      {
-        "lineNumber": 64,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 65,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "public class EditCommandSystemTest extends AddressBookSystemTest {"
-      },
-      {
-        "lineNumber": 66,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 67,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    @Test"
-      },
-      {
-        "lineNumber": 68,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public void edit() throws Exception {"
-      },
-      {
-        "lineNumber": 69,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        Model model \u003d getModel();"
-      },
-      {
-        "lineNumber": 70,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 71,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        /* ----------------- Performing edit operation while an unfiltered list is being shown ---------------------- */"
-      },
-      {
-        "lineNumber": 72,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 73,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        /* Case: edit all fields, command with leading spaces, trailing spaces and multiple spaces between each field"
-      },
-      {
-        "lineNumber": 74,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "         * -\u003e edited"
-      },
-      {
-        "lineNumber": 75,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "         */"
-      },
-      {
-        "lineNumber": 76,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        Index index \u003d INDEX_FIRST_PERSON;"
-      },
-      {
-        "lineNumber": 77,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        String command \u003d \" \" + EditCommand.COMMAND_WORD + \"  \" + index.getOneBased() + \"  \" + NAME_DESC_BOB + \"  \""
-      },
-      {
-        "lineNumber": 78,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "                + PHONE_DESC_BOB + \" \" + EMAIL_DESC_BOB + \"  \" + ADDRESS_DESC_BOB + \" \" + TAG_DESC_HUSBAND + \" \""
-      },
-      {
-        "lineNumber": 79,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "                + RATING_DESC_1 + \" \" + POSITION_DESC_MIDFILED + \" \" + JERSEY_NUMBER_DESC_2;"
-      },
-      {
-        "lineNumber": 80,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        Person editedPerson \u003d new PersonBuilder().withName(VALID_NAME_BOB).withPhone(VALID_PHONE_BOB)"
-      },
-      {
-        "lineNumber": 81,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "                .withEmail(VALID_EMAIL_BOB).withAddress(VALID_ADDRESS_BOB).withTags(VALID_TAG_HUSBAND)"
-      },
-      {
-        "lineNumber": 82,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "                .withRating(VALID_RATING_1).withPosition(VALID_POSITION_MIDFIELD)"
-      },
-      {
-        "lineNumber": 83,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "                .withJerseyNumber(VALID_JERSEY_NUMBER_2).build();"
-      },
-      {
-        "lineNumber": 84,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertCommandSuccess(command, index, editedPerson);"
-      },
-      {
-        "lineNumber": 85,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 86,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        /* Case: undo editing the last person in the list -\u003e last person restored */"
-      },
-      {
-        "lineNumber": 87,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        command \u003d UndoCommand.COMMAND_WORD;"
-      },
-      {
-        "lineNumber": 88,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        String expectedResultMessage \u003d UndoCommand.MESSAGE_SUCCESS;"
-      },
-      {
-        "lineNumber": 89,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertCommandSuccess(command, model, expectedResultMessage);"
-      },
-      {
-        "lineNumber": 90,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 91,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        /* Case: redo editing the last person in the list -\u003e last person edited again */"
-      },
-      {
-        "lineNumber": 92,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        command \u003d RedoCommand.COMMAND_WORD;"
-      },
-      {
-        "lineNumber": 93,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        expectedResultMessage \u003d RedoCommand.MESSAGE_SUCCESS;"
-      },
-      {
-        "lineNumber": 94,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        model.updatePerson("
-      },
-      {
-        "lineNumber": 95,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "                getModel().getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased()), editedPerson);"
-      },
-      {
-        "lineNumber": 96,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertCommandSuccess(command, model, expectedResultMessage);"
-      },
-      {
-        "lineNumber": 97,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 98,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        /* Case: edit a person with new values same as existing values -\u003e edited */"
-      },
-      {
-        "lineNumber": 99,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        command \u003d EditCommand.COMMAND_WORD + \" \" + index.getOneBased() + NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB"
-      },
-      {
-        "lineNumber": 100,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "                + ADDRESS_DESC_BOB + TAG_DESC_FRIEND + TAG_DESC_HUSBAND + POSITION_DESC_MIDFILED + RATING_DESC_1"
-      },
-      {
-        "lineNumber": 101,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "                + JERSEY_NUMBER_DESC_17;"
-      },
-      {
-        "lineNumber": 102,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertCommandSuccess(command, index, BOB);"
-      },
-      {
-        "lineNumber": 103,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 104,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        /* Case: edit some fields -\u003e edited */"
-      },
-      {
-        "lineNumber": 105,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        index \u003d INDEX_FIRST_PERSON;"
-      },
-      {
-        "lineNumber": 106,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        command \u003d EditCommand.COMMAND_WORD + \" \" + index.getOneBased() + TAG_DESC_FRIEND;"
-      },
-      {
-        "lineNumber": 107,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        Person personToEdit \u003d getModel().getFilteredPersonList().get(index.getZeroBased());"
-      },
-      {
-        "lineNumber": 108,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        editedPerson \u003d new PersonBuilder(personToEdit).withTags(VALID_TAG_FRIEND).build();"
-      },
-      {
-        "lineNumber": 109,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertCommandSuccess(command, index, editedPerson);"
-      },
-      {
-        "lineNumber": 110,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 111,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        /* Case: clear tags -\u003e cleared */"
-      },
-      {
-        "lineNumber": 112,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        index \u003d INDEX_FIRST_PERSON;"
-      },
-      {
-        "lineNumber": 113,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        command \u003d EditCommand.COMMAND_WORD + \" \" + index.getOneBased() + \" \" + PREFIX_TAG.getPrefix();"
-      },
-      {
-        "lineNumber": 114,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        editedPerson \u003d new PersonBuilder(personToEdit).withTags().build();"
-      },
-      {
-        "lineNumber": 115,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertCommandSuccess(command, index, editedPerson);"
-      },
-      {
-        "lineNumber": 116,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 117,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        /* ------------------ Performing edit operation while a filtered list is being shown ------------------------ */"
-      },
-      {
-        "lineNumber": 118,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 119,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        /* Case: filtered person list, edit index within bounds of address book and person list -\u003e edited */"
-      },
-      {
-        "lineNumber": 120,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        showPersonsWithName(KEYWORD_MATCHING_MEIER);"
-      },
-      {
-        "lineNumber": 121,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        index \u003d INDEX_FIRST_PERSON;"
-      },
-      {
-        "lineNumber": 122,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertTrue(index.getZeroBased() \u003c getModel().getFilteredPersonList().size());"
-      },
-      {
-        "lineNumber": 123,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        command \u003d EditCommand.COMMAND_WORD + \" \" + index.getOneBased() + \" \" + NAME_DESC_BOB;"
-      },
-      {
-        "lineNumber": 124,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        personToEdit \u003d getModel().getFilteredPersonList().get(index.getZeroBased());"
-      },
-      {
-        "lineNumber": 125,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        editedPerson \u003d new PersonBuilder(personToEdit).withName(VALID_NAME_BOB).build();"
-      },
-      {
-        "lineNumber": 126,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertCommandSuccess(command, index, editedPerson);"
-      },
-      {
-        "lineNumber": 127,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 128,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        /* Case: filtered person list, edit index within bounds of address book but out of bounds of person list"
-      },
-      {
-        "lineNumber": 129,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "         * -\u003e rejected"
-      },
-      {
-        "lineNumber": 130,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "         */"
-      },
-      {
-        "lineNumber": 131,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        showPersonsWithName(KEYWORD_MATCHING_MEIER);"
-      },
-      {
-        "lineNumber": 132,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        int invalidIndex \u003d getModel().getAddressBook().getPersonList().size();"
-      },
-      {
-        "lineNumber": 133,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertCommandFailure(EditCommand.COMMAND_WORD + \" \" + invalidIndex + NAME_DESC_BOB,"
-      },
-      {
-        "lineNumber": 134,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "                Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);"
-      },
-      {
-        "lineNumber": 135,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 136,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        /* --------------------- Performing edit operation while a person card is selected -------------------------- */"
-      },
-      {
-        "lineNumber": 137,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 138,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        /* Case: selects first card in the person list, edit a person -\u003e edited, card selection remains unchanged but"
-      },
-      {
-        "lineNumber": 139,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "         * browser url changes"
-      },
-      {
-        "lineNumber": 140,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "         */"
-      },
-      {
-        "lineNumber": 141,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        showAllPersons();"
-      },
-      {
-        "lineNumber": 142,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        index \u003d INDEX_FIRST_PERSON;"
-      },
-      {
-        "lineNumber": 143,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        selectPerson(index);"
-      },
-      {
-        "lineNumber": 144,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        command \u003d EditCommand.COMMAND_WORD + \" \" + index.getOneBased() + NAME_DESC_AMY + PHONE_DESC_AMY + EMAIL_DESC_AMY"
-      },
-      {
-        "lineNumber": 145,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "                + ADDRESS_DESC_AMY + TAG_DESC_FRIEND + RATING_DESC_0 + POSITION_DESC_STRIKER + JERSEY_NUMBER_DESC_2;"
-      },
-      {
-        "lineNumber": 146,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        // this can be misleading: card selection actually remains unchanged but the"
-      },
-      {
-        "lineNumber": 147,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        // browser\u0027s url is updated to reflect the new person\u0027s name"
-      },
-      {
-        "lineNumber": 148,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertCommandSuccess(command, index, AMY, index);"
-      },
-      {
-        "lineNumber": 149,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 150,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        /* --------------------------------- Performing invalid edit operation -------------------------------------- */"
-      },
-      {
-        "lineNumber": 151,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 152,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        /* Case: invalid index (0) -\u003e rejected */"
-      },
-      {
-        "lineNumber": 153,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertCommandFailure(EditCommand.COMMAND_WORD + \" 0\" + NAME_DESC_BOB,"
-      },
-      {
-        "lineNumber": 154,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "                String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE));"
-      },
-      {
-        "lineNumber": 155,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 156,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        /* Case: invalid index (-1) -\u003e rejected */"
-      },
-      {
-        "lineNumber": 157,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertCommandFailure(EditCommand.COMMAND_WORD + \" -1\" + NAME_DESC_BOB,"
-      },
-      {
-        "lineNumber": 158,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "                String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE));"
-      },
-      {
-        "lineNumber": 159,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 160,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        /* Case: invalid index (size + 1) -\u003e rejected */"
-      },
-      {
-        "lineNumber": 161,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        invalidIndex \u003d getModel().getFilteredPersonList().size() + 1;"
-      },
-      {
-        "lineNumber": 162,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertCommandFailure(EditCommand.COMMAND_WORD + \" \" + invalidIndex + NAME_DESC_BOB,"
-      },
-      {
-        "lineNumber": 163,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "                Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);"
-      },
-      {
-        "lineNumber": 164,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 165,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        /* Case: missing index -\u003e rejected */"
-      },
-      {
-        "lineNumber": 166,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertCommandFailure(EditCommand.COMMAND_WORD + NAME_DESC_BOB,"
-      },
-      {
-        "lineNumber": 167,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "                String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE));"
-      },
-      {
-        "lineNumber": 168,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 169,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        /* Case: missing all fields -\u003e rejected */"
-      },
-      {
-        "lineNumber": 170,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertCommandFailure(EditCommand.COMMAND_WORD + \" \" + INDEX_FIRST_PERSON.getOneBased(),"
-      },
-      {
-        "lineNumber": 171,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "                EditCommand.MESSAGE_NOT_EDITED);"
-      },
-      {
-        "lineNumber": 172,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 173,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        /* Case: invalid name -\u003e rejected */"
-      },
-      {
-        "lineNumber": 174,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertCommandFailure(EditCommand.COMMAND_WORD + \" \" + INDEX_FIRST_PERSON.getOneBased() + INVALID_NAME_DESC,"
-      },
-      {
-        "lineNumber": 175,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "                Name.MESSAGE_NAME_CONSTRAINTS);"
-      },
-      {
-        "lineNumber": 176,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 177,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        /* Case: invalid phone -\u003e rejected */"
-      },
-      {
-        "lineNumber": 178,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertCommandFailure(EditCommand.COMMAND_WORD + \" \" + INDEX_FIRST_PERSON.getOneBased() + INVALID_PHONE_DESC,"
-      },
-      {
-        "lineNumber": 179,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "                Phone.MESSAGE_PHONE_CONSTRAINTS);"
-      },
-      {
-        "lineNumber": 180,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 181,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        /* Case: invalid email -\u003e rejected */"
-      },
-      {
-        "lineNumber": 182,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertCommandFailure(EditCommand.COMMAND_WORD + \" \" + INDEX_FIRST_PERSON.getOneBased() + INVALID_EMAIL_DESC,"
-      },
-      {
-        "lineNumber": 183,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "                Email.MESSAGE_EMAIL_CONSTRAINTS);"
-      },
-      {
-        "lineNumber": 184,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 185,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        /* Case: invalid address -\u003e rejected */"
-      },
-      {
-        "lineNumber": 186,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertCommandFailure(EditCommand.COMMAND_WORD + \" \" + INDEX_FIRST_PERSON.getOneBased() + INVALID_ADDRESS_DESC,"
-      },
-      {
-        "lineNumber": 187,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "                Address.MESSAGE_ADDRESS_CONSTRAINTS);"
-      },
-      {
-        "lineNumber": 188,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 189,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        Avatar.setUpPlaceholderForTest();"
-      },
-      {
-        "lineNumber": 190,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 191,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        /* Case: invalid tag -\u003e rejected */"
-      },
-      {
-        "lineNumber": 192,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertCommandFailure(EditCommand.COMMAND_WORD + \" \" + INDEX_FIRST_PERSON.getOneBased() + INVALID_TAG_DESC,"
-      },
-      {
-        "lineNumber": 193,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "                Tag.MESSAGE_TAG_CONSTRAINTS);"
-      },
-      {
-        "lineNumber": 194,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 195,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        /* Case: invalid avatar -\u003e rejected */"
-      },
-      {
-        "lineNumber": 196,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        assertCommandFailure(EditCommand.COMMAND_WORD + \" \" + INDEX_FIRST_PERSON.getOneBased() + INVALID_AVATAR_NO_FILE,"
-      },
-      {
-        "lineNumber": 197,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "                EditCommand.MESSAGE_FILE_NOT_FOUND);"
-      },
-      {
-        "lineNumber": 198,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 199,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        /* Case: invalid avatar -\u003e rejected */"
-      },
-      {
-        "lineNumber": 200,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        assertCommandFailure(EditCommand.COMMAND_WORD + \" \" + INDEX_FIRST_PERSON.getOneBased() + INVALID_AVATAR_TYPE,"
-      },
-      {
-        "lineNumber": 201,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "                Avatar.MESSAGE_AVATAR_CONSTRAINTS);"
-      },
-      {
-        "lineNumber": 202,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 203,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        /* Case: edit a person with new values same as another person\u0027s values -\u003e rejected */"
-      },
-      {
-        "lineNumber": 204,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        executeCommand(PersonUtil.getAddCommand(BOB));"
-      },
-      {
-        "lineNumber": 205,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertTrue(getModel().getAddressBook().getPersonList().contains(BOB));"
-      },
-      {
-        "lineNumber": 206,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        index \u003d INDEX_FIRST_PERSON;"
-      },
-      {
-        "lineNumber": 207,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertFalse(getModel().getFilteredPersonList().get(index.getZeroBased()).equals(BOB));"
-      },
-      {
-        "lineNumber": 208,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        command \u003d EditCommand.COMMAND_WORD + \" \" + index.getOneBased() + NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB"
-      },
-      {
-        "lineNumber": 209,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "                + ADDRESS_DESC_BOB + TAG_DESC_FRIEND + TAG_DESC_HUSBAND;"
-      },
-      {
-        "lineNumber": 210,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertCommandFailure(command, EditCommand.MESSAGE_DUPLICATE_PERSON);"
-      },
-      {
-        "lineNumber": 211,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 212,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        /* Case: edit a person with new values same as another person\u0027s values but with different tags -\u003e rejected */"
-      },
-      {
-        "lineNumber": 213,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        command \u003d EditCommand.COMMAND_WORD + \" \" + index.getOneBased() + NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB"
-      },
-      {
-        "lineNumber": 214,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "                + ADDRESS_DESC_BOB + TAG_DESC_HUSBAND;"
-      },
-      {
-        "lineNumber": 215,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertCommandFailure(command, EditCommand.MESSAGE_DUPLICATE_PERSON);"
-      },
-      {
-        "lineNumber": 216,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 217,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 218,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    /**"
-      },
-      {
-        "lineNumber": 219,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     * Performs the same verification as {@code assertCommandSuccess(String, Index, Person, Index)} except that"
-      },
-      {
-        "lineNumber": 220,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     * the browser url and selected card remain unchanged."
-      },
-      {
-        "lineNumber": 221,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     * @param toEdit the index of the current model\u0027s filtered list"
-      },
-      {
-        "lineNumber": 222,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     * @see EditCommandSystemTest#assertCommandSuccess(String, Index, Person, Index)"
-      },
-      {
-        "lineNumber": 223,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     */"
-      },
-      {
-        "lineNumber": 224,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    private void assertCommandSuccess(String command, Index toEdit, Person editedPerson) {"
-      },
-      {
-        "lineNumber": 225,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertCommandSuccess(command, toEdit, editedPerson, null);"
-      },
-      {
-        "lineNumber": 226,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 227,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 228,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    /**"
-      },
-      {
-        "lineNumber": 229,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     * Performs the same verification as {@code assertCommandSuccess(String, Model, String, Index)} and in addition,\u003cbr\u003e"
-      },
-      {
-        "lineNumber": 230,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     * 1. Asserts that result display box displays the success message of executing {@code EditCommand}.\u003cbr\u003e"
-      },
-      {
-        "lineNumber": 231,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     * 2. Asserts that the model related components are updated to reflect the person at index {@code toEdit} being"
-      },
-      {
-        "lineNumber": 232,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     * updated to values specified {@code editedPerson}.\u003cbr\u003e"
-      },
-      {
-        "lineNumber": 233,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     * @param toEdit the index of the current model\u0027s filtered list."
-      },
-      {
-        "lineNumber": 234,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     * @see EditCommandSystemTest#assertCommandSuccess(String, Model, String, Index)"
-      },
-      {
-        "lineNumber": 235,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     */"
-      },
-      {
-        "lineNumber": 236,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    private void assertCommandSuccess(String command, Index toEdit, Person editedPerson,"
-      },
-      {
-        "lineNumber": 237,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "            Index expectedSelectedCardIndex) {"
-      },
-      {
-        "lineNumber": 238,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        Model expectedModel \u003d getModel();"
-      },
-      {
-        "lineNumber": 239,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        try {"
-      },
-      {
-        "lineNumber": 240,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "            expectedModel.updatePerson("
-      },
-      {
-        "lineNumber": 241,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "                    expectedModel.getFilteredPersonList().get(toEdit.getZeroBased()), editedPerson);"
-      },
-      {
-        "lineNumber": 242,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "            expectedModel.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);"
-      },
-      {
-        "lineNumber": 243,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        } catch (DuplicatePersonException | PersonNotFoundException e) {"
-      },
-      {
-        "lineNumber": 244,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "            throw new IllegalArgumentException("
-      },
-      {
-        "lineNumber": 245,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "                    \"editedPerson is a duplicate in expectedModel, or it isn\u0027t found in the model.\");"
-      },
-      {
-        "lineNumber": 246,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        }"
-      },
-      {
-        "lineNumber": 247,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertCommandSuccess(command, expectedModel,"
-      },
-      {
-        "lineNumber": 248,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "                String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS, editedPerson), expectedSelectedCardIndex);"
-      },
-      {
-        "lineNumber": 249,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 250,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 251,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    /**"
-      },
-      {
-        "lineNumber": 252,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     * Performs the same verification as {@code assertCommandSuccess(String, Model, String, Index)} except that the"
-      },
-      {
-        "lineNumber": 253,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     * browser url and selected card remain unchanged."
-      },
-      {
-        "lineNumber": 254,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     * @see EditCommandSystemTest#assertCommandSuccess(String, Model, String, Index)"
-      },
-      {
-        "lineNumber": 255,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     */"
-      },
-      {
-        "lineNumber": 256,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    private void assertCommandSuccess(String command, Model expectedModel, String expectedResultMessage) {"
-      },
-      {
-        "lineNumber": 257,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertCommandSuccess(command, expectedModel, expectedResultMessage, null);"
-      },
-      {
-        "lineNumber": 258,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 259,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 260,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    /**"
-      },
-      {
-        "lineNumber": 261,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     * Executes {@code command} and in addition,\u003cbr\u003e"
-      },
-      {
-        "lineNumber": 262,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     * 1. Asserts that the command box displays an empty string.\u003cbr\u003e"
-      },
-      {
-        "lineNumber": 263,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     * 2. Asserts that the result display box displays {@code expectedResultMessage}.\u003cbr\u003e"
-      },
-      {
-        "lineNumber": 264,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     * 3. Asserts that the model related components equal to {@code expectedModel}.\u003cbr\u003e"
-      },
-      {
-        "lineNumber": 265,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     * 4. Asserts that the browser url and selected card update accordingly depending on the card at"
-      },
-      {
-        "lineNumber": 266,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     * {@code expectedSelectedCardIndex}.\u003cbr\u003e"
-      },
-      {
-        "lineNumber": 267,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     * 5. Asserts that the status bar\u0027s sync status changes.\u003cbr\u003e"
-      },
-      {
-        "lineNumber": 268,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     * 6. Asserts that the command box has the default style class.\u003cbr\u003e"
-      },
-      {
-        "lineNumber": 269,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     * Verifications 1 to 3 are performed by"
-      },
-      {
-        "lineNumber": 270,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     * {@code AddressBookSystemTest#assertApplicationDisplaysExpected(String, String, Model)}.\u003cbr\u003e"
-      },
-      {
-        "lineNumber": 271,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     * @see AddressBookSystemTest#assertApplicationDisplaysExpected(String, String, Model)"
-      },
-      {
-        "lineNumber": 272,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     * @see AddressBookSystemTest#assertSelectedCardChanged(Index)"
-      },
-      {
-        "lineNumber": 273,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     */"
-      },
-      {
-        "lineNumber": 274,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    private void assertCommandSuccess(String command, Model expectedModel, String expectedResultMessage,"
-      },
-      {
-        "lineNumber": 275,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "            Index expectedSelectedCardIndex) {"
-      },
-      {
-        "lineNumber": 276,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        executeCommand(command);"
-      },
-      {
-        "lineNumber": 277,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        expectedModel.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);"
-      },
-      {
-        "lineNumber": 278,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertApplicationDisplaysExpected(\"\", expectedResultMessage, expectedModel);"
-      },
-      {
-        "lineNumber": 279,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertCommandBoxShowsDefaultStyle();"
-      },
-      {
-        "lineNumber": 280,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        if (expectedSelectedCardIndex !\u003d null) {"
-      },
-      {
-        "lineNumber": 281,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "            assertSelectedCardChanged(expectedSelectedCardIndex);"
-      },
-      {
-        "lineNumber": 282,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        } else {"
-      },
-      {
-        "lineNumber": 283,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "            assertSelectedCardUnchanged();"
-      },
-      {
-        "lineNumber": 284,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        }"
-      },
-      {
-        "lineNumber": 285,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertStatusBarUnchangedExceptSyncStatus();"
-      },
-      {
-        "lineNumber": 286,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 287,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 288,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    /**"
-      },
-      {
-        "lineNumber": 289,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     * Executes {@code command} and in addition,\u003cbr\u003e"
-      },
-      {
-        "lineNumber": 290,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     * 1. Asserts that the command box displays {@code command}.\u003cbr\u003e"
-      },
-      {
-        "lineNumber": 291,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     * 2. Asserts that result display box displays {@code expectedResultMessage}.\u003cbr\u003e"
-      },
-      {
-        "lineNumber": 292,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     * 3. Asserts that the model related components equal to the current model.\u003cbr\u003e"
-      },
-      {
-        "lineNumber": 293,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     * 4. Asserts that the browser url, selected card and status bar remain unchanged.\u003cbr\u003e"
-      },
-      {
-        "lineNumber": 294,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     * 5. Asserts that the command box has the error style.\u003cbr\u003e"
-      },
-      {
-        "lineNumber": 295,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     * Verifications 1 to 3 are performed by"
-      },
-      {
-        "lineNumber": 296,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     * {@code AddressBookSystemTest#assertApplicationDisplaysExpected(String, String, Model)}.\u003cbr\u003e"
-      },
-      {
-        "lineNumber": 297,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     * @see AddressBookSystemTest#assertApplicationDisplaysExpected(String, String, Model)"
-      },
-      {
-        "lineNumber": 298,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     */"
-      },
-      {
-        "lineNumber": 299,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    private void assertCommandFailure(String command, String expectedResultMessage) {"
-      },
-      {
-        "lineNumber": 300,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        Model expectedModel \u003d getModel();"
-      },
-      {
-        "lineNumber": 301,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 302,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        executeCommand(command);"
-      },
-      {
-        "lineNumber": 303,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertApplicationDisplaysExpected(command, expectedResultMessage, expectedModel);"
-      },
-      {
-        "lineNumber": 304,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertSelectedCardUnchanged();"
-      },
-      {
-        "lineNumber": 305,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertCommandBoxShowsErrorStyle();"
-      },
-      {
-        "lineNumber": 306,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertStatusBarUnchanged();"
-      },
-      {
-        "lineNumber": 307,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 308,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "}"
-      }
-    ],
-    "authorContributionMap": {
-      "lithiumlkid": 25,
-      "-": 283
+      "-": 255
     }
   }
 ]

--- a/src/functional/resources/noDateRange/expected/reposense_testrepo-Delta_master/commits.json
+++ b/src/functional/resources/noDateRange/expected/reposense_testrepo-Delta_master/commits.json
@@ -2,7 +2,7 @@
   "authorWeeklyIntervalContributions": {
     "lithiumlkid": [
       {
-        "insertions": 17,
+        "insertions": 5,
         "deletions": 6,
         "sinceDate": "2018-03-01",
         "untilDate": "2018-03-08"
@@ -14,32 +14,32 @@
         "untilDate": "2018-03-15"
       },
       {
-        "insertions": 294,
-        "deletions": 224,
+        "insertions": 46,
+        "deletions": 2,
         "sinceDate": "2018-03-15",
         "untilDate": "2018-03-22"
       },
       {
-        "insertions": 204,
-        "deletions": 42,
+        "insertions": 10,
+        "deletions": 9,
         "sinceDate": "2018-03-22",
         "untilDate": "2018-03-29"
       },
       {
-        "insertions": 1003,
-        "deletions": 119,
+        "insertions": 2,
+        "deletions": 2,
         "sinceDate": "2018-03-29",
         "untilDate": "2018-04-05"
       },
       {
-        "insertions": 533,
-        "deletions": 148,
+        "insertions": 117,
+        "deletions": 52,
         "sinceDate": "2018-04-05",
         "untilDate": "2018-04-12"
       },
       {
-        "insertions": 469,
-        "deletions": 128,
+        "insertions": 305,
+        "deletions": 95,
         "sinceDate": "2018-04-12",
         "untilDate": "2018-04-19"
       }
@@ -186,7 +186,7 @@
         "untilDate": "2018-03-02"
       },
       {
-        "insertions": 15,
+        "insertions": 3,
         "deletions": 4,
         "sinceDate": "2018-03-02",
         "untilDate": "2018-03-03"
@@ -264,8 +264,8 @@
         "untilDate": "2018-03-15"
       },
       {
-        "insertions": 287,
-        "deletions": 208,
+        "insertions": 46,
+        "deletions": 2,
         "sinceDate": "2018-03-15",
         "untilDate": "2018-03-16"
       },
@@ -300,20 +300,20 @@
         "untilDate": "2018-03-21"
       },
       {
-        "insertions": 7,
-        "deletions": 16,
+        "insertions": 0,
+        "deletions": 0,
         "sinceDate": "2018-03-21",
         "untilDate": "2018-03-22"
       },
       {
-        "insertions": 173,
-        "deletions": 28,
+        "insertions": 0,
+        "deletions": 0,
         "sinceDate": "2018-03-22",
         "untilDate": "2018-03-23"
       },
       {
-        "insertions": 31,
-        "deletions": 14,
+        "insertions": 10,
+        "deletions": 9,
         "sinceDate": "2018-03-23",
         "untilDate": "2018-03-24"
       },
@@ -354,8 +354,8 @@
         "untilDate": "2018-03-30"
       },
       {
-        "insertions": 806,
-        "deletions": 98,
+        "insertions": 2,
+        "deletions": 2,
         "sinceDate": "2018-03-30",
         "untilDate": "2018-03-31"
       },
@@ -372,8 +372,8 @@
         "untilDate": "2018-04-02"
       },
       {
-        "insertions": 197,
-        "deletions": 21,
+        "insertions": 0,
+        "deletions": 0,
         "sinceDate": "2018-04-02",
         "untilDate": "2018-04-03"
       },
@@ -390,14 +390,14 @@
         "untilDate": "2018-04-05"
       },
       {
-        "insertions": 160,
-        "deletions": 47,
+        "insertions": 0,
+        "deletions": 0,
         "sinceDate": "2018-04-05",
         "untilDate": "2018-04-06"
       },
       {
-        "insertions": 20,
-        "deletions": 16,
+        "insertions": 0,
+        "deletions": 0,
         "sinceDate": "2018-04-06",
         "untilDate": "2018-04-07"
       },
@@ -414,32 +414,32 @@
         "untilDate": "2018-04-09"
       },
       {
-        "insertions": 9,
-        "deletions": 4,
+        "insertions": 1,
+        "deletions": 1,
         "sinceDate": "2018-04-09",
         "untilDate": "2018-04-10"
       },
       {
-        "insertions": 66,
-        "deletions": 14,
+        "insertions": 56,
+        "deletions": 5,
         "sinceDate": "2018-04-10",
         "untilDate": "2018-04-11"
       },
       {
-        "insertions": 278,
-        "deletions": 67,
+        "insertions": 60,
+        "deletions": 46,
         "sinceDate": "2018-04-11",
         "untilDate": "2018-04-12"
       },
       {
-        "insertions": 213,
-        "deletions": 43,
+        "insertions": 73,
+        "deletions": 16,
         "sinceDate": "2018-04-12",
         "untilDate": "2018-04-13"
       },
       {
-        "insertions": 88,
-        "deletions": 65,
+        "insertions": 76,
+        "deletions": 64,
         "sinceDate": "2018-04-13",
         "untilDate": "2018-04-14"
       },
@@ -450,8 +450,8 @@
         "untilDate": "2018-04-15"
       },
       {
-        "insertions": 166,
-        "deletions": 20,
+        "insertions": 154,
+        "deletions": 15,
         "sinceDate": "2018-04-15",
         "untilDate": "2018-04-16"
       }
@@ -1292,13 +1292,13 @@
     ]
   },
   "authorFinalContributionMap": {
-    "lithiumlkid": 2705,
+    "lithiumlkid": 1782,
     "lohtianwei": 2164,
     "codeeong": 1159,
     "jordancjq": 5321
   },
   "authorContributionVariance": {
-    "lithiumlkid": 26536.328,
+    "lithiumlkid": 1465.0459,
     "lohtianwei": 20085.645,
     "codeeong": 0.0,
     "jordancjq": 108832.89

--- a/src/functional/resources/noDateRange/expected/reposense_testrepo-Delta_master/commits.json
+++ b/src/functional/resources/noDateRange/expected/reposense_testrepo-Delta_master/commits.json
@@ -90,44 +90,44 @@
     ],
     "codeeong": [
       {
-        "insertions": 99,
-        "deletions": 15,
+        "insertions": 0,
+        "deletions": 0,
         "sinceDate": "2018-03-01",
         "untilDate": "2018-03-08"
       },
       {
-        "insertions": 243,
-        "deletions": 51,
+        "insertions": 0,
+        "deletions": 0,
         "sinceDate": "2018-03-08",
         "untilDate": "2018-03-15"
       },
       {
-        "insertions": 426,
-        "deletions": 183,
+        "insertions": 0,
+        "deletions": 0,
         "sinceDate": "2018-03-15",
         "untilDate": "2018-03-22"
       },
       {
-        "insertions": 227,
-        "deletions": 232,
+        "insertions": 0,
+        "deletions": 0,
         "sinceDate": "2018-03-22",
         "untilDate": "2018-03-29"
       },
       {
-        "insertions": 406,
-        "deletions": 85,
+        "insertions": 0,
+        "deletions": 0,
         "sinceDate": "2018-03-29",
         "untilDate": "2018-04-05"
       },
       {
-        "insertions": 1194,
-        "deletions": 318,
+        "insertions": 0,
+        "deletions": 0,
         "sinceDate": "2018-04-05",
         "untilDate": "2018-04-12"
       },
       {
-        "insertions": 294,
-        "deletions": 79,
+        "insertions": 0,
+        "deletions": 0,
         "sinceDate": "2018-04-12",
         "untilDate": "2018-04-19"
       }
@@ -766,8 +766,8 @@
         "untilDate": "2018-03-06"
       },
       {
-        "insertions": 99,
-        "deletions": 15,
+        "insertions": 0,
+        "deletions": 0,
         "sinceDate": "2018-03-06",
         "untilDate": "2018-03-07"
       },
@@ -778,14 +778,14 @@
         "untilDate": "2018-03-08"
       },
       {
-        "insertions": 14,
-        "deletions": 3,
+        "insertions": 0,
+        "deletions": 0,
         "sinceDate": "2018-03-08",
         "untilDate": "2018-03-09"
       },
       {
-        "insertions": 24,
-        "deletions": 23,
+        "insertions": 0,
+        "deletions": 0,
         "sinceDate": "2018-03-09",
         "untilDate": "2018-03-10"
       },
@@ -814,20 +814,20 @@
         "untilDate": "2018-03-14"
       },
       {
-        "insertions": 205,
-        "deletions": 25,
+        "insertions": 0,
+        "deletions": 0,
         "sinceDate": "2018-03-14",
         "untilDate": "2018-03-15"
       },
       {
-        "insertions": 23,
-        "deletions": 13,
+        "insertions": 0,
+        "deletions": 0,
         "sinceDate": "2018-03-15",
         "untilDate": "2018-03-16"
       },
       {
-        "insertions": 224,
-        "deletions": 70,
+        "insertions": 0,
+        "deletions": 0,
         "sinceDate": "2018-03-16",
         "untilDate": "2018-03-17"
       },
@@ -838,38 +838,38 @@
         "untilDate": "2018-03-18"
       },
       {
-        "insertions": 16,
-        "deletions": 3,
+        "insertions": 0,
+        "deletions": 0,
         "sinceDate": "2018-03-18",
         "untilDate": "2018-03-19"
       },
       {
-        "insertions": 35,
-        "deletions": 3,
+        "insertions": 0,
+        "deletions": 0,
         "sinceDate": "2018-03-19",
         "untilDate": "2018-03-20"
       },
       {
         "insertions": 0,
-        "deletions": 1,
+        "deletions": 0,
         "sinceDate": "2018-03-20",
         "untilDate": "2018-03-21"
       },
       {
-        "insertions": 128,
-        "deletions": 93,
+        "insertions": 0,
+        "deletions": 0,
         "sinceDate": "2018-03-21",
         "untilDate": "2018-03-22"
       },
       {
-        "insertions": 91,
-        "deletions": 192,
+        "insertions": 0,
+        "deletions": 0,
         "sinceDate": "2018-03-22",
         "untilDate": "2018-03-23"
       },
       {
-        "insertions": 3,
-        "deletions": 16,
+        "insertions": 0,
+        "deletions": 0,
         "sinceDate": "2018-03-23",
         "untilDate": "2018-03-24"
       },
@@ -898,8 +898,8 @@
         "untilDate": "2018-03-28"
       },
       {
-        "insertions": 133,
-        "deletions": 24,
+        "insertions": 0,
+        "deletions": 0,
         "sinceDate": "2018-03-28",
         "untilDate": "2018-03-29"
       },
@@ -910,26 +910,26 @@
         "untilDate": "2018-03-30"
       },
       {
-        "insertions": 3,
-        "deletions": 4,
+        "insertions": 0,
+        "deletions": 0,
         "sinceDate": "2018-03-30",
         "untilDate": "2018-03-31"
       },
       {
-        "insertions": 178,
-        "deletions": 41,
+        "insertions": 0,
+        "deletions": 0,
         "sinceDate": "2018-03-31",
         "untilDate": "2018-04-01"
       },
       {
-        "insertions": 173,
-        "deletions": 29,
+        "insertions": 0,
+        "deletions": 0,
         "sinceDate": "2018-04-01",
         "untilDate": "2018-04-02"
       },
       {
-        "insertions": 52,
-        "deletions": 11,
+        "insertions": 0,
+        "deletions": 0,
         "sinceDate": "2018-04-02",
         "untilDate": "2018-04-03"
       },
@@ -946,56 +946,56 @@
         "untilDate": "2018-04-05"
       },
       {
-        "insertions": 227,
-        "deletions": 72,
+        "insertions": 0,
+        "deletions": 0,
         "sinceDate": "2018-04-05",
         "untilDate": "2018-04-06"
       },
       {
-        "insertions": 358,
-        "deletions": 35,
+        "insertions": 0,
+        "deletions": 0,
         "sinceDate": "2018-04-06",
         "untilDate": "2018-04-07"
       },
       {
-        "insertions": 31,
-        "deletions": 25,
+        "insertions": 0,
+        "deletions": 0,
         "sinceDate": "2018-04-07",
         "untilDate": "2018-04-08"
       },
       {
-        "insertions": 25,
+        "insertions": 0,
         "deletions": 0,
         "sinceDate": "2018-04-08",
         "untilDate": "2018-04-09"
       },
       {
-        "insertions": 77,
-        "deletions": 14,
+        "insertions": 0,
+        "deletions": 0,
         "sinceDate": "2018-04-09",
         "untilDate": "2018-04-10"
       },
       {
-        "insertions": 258,
-        "deletions": 17,
+        "insertions": 0,
+        "deletions": 0,
         "sinceDate": "2018-04-10",
         "untilDate": "2018-04-11"
       },
       {
-        "insertions": 218,
-        "deletions": 155,
+        "insertions": 0,
+        "deletions": 0,
         "sinceDate": "2018-04-11",
         "untilDate": "2018-04-12"
       },
       {
-        "insertions": 15,
-        "deletions": 4,
+        "insertions": 0,
+        "deletions": 0,
         "sinceDate": "2018-04-12",
         "untilDate": "2018-04-13"
       },
       {
-        "insertions": 182,
-        "deletions": 27,
+        "insertions": 0,
+        "deletions": 0,
         "sinceDate": "2018-04-13",
         "untilDate": "2018-04-14"
       },
@@ -1006,8 +1006,8 @@
         "untilDate": "2018-04-15"
       },
       {
-        "insertions": 97,
-        "deletions": 48,
+        "insertions": 0,
+        "deletions": 0,
         "sinceDate": "2018-04-15",
         "untilDate": "2018-04-16"
       }
@@ -1294,13 +1294,13 @@
   "authorFinalContributionMap": {
     "lithiumlkid": 2705,
     "lohtianwei": 2164,
-    "codeeong": 2289,
+    "codeeong": 1159,
     "jordancjq": 5321
   },
   "authorContributionVariance": {
     "lithiumlkid": 26536.328,
     "lohtianwei": 20085.645,
-    "codeeong": 13430.541,
+    "codeeong": 0.0,
     "jordancjq": 108832.89
   },
   "authorDisplayNameMap": {

--- a/src/main/java/reposense/model/RepoConfiguration.java
+++ b/src/main/java/reposense/model/RepoConfiguration.java
@@ -8,7 +8,6 @@ import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
@@ -106,7 +105,7 @@ public class RepoConfiguration {
                     !sa.getIgnoreGlobList().isEmpty() ? sa.getIgnoreGlobList() : ignoreGlobList;
 
             authorList.add(author);
-            author.setAuthorAliases(Arrays.asList(sa.getAuthorNames()));
+            author.setAuthorAliases(sa.getAuthorNames());
             author.setIgnoreGlobList(authorIgnoreGlobList);
 
             this.setAuthorDisplayName(author, displayName);
@@ -239,10 +238,14 @@ public class RepoConfiguration {
         authorDisplayNameMap.put(author, displayName);
     }
 
-    public void setAuthorAliases(Author author, String... aliases) {
+    public void setAuthorAliases(Author author, List<String> aliases) {
         for (String alias : aliases) {
-            authorAliasMap.put(alias, author);
+            setAuthorAliases(author, alias);
         }
+    }
+
+    public void setAuthorAliases(Author author, String alias) {
+        authorAliasMap.put(alias, author);
     }
 
     public String getDisplayName() {

--- a/src/main/java/reposense/model/RepoConfiguration.java
+++ b/src/main/java/reposense/model/RepoConfiguration.java
@@ -102,8 +102,8 @@ public class RepoConfiguration {
         for (StandaloneAuthor sa : standaloneConfig.getAuthors()) {
             Author author = new Author(sa.getGithubId());
             String displayName = !sa.getDisplayName().isEmpty() ? sa.getDisplayName() : sa.getGithubId();
-            List<String> authorIgnoreGlobList =
-                    !sa.getIgnoreGlobList().isEmpty() ? sa.getIgnoreGlobList() : ignoreGlobList;
+            List<String> authorIgnoreGlobList = new ArrayList<>(ignoreGlobList);
+            authorIgnoreGlobList.addAll(sa.getIgnoreGlobList());
 
             authorList.add(author);
             author.setAuthorAliases(sa.getAuthorNames());

--- a/src/main/java/reposense/model/RepoConfiguration.java
+++ b/src/main/java/reposense/model/RepoConfiguration.java
@@ -109,7 +109,7 @@ public class RepoConfiguration {
             author.setAuthorAliases(sa.getAuthorNames());
             author.setIgnoreGlobList(authorIgnoreGlobList);
 
-            this.addAuthorDisplayName(author, displayName);
+            this.setAuthorDisplayName(author, displayName);
             this.addAuthorAliases(author, Arrays.asList(sa.getGithubId()));
             this.addAuthorAliases(author, sa.getAuthorNames());
         }
@@ -235,7 +235,7 @@ public class RepoConfiguration {
         this.formats = formats;
     }
 
-    public void addAuthorDisplayName(Author author, String displayName) {
+    public void setAuthorDisplayName(Author author, String displayName) {
         authorDisplayNameMap.put(author, displayName);
     }
 

--- a/src/main/java/reposense/model/RepoConfiguration.java
+++ b/src/main/java/reposense/model/RepoConfiguration.java
@@ -97,18 +97,21 @@ public class RepoConfiguration {
         authorList.clear();
         authorAliasMap.clear();
         authorDisplayNameMap.clear();
+        ignoreGlobList = standaloneConfig.getIgnoreGlobList();
 
         for (StandaloneAuthor sa : standaloneConfig.getAuthors()) {
             Author author = new Author(sa.getGithubId());
             String displayName = !sa.getDisplayName().isEmpty() ? sa.getDisplayName() : sa.getGithubId();
+            List<String> authorIgnoreGlobList =
+                    !sa.getIgnoreGlobList().isEmpty() ? sa.getIgnoreGlobList() : ignoreGlobList;
 
             authorList.add(author);
             author.setAuthorAliases(Arrays.asList(sa.getAuthorNames()));
-            author.setIgnoreGlobList(Arrays.asList(sa.getIgnoreGlobList()));
+            author.setIgnoreGlobList(authorIgnoreGlobList);
 
-            setAuthorDisplayName(author, displayName);
-            setAuthorAliases(author, sa.getGithubId());
-            setAuthorAliases(author, sa.getAuthorNames());
+            this.setAuthorDisplayName(author, displayName);
+            this.setAuthorAliases(author, sa.getGithubId());
+            this.setAuthorAliases(author, sa.getAuthorNames());
         }
     }
 

--- a/src/main/java/reposense/model/RepoConfiguration.java
+++ b/src/main/java/reposense/model/RepoConfiguration.java
@@ -8,6 +8,7 @@ import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
@@ -108,9 +109,9 @@ public class RepoConfiguration {
             author.setAuthorAliases(sa.getAuthorNames());
             author.setIgnoreGlobList(authorIgnoreGlobList);
 
-            this.setAuthorDisplayName(author, displayName);
-            this.setAuthorAliases(author, sa.getGithubId());
-            this.setAuthorAliases(author, sa.getAuthorNames());
+            this.addAuthorDisplayName(author, displayName);
+            this.addAuthorAliases(author, Arrays.asList(sa.getGithubId()));
+            this.addAuthorAliases(author, sa.getAuthorNames());
         }
     }
 
@@ -199,7 +200,7 @@ public class RepoConfiguration {
         this.authorList = authorList;
 
         // Set GitHub Id as default alias
-        authorList.forEach(author -> setAuthorAliases(author, author.getGitId()));
+        authorList.forEach(author -> addAuthorAliases(author, Arrays.asList(author.getGitId())));
     }
 
     public TreeMap<String, Author> getAuthorAliasMap() {
@@ -234,18 +235,12 @@ public class RepoConfiguration {
         this.formats = formats;
     }
 
-    public void setAuthorDisplayName(Author author, String displayName) {
+    public void addAuthorDisplayName(Author author, String displayName) {
         authorDisplayNameMap.put(author, displayName);
     }
 
-    public void setAuthorAliases(Author author, List<String> aliases) {
-        for (String alias : aliases) {
-            setAuthorAliases(author, alias);
-        }
-    }
-
-    public void setAuthorAliases(Author author, String alias) {
-        authorAliasMap.put(alias, author);
+    public void addAuthorAliases(Author author, List<String> aliases) {
+        aliases.forEach(alias -> authorAliasMap.put(alias, author));
     }
 
     public String getDisplayName() {

--- a/src/main/java/reposense/model/StandaloneAuthor.java
+++ b/src/main/java/reposense/model/StandaloneAuthor.java
@@ -1,5 +1,8 @@
 package reposense.model;
 
+import java.util.Collections;
+import java.util.List;
+
 /**
  * Represents an author in {@code StandaloneConfig}.
  */
@@ -7,9 +10,9 @@ public class StandaloneAuthor {
     private String githubId;
     private String displayName;
     private String[] authorNames;
-    private String[] ignoreGlobList;
+    private List<String> ignoreGlobList;
 
-    public StandaloneAuthor(String githubId, String displayName, String[] authorNames, String[] ignoreGlobList) {
+    public StandaloneAuthor(String githubId, String displayName, String[] authorNames, List<String> ignoreGlobList) {
         this.githubId = githubId;
         this.displayName = displayName;
         this.authorNames = authorNames;
@@ -32,9 +35,9 @@ public class StandaloneAuthor {
         return authorNames;
     }
 
-    public String[] getIgnoreGlobList() {
+    public List<String> getIgnoreGlobList() {
         if (ignoreGlobList == null) {
-            return new String[]{};
+            return Collections.emptyList();
         }
 
         return ignoreGlobList;

--- a/src/main/java/reposense/model/StandaloneAuthor.java
+++ b/src/main/java/reposense/model/StandaloneAuthor.java
@@ -12,14 +12,6 @@ public class StandaloneAuthor {
     private List<String>  authorNames;
     private List<String> ignoreGlobList;
 
-    public StandaloneAuthor(
-            String githubId, String displayName, List<String> authorNames, List<String> ignoreGlobList) {
-        this.githubId = githubId;
-        this.displayName = displayName;
-        this.authorNames = authorNames;
-        this.ignoreGlobList = ignoreGlobList;
-    }
-
     public String getGithubId() {
         return githubId;
     }

--- a/src/main/java/reposense/model/StandaloneAuthor.java
+++ b/src/main/java/reposense/model/StandaloneAuthor.java
@@ -9,10 +9,11 @@ import java.util.List;
 public class StandaloneAuthor {
     private String githubId;
     private String displayName;
-    private String[] authorNames;
+    private List<String>  authorNames;
     private List<String> ignoreGlobList;
 
-    public StandaloneAuthor(String githubId, String displayName, String[] authorNames, List<String> ignoreGlobList) {
+    public StandaloneAuthor(
+            String githubId, String displayName, List<String> authorNames, List<String> ignoreGlobList) {
         this.githubId = githubId;
         this.displayName = displayName;
         this.authorNames = authorNames;
@@ -27,9 +28,9 @@ public class StandaloneAuthor {
         return displayName;
     }
 
-    public String[] getAuthorNames() {
+    public List<String> getAuthorNames() {
         if (authorNames == null) {
-            return new String[]{};
+            return Collections.emptyList();
         }
 
         return authorNames;

--- a/src/main/java/reposense/model/StandaloneConfig.java
+++ b/src/main/java/reposense/model/StandaloneConfig.java
@@ -1,5 +1,6 @@
 package reposense.model;
 
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -7,6 +8,7 @@ import java.util.List;
  */
 public class StandaloneConfig {
     private List<StandaloneAuthor> authors;
+    private List<String> ignoreGlobList;
 
     public StandaloneConfig(List<StandaloneAuthor> authors) {
         this.authors = authors;
@@ -14,5 +16,13 @@ public class StandaloneConfig {
 
     public List<StandaloneAuthor> getAuthors() {
         return authors;
+    }
+
+    public List<String> getIgnoreGlobList() {
+        if (ignoreGlobList == null) {
+            return Collections.emptyList();
+        }
+        
+        return ignoreGlobList;
     }
 }

--- a/src/main/java/reposense/model/StandaloneConfig.java
+++ b/src/main/java/reposense/model/StandaloneConfig.java
@@ -10,10 +10,6 @@ public class StandaloneConfig {
     private List<StandaloneAuthor> authors;
     private List<String> ignoreGlobList;
 
-    public StandaloneConfig(List<StandaloneAuthor> authors) {
-        this.authors = authors;
-    }
-
     public List<StandaloneAuthor> getAuthors() {
         return authors;
     }

--- a/src/main/java/reposense/model/StandaloneConfig.java
+++ b/src/main/java/reposense/model/StandaloneConfig.java
@@ -22,7 +22,7 @@ public class StandaloneConfig {
         if (ignoreGlobList == null) {
             return Collections.emptyList();
         }
-        
+
         return ignoreGlobList;
     }
 }

--- a/src/main/java/reposense/parser/CsvParser.java
+++ b/src/main/java/reposense/parser/CsvParser.java
@@ -113,7 +113,7 @@ public class CsvParser {
         boolean isDisplayNameInElements = elements.length > DISPLAY_NAME_POSITION
                 && !elements[DISPLAY_NAME_POSITION].isEmpty();
 
-        config.addAuthorDisplayName(author,
+        config.setAuthorDisplayName(author,
                 isDisplayNameInElements ? elements[DISPLAY_NAME_POSITION] : author.getGitId());
     }
 

--- a/src/main/java/reposense/parser/CsvParser.java
+++ b/src/main/java/reposense/parser/CsvParser.java
@@ -113,7 +113,7 @@ public class CsvParser {
         boolean isDisplayNameInElements = elements.length > DISPLAY_NAME_POSITION
                 && !elements[DISPLAY_NAME_POSITION].isEmpty();
 
-        config.setAuthorDisplayName(author,
+        config.addAuthorDisplayName(author,
                 isDisplayNameInElements ? elements[DISPLAY_NAME_POSITION] : author.getGitId());
     }
 
@@ -127,7 +127,7 @@ public class CsvParser {
 
         if (areAliasesInElements) {
             List<String> aliases = Arrays.asList(elements[ALIAS_POSITION].split(AUTHOR_ALIAS_AND_GLOB_SEPARATOR));
-            config.setAuthorAliases(author, aliases);
+            config.addAuthorAliases(author, aliases);
             author.setAuthorAliases(aliases);
         }
     }

--- a/src/main/java/reposense/parser/CsvParser.java
+++ b/src/main/java/reposense/parser/CsvParser.java
@@ -126,9 +126,9 @@ public class CsvParser {
                 && !elements[ALIAS_POSITION].isEmpty();
 
         if (areAliasesInElements) {
-            String[] aliases = elements[ALIAS_POSITION].split(AUTHOR_ALIAS_AND_GLOB_SEPARATOR);
+            List<String> aliases = Arrays.asList(elements[ALIAS_POSITION].split(AUTHOR_ALIAS_AND_GLOB_SEPARATOR));
             config.setAuthorAliases(author, aliases);
-            author.setAuthorAliases(Arrays.asList(aliases));
+            author.setAuthorAliases(aliases);
         }
     }
 

--- a/src/main/java/reposense/system/CommandRunner.java
+++ b/src/main/java/reposense/system/CommandRunner.java
@@ -8,6 +8,7 @@ import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.List;
+import java.util.function.Predicate;
 import java.util.regex.Pattern;
 
 import reposense.model.Author;
@@ -222,6 +223,7 @@ public class CommandRunner {
         StringBuilder gitExcludeGlobArgsBuilder = new StringBuilder();
         final String cmdFormat = " " + addQuote(":(exclude)%s");
         ignoreGlobList.stream()
+                .filter(item -> !item.isEmpty())
                 .map(ignoreGlob -> String.format(cmdFormat, ignoreGlob))
                 .forEach(gitExcludeGlobArgsBuilder::append);
 

--- a/src/main/java/reposense/system/CommandRunner.java
+++ b/src/main/java/reposense/system/CommandRunner.java
@@ -8,7 +8,6 @@ import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.List;
-import java.util.function.Predicate;
 import java.util.regex.Pattern;
 
 import reposense.model.Author;

--- a/src/test/java/reposense/parser/RepoConfigurationTest.java
+++ b/src/test/java/reposense/parser/RepoConfigurationTest.java
@@ -2,7 +2,6 @@ package reposense.parser;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 
 import org.junit.Assert;
@@ -49,10 +48,10 @@ public class RepoConfigurationTest {
         expectedConfig.addAuthorAliases(SECOND_AUTHOR, SECOND_AUTHOR_ALIASES);
         expectedConfig.addAuthorAliases(THIRD_AUTHOR, THIRD_AUTHOR_ALIASES);
         expectedConfig.addAuthorAliases(FOURTH_AUTHOR, FOURTH_AUTHOR_ALIASES);
-        expectedConfig.addAuthorDisplayName(FIRST_AUTHOR, "Ahm");
-        expectedConfig.addAuthorDisplayName(SECOND_AUTHOR, "Cod");
-        expectedConfig.addAuthorDisplayName(THIRD_AUTHOR, "Jor");
-        expectedConfig.addAuthorDisplayName(FOURTH_AUTHOR, "Loh");
+        expectedConfig.setAuthorDisplayName(FIRST_AUTHOR, "Ahm");
+        expectedConfig.setAuthorDisplayName(SECOND_AUTHOR, "Cod");
+        expectedConfig.setAuthorDisplayName(THIRD_AUTHOR, "Jor");
+        expectedConfig.setAuthorDisplayName(FOURTH_AUTHOR, "Loh");
 
         expectedConfig.setIgnoreGlobList(REPO_LEVEL_GLOB_LIST);
 

--- a/src/test/java/reposense/parser/RepoConfigurationTest.java
+++ b/src/test/java/reposense/parser/RepoConfigurationTest.java
@@ -28,17 +28,16 @@ public class RepoConfigurationTest {
     private static final List<String> FOURTH_AUTHOR_ALIASES = Arrays.asList("Tianwei");
 
     private static final List<String> REPO_LEVEL_GLOB_LIST = Arrays.asList("*.pyc");
-    private static final List<String> FIRST_AUTHOR_GLOB_LIST = Arrays.asList("*.aa1", "**.aa2");
-    private static final List<String> SECOND_AUTHOR_GLOB_LIST = Collections.emptyList();
+    private static final List<String> FIRST_AUTHOR_GLOB_LIST = Arrays.asList("*.pyc, *.aa1", "**.aa2");
 
     @Test
     public void configJson_overridesRepoConfig_success() throws InvalidLocationException, GitDownloaderException {
         FIRST_AUTHOR.setIgnoreGlobList(FIRST_AUTHOR_GLOB_LIST);
-        SECOND_AUTHOR.setIgnoreGlobList(SECOND_AUTHOR_GLOB_LIST);
+        SECOND_AUTHOR.setIgnoreGlobList(REPO_LEVEL_GLOB_LIST);
         THIRD_AUTHOR.setIgnoreGlobList(REPO_LEVEL_GLOB_LIST);
         FOURTH_AUTHOR.setIgnoreGlobList(REPO_LEVEL_GLOB_LIST);
 
-        List<Author> expectedAuthors = new ArrayList<Author>();
+        List<Author> expectedAuthors = new ArrayList<>();
         expectedAuthors.add(FIRST_AUTHOR);
         expectedAuthors.add(SECOND_AUTHOR);
         expectedAuthors.add(THIRD_AUTHOR);
@@ -54,10 +53,6 @@ public class RepoConfigurationTest {
         expectedConfig.addAuthorDisplayName(SECOND_AUTHOR, "Cod");
         expectedConfig.addAuthorDisplayName(THIRD_AUTHOR, "Jor");
         expectedConfig.addAuthorDisplayName(FOURTH_AUTHOR, "Loh");
-        expectedConfig.addAuthorAliases(FIRST_AUTHOR, Arrays.asList("Ahmad Syafiq"));
-        expectedConfig.addAuthorAliases(SECOND_AUTHOR, Arrays.asList("Codee"));
-        expectedConfig.addAuthorAliases(THIRD_AUTHOR, Arrays.asList("Jordan Chong"));
-        expectedConfig.addAuthorAliases(FOURTH_AUTHOR, Arrays.asList("Tianwei"));
 
         expectedConfig.setIgnoreGlobList(REPO_LEVEL_GLOB_LIST);
 

--- a/src/test/java/reposense/parser/RepoConfigurationTest.java
+++ b/src/test/java/reposense/parser/RepoConfigurationTest.java
@@ -26,13 +26,14 @@ public class RepoConfigurationTest {
     private static final List<String> THIRD_AUTHOR_ALIASES = Arrays.asList("Jordan Chong");
     private static final List<String> FOURTH_AUTHOR_ALIASES = Arrays.asList("Tianwei");
 
-    private static final List<String> REPO_LEVEL_GLOB_LIST = Arrays.asList("*.pyc");
-    private static final List<String> FIRST_AUTHOR_GLOB_LIST = Arrays.asList("*.pyc, *.aa1", "**.aa2");
+    private static final List<String> REPO_LEVEL_GLOB_LIST = Arrays.asList("collated**");
+    private static final List<String> FIRST_AUTHOR_GLOB_LIST = Arrays.asList("collated**", "*.aa1", "**.aa2");
+    private static final List<String> SECOND_AUTHOR_GLOB_LIST = Arrays.asList("collated**", "**[!(.md)]");
 
     @Test
     public void configJson_overridesRepoConfig_success() throws InvalidLocationException, GitDownloaderException {
         FIRST_AUTHOR.setIgnoreGlobList(FIRST_AUTHOR_GLOB_LIST);
-        SECOND_AUTHOR.setIgnoreGlobList(REPO_LEVEL_GLOB_LIST);
+        SECOND_AUTHOR.setIgnoreGlobList(SECOND_AUTHOR_GLOB_LIST);
         THIRD_AUTHOR.setIgnoreGlobList(REPO_LEVEL_GLOB_LIST);
         FOURTH_AUTHOR.setIgnoreGlobList(REPO_LEVEL_GLOB_LIST);
 

--- a/src/test/java/reposense/parser/RepoConfigurationTest.java
+++ b/src/test/java/reposense/parser/RepoConfigurationTest.java
@@ -2,6 +2,7 @@ package reposense.parser;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import org.junit.Assert;
@@ -27,8 +28,8 @@ public class RepoConfigurationTest {
     private static final List<String> FOURTH_AUTHOR_ALIASES = Arrays.asList("Tianwei");
 
     private static final List<String> REPO_LEVEL_GLOB_LIST = Arrays.asList("*.pyc");
-    private static final List<String> FIRST_AUTHOR_GLOB_LIST = Arrays.asList("*.aa1", "*.aa2");
-    private static final List<String> SECOND_AUTHOR_GLOB_LIST = Arrays.asList("");
+    private static final List<String> FIRST_AUTHOR_GLOB_LIST = Arrays.asList("*.aa1", "**.aa2");
+    private static final List<String> SECOND_AUTHOR_GLOB_LIST = Collections.emptyList();
 
     @Test
     public void configJson_overridesRepoConfig_success() throws InvalidLocationException, GitDownloaderException {

--- a/src/test/java/reposense/parser/RepoConfigurationTest.java
+++ b/src/test/java/reposense/parser/RepoConfigurationTest.java
@@ -1,7 +1,7 @@
 package reposense.parser;
 
-import java.io.FileNotFoundException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import org.junit.Assert;
@@ -26,11 +26,18 @@ public class RepoConfigurationTest {
     private static final String[] THIRD_AUTHOR_ALIASES = {"Jordan Chong"};
     private static final String[] FOURTH_AUTHOR_ALIASES = {"Tianwei"};
 
+    private static final List<String> REPO_LEVEL_GLOB_LIST = Arrays.asList("*.pyc");
+    private static final List<String> FIRST_AUTHOR_GLOB_LIST = Arrays.asList("*.aa1", "*.aa2");
+    private static final List<String> SECOND_AUTHOR_GLOB_LIST = Arrays.asList("");
 
     @Test
-    public void configJson_overridesRepoConfig_success()
-            throws InvalidLocationException, FileNotFoundException, GitDownloaderException {
+    public void configJson_overridesRepoConfig_success() throws InvalidLocationException, GitDownloaderException {
         RepoConfiguration expectedConfig = new RepoConfiguration(TEST_REPO_DELTA, "master");
+
+        FIRST_AUTHOR.setIgnoreGlobList(FIRST_AUTHOR_GLOB_LIST);
+        SECOND_AUTHOR.setIgnoreGlobList(SECOND_AUTHOR_GLOB_LIST);
+        THIRD_AUTHOR.setIgnoreGlobList(REPO_LEVEL_GLOB_LIST);
+        FOURTH_AUTHOR.setIgnoreGlobList(REPO_LEVEL_GLOB_LIST);
 
         List<Author> authors = new ArrayList<Author>();
         authors.add(FIRST_AUTHOR);
@@ -50,10 +57,7 @@ public class RepoConfigurationTest {
         expectedConfig.setAuthorDisplayName(THIRD_AUTHOR, "Jor");
         expectedConfig.setAuthorDisplayName(FOURTH_AUTHOR, "Loh");
 
-        expectedConfig.setAuthorAliases(FIRST_AUTHOR, "Ahmad Syafiq");
-        expectedConfig.setAuthorAliases(SECOND_AUTHOR, "Codee");
-        expectedConfig.setAuthorAliases(THIRD_AUTHOR, "Jordan Chong");
-        expectedConfig.setAuthorAliases(FOURTH_AUTHOR, "Tianwei");
+        expectedConfig.setIgnoreGlobList(REPO_LEVEL_GLOB_LIST);
 
         RepoConfiguration actualConfig = new RepoConfiguration(TEST_REPO_DELTA, "master");
         GitDownloader.downloadRepo(actualConfig);
@@ -65,5 +69,10 @@ public class RepoConfigurationTest {
         Assert.assertEquals(
                 expectedConfig.getAuthorDisplayNameMap().hashCode(), actualConfig.getAuthorDisplayNameMap().hashCode());
         Assert.assertEquals(expectedConfig.getAuthorAliasMap().hashCode(), actualConfig.getAuthorAliasMap().hashCode());
+
+        Assert.assertEquals(REPO_LEVEL_GLOB_LIST, actualConfig.getIgnoreGlobList());
     }
+
+
+
 }

--- a/src/test/java/reposense/parser/RepoConfigurationTest.java
+++ b/src/test/java/reposense/parser/RepoConfigurationTest.java
@@ -27,7 +27,8 @@ public class RepoConfigurationTest {
     private static final List<String> FOURTH_AUTHOR_ALIASES = Arrays.asList("Tianwei");
 
     private static final List<String> REPO_LEVEL_GLOB_LIST = Arrays.asList("collated**");
-    private static final List<String> FIRST_AUTHOR_GLOB_LIST = Arrays.asList("collated**", "*.aa1", "**.aa2", "**.java");
+    private static final List<String> FIRST_AUTHOR_GLOB_LIST =
+            Arrays.asList("collated**", "*.aa1", "**.aa2", "**.java");
     private static final List<String> SECOND_AUTHOR_GLOB_LIST = Arrays.asList("collated**", "**[!(.md)]");
 
     @Test

--- a/src/test/java/reposense/parser/RepoConfigurationTest.java
+++ b/src/test/java/reposense/parser/RepoConfigurationTest.java
@@ -33,36 +33,36 @@ public class RepoConfigurationTest {
 
     @Test
     public void configJson_overridesRepoConfig_success() throws InvalidLocationException, GitDownloaderException {
-        RepoConfiguration expectedConfig = new RepoConfiguration(TEST_REPO_DELTA, "master");
-
         FIRST_AUTHOR.setIgnoreGlobList(FIRST_AUTHOR_GLOB_LIST);
         SECOND_AUTHOR.setIgnoreGlobList(SECOND_AUTHOR_GLOB_LIST);
         THIRD_AUTHOR.setIgnoreGlobList(REPO_LEVEL_GLOB_LIST);
         FOURTH_AUTHOR.setIgnoreGlobList(REPO_LEVEL_GLOB_LIST);
 
-        List<Author> authors = new ArrayList<Author>();
-        authors.add(FIRST_AUTHOR);
-        authors.add(SECOND_AUTHOR);
-        authors.add(THIRD_AUTHOR);
-        authors.add(FOURTH_AUTHOR);
+        List<Author> expectedAuthors = new ArrayList<Author>();
+        expectedAuthors.add(FIRST_AUTHOR);
+        expectedAuthors.add(SECOND_AUTHOR);
+        expectedAuthors.add(THIRD_AUTHOR);
+        expectedAuthors.add(FOURTH_AUTHOR);
 
-        expectedConfig.setAuthorList(authors);
-
-        expectedConfig.setAuthorAliases(FIRST_AUTHOR, FIRST_AUTHOR_ALIASES);
-        expectedConfig.setAuthorAliases(SECOND_AUTHOR, SECOND_AUTHOR_ALIASES);
-        expectedConfig.setAuthorAliases(THIRD_AUTHOR, THIRD_AUTHOR_ALIASES);
-        expectedConfig.setAuthorAliases(FOURTH_AUTHOR, FOURTH_AUTHOR_ALIASES);
-
-        expectedConfig.setAuthorDisplayName(FIRST_AUTHOR, "Ahm");
-        expectedConfig.setAuthorDisplayName(SECOND_AUTHOR, "Cod");
-        expectedConfig.setAuthorDisplayName(THIRD_AUTHOR, "Jor");
-        expectedConfig.setAuthorDisplayName(FOURTH_AUTHOR, "Loh");
+        RepoConfiguration expectedConfig = new RepoConfiguration(TEST_REPO_DELTA, "master");
+        expectedConfig.setAuthorList(expectedAuthors);
+        expectedConfig.addAuthorAliases(FIRST_AUTHOR, FIRST_AUTHOR_ALIASES);
+        expectedConfig.addAuthorAliases(SECOND_AUTHOR, SECOND_AUTHOR_ALIASES);
+        expectedConfig.addAuthorAliases(THIRD_AUTHOR, THIRD_AUTHOR_ALIASES);
+        expectedConfig.addAuthorAliases(FOURTH_AUTHOR, FOURTH_AUTHOR_ALIASES);
+        expectedConfig.addAuthorDisplayName(FIRST_AUTHOR, "Ahm");
+        expectedConfig.addAuthorDisplayName(SECOND_AUTHOR, "Cod");
+        expectedConfig.addAuthorDisplayName(THIRD_AUTHOR, "Jor");
+        expectedConfig.addAuthorDisplayName(FOURTH_AUTHOR, "Loh");
+        expectedConfig.addAuthorAliases(FIRST_AUTHOR, Arrays.asList("Ahmad Syafiq"));
+        expectedConfig.addAuthorAliases(SECOND_AUTHOR, Arrays.asList("Codee"));
+        expectedConfig.addAuthorAliases(THIRD_AUTHOR, Arrays.asList("Jordan Chong"));
+        expectedConfig.addAuthorAliases(FOURTH_AUTHOR, Arrays.asList("Tianwei"));
 
         expectedConfig.setIgnoreGlobList(REPO_LEVEL_GLOB_LIST);
 
         RepoConfiguration actualConfig = new RepoConfiguration(TEST_REPO_DELTA, "master");
         GitDownloader.downloadRepo(actualConfig);
-
         ReportGenerator.updateRepoConfig(actualConfig);
 
         Assert.assertEquals(expectedConfig.getLocation(), actualConfig.getLocation());
@@ -70,7 +70,6 @@ public class RepoConfigurationTest {
         Assert.assertEquals(
                 expectedConfig.getAuthorDisplayNameMap().hashCode(), actualConfig.getAuthorDisplayNameMap().hashCode());
         Assert.assertEquals(expectedConfig.getAuthorAliasMap().hashCode(), actualConfig.getAuthorAliasMap().hashCode());
-
         Assert.assertEquals(REPO_LEVEL_GLOB_LIST, actualConfig.getIgnoreGlobList());
     }
 }

--- a/src/test/java/reposense/parser/RepoConfigurationTest.java
+++ b/src/test/java/reposense/parser/RepoConfigurationTest.java
@@ -27,7 +27,7 @@ public class RepoConfigurationTest {
     private static final List<String> FOURTH_AUTHOR_ALIASES = Arrays.asList("Tianwei");
 
     private static final List<String> REPO_LEVEL_GLOB_LIST = Arrays.asList("collated**");
-    private static final List<String> FIRST_AUTHOR_GLOB_LIST = Arrays.asList("collated**", "*.aa1", "**.aa2");
+    private static final List<String> FIRST_AUTHOR_GLOB_LIST = Arrays.asList("collated**", "*.aa1", "**.aa2", "**.java");
     private static final List<String> SECOND_AUTHOR_GLOB_LIST = Arrays.asList("collated**", "**[!(.md)]");
 
     @Test

--- a/src/test/java/reposense/parser/RepoConfigurationTest.java
+++ b/src/test/java/reposense/parser/RepoConfigurationTest.java
@@ -21,10 +21,10 @@ public class RepoConfigurationTest {
     private static final Author THIRD_AUTHOR = new Author("jordancjq");
     private static final Author FOURTH_AUTHOR = new Author("lohtianwei");
 
-    private static final String[] FIRST_AUTHOR_ALIASES = {"Ahmad Syafiq"};
-    private static final String[] SECOND_AUTHOR_ALIASES = {"Codee"};
-    private static final String[] THIRD_AUTHOR_ALIASES = {"Jordan Chong"};
-    private static final String[] FOURTH_AUTHOR_ALIASES = {"Tianwei"};
+    private static final List<String> FIRST_AUTHOR_ALIASES = Arrays.asList("Ahmad Syafiq");
+    private static final List<String> SECOND_AUTHOR_ALIASES = Arrays.asList("Codee");
+    private static final List<String> THIRD_AUTHOR_ALIASES = Arrays.asList("Jordan Chong");
+    private static final List<String> FOURTH_AUTHOR_ALIASES = Arrays.asList("Tianwei");
 
     private static final List<String> REPO_LEVEL_GLOB_LIST = Arrays.asList("*.pyc");
     private static final List<String> FIRST_AUTHOR_GLOB_LIST = Arrays.asList("*.aa1", "*.aa2");
@@ -72,7 +72,4 @@ public class RepoConfigurationTest {
 
         Assert.assertEquals(REPO_LEVEL_GLOB_LIST, actualConfig.getIgnoreGlobList());
     }
-
-
-
 }


### PR DESCRIPTION
Fixes #244

```
Following #218, file exclusion glob patterns can be supplied in the
csv config file.

Let's decentralized this setting to the _reposense/config.json so
repository owners can apply it to their repositories.
```