### PR TITLE
 Some browsers show extra element #209

### DIFF
--- a/frontend/src/static/css/style.scss
+++ b/frontend/src/static/css/style.scss
@@ -150,6 +150,10 @@ header{
     &__date:first-child{
         margin-right:0.5rem;
     }
+
+    label{
+        overflow-y:hidden;
+    }
 }
 
 .summary-charts{


### PR DESCRIPTION
fixes #209 

```In some browsers (chrome, edge), the height of the content in the
"label" tag seems to be greater than the height allocated to it by the
render engine. This results in the "scrollbar" arrows popping up to
show the users the "full content".

This can be distracting for users when they are trying to navigate the
site. Let's remove this scrollbar arrows by applying the "overflow-y:
hidden" CSS setting to the filter labels.
```