### PR TITLE
Dashboard unable to load authorship.json file #254

### DIFF
--- a/frontend/src/static/js/v_authorship.js
+++ b/frontend/src/static/js/v_authorship.js
@@ -27,7 +27,7 @@ window.vAuthorship = {
       if (repo.files) {
         this.processFiles(repo.files);
       } else {
-        window.api.loadAuthorship(this.repo)
+        window.api.loadAuthorship(this.info.repo)
           .then(files => this.processFiles(files));
       }
     },


### PR DESCRIPTION
fixes #254 

```
When trying to open up the right side tab panel to load the authorship
information, the file not found error pops up, and the panel stays
blank.

Turns out, the error was introduced when we were trying to package all
the information into a single object when passing it into the module.
To fix this, let's update the way the directory whereby the file is
being loaded.
```