### PR TITLE
 Large ramp blocks interaction of ramps under it #189

### DIFF
--- a/frontend/src/index.jade
+++ b/frontend/src/index.jade
@@ -92,6 +92,7 @@ html
                   v-bind:href="getSliceLink(user, slice)", target="_blank",
                   v-bind:class="'summary-chart__ramp__slice--color'+j%5",
                   v-bind:style="{\
+                    zIndex: user.commits.length - j,\
                     borderLeftWidth: getWidth(slice) + 'em',\
                     right: (((user.commits.length-j-1)/user.commits.length) * 100) + '%'\
                   }"


### PR DESCRIPTION
fixes #189 

```
Ramps representing very huge commits will be rendered as a very
humongous triangle. This display blocks up the commits in the earlier
periods, hence causing them to be unclickable.

To fix this, let's render the ramps such that the earlier ramps will
have a larger z-index value to place it on top of the more recent
ramps. This ensures that users will be able to interact with all the
ramps.
```