### PR TITLE
Dashboard does not work with microsoft edge #239

### DIFF
--- a/frontend/src/static/js/main.js
+++ b/frontend/src/static/js/main.js
@@ -78,7 +78,7 @@ window.app = new window.Vue({
 
     updateTabAuthorship(obj) {
       this.deactivateTabs();
-      this.tabInfo.tabAuthorship = { ...obj };
+      this.tabInfo.tabAuthorship = Object.assign({}, obj);
 
       this.isTabActive = true;
       this.isTabAuthorship = true;


### PR DESCRIPTION
fixes #239 

```
Microsoft Edges does not support the full set of features available in
the ES6 specification, amongst which, includes the object spread
operator. [1]

Let's remove the usage of the object spread operator so allow the
dashboard to be run from edge browser.

[1] Discussion on Edge's support for object spread operator
https://github.com/Polymer/tools/issues/173
```
