### PR TITLE
Ignore glob list does not propagate to code view #262

### DIFF
--- a/src/functional/resources/noDateRange/expected/reposense_testrepo-Delta_master/authorship.json
+++ b/src/functional/resources/noDateRange/expected/reposense_testrepo-Delta_master/authorship.json
@@ -25600,1012 +25600,6 @@
     }
   },
   {
-    "path": "src/main/java/seedu/address/commons/events/ui/ChangeTagColourEvent.java",
-    "lines": [
-      {
-        "lineNumber": 1,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "package seedu.address.commons.events.ui;"
-      },
-      {
-        "lineNumber": 2,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 3,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.commons.events.BaseEvent;"
-      },
-      {
-        "lineNumber": 4,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 5,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "/**"
-      },
-      {
-        "lineNumber": 6,
-        "author": {
-          "gitId": "-"
-        },
-        "content": " * Indicates a request to change tag colour"
-      },
-      {
-        "lineNumber": 7,
-        "author": {
-          "gitId": "-"
-        },
-        "content": " */"
-      },
-      {
-        "lineNumber": 8,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "/** @@author Codee */"
-      },
-      {
-        "lineNumber": 9,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "public class ChangeTagColourEvent extends BaseEvent {"
-      },
-      {
-        "lineNumber": 10,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 11,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    public final String tagColour;"
-      },
-      {
-        "lineNumber": 12,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    public final String tagName;"
-      },
-      {
-        "lineNumber": 13,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 14,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    public ChangeTagColourEvent(String tagName, String tagColour) {"
-      },
-      {
-        "lineNumber": 15,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        this.tagName \u003d tagName;"
-      },
-      {
-        "lineNumber": 16,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        this.tagColour \u003d tagColour;"
-      },
-      {
-        "lineNumber": 17,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 18,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 19,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    @Override"
-      },
-      {
-        "lineNumber": 20,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    public String toString() {"
-      },
-      {
-        "lineNumber": 21,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        return this.getClass().getSimpleName();"
-      },
-      {
-        "lineNumber": 22,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 23,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "}"
-      }
-    ],
-    "authorContributionMap": {
-      "codeeong": 16,
-      "-": 7
-    }
-  },
-  {
-    "path": "src/main/java/seedu/address/commons/events/ui/ChangeThemeEvent.java",
-    "lines": [
-      {
-        "lineNumber": 1,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "package seedu.address.commons.events.ui;"
-      },
-      {
-        "lineNumber": 2,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 3,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.commons.events.BaseEvent;"
-      },
-      {
-        "lineNumber": 4,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 5,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "/**@@author Codee */"
-      },
-      {
-        "lineNumber": 6,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "/**"
-      },
-      {
-        "lineNumber": 7,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": " * Indicates a request for theme change."
-      },
-      {
-        "lineNumber": 8,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": " */"
-      },
-      {
-        "lineNumber": 9,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "public class ChangeThemeEvent extends BaseEvent {"
-      },
-      {
-        "lineNumber": 10,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 11,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    public final String theme;"
-      },
-      {
-        "lineNumber": 12,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 13,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    public ChangeThemeEvent(String theme) {"
-      },
-      {
-        "lineNumber": 14,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        this.theme \u003d theme;"
-      },
-      {
-        "lineNumber": 15,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 16,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 17,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    @Override"
-      },
-      {
-        "lineNumber": 18,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    public String toString() {"
-      },
-      {
-        "lineNumber": 19,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        return this.getClass().toString();"
-      },
-      {
-        "lineNumber": 20,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 21,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "}"
-      }
-    ],
-    "authorContributionMap": {
-      "codeeong": 17,
-      "-": 4
-    }
-  },
-  {
-    "path": "src/main/java/seedu/address/commons/events/ui/ClearTeamsEvent.java",
-    "lines": [
-      {
-        "lineNumber": 1,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "package seedu.address.commons.events.ui;"
-      },
-      {
-        "lineNumber": 2,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 3,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.commons.events.BaseEvent;"
-      },
-      {
-        "lineNumber": 4,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 5,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "/**"
-      },
-      {
-        "lineNumber": 6,
-        "author": {
-          "gitId": "-"
-        },
-        "content": " * Event handler for clearing of all teams."
-      },
-      {
-        "lineNumber": 7,
-        "author": {
-          "gitId": "-"
-        },
-        "content": " */"
-      },
-      {
-        "lineNumber": 8,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "// @@author Codee"
-      },
-      {
-        "lineNumber": 9,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "public class ClearTeamsEvent extends BaseEvent {"
-      },
-      {
-        "lineNumber": 10,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 11,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    public ClearTeamsEvent() {"
-      },
-      {
-        "lineNumber": 12,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 13,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 14,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    @Override"
-      },
-      {
-        "lineNumber": 15,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    public String toString() {"
-      },
-      {
-        "lineNumber": 16,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        return this.getClass().getSimpleName();"
-      },
-      {
-        "lineNumber": 17,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 18,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 19,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "}"
-      },
-      {
-        "lineNumber": 20,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ""
-      }
-    ],
-    "authorContributionMap": {
-      "codeeong": 13,
-      "-": 7
-    }
-  },
-  {
-    "path": "src/main/java/seedu/address/commons/events/ui/HighlightSelectedTeamEvent.java",
-    "lines": [
-      {
-        "lineNumber": 1,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "package seedu.address.commons.events.ui;"
-      },
-      {
-        "lineNumber": 2,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 3,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.commons.events.BaseEvent;"
-      },
-      {
-        "lineNumber": 4,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 5,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "/**"
-      },
-      {
-        "lineNumber": 6,
-        "author": {
-          "gitId": "-"
-        },
-        "content": " * Indicates a request to highlight selected team name."
-      },
-      {
-        "lineNumber": 7,
-        "author": {
-          "gitId": "-"
-        },
-        "content": " */"
-      },
-      {
-        "lineNumber": 8,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "/** @@author Codee */"
-      },
-      {
-        "lineNumber": 9,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "public class HighlightSelectedTeamEvent extends BaseEvent {"
-      },
-      {
-        "lineNumber": 10,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 11,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    public final String teamName;"
-      },
-      {
-        "lineNumber": 12,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 13,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    public HighlightSelectedTeamEvent(String teamName) {"
-      },
-      {
-        "lineNumber": 14,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        this.teamName \u003d teamName;"
-      },
-      {
-        "lineNumber": 15,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 16,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 17,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    @Override"
-      },
-      {
-        "lineNumber": 18,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    public String toString() {"
-      },
-      {
-        "lineNumber": 19,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        return this.getClass().getSimpleName();"
-      },
-      {
-        "lineNumber": 20,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 21,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "}"
-      }
-    ],
-    "authorContributionMap": {
-      "codeeong": 14,
-      "-": 7
-    }
-  },
-  {
-    "path": "src/main/java/seedu/address/commons/events/ui/PersonDetailsChangedEvent.java",
-    "lines": [
-      {
-        "lineNumber": 1,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "package seedu.address.commons.events.ui;"
-      },
-      {
-        "lineNumber": 2,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 3,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.commons.core.index.Index;"
-      },
-      {
-        "lineNumber": 4,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.commons.events.BaseEvent;"
-      },
-      {
-        "lineNumber": 5,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.model.person.Person;"
-      },
-      {
-        "lineNumber": 6,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 7,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "/**"
-      },
-      {
-        "lineNumber": 8,
-        "author": {
-          "gitId": "-"
-        },
-        "content": " * Represents a change in the person details panel."
-      },
-      {
-        "lineNumber": 9,
-        "author": {
-          "gitId": "-"
-        },
-        "content": " *"
-      },
-      {
-        "lineNumber": 10,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": " /** @@author Codee */"
-      },
-      {
-        "lineNumber": 11,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "public class PersonDetailsChangedEvent extends BaseEvent {"
-      },
-      {
-        "lineNumber": 12,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 13,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    private final Person editedPerson;"
-      },
-      {
-        "lineNumber": 14,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    private final Index index;"
-      },
-      {
-        "lineNumber": 15,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 16,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    public PersonDetailsChangedEvent(Person editedPerson, Index index) {"
-      },
-      {
-        "lineNumber": 17,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 18,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        this.editedPerson \u003d editedPerson;"
-      },
-      {
-        "lineNumber": 19,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        this.index \u003d index;"
-      },
-      {
-        "lineNumber": 20,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 21,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 22,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    public Person getPerson() {"
-      },
-      {
-        "lineNumber": 23,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        return this.editedPerson;"
-      },
-      {
-        "lineNumber": 24,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 25,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 26,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    public Index getIndex() {"
-      },
-      {
-        "lineNumber": 27,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        return this.index;"
-      },
-      {
-        "lineNumber": 28,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 29,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 30,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    @Override"
-      },
-      {
-        "lineNumber": 31,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    public String toString() {"
-      },
-      {
-        "lineNumber": 32,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        return this.getClass().getSimpleName();"
-      },
-      {
-        "lineNumber": 33,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 34,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "}"
-      }
-    ],
-    "authorContributionMap": {
-      "codeeong": 25,
-      "-": 9
-    }
-  },
-  {
-    "path": "src/main/java/seedu/address/commons/events/ui/PersonDetailsChangedNoParamEvent.java",
-    "lines": [
-      {
-        "lineNumber": 1,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "package seedu.address.commons.events.ui;"
-      },
-      {
-        "lineNumber": 2,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 3,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.commons.events.BaseEvent;"
-      },
-      {
-        "lineNumber": 4,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 5,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "/**"
-      },
-      {
-        "lineNumber": 6,
-        "author": {
-          "gitId": "-"
-        },
-        "content": " * Represents a change in the person details panel, but no paramaters."
-      },
-      {
-        "lineNumber": 7,
-        "author": {
-          "gitId": "-"
-        },
-        "content": " *"
-      },
-      {
-        "lineNumber": 8,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": " /** @@author Codee */"
-      },
-      {
-        "lineNumber": 9,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "public class PersonDetailsChangedNoParamEvent extends BaseEvent {"
-      },
-      {
-        "lineNumber": 10,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 11,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    public PersonDetailsChangedNoParamEvent() { }"
-      },
-      {
-        "lineNumber": 12,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 13,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    @Override"
-      },
-      {
-        "lineNumber": 14,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    public String toString() {"
-      },
-      {
-        "lineNumber": 15,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        return this.getClass().getSimpleName();"
-      },
-      {
-        "lineNumber": 16,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 17,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "}"
-      }
-    ],
-    "authorContributionMap": {
-      "codeeong": 10,
-      "-": 7
-    }
-  },
-  {
     "path": "src/main/java/seedu/address/commons/events/ui/RemoveSelectedTeamEvent.java",
     "lines": [
       {
@@ -26765,304 +25759,6 @@
     ],
     "authorContributionMap": {
       "jordancjq": 22
-    }
-  },
-  {
-    "path": "src/main/java/seedu/address/commons/events/ui/ShowNewTeamNameEvent.java",
-    "lines": [
-      {
-        "lineNumber": 1,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "package seedu.address.commons.events.ui;"
-      },
-      {
-        "lineNumber": 2,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 3,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.commons.events.BaseEvent;"
-      },
-      {
-        "lineNumber": 4,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 5,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "/**"
-      },
-      {
-        "lineNumber": 6,
-        "author": {
-          "gitId": "-"
-        },
-        "content": " * Indicates a request to show new team name."
-      },
-      {
-        "lineNumber": 7,
-        "author": {
-          "gitId": "-"
-        },
-        "content": " */"
-      },
-      {
-        "lineNumber": 8,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "/** @@author Codee */"
-      },
-      {
-        "lineNumber": 9,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "public class ShowNewTeamNameEvent extends BaseEvent {"
-      },
-      {
-        "lineNumber": 10,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 11,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    public final String teamName;"
-      },
-      {
-        "lineNumber": 12,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 13,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    public ShowNewTeamNameEvent(String teamName) {"
-      },
-      {
-        "lineNumber": 14,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        this.teamName \u003d teamName;"
-      },
-      {
-        "lineNumber": 15,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 16,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 17,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    @Override"
-      },
-      {
-        "lineNumber": 18,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    public String toString() {"
-      },
-      {
-        "lineNumber": 19,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        return this.getClass().getSimpleName();"
-      },
-      {
-        "lineNumber": 20,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 21,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 22,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "}"
-      }
-    ],
-    "authorContributionMap": {
-      "codeeong": 15,
-      "-": 7
-    }
-  },
-  {
-    "path": "src/main/java/seedu/address/commons/events/ui/UndoTeamsEvent.java",
-    "lines": [
-      {
-        "lineNumber": 1,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "package seedu.address.commons.events.ui;"
-      },
-      {
-        "lineNumber": 2,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 3,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.commons.events.BaseEvent;"
-      },
-      {
-        "lineNumber": 4,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 5,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "/**"
-      },
-      {
-        "lineNumber": 6,
-        "author": {
-          "gitId": "-"
-        },
-        "content": " * Event handler for undoing clearing of all teams."
-      },
-      {
-        "lineNumber": 7,
-        "author": {
-          "gitId": "-"
-        },
-        "content": " */"
-      },
-      {
-        "lineNumber": 8,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "// @@author Codee"
-      },
-      {
-        "lineNumber": 9,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "public class UndoTeamsEvent extends BaseEvent {"
-      },
-      {
-        "lineNumber": 10,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 11,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    public UndoTeamsEvent() {"
-      },
-      {
-        "lineNumber": 12,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 13,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 14,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    @Override"
-      },
-      {
-        "lineNumber": 15,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    public String toString() {"
-      },
-      {
-        "lineNumber": 16,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        return this.getClass().getSimpleName();"
-      },
-      {
-        "lineNumber": 17,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 18,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "}"
-      }
-    ],
-    "authorContributionMap": {
-      "codeeong": 11,
-      "-": 7
     }
   },
   {
@@ -27766,687 +26462,687 @@
       {
         "lineNumber": 28,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "//@@author lithiumlkid"
       },
       {
         "lineNumber": 29,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "/**"
       },
       {
         "lineNumber": 30,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": " * Adds a player to the address book."
       },
       {
         "lineNumber": 31,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": " */"
       },
       {
         "lineNumber": 32,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "public class AddCommand extends UndoableCommand {"
       },
       {
         "lineNumber": 33,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 34,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    public static final String COMMAND_WORD \u003d \"add\";"
       },
       {
         "lineNumber": 35,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "lohtianwei"
         },
         "content": "    public static final String COMMAND_ALIAS \u003d \"a\";"
       },
       {
         "lineNumber": 36,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 37,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    public static final String MESSAGE_USAGE \u003d COMMAND_WORD + \": Adds a player to the address book. \""
       },
       {
         "lineNumber": 38,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "            + \"Parameters: \""
       },
       {
         "lineNumber": 39,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "            + PREFIX_NAME + \"NAME \""
       },
       {
         "lineNumber": 40,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "            + PREFIX_EMAIL + \"EMAIL \""
       },
       {
         "lineNumber": 41,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "jordancjq"
         },
         "content": "            + \"[\" + PREFIX_TEAM_NAME + \"TEAMNAME] \""
       },
       {
         "lineNumber": 42,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "jordancjq"
         },
         "content": "            + \"[\" + PREFIX_PHONE + \"PHONE] \""
       },
       {
         "lineNumber": 43,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "jordancjq"
         },
         "content": "            + \"[\" + PREFIX_ADDRESS + \"ADDRESS] \""
       },
       {
         "lineNumber": 44,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "            + \"[\" + PREFIX_RATING + \"RATING] \""
       },
       {
         "lineNumber": 45,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "            + \"[\" + PREFIX_POSITION + \"POSITION] \""
       },
       {
         "lineNumber": 46,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "            + \"[\" + PREFIX_JERSEY_NUMBER + \"JERSEY_NUMBER] \""
       },
       {
         "lineNumber": 47,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "            + \"[\" + PREFIX_AVATAR + \"AVATAR] \""
       },
       {
         "lineNumber": 48,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "            + \"[\" + PREFIX_TAG + \"TAG]...\\n\""
       },
       {
         "lineNumber": 49,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "            + \"Example: \" + COMMAND_WORD + \" \""
       },
       {
         "lineNumber": 50,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "            + PREFIX_NAME + \"John Doe \""
       },
       {
         "lineNumber": 51,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "            + PREFIX_EMAIL + \"johnd@example.com \""
       },
       {
         "lineNumber": 52,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "jordancjq"
         },
         "content": "            + PREFIX_PHONE + \"98765432 \""
       },
       {
         "lineNumber": 53,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "            + PREFIX_ADDRESS + \"311, Clementi Ave 2, #02-25 \""
       },
       {
         "lineNumber": 54,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "            + PREFIX_RATING + \"0 \""
       },
       {
         "lineNumber": 55,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "            + PREFIX_POSITION + \"1 \""
       },
       {
         "lineNumber": 56,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "            + PREFIX_JERSEY_NUMBER + \"17 \""
       },
       {
         "lineNumber": 57,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "            + PREFIX_TAG + \"goodAttitude\";"
       },
       {
         "lineNumber": 58,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 59,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    public static final String MESSAGE_PARAMETERS \u003d PREFIX_NAME + \"NAME \""
       },
       {
         "lineNumber": 60,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "            + PREFIX_EMAIL + \"EMAIL \""
       },
       {
         "lineNumber": 61,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "            + \"[\" + PREFIX_PHONE + \"PHONE] \""
       },
       {
         "lineNumber": 62,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "            + \"[\" + PREFIX_ADDRESS + \"ADDRESS] \""
       },
       {
         "lineNumber": 63,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "            + \"[\" + PREFIX_RATING + \"RATING] \""
       },
       {
         "lineNumber": 64,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "            + \"[\" + PREFIX_POSITION + \"POSITION] \""
       },
       {
         "lineNumber": 65,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "            + \"[\" + PREFIX_JERSEY_NUMBER + \"JERSEY_NUMBER] \""
       },
       {
         "lineNumber": 66,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "            + \"[\" + PREFIX_AVATAR + \"AVATAR] \""
       },
       {
         "lineNumber": 67,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "            + \"[\" + PREFIX_TAG + \"TAG]\";"
       },
       {
         "lineNumber": 68,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 69,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    public static final String MESSAGE_SUCCESS \u003d \"New player added: %1$s\";"
       },
       {
         "lineNumber": 70,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    public static final String MESSAGE_DUPLICATE_PERSON \u003d \"This player already exists in the address book\";"
       },
       {
         "lineNumber": 71,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    public static final String MESSAGE_FILE_NOT_FOUND \u003d \"Avatar image file specified does not exist\";"
       },
       {
         "lineNumber": 72,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 73,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    private final Person toAdd;"
       },
       {
         "lineNumber": 74,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 75,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    /**"
       },
       {
         "lineNumber": 76,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "     * Creates an AddCommand to add the specified {@code Person}"
       },
       {
         "lineNumber": 77,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "     */"
       },
       {
         "lineNumber": 78,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    public AddCommand(Person person) {"
       },
       {
         "lineNumber": 79,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        requireNonNull(person);"
       },
       {
         "lineNumber": 80,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        toAdd \u003d person;"
       },
       {
         "lineNumber": 81,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    }"
       },
       {
         "lineNumber": 82,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 83,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    @Override"
       },
       {
         "lineNumber": 84,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    public CommandResult executeUndoableCommand() throws CommandException {"
       },
       {
         "lineNumber": 85,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        requireNonNull(model);"
       },
       {
         "lineNumber": 86,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        try {"
       },
       {
         "lineNumber": 87,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "            if (!toAdd.getAvatar().toString().equals(UNSPECIFIED_FIELD)) {"
       },
       {
         "lineNumber": 88,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "                toAdd.getAvatar().setFilePath(toAdd.getName().fullName);"
       },
       {
         "lineNumber": 89,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "            }"
       },
       {
         "lineNumber": 90,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "            model.addPerson(toAdd);"
       },
       {
         "lineNumber": 91,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "jordancjq"
         },
         "content": "            if (!toAdd.getTeamName().toString().equals(UNSPECIFIED_FIELD)) {"
       },
       {
         "lineNumber": 92,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "jordancjq"
         },
         "content": "                model.assignPersonToTeam(toAdd, toAdd.getTeamName());"
       },
       {
         "lineNumber": 93,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "jordancjq"
         },
         "content": "                model.updateFilteredPersonList(toAdd.getTeamName());"
       },
       {
         "lineNumber": 94,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "jordancjq"
         },
         "content": "                EventsCenter.getInstance().post(new HighlightSelectedTeamEvent(toAdd.getTeamName().toString()));"
       },
       {
         "lineNumber": 95,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "jordancjq"
         },
         "content": "            } else {"
       },
       {
         "lineNumber": 96,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "jordancjq"
         },
         "content": "                EventsCenter.getInstance().post(new DeselectTeamEvent());"
       },
       {
         "lineNumber": 97,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "jordancjq"
         },
         "content": "            }"
       },
       {
         "lineNumber": 98,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "            return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd));"
       },
       {
         "lineNumber": 99,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        } catch (DuplicatePersonException e) {"
       },
       {
         "lineNumber": 100,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "            throw new CommandException(MESSAGE_DUPLICATE_PERSON);"
       },
       {
         "lineNumber": 101,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        } catch (IOException e) {"
       },
       {
         "lineNumber": 102,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "            throw new CommandException(MESSAGE_FILE_NOT_FOUND);"
       },
       {
         "lineNumber": 103,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "jordancjq"
         },
         "content": "        } catch (TeamNotFoundException e) {"
       },
       {
         "lineNumber": 104,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "jordancjq"
         },
         "content": "            throw new CommandException(Messages.MESSAGE_TEAM_NOT_FOUND);"
       },
       {
         "lineNumber": 105,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "jordancjq"
         },
         "content": "        }"
       },
       {
         "lineNumber": 106,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "jordancjq"
         },
         "content": "    }"
       },
       {
         "lineNumber": 107,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "jordancjq"
         },
         "content": ""
       },
       {
         "lineNumber": 108,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "jordancjq"
         },
         "content": "    @Override"
       },
       {
         "lineNumber": 109,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "jordancjq"
         },
         "content": "    protected void preprocessUndoableCommand() throws CommandException {"
       },
       {
         "lineNumber": 110,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "jordancjq"
         },
         "content": "        TeamName teamName \u003d toAdd.getTeamName();"
       },
       {
         "lineNumber": 111,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "jordancjq"
         },
         "content": "        if (!model.getAddressBook().getTeamList().stream().anyMatch(t -\u003e t.getTeamName().equals(teamName))) {"
       },
       {
         "lineNumber": 112,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "jordancjq"
         },
         "content": "            if (!teamName.toString().equals(UNSPECIFIED_FIELD)) {"
       },
       {
         "lineNumber": 113,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "jordancjq"
         },
         "content": "                throw new CommandException((Messages.MESSAGE_TEAM_NOT_FOUND));"
       },
       {
         "lineNumber": 114,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "            }"
       },
       {
         "lineNumber": 115,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        }"
       },
       {
         "lineNumber": 116,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "jordancjq"
         },
         "content": "    }"
       },
       {
         "lineNumber": 117,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 118,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    @Override"
       },
       {
         "lineNumber": 119,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    public boolean equals(Object other) {"
       },
       {
         "lineNumber": 120,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        return other \u003d\u003d this // short circuit if same object"
       },
       {
         "lineNumber": 121,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "                || (other instanceof AddCommand // instanceof handles nulls"
       },
       {
         "lineNumber": 122,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "                \u0026\u0026 toAdd.equals(((AddCommand) other).toAdd));"
       },
       {
         "lineNumber": 123,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    }"
       },
       {
         "lineNumber": 124,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "}"
       }
     ],
     "authorContributionMap": {
-      "lithiumlkid": 97,
-      "jordancjq": 8,
-      "-": 19
+      "lohtianwei": 1,
+      "jordancjq": 31,
+      "-": 92
     }
   },
   {
@@ -29466,393 +28162,6 @@
     }
   },
   {
-    "path": "src/main/java/seedu/address/logic/commands/ChangeThemeCommand.java",
-    "lines": [
-      {
-        "lineNumber": 1,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "package seedu.address.logic.commands;"
-      },
-      {
-        "lineNumber": 2,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 3,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.commons.core.EventsCenter;"
-      },
-      {
-        "lineNumber": 4,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.commons.core.Messages;"
-      },
-      {
-        "lineNumber": 5,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.commons.events.ui.ChangeThemeEvent;"
-      },
-      {
-        "lineNumber": 6,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.logic.commands.exceptions.CommandException;"
-      },
-      {
-        "lineNumber": 7,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.ui.MainWindow;"
-      },
-      {
-        "lineNumber": 8,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 9,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "/**"
-      },
-      {
-        "lineNumber": 10,
-        "author": {
-          "gitId": "-"
-        },
-        "content": " * Changes the theme of the Address Book."
-      },
-      {
-        "lineNumber": 11,
-        "author": {
-          "gitId": "-"
-        },
-        "content": " */"
-      },
-      {
-        "lineNumber": 12,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "/** @@author Codee */"
-      },
-      {
-        "lineNumber": 13,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "public class ChangeThemeCommand extends Command {"
-      },
-      {
-        "lineNumber": 14,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 15,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    public static final String COMMAND_WORD \u003d \"changeTheme\";"
-      },
-      {
-        "lineNumber": 16,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    public static final String COMMAND_ALIAS \u003d \"cte\";"
-      },
-      {
-        "lineNumber": 17,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 18,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    public static final String MESSAGE_USAGE \u003d COMMAND_WORD"
-      },
-      {
-        "lineNumber": 19,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "            + \": Changes the theme of MTM.\\n\""
-      },
-      {
-        "lineNumber": 20,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "            + \"Parameters: THEME (must be either Light, or Dark)\\n\""
-      },
-      {
-        "lineNumber": 21,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "            + \"Examples: changeTheme Light, cte Dark\";"
-      },
-      {
-        "lineNumber": 22,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 23,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    public static final String MESSAGE_THEME_SUCCESS \u003d \"Theme updated to: %1$s\";"
-      },
-      {
-        "lineNumber": 24,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 25,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    private final String theme;"
-      },
-      {
-        "lineNumber": 26,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 27,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    public ChangeThemeCommand(String theme) {"
-      },
-      {
-        "lineNumber": 28,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        this.theme \u003d theme.trim();"
-      },
-      {
-        "lineNumber": 29,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 30,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 31,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    @Override"
-      },
-      {
-        "lineNumber": 32,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    public CommandResult execute() throws CommandException {"
-      },
-      {
-        "lineNumber": 33,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        if (!isValidTheme(this.theme)) {"
-      },
-      {
-        "lineNumber": 34,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "            throw new CommandException(Messages.MESSAGE_INVALID_THEME);"
-      },
-      {
-        "lineNumber": 35,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        }"
-      },
-      {
-        "lineNumber": 36,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        if ((MainWindow.getCurrentTheme()).contains(this.theme)) {"
-      },
-      {
-        "lineNumber": 37,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "            throw new CommandException(\"Theme is already set to \" + this.theme + \"!\");"
-      },
-      {
-        "lineNumber": 38,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        }"
-      },
-      {
-        "lineNumber": 39,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        EventsCenter.getInstance().post(new ChangeThemeEvent(this.theme));"
-      },
-      {
-        "lineNumber": 40,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        return new CommandResult(String.format(MESSAGE_THEME_SUCCESS, this.theme));"
-      },
-      {
-        "lineNumber": 41,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 42,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 43,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    private boolean isValidTheme(String theme) {"
-      },
-      {
-        "lineNumber": 44,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        return theme.equals(\"Light\") || theme.equals(\"Dark\");"
-      },
-      {
-        "lineNumber": 45,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 46,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 47,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    @Override"
-      },
-      {
-        "lineNumber": 48,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    public boolean equals(Object other) {"
-      },
-      {
-        "lineNumber": 49,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        return other \u003d\u003d this // short circuit if same object"
-      },
-      {
-        "lineNumber": 50,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "                || (other instanceof ChangeThemeCommand // instanceof handles nulls"
-      },
-      {
-        "lineNumber": 51,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "                \u0026\u0026 this.theme.equals(((ChangeThemeCommand) other).theme)); // state check"
-      },
-      {
-        "lineNumber": 52,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 53,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 54,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "}"
-      }
-    ],
-    "authorContributionMap": {
-      "codeeong": 43,
-      "-": 11
-    }
-  },
-  {
     "path": "src/main/java/seedu/address/logic/commands/ClearCommand.java",
     "lines": [
       {
@@ -30012,22 +28321,19 @@
       {
         "lineNumber": 23,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        // @@author Codee"
       },
       {
         "lineNumber": 24,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        EventsCenter.getInstance().post(new ClearTeamsEvent());"
       },
       {
         "lineNumber": 25,
-        "author": {
-          "gitId": "codeeong"
-        },
         "content": "        // @@author"
       },
       {
@@ -30053,1348 +28359,9 @@
       }
     ],
     "authorContributionMap": {
+      "null": 1,
       "lohtianwei": 1,
-      "codeeong": 3,
-      "-": 24
-    }
-  },
-  {
-    "path": "src/main/java/seedu/address/logic/commands/CommandTrie.java",
-    "lines": [
-      {
-        "lineNumber": 1,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "package seedu.address.logic.commands;"
-      },
-      {
-        "lineNumber": 2,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 3,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import java.util.ArrayList;"
-      },
-      {
-        "lineNumber": 4,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import java.util.HashMap;"
-      },
-      {
-        "lineNumber": 5,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import java.util.List;"
-      },
-      {
-        "lineNumber": 6,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import java.util.Map;"
-      },
-      {
-        "lineNumber": 7,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import java.util.Set;"
-      },
-      {
-        "lineNumber": 8,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import java.util.stream.Collectors;"
-      },
-      {
-        "lineNumber": 9,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import java.util.stream.Stream;"
-      },
-      {
-        "lineNumber": 10,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 11,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "//@@author lithiumlkid"
-      },
-      {
-        "lineNumber": 12,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "/**"
-      },
-      {
-        "lineNumber": 13,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": " * Trie of possible commands. Stores all possible commands for the addressbook."
-      },
-      {
-        "lineNumber": 14,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": " * Used for autocomplete functionality by returning a possible command via the attemptAutoComplete function."
-      },
-      {
-        "lineNumber": 15,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": " */"
-      },
-      {
-        "lineNumber": 16,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "public class CommandTrie {"
-      },
-      {
-        "lineNumber": 17,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 18,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    private TrieNode root \u003d null;"
-      },
-      {
-        "lineNumber": 19,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    private Set\u003cString\u003e commandSet;"
-      },
-      {
-        "lineNumber": 20,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    private Map\u003cString, String\u003e commandMap;"
-      },
-      {
-        "lineNumber": 21,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 22,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    public CommandTrie() {"
-      },
-      {
-        "lineNumber": 23,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        commandSet \u003d Stream.of("
-      },
-      {
-        "lineNumber": 24,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "                EditCommand.COMMAND_WORD, ExitCommand.COMMAND_WORD, FindCommand.COMMAND_WORD,"
-      },
-      {
-        "lineNumber": 25,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "                AddCommand.COMMAND_WORD, ClearCommand.COMMAND_WORD, DeleteCommand.COMMAND_WORD,"
-      },
-      {
-        "lineNumber": 26,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "                HelpCommand.COMMAND_WORD, SelectCommand.COMMAND_WORD, HistoryCommand.COMMAND_WORD,"
-      },
-      {
-        "lineNumber": 27,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "                ListCommand.COMMAND_WORD, RedoCommand.COMMAND_WORD,  UndoCommand.COMMAND_WORD,"
-      },
-      {
-        "lineNumber": 28,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "                SortCommand.COMMAND_WORD, SetCommand.COMMAND_WORD, RemarkCommand.COMMAND_WORD,"
-      },
-      {
-        "lineNumber": 29,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "                CreateCommand.COMMAND_WORD, AssignCommand.COMMAND_WORD, ViewCommand.COMMAND_WORD,"
-      },
-      {
-        "lineNumber": 30,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "                RemoveCommand.COMMAND_WORD, KeyCommand.COMMAND_WORD, TogglePrivacyCommand.COMMAND_WORD"
-      },
-      {
-        "lineNumber": 31,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        ).collect(Collectors.toSet());"
-      },
-      {
-        "lineNumber": 32,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 33,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        for (String command : commandSet) {"
-      },
-      {
-        "lineNumber": 34,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "            this.insert(command);"
-      },
-      {
-        "lineNumber": 35,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        }"
-      },
-      {
-        "lineNumber": 36,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 37,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        commandMap \u003d new HashMap\u003c\u003e();"
-      },
-      {
-        "lineNumber": 38,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        commandMap.put(AddCommand.COMMAND_WORD, AddCommand.MESSAGE_PARAMETERS);"
-      },
-      {
-        "lineNumber": 39,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        commandMap.put(DeleteCommand.COMMAND_WORD, DeleteCommand.MESSAGE_PARAMETERS);"
-      },
-      {
-        "lineNumber": 40,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        commandMap.put(EditCommand.COMMAND_WORD, EditCommand.MESSAGE_PARAMETERS);"
-      },
-      {
-        "lineNumber": 41,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        commandMap.put(FindCommand.COMMAND_WORD, FindCommand.MESSAGE_PARAMETERS);"
-      },
-      {
-        "lineNumber": 42,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        commandMap.put(SelectCommand.COMMAND_WORD, SelectCommand.MESSAGE_PARAMETERS);"
-      },
-      {
-        "lineNumber": 43,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        commandMap.put(SortCommand.COMMAND_WORD, SortCommand.MESSAGE_PARAMETERS);"
-      },
-      {
-        "lineNumber": 44,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        commandMap.put(SetCommand.COMMAND_WORD, SetCommand.MESSAGE_PARAMETERS);"
-      },
-      {
-        "lineNumber": 45,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        commandMap.put(RemarkCommand.COMMAND_WORD, RemarkCommand.MESSAGE_PARAMETERS);"
-      },
-      {
-        "lineNumber": 46,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        commandMap.put(CreateCommand.COMMAND_WORD, CreateCommand.MESSAGE_PARAMETERS);"
-      },
-      {
-        "lineNumber": 47,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        commandMap.put(AssignCommand.COMMAND_WORD, AssignCommand.MESSAGE_PARAMETERS);"
-      },
-      {
-        "lineNumber": 48,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        commandMap.put(ViewCommand.COMMAND_WORD, ViewCommand.MESSAGE_PARAMETERS);"
-      },
-      {
-        "lineNumber": 49,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        commandMap.put(RemoveCommand.COMMAND_WORD, RemoveCommand.MESSAGE_PARAMETERS);"
-      },
-      {
-        "lineNumber": 50,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        commandMap.put(KeyCommand.COMMAND_WORD, KeyCommand.MESSAGE_PARAMETERS);"
-      },
-      {
-        "lineNumber": 51,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        commandMap.put(TogglePrivacyCommand.COMMAND_WORD, TogglePrivacyCommand.MESSAGE_PARAMETERS);"
-      },
-      {
-        "lineNumber": 52,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 53,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 54,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    /**"
-      },
-      {
-        "lineNumber": 55,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "     * Inserts input into Trie"
-      },
-      {
-        "lineNumber": 56,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "     *"
-      },
-      {
-        "lineNumber": 57,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "     * @param input command string"
-      },
-      {
-        "lineNumber": 58,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "     */"
-      },
-      {
-        "lineNumber": 59,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    private void insert(String input) {"
-      },
-      {
-        "lineNumber": 60,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        char[] inputArray \u003d input.toCharArray();"
-      },
-      {
-        "lineNumber": 61,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 62,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        if (root \u003d\u003d null) {"
-      },
-      {
-        "lineNumber": 63,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "            root \u003d new TrieNode(inputArray[0], null, null);"
-      },
-      {
-        "lineNumber": 64,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "            TrieNode temp \u003d root;"
-      },
-      {
-        "lineNumber": 65,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "            for (int i \u003d 1; i \u003c inputArray.length; i++) {"
-      },
-      {
-        "lineNumber": 66,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "                temp.setChild(new TrieNode(inputArray[i], null, null));"
-      },
-      {
-        "lineNumber": 67,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "                temp \u003d temp.getChild();"
-      },
-      {
-        "lineNumber": 68,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "            }"
-      },
-      {
-        "lineNumber": 69,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        } else {"
-      },
-      {
-        "lineNumber": 70,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "            TrieNode temp \u003d root;"
-      },
-      {
-        "lineNumber": 71,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "            int i \u003d 0;"
-      },
-      {
-        "lineNumber": 72,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "            while (temp.hasSibling()) {"
-      },
-      {
-        "lineNumber": 73,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "                if (temp.getKey() \u003d\u003d inputArray[i]) {"
-      },
-      {
-        "lineNumber": 74,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "                    temp \u003d temp.getChild();"
-      },
-      {
-        "lineNumber": 75,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "                    i++;"
-      },
-      {
-        "lineNumber": 76,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "                } else {"
-      },
-      {
-        "lineNumber": 77,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "                    temp \u003d temp.getSibling();"
-      },
-      {
-        "lineNumber": 78,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "                }"
-      },
-      {
-        "lineNumber": 79,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "            }"
-      },
-      {
-        "lineNumber": 80,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 81,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "            while (i \u003c inputArray.length - 1) {"
-      },
-      {
-        "lineNumber": 82,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "                if (temp.getKey() \u003d\u003d inputArray[i] \u0026\u0026 temp.hasChild()) {"
-      },
-      {
-        "lineNumber": 83,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "                    i++;"
-      },
-      {
-        "lineNumber": 84,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "                    temp \u003d temp.getChild();"
-      },
-      {
-        "lineNumber": 85,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "                } else if (temp.getKey() \u003d\u003d inputArray[i] \u0026\u0026 !temp.hasChild()) {"
-      },
-      {
-        "lineNumber": 86,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "                    i++;"
-      },
-      {
-        "lineNumber": 87,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "                    temp.setChild(new TrieNode(inputArray[i], null, null));"
-      },
-      {
-        "lineNumber": 88,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "                    temp \u003d temp.getChild();"
-      },
-      {
-        "lineNumber": 89,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "                } else {"
-      },
-      {
-        "lineNumber": 90,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "                    temp.setSibling(new TrieNode(inputArray[i], null, null));"
-      },
-      {
-        "lineNumber": 91,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "                    temp \u003d temp.getSibling();"
-      },
-      {
-        "lineNumber": 92,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "                }"
-      },
-      {
-        "lineNumber": 93,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "            }"
-      },
-      {
-        "lineNumber": 94,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        }"
-      },
-      {
-        "lineNumber": 95,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 96,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 97,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    /**"
-      },
-      {
-        "lineNumber": 98,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "     * Indicates whether a node is a endOfWord"
-      },
-      {
-        "lineNumber": 99,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "     */"
-      },
-      {
-        "lineNumber": 100,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    private boolean isEndOfWord(TrieNode current) {"
-      },
-      {
-        "lineNumber": 101,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        return !current.hasSibling() \u0026\u0026 !current.hasChild();"
-      },
-      {
-        "lineNumber": 102,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 103,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 104,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    /**"
-      },
-      {
-        "lineNumber": 105,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "     * @param input string to autocomplete by returning command with matching prefix"
-      },
-      {
-        "lineNumber": 106,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "     * @return input if the command is not found, matching command word otherwise"
-      },
-      {
-        "lineNumber": 107,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "     */"
-      },
-      {
-        "lineNumber": 108,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    public String attemptAutoComplete(String input) throws NullPointerException {"
-      },
-      {
-        "lineNumber": 109,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        StringBuilder output \u003d new StringBuilder();"
-      },
-      {
-        "lineNumber": 110,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 111,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        if (commandSet.contains(input)) {"
-      },
-      {
-        "lineNumber": 112,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "            if (commandMap.containsKey(input)) {"
-      },
-      {
-        "lineNumber": 113,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "                output.append(\" \");"
-      },
-      {
-        "lineNumber": 114,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "                output.append(commandMap.get(input));"
-      },
-      {
-        "lineNumber": 115,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "            }"
-      },
-      {
-        "lineNumber": 116,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        } else {"
-      },
-      {
-        "lineNumber": 117,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "            char[] inputArray \u003d input.toCharArray();"
-      },
-      {
-        "lineNumber": 118,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "            TrieNode temp \u003d root;"
-      },
-      {
-        "lineNumber": 119,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "            int i \u003d 0;"
-      },
-      {
-        "lineNumber": 120,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 121,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "            while (!isEndOfWord(temp)) {"
-      },
-      {
-        "lineNumber": 122,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "                if (i \u003c inputArray.length) {"
-      },
-      {
-        "lineNumber": 123,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "                    if (Character.toLowerCase(temp.getKey()) \u003d\u003d Character.toLowerCase(inputArray[i])) {"
-      },
-      {
-        "lineNumber": 124,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "                        output.append(temp.getKey());"
-      },
-      {
-        "lineNumber": 125,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "                        temp \u003d temp.getChild();"
-      },
-      {
-        "lineNumber": 126,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "                        i++;"
-      },
-      {
-        "lineNumber": 127,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "                    } else {"
-      },
-      {
-        "lineNumber": 128,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "                        temp \u003d temp.getSibling();"
-      },
-      {
-        "lineNumber": 129,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "                    }"
-      },
-      {
-        "lineNumber": 130,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "                } else if (temp.hasSibling()) {"
-      },
-      {
-        "lineNumber": 131,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "                    return input;"
-      },
-      {
-        "lineNumber": 132,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "                } else {"
-      },
-      {
-        "lineNumber": 133,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "                    output.append(temp.getKey());"
-      },
-      {
-        "lineNumber": 134,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "                    temp \u003d temp.getChild();"
-      },
-      {
-        "lineNumber": 135,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "                }"
-      },
-      {
-        "lineNumber": 136,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "            }"
-      },
-      {
-        "lineNumber": 137,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "            output.append(temp.getKey());"
-      },
-      {
-        "lineNumber": 138,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        }"
-      },
-      {
-        "lineNumber": 139,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        return output.toString();"
-      },
-      {
-        "lineNumber": 140,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 141,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 142,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    public Set\u003cString\u003e getCommandSet() {"
-      },
-      {
-        "lineNumber": 143,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        return commandSet;"
-      },
-      {
-        "lineNumber": 144,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 145,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 146,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    /**"
-      },
-      {
-        "lineNumber": 147,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "     * @return a list of all possible commands for the given input"
-      },
-      {
-        "lineNumber": 148,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "     */"
-      },
-      {
-        "lineNumber": 149,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    public List\u003cString\u003e getOptions(String input) {"
-      },
-      {
-        "lineNumber": 150,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        char[] inputArray \u003d input.toLowerCase().toCharArray();"
-      },
-      {
-        "lineNumber": 151,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        TrieNode start \u003d root;"
-      },
-      {
-        "lineNumber": 152,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        int i \u003d 0;"
-      },
-      {
-        "lineNumber": 153,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        StringBuilder stub \u003d new StringBuilder();"
-      },
-      {
-        "lineNumber": 154,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 155,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        while (!isEndOfWord(start) \u0026\u0026 i \u003c inputArray.length) {"
-      },
-      {
-        "lineNumber": 156,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "            if (start.getKey() \u003d\u003d inputArray[i]) {"
-      },
-      {
-        "lineNumber": 157,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "                i++;"
-      },
-      {
-        "lineNumber": 158,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "                stub.append(start.getKey());"
-      },
-      {
-        "lineNumber": 159,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "                start \u003d start.getChild();"
-      },
-      {
-        "lineNumber": 160,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "            } else {"
-      },
-      {
-        "lineNumber": 161,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "                start \u003d start.getSibling();"
-      },
-      {
-        "lineNumber": 162,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "            }"
-      },
-      {
-        "lineNumber": 163,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        }"
-      },
-      {
-        "lineNumber": 164,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 165,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        return findOptions(start, stub.toString());"
-      },
-      {
-        "lineNumber": 166,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 167,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 168,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    /**"
-      },
-      {
-        "lineNumber": 169,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "     * Traverses the trie and gets possible options"
-      },
-      {
-        "lineNumber": 170,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "     */"
-      },
-      {
-        "lineNumber": 171,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    private List\u003cString\u003e findOptions(TrieNode start, String stub) {"
-      },
-      {
-        "lineNumber": 172,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        List\u003cString\u003e options \u003d new ArrayList\u003c\u003e();"
-      },
-      {
-        "lineNumber": 173,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        StringBuilder output \u003d new StringBuilder();"
-      },
-      {
-        "lineNumber": 174,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        output.append(stub);"
-      },
-      {
-        "lineNumber": 175,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 176,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        if (isEndOfWord(start)) {"
-      },
-      {
-        "lineNumber": 177,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "            output.append(start.getKey());"
-      },
-      {
-        "lineNumber": 178,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "            options.add(output.toString());"
-      },
-      {
-        "lineNumber": 179,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "            return options;"
-      },
-      {
-        "lineNumber": 180,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        }"
-      },
-      {
-        "lineNumber": 181,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        if (start.hasSibling()) {"
-      },
-      {
-        "lineNumber": 182,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "            options.addAll(findOptions(start.getSibling(), output.toString()));"
-      },
-      {
-        "lineNumber": 183,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        }"
-      },
-      {
-        "lineNumber": 184,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        if (start.hasChild()) {"
-      },
-      {
-        "lineNumber": 185,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "            output.append(start.getKey());"
-      },
-      {
-        "lineNumber": 186,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "            options.addAll(findOptions(start.getChild(), output.toString()));"
-      },
-      {
-        "lineNumber": 187,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        }"
-      },
-      {
-        "lineNumber": 188,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        return options;"
-      },
-      {
-        "lineNumber": 189,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 190,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "}"
-      }
-    ],
-    "authorContributionMap": {
-      "lithiumlkid": 180,
-      "-": 10
+      "-": 26
     }
   },
   {
@@ -32646,540 +29613,537 @@
       {
         "lineNumber": 46,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "//@@author lithiumlkid"
       },
       {
         "lineNumber": 47,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "/**"
       },
       {
         "lineNumber": 48,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": " * Edits the details of an existing player in the address book."
       },
       {
         "lineNumber": 49,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": " */"
       },
       {
         "lineNumber": 50,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "public class EditCommand extends UndoableCommand {"
       },
       {
         "lineNumber": 51,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 52,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    public static final String COMMAND_WORD \u003d \"edit\";"
       },
       {
         "lineNumber": 53,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "lohtianwei"
         },
         "content": "    public static final String COMMAND_ALIAS \u003d \"e\";"
       },
       {
         "lineNumber": 54,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 55,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    public static final String MESSAGE_USAGE \u003d COMMAND_WORD + \": Edits the details of the player identified \""
       },
       {
         "lineNumber": 56,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "            + \"by the index number used in the last player listing. \""
       },
       {
         "lineNumber": 57,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "            + \"Existing values will be overwritten by the input values.\\n\""
       },
       {
         "lineNumber": 58,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "            + \"Parameters: INDEX (must be a positive integer) \""
       },
       {
         "lineNumber": 59,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "            + \"[\" + PREFIX_NAME + \"NAME] \""
       },
       {
         "lineNumber": 60,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "            + \"[\" + PREFIX_PHONE + \"PHONE] \""
       },
       {
         "lineNumber": 61,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "            + \"[\" + PREFIX_EMAIL + \"EMAIL] \""
       },
       {
         "lineNumber": 62,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "            + \"[\" + PREFIX_ADDRESS + \"ADDRESS] \""
       },
       {
         "lineNumber": 63,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "            + \"[\" + PREFIX_RATING + \"RATING] \""
       },
       {
         "lineNumber": 64,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "            + \"[\" + PREFIX_POSITION + \"POSITION] \""
       },
       {
         "lineNumber": 65,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "            + \"[\" + PREFIX_JERSEY_NUMBER + \"JERSEY_NUMBER] \""
       },
       {
         "lineNumber": 66,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "            + \"[\" + PREFIX_AVATAR + \"AVATAR] \""
       },
       {
         "lineNumber": 67,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "            + \"[\" + PREFIX_TAG + \"TAG]...\\n\""
       },
       {
         "lineNumber": 68,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "            + \"Example: \" + COMMAND_WORD + \" 1 \""
       },
       {
         "lineNumber": 69,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "            + PREFIX_PHONE + \"91234567 \""
       },
       {
         "lineNumber": 70,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "            + PREFIX_EMAIL + \"johndoe@example.com\";"
       },
       {
         "lineNumber": 71,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 72,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    public static final String MESSAGE_PARAMETERS \u003d \"INDEX \""
       },
       {
         "lineNumber": 73,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "            + \"[\" + PREFIX_NAME + \"NAME] \""
       },
       {
         "lineNumber": 74,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "            + \"[\" + PREFIX_PHONE + \"PHONE] \""
       },
       {
         "lineNumber": 75,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "            + \"[\" + PREFIX_EMAIL + \"EMAIL] \""
       },
       {
         "lineNumber": 76,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "            + \"[\" + PREFIX_ADDRESS + \"ADDRESS] \""
       },
       {
         "lineNumber": 77,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "            + \"[\" + PREFIX_RATING + \"RATING] \""
       },
       {
         "lineNumber": 78,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "            + \"[\" + PREFIX_POSITION + \"POSITION] \""
       },
       {
         "lineNumber": 79,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "            + \"[\" + PREFIX_JERSEY_NUMBER + \"JERSEY_NUMBER] \""
       },
       {
         "lineNumber": 80,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "            + \"[\" + PREFIX_AVATAR + \"AVATAR] \""
       },
       {
         "lineNumber": 81,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "            + \"[\" + PREFIX_TAG + \"TAG]\";"
       },
       {
         "lineNumber": 82,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 83,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    public static final String MESSAGE_EDIT_PERSON_SUCCESS \u003d \"Edited Person: %1$s\";"
       },
       {
         "lineNumber": 84,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    public static final String MESSAGE_NOT_EDITED \u003d \"At least one field to edit must be provided.\";"
       },
       {
         "lineNumber": 85,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    public static final String MESSAGE_DUPLICATE_PERSON \u003d \"This player already exists in the address book.\";"
       },
       {
         "lineNumber": 86,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    public static final String MESSAGE_FILE_NOT_FOUND \u003d \"Avatar image file specified does not exist\";"
       },
       {
         "lineNumber": 87,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 88,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    private final Index index;"
       },
       {
         "lineNumber": 89,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    private final EditPersonDescriptor editPersonDescriptor;"
       },
       {
         "lineNumber": 90,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 91,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    private Person personToEdit;"
       },
       {
         "lineNumber": 92,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    private Person editedPerson;"
       },
       {
         "lineNumber": 93,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 94,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    /**"
       },
       {
         "lineNumber": 95,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "     * @param index of the player in the filtered player list to edit"
       },
       {
         "lineNumber": 96,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "     * @param editPersonDescriptor details to edit the player with"
       },
       {
         "lineNumber": 97,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "     */"
       },
       {
         "lineNumber": 98,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    public EditCommand(Index index, EditPersonDescriptor editPersonDescriptor) {"
       },
       {
         "lineNumber": 99,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        requireNonNull(index);"
       },
       {
         "lineNumber": 100,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        requireNonNull(editPersonDescriptor);"
       },
       {
         "lineNumber": 101,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 102,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        this.index \u003d index;"
       },
       {
         "lineNumber": 103,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        this.editPersonDescriptor \u003d new EditPersonDescriptor(editPersonDescriptor);"
       },
       {
         "lineNumber": 104,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    }"
       },
       {
         "lineNumber": 105,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 106,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    @Override"
       },
       {
         "lineNumber": 107,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    public CommandResult executeUndoableCommand() throws CommandException {"
       },
       {
         "lineNumber": 108,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        try {"
       },
       {
         "lineNumber": 109,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "            if (!editedPerson.getAvatar().toString().equals(UNSPECIFIED_FIELD)) {"
       },
       {
         "lineNumber": 110,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "                editedPerson.getAvatar().setFilePath(editedPerson.getName().fullName);"
       },
       {
         "lineNumber": 111,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "            }"
       },
       {
         "lineNumber": 112,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "            model.updatePerson(personToEdit, editedPerson);"
       },
       {
         "lineNumber": 113,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        } catch (DuplicatePersonException dpe) {"
       },
       {
         "lineNumber": 114,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "            throw new CommandException(MESSAGE_DUPLICATE_PERSON);"
       },
       {
         "lineNumber": 115,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        } catch (PersonNotFoundException pnfe) {"
       },
       {
         "lineNumber": 116,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "            throw new AssertionError(\"The target player cannot be missing\");"
       },
       {
         "lineNumber": 117,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        } catch (IOException e) {"
       },
       {
         "lineNumber": 118,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "            throw new CommandException(MESSAGE_FILE_NOT_FOUND);"
       },
       {
         "lineNumber": 119,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        }"
       },
       {
         "lineNumber": 120,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        //@@author Codee"
       },
       {
         "lineNumber": 121,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        EventsCenter.getInstance().post(new PersonDetailsChangedEvent(editedPerson, index));"
       },
       {
         "lineNumber": 122,
-        "author": {
-          "gitId": "codeeong"
-        },
         "content": "        //@@author"
       },
       {
@@ -34689,11 +31653,10 @@
       }
     ],
     "authorContributionMap": {
-      "lithiumlkid": 74,
-      "lohtianwei": 9,
+      "null": 1,
+      "lohtianwei": 10,
       "jordancjq": 7,
-      "codeeong": 3,
-      "-": 244
+      "-": 319
     }
   },
   {
@@ -36193,29 +33156,26 @@
       {
         "lineNumber": 32,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        // @@author Codee"
       },
       {
         "lineNumber": 33,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        EventsCenter.getInstance().post(new UndoTeamsEvent());"
       },
       {
         "lineNumber": 34,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        EventsCenter.getInstance().post(new PersonDetailsChangedNoParamEvent());"
       },
       {
         "lineNumber": 35,
-        "author": {
-          "gitId": "codeeong"
-        },
         "content": "        // @@author"
       },
       {
@@ -36283,9 +33243,9 @@
       }
     ],
     "authorContributionMap": {
+      "null": 1,
       "lohtianwei": 1,
-      "codeeong": 4,
-      "-": 39
+      "-": 42
     }
   },
   {
@@ -38588,498 +35548,6 @@
     "authorContributionMap": {
       "lohtianwei": 1,
       "-": 54
-    }
-  },
-  {
-    "path": "src/main/java/seedu/address/logic/commands/SetCommand.java",
-    "lines": [
-      {
-        "lineNumber": 1,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "package seedu.address.logic.commands;"
-      },
-      {
-        "lineNumber": 2,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 3,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static java.util.Objects.requireNonNull;"
-      },
-      {
-        "lineNumber": 4,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;"
-      },
-      {
-        "lineNumber": 5,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG_COLOUR;"
-      },
-      {
-        "lineNumber": 6,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 7,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.commons.core.EventsCenter;"
-      },
-      {
-        "lineNumber": 8,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.commons.events.ui.ChangeTagColourEvent;"
-      },
-      {
-        "lineNumber": 9,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.model.tag.Tag;"
-      },
-      {
-        "lineNumber": 10,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 11,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "/**"
-      },
-      {
-        "lineNumber": 12,
-        "author": {
-          "gitId": "-"
-        },
-        "content": " * Adds a colour to a tag in address book."
-      },
-      {
-        "lineNumber": 13,
-        "author": {
-          "gitId": "-"
-        },
-        "content": " */"
-      },
-      {
-        "lineNumber": 14,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "/** @@author Codee Ong Ong */"
-      },
-      {
-        "lineNumber": 15,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "public class SetCommand extends Command {"
-      },
-      {
-        "lineNumber": 16,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 17,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    public static final String COMMAND_WORD \u003d \"setTagColour\";"
-      },
-      {
-        "lineNumber": 18,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    public static final String COMMAND_ALIAS \u003d \"stc\";"
-      },
-      {
-        "lineNumber": 19,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 20,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    public static final String MESSAGE_USAGE \u003d COMMAND_WORD + \": Sets the colour of tags to the colour of choice \""
-      },
-      {
-        "lineNumber": 21,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "            + \"Parameters: \""
-      },
-      {
-        "lineNumber": 22,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "            + PREFIX_TAG + \"TAG \""
-      },
-      {
-        "lineNumber": 23,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "            + PREFIX_TAG_COLOUR + \"TAG_COLOUR\\n\""
-      },
-      {
-        "lineNumber": 24,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "            + \"Example: \" + COMMAND_WORD + \" \""
-      },
-      {
-        "lineNumber": 25,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "            + PREFIX_TAG + \"friends \""
-      },
-      {
-        "lineNumber": 26,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "            + PREFIX_TAG_COLOUR + \"green\\n\""
-      },
-      {
-        "lineNumber": 27,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "            + \"Colours to choose from are : teal, red, yellow, blue, orange, brown, \\n\""
-      },
-      {
-        "lineNumber": 28,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "            + \"green, pink, black, grey\\n\";"
-      },
-      {
-        "lineNumber": 29,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 30,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    public static final String MESSAGE_PARAMETERS \u003d PREFIX_TAG + \"TAG \" + PREFIX_TAG_COLOUR + \"TAG_COLOUR\";"
-      },
-      {
-        "lineNumber": 31,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 32,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    public static final String MESSAGE_INVALID_TAG \u003d \"tag is invalid! Please input a valid tag name!\";"
-      },
-      {
-        "lineNumber": 33,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    public static final String MESSAGE_SUCCESS \u003d \"tag %1$s colour changed to %2$s\";"
-      },
-      {
-        "lineNumber": 34,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 35,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    private final Tag tagToSet;"
-      },
-      {
-        "lineNumber": 36,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    private final String tagColour;"
-      },
-      {
-        "lineNumber": 37,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 38,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    /**"
-      },
-      {
-        "lineNumber": 39,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "     * Creates an AddCommand to add the specified {@code Person}"
-      },
-      {
-        "lineNumber": 40,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "     */"
-      },
-      {
-        "lineNumber": 41,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    public SetCommand(Tag tag, String colour) {"
-      },
-      {
-        "lineNumber": 42,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        requireNonNull(tag);"
-      },
-      {
-        "lineNumber": 43,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        tagToSet \u003d tag;"
-      },
-      {
-        "lineNumber": 44,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        tagColour \u003d colour;"
-      },
-      {
-        "lineNumber": 45,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 46,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 47,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    @Override"
-      },
-      {
-        "lineNumber": 48,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    public CommandResult execute() {"
-      },
-      {
-        "lineNumber": 49,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        requireNonNull(model);"
-      },
-      {
-        "lineNumber": 50,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        boolean isTagValid \u003d model.setTagColour(tagToSet, tagColour);"
-      },
-      {
-        "lineNumber": 51,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        if (!tagToSet.isValidTagName(tagToSet.getTagName()) || !isTagValid) {"
-      },
-      {
-        "lineNumber": 52,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "            return new CommandResult(String.format(MESSAGE_INVALID_TAG));"
-      },
-      {
-        "lineNumber": 53,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        }"
-      },
-      {
-        "lineNumber": 54,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        EventsCenter.getInstance().post(new ChangeTagColourEvent(tagToSet.getTagName(), tagColour));"
-      },
-      {
-        "lineNumber": 55,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        return new CommandResult(String.format(MESSAGE_SUCCESS, tagToSet.toString(), tagColour));"
-      },
-      {
-        "lineNumber": 56,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 57,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 58,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    @Override"
-      },
-      {
-        "lineNumber": 59,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    public boolean equals(Object other) {"
-      },
-      {
-        "lineNumber": 60,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        // Check if"
-      },
-      {
-        "lineNumber": 61,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        // (a) Object is the same object"
-      },
-      {
-        "lineNumber": 62,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        // (b) Object is an instance of the object and that toSet, tag and color are the same"
-      },
-      {
-        "lineNumber": 63,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        return other \u003d\u003d this // short circuit if same object"
-      },
-      {
-        "lineNumber": 64,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "                || (other instanceof SetCommand // instanceof handles nulls"
-      },
-      {
-        "lineNumber": 65,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "                \u0026\u0026 this.tagToSet.getTagName().equals(((SetCommand) other).tagToSet.getTagName()))"
-      },
-      {
-        "lineNumber": 66,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "                \u0026\u0026 this.tagColour.equals(((SetCommand) other).tagColour);"
-      },
-      {
-        "lineNumber": 67,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 68,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "}"
-      },
-      {
-        "lineNumber": 69,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ""
-      }
-    ],
-    "authorContributionMap": {
-      "codeeong": 56,
-      "-": 13
     }
   },
   {
@@ -42305,337 +38773,6 @@
     }
   },
   {
-    "path": "src/main/java/seedu/address/logic/commands/TrieNode.java",
-    "lines": [
-      {
-        "lineNumber": 1,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "package seedu.address.logic.commands;"
-      },
-      {
-        "lineNumber": 2,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 3,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "//@@author lithiumlkid"
-      },
-      {
-        "lineNumber": 4,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "/**"
-      },
-      {
-        "lineNumber": 5,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": " * Represents a Trie Node object. Contains a character, a reference to sibling Trie Node and child Trie Node ."
-      },
-      {
-        "lineNumber": 6,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": " */"
-      },
-      {
-        "lineNumber": 7,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "public class TrieNode {"
-      },
-      {
-        "lineNumber": 8,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    private TrieNode sibling;"
-      },
-      {
-        "lineNumber": 9,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    private TrieNode child;"
-      },
-      {
-        "lineNumber": 10,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 11,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    private char key;"
-      },
-      {
-        "lineNumber": 12,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 13,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    TrieNode(char key, TrieNode sibling, TrieNode child) {"
-      },
-      {
-        "lineNumber": 14,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        this.key \u003d key;"
-      },
-      {
-        "lineNumber": 15,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        this.sibling \u003d sibling;"
-      },
-      {
-        "lineNumber": 16,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        this.child \u003d child;"
-      },
-      {
-        "lineNumber": 17,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 18,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 19,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    public char getKey() {"
-      },
-      {
-        "lineNumber": 20,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        return key;"
-      },
-      {
-        "lineNumber": 21,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 22,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 23,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    public boolean hasSibling() {"
-      },
-      {
-        "lineNumber": 24,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        return sibling !\u003d null;"
-      },
-      {
-        "lineNumber": 25,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 26,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 27,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    public TrieNode getSibling() {"
-      },
-      {
-        "lineNumber": 28,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        return sibling;"
-      },
-      {
-        "lineNumber": 29,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 30,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 31,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    public void setSibling(TrieNode sibling) {"
-      },
-      {
-        "lineNumber": 32,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        this.sibling \u003d sibling;"
-      },
-      {
-        "lineNumber": 33,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 34,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 35,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    public boolean hasChild() {"
-      },
-      {
-        "lineNumber": 36,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        return child !\u003d null;"
-      },
-      {
-        "lineNumber": 37,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 38,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 39,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    public TrieNode getChild() {"
-      },
-      {
-        "lineNumber": 40,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        return child;"
-      },
-      {
-        "lineNumber": 41,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 42,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 43,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    public void setChild(TrieNode child) {"
-      },
-      {
-        "lineNumber": 44,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        this.child \u003d child;"
-      },
-      {
-        "lineNumber": 45,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 46,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "}"
-      }
-    ],
-    "authorContributionMap": {
-      "lithiumlkid": 44,
-      "-": 2
-    }
-  },
-  {
     "path": "src/main/java/seedu/address/logic/commands/UndoCommand.java",
     "lines": [
       {
@@ -42858,29 +38995,26 @@
       {
         "lineNumber": 32,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        // @@author Codee"
       },
       {
         "lineNumber": 33,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        EventsCenter.getInstance().post(new UndoTeamsEvent());"
       },
       {
         "lineNumber": 34,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        EventsCenter.getInstance().post(new PersonDetailsChangedNoParamEvent());"
       },
       {
         "lineNumber": 35,
-        "author": {
-          "gitId": "codeeong"
-        },
         "content": "        // @@author"
       },
       {
@@ -42948,9 +39082,9 @@
       }
     ],
     "authorContributionMap": {
+      "null": 1,
       "lohtianwei": 1,
-      "codeeong": 4,
-      "-": 39
+      "-": 42
     }
   },
   {
@@ -43570,421 +39704,420 @@
       {
         "lineNumber": 34,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "//@@author lithiumlkid"
       },
       {
         "lineNumber": 35,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "/**"
       },
       {
         "lineNumber": 36,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": " * Parses input arguments and creates a new AddCommand object"
       },
       {
         "lineNumber": 37,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": " */"
       },
       {
         "lineNumber": 38,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "public class AddCommandParser implements Parser\u003cAddCommand\u003e {"
       },
       {
         "lineNumber": 39,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 40,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    /**"
       },
       {
         "lineNumber": 41,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "     * Parses the given {@code String} of arguments in the context of the AddCommand"
       },
       {
         "lineNumber": 42,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "     * and returns an AddCommand object for execution."
       },
       {
         "lineNumber": 43,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "     * @throws ParseException if the user input does not conform the expected format"
       },
       {
         "lineNumber": 44,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "     */"
       },
       {
         "lineNumber": 45,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    public AddCommand parse(String args) throws ParseException {"
       },
       {
         "lineNumber": 46,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        ArgumentMultimap argMultimap \u003d"
       },
       {
         "lineNumber": 47,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "jordancjq"
         },
         "content": "                ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS,"
       },
       {
         "lineNumber": 48,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "                        PREFIX_TEAM_NAME, PREFIX_TAG, PREFIX_JERSEY_NUMBER, PREFIX_POSITION, PREFIX_RATING,"
       },
       {
         "lineNumber": 49,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "                        PREFIX_AVATAR);"
       },
       {
         "lineNumber": 50,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 51,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "jordancjq"
         },
         "content": "        if (!arePrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_EMAIL)"
       },
       {
         "lineNumber": 52,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "                || !argMultimap.getPreamble().isEmpty()) {"
       },
       {
         "lineNumber": 53,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));"
       },
       {
         "lineNumber": 54,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        }"
       },
       {
         "lineNumber": 55,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 56,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        try {"
       },
       {
         "lineNumber": 57,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "            Name name \u003d ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME)).get();"
       },
       {
         "lineNumber": 58,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "jordancjq"
         },
         "content": "            Phone phone \u003d ParserUtil.parsePhone(ParserUtil.parseValue(argMultimap.getValue(PREFIX_PHONE),"
       },
       {
         "lineNumber": 59,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "jordancjq"
         },
         "content": "                    Phone.MESSAGE_PHONE_CONSTRAINTS)).get();"
       },
       {
         "lineNumber": 60,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "            Email email \u003d ParserUtil.parseEmail(argMultimap.getValue(PREFIX_EMAIL)).get();"
       },
       {
         "lineNumber": 61,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "jordancjq"
         },
         "content": "            Address address \u003d ParserUtil.parseAddress(ParserUtil.parseValue(argMultimap"
       },
       {
         "lineNumber": 62,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "jordancjq"
         },
         "content": "                    .getValue(PREFIX_ADDRESS), Address.MESSAGE_ADDRESS_CONSTRAINTS)).get();"
       },
       {
         "lineNumber": 63,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "jordancjq"
         },
         "content": "            Remark remark \u003d new Remark(\"\");"
       },
       {
         "lineNumber": 64,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "jordancjq"
         },
         "content": "            TeamName teamName \u003d ParserUtil.parseTeamName(ParserUtil.parseValue(argMultimap.getValue(PREFIX_TEAM_NAME),"
       },
       {
         "lineNumber": 65,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "jordancjq"
         },
         "content": "                    TeamName.MESSAGE_TEAM_NAME_CONSTRAINTS)).get();"
       },
       {
         "lineNumber": 66,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "            Set\u003cTag\u003e tagList \u003d ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));"
       },
       {
         "lineNumber": 67,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "jordancjq"
         },
         "content": "            Rating rating \u003d ParserUtil.parseRating(ParserUtil.parseValue(argMultimap.getValue(PREFIX_RATING),"
       },
       {
         "lineNumber": 68,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "jordancjq"
         },
         "content": "                    Rating.MESSAGE_RATING_CONSTRAINTS)).get();"
       },
       {
         "lineNumber": 69,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "            Position position \u003d ParserUtil.parsePosition(ParserUtil.parseValue(argMultimap"
       },
       {
         "lineNumber": 70,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "jordancjq"
         },
         "content": "                    .getValue(PREFIX_POSITION), Position.MESSAGE_POSITION_CONSTRAINTS)).get();"
       },
       {
         "lineNumber": 71,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "            JerseyNumber jerseyNumber \u003d ParserUtil.parseJerseyNumber(ParserUtil.parseValue(argMultimap"
       },
       {
         "lineNumber": 72,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "jordancjq"
         },
         "content": "                    .getValue(PREFIX_JERSEY_NUMBER), JerseyNumber.MESSAGE_JERSEY_NUMBER_CONSTRAINTS)).get();"
       },
       {
         "lineNumber": 73,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "            Avatar avatar \u003d ParserUtil.parseAvatar(ParserUtil.parseValue(argMultimap"
       },
       {
         "lineNumber": 74,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "                    .getValue(PREFIX_AVATAR), Avatar.MESSAGE_AVATAR_CONSTRAINTS)).get();"
       },
       {
         "lineNumber": 75,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "            Person person \u003d new Person(name, phone, email, address, remark, teamName, tagList, rating, position,"
       },
       {
         "lineNumber": 76,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "                    jerseyNumber, avatar);"
       },
       {
         "lineNumber": 77,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 78,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "            return new AddCommand(person);"
       },
       {
         "lineNumber": 79,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        } catch (IllegalValueException ive) {"
       },
       {
         "lineNumber": 80,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "            throw new ParseException(ive.getMessage(), ive);"
       },
       {
         "lineNumber": 81,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        }"
       },
       {
         "lineNumber": 82,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    }"
       },
       {
         "lineNumber": 83,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 84,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    /**"
       },
       {
         "lineNumber": 85,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "     * Returns true if none of the prefixes contains empty {@code Optional} values in the given"
       },
       {
         "lineNumber": 86,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "     * {@code ArgumentMultimap}."
       },
       {
         "lineNumber": 87,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "     */"
       },
       {
         "lineNumber": 88,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {"
       },
       {
         "lineNumber": 89,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        return Stream.of(prefixes).allMatch(prefix -\u003e argumentMultimap.getValue(prefix).isPresent());"
       },
       {
         "lineNumber": 90,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    }"
       },
       {
         "lineNumber": 91,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 92,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "}"
       }
     ],
     "authorContributionMap": {
-      "lithiumlkid": 59,
-      "jordancjq": 3,
-      "-": 30
+      "jordancjq": 16,
+      "-": 76
     }
   },
   {
@@ -45630,197 +41763,6 @@
     }
   },
   {
-    "path": "src/main/java/seedu/address/logic/parser/ChangeThemeCommandParser.java",
-    "lines": [
-      {
-        "lineNumber": 1,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "package seedu.address.logic.parser;"
-      },
-      {
-        "lineNumber": 2,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 3,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;"
-      },
-      {
-        "lineNumber": 4,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static seedu.address.logic.commands.ChangeThemeCommand.MESSAGE_USAGE;"
-      },
-      {
-        "lineNumber": 5,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 6,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.logic.commands.ChangeThemeCommand;"
-      },
-      {
-        "lineNumber": 7,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.logic.parser.exceptions.ParseException;"
-      },
-      {
-        "lineNumber": 8,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 9,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "/**"
-      },
-      {
-        "lineNumber": 10,
-        "author": {
-          "gitId": "-"
-        },
-        "content": " * Parses input arguments and creates a new ThemeCommand object."
-      },
-      {
-        "lineNumber": 11,
-        "author": {
-          "gitId": "-"
-        },
-        "content": " */"
-      },
-      {
-        "lineNumber": 12,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "/** @@author Codee */"
-      },
-      {
-        "lineNumber": 13,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "public class ChangeThemeCommandParser implements Parser\u003cChangeThemeCommand\u003e {"
-      },
-      {
-        "lineNumber": 14,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 15,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    /**"
-      },
-      {
-        "lineNumber": 16,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "     * Parses the given (@code String) in the context of a ThemeCommand."
-      },
-      {
-        "lineNumber": 17,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "     * @return ThemeCommand Object for execution"
-      },
-      {
-        "lineNumber": 18,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "     * @throws ParseException if the user input does not conform the expected format"
-      },
-      {
-        "lineNumber": 19,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "     */"
-      },
-      {
-        "lineNumber": 20,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    public ChangeThemeCommand parse(String userInput) throws ParseException {"
-      },
-      {
-        "lineNumber": 21,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        if (userInput.length() \u003d\u003d 0) {"
-      },
-      {
-        "lineNumber": 22,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_USAGE));"
-      },
-      {
-        "lineNumber": 23,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        }"
-      },
-      {
-        "lineNumber": 24,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        return new ChangeThemeCommand(userInput);"
-      },
-      {
-        "lineNumber": 25,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 26,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "}"
-      }
-    ],
-    "authorContributionMap": {
-      "codeeong": 15,
-      "-": 11
-    }
-  },
-  {
     "path": "src/main/java/seedu/address/logic/parser/CliSyntax.java",
     "lines": [
       {
@@ -46291,659 +42233,6 @@
     ],
     "authorContributionMap": {
       "jordancjq": 42
-    }
-  },
-  {
-    "path": "src/main/java/seedu/address/logic/parser/EditCommandParser.java",
-    "lines": [
-      {
-        "lineNumber": 1,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "package seedu.address.logic.parser;"
-      },
-      {
-        "lineNumber": 2,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 3,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static java.util.Objects.requireNonNull;"
-      },
-      {
-        "lineNumber": 4,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;"
-      },
-      {
-        "lineNumber": 5,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;"
-      },
-      {
-        "lineNumber": 6,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static seedu.address.logic.parser.CliSyntax.PREFIX_AVATAR;"
-      },
-      {
-        "lineNumber": 7,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;"
-      },
-      {
-        "lineNumber": 8,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static seedu.address.logic.parser.CliSyntax.PREFIX_JERSEY_NUMBER;"
-      },
-      {
-        "lineNumber": 9,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;"
-      },
-      {
-        "lineNumber": 10,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;"
-      },
-      {
-        "lineNumber": 11,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static seedu.address.logic.parser.CliSyntax.PREFIX_POSITION;"
-      },
-      {
-        "lineNumber": 12,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static seedu.address.logic.parser.CliSyntax.PREFIX_RATING;"
-      },
-      {
-        "lineNumber": 13,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;"
-      },
-      {
-        "lineNumber": 14,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 15,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import java.util.Collection;"
-      },
-      {
-        "lineNumber": 16,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import java.util.Collections;"
-      },
-      {
-        "lineNumber": 17,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import java.util.Optional;"
-      },
-      {
-        "lineNumber": 18,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import java.util.Set;"
-      },
-      {
-        "lineNumber": 19,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 20,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.commons.core.index.Index;"
-      },
-      {
-        "lineNumber": 21,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.commons.exceptions.IllegalValueException;"
-      },
-      {
-        "lineNumber": 22,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.logic.commands.EditCommand;"
-      },
-      {
-        "lineNumber": 23,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.logic.commands.EditCommand.EditPersonDescriptor;"
-      },
-      {
-        "lineNumber": 24,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.logic.parser.exceptions.ParseException;"
-      },
-      {
-        "lineNumber": 25,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.model.tag.Tag;"
-      },
-      {
-        "lineNumber": 26,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 27,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "//@@author lithiumlkid"
-      },
-      {
-        "lineNumber": 28,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "/**"
-      },
-      {
-        "lineNumber": 29,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": " * Parses input arguments and creates a new EditCommand object"
-      },
-      {
-        "lineNumber": 30,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": " */"
-      },
-      {
-        "lineNumber": 31,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "public class EditCommandParser implements Parser\u003cEditCommand\u003e {"
-      },
-      {
-        "lineNumber": 32,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 33,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    /**"
-      },
-      {
-        "lineNumber": 34,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "     * Parses the given {@code String} of arguments in the context of the EditCommand"
-      },
-      {
-        "lineNumber": 35,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "     * and returns an EditCommand object for execution."
-      },
-      {
-        "lineNumber": 36,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "     * @throws ParseException if the user input does not conform the expected format"
-      },
-      {
-        "lineNumber": 37,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "     */"
-      },
-      {
-        "lineNumber": 38,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    public EditCommand parse(String args) throws ParseException {"
-      },
-      {
-        "lineNumber": 39,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        requireNonNull(args);"
-      },
-      {
-        "lineNumber": 40,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        ArgumentMultimap argMultimap \u003d"
-      },
-      {
-        "lineNumber": 41,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "                ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL,"
-      },
-      {
-        "lineNumber": 42,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "                        PREFIX_ADDRESS, PREFIX_TAG, PREFIX_RATING, PREFIX_POSITION, PREFIX_JERSEY_NUMBER,"
-      },
-      {
-        "lineNumber": 43,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "                        PREFIX_AVATAR);"
-      },
-      {
-        "lineNumber": 44,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 45,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        Index index;"
-      },
-      {
-        "lineNumber": 46,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 47,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        try {"
-      },
-      {
-        "lineNumber": 48,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "            index \u003d ParserUtil.parseIndex(argMultimap.getPreamble());"
-      },
-      {
-        "lineNumber": 49,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        } catch (IllegalValueException ive) {"
-      },
-      {
-        "lineNumber": 50,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE));"
-      },
-      {
-        "lineNumber": 51,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        }"
-      },
-      {
-        "lineNumber": 52,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 53,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        EditPersonDescriptor editPersonDescriptor \u003d new EditPersonDescriptor();"
-      },
-      {
-        "lineNumber": 54,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        try {"
-      },
-      {
-        "lineNumber": 55,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "            ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME)).ifPresent(editPersonDescriptor::setName);"
-      },
-      {
-        "lineNumber": 56,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "            ParserUtil.parsePhone(argMultimap.getValue(PREFIX_PHONE)).ifPresent(editPersonDescriptor::setPhone);"
-      },
-      {
-        "lineNumber": 57,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "            ParserUtil.parseEmail(argMultimap.getValue(PREFIX_EMAIL)).ifPresent(editPersonDescriptor::setEmail);"
-      },
-      {
-        "lineNumber": 58,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "            ParserUtil.parseAddress(argMultimap.getValue(PREFIX_ADDRESS)).ifPresent(editPersonDescriptor::setAddress);"
-      },
-      {
-        "lineNumber": 59,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "            parseTagsForEdit(argMultimap.getAllValues(PREFIX_TAG)).ifPresent(editPersonDescriptor::setTags);"
-      },
-      {
-        "lineNumber": 60,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "            ParserUtil.parseRating(argMultimap.getValue(PREFIX_RATING)).ifPresent(editPersonDescriptor::setRating);"
-      },
-      {
-        "lineNumber": 61,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "            ParserUtil.parsePosition(argMultimap.getValue(PREFIX_POSITION))"
-      },
-      {
-        "lineNumber": 62,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "                    .ifPresent(editPersonDescriptor::setPosition);"
-      },
-      {
-        "lineNumber": 63,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "            ParserUtil.parseJerseyNumber(argMultimap.getValue(PREFIX_JERSEY_NUMBER))"
-      },
-      {
-        "lineNumber": 64,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "                    .ifPresent(editPersonDescriptor::setJerseyNumber);"
-      },
-      {
-        "lineNumber": 65,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "            ParserUtil.parseAvatar(argMultimap.getValue(PREFIX_AVATAR)).ifPresent(editPersonDescriptor::setAvatar);"
-      },
-      {
-        "lineNumber": 66,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        } catch (IllegalValueException ive) {"
-      },
-      {
-        "lineNumber": 67,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "            throw new ParseException(ive.getMessage(), ive);"
-      },
-      {
-        "lineNumber": 68,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        }"
-      },
-      {
-        "lineNumber": 69,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 70,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        if (!editPersonDescriptor.isAnyFieldEdited()) {"
-      },
-      {
-        "lineNumber": 71,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "            throw new ParseException(EditCommand.MESSAGE_NOT_EDITED);"
-      },
-      {
-        "lineNumber": 72,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        }"
-      },
-      {
-        "lineNumber": 73,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 74,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        return new EditCommand(index, editPersonDescriptor);"
-      },
-      {
-        "lineNumber": 75,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 76,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 77,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    /**"
-      },
-      {
-        "lineNumber": 78,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "     * Parses {@code Collection\u003cString\u003e tags} into a {@code Set\u003cTag\u003e} if {@code tags} is non-empty."
-      },
-      {
-        "lineNumber": 79,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "     * If {@code tags} contain only one element which is an empty string, it will be parsed into a"
-      },
-      {
-        "lineNumber": 80,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "     * {@code Set\u003cTag\u003e} containing zero tags."
-      },
-      {
-        "lineNumber": 81,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "     */"
-      },
-      {
-        "lineNumber": 82,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    private Optional\u003cSet\u003cTag\u003e\u003e parseTagsForEdit(Collection\u003cString\u003e tags) throws IllegalValueException {"
-      },
-      {
-        "lineNumber": 83,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        assert tags !\u003d null;"
-      },
-      {
-        "lineNumber": 84,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 85,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        if (tags.isEmpty()) {"
-      },
-      {
-        "lineNumber": 86,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "            return Optional.empty();"
-      },
-      {
-        "lineNumber": 87,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        }"
-      },
-      {
-        "lineNumber": 88,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        Collection\u003cString\u003e tagSet \u003d tags.size() \u003d\u003d 1 \u0026\u0026 tags.contains(\"\") ? Collections.emptySet() : tags;"
-      },
-      {
-        "lineNumber": 89,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        return Optional.of(ParserUtil.parseTags(tagSet));"
-      },
-      {
-        "lineNumber": 90,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 91,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 92,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "}"
-      }
-    ],
-    "authorContributionMap": {
-      "lithiumlkid": 66,
-      "-": 26
     }
   },
   {
@@ -50530,407 +45819,6 @@
     }
   },
   {
-    "path": "src/main/java/seedu/address/logic/parser/SetCommandParser.java",
-    "lines": [
-      {
-        "lineNumber": 1,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "package seedu.address.logic.parser;"
-      },
-      {
-        "lineNumber": 2,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 3,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;"
-      },
-      {
-        "lineNumber": 4,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;"
-      },
-      {
-        "lineNumber": 5,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG_COLOUR;"
-      },
-      {
-        "lineNumber": 6,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 7,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import java.util.stream.Stream;"
-      },
-      {
-        "lineNumber": 8,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 9,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.commons.exceptions.IllegalValueException;"
-      },
-      {
-        "lineNumber": 10,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.logic.commands.SetCommand;"
-      },
-      {
-        "lineNumber": 11,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.logic.parser.exceptions.ParseException;"
-      },
-      {
-        "lineNumber": 12,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.model.tag.Tag;"
-      },
-      {
-        "lineNumber": 13,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 14,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "/**"
-      },
-      {
-        "lineNumber": 15,
-        "author": {
-          "gitId": "-"
-        },
-        "content": " * This class is to check whether Set Command was input correctly"
-      },
-      {
-        "lineNumber": 16,
-        "author": {
-          "gitId": "-"
-        },
-        "content": " */"
-      },
-      {
-        "lineNumber": 17,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "/** @@author Codee */"
-      },
-      {
-        "lineNumber": 18,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "public class SetCommandParser implements Parser\u003cSetCommand\u003e {"
-      },
-      {
-        "lineNumber": 19,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 20,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    /**"
-      },
-      {
-        "lineNumber": 21,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "     * Parses the given {@code String} of arguments in the context of the SetCommand"
-      },
-      {
-        "lineNumber": 22,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "     * and returns an SetCommand object for execution."
-      },
-      {
-        "lineNumber": 23,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "     * @throws ParseException if the user input does not conform the expected format"
-      },
-      {
-        "lineNumber": 24,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "     */"
-      },
-      {
-        "lineNumber": 25,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    public SetCommand parse(String args) throws ParseException {"
-      },
-      {
-        "lineNumber": 26,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 27,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        ArgumentMultimap argMultimap \u003d"
-      },
-      {
-        "lineNumber": 28,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "                ArgumentTokenizer.tokenize(args, PREFIX_TAG, PREFIX_TAG_COLOUR);"
-      },
-      {
-        "lineNumber": 29,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 30,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        if (!arePrefixesPresent(argMultimap, PREFIX_TAG, PREFIX_TAG_COLOUR)"
-      },
-      {
-        "lineNumber": 31,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "                || !argMultimap.getPreamble().isEmpty()) {"
-      },
-      {
-        "lineNumber": 32,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, SetCommand.MESSAGE_USAGE));"
-      },
-      {
-        "lineNumber": 33,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        }"
-      },
-      {
-        "lineNumber": 34,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 35,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        try {"
-      },
-      {
-        "lineNumber": 36,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "            Tag tag \u003d ParserUtil.parseTag(argMultimap.getValue(PREFIX_TAG).get());"
-      },
-      {
-        "lineNumber": 37,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "            String colour \u003d ParserUtil.parseTagColour(argMultimap.getValue(PREFIX_TAG_COLOUR).get());"
-      },
-      {
-        "lineNumber": 38,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "            if (!tag.isValidTagColour(colour)) {"
-      },
-      {
-        "lineNumber": 39,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "                throw new ParseException("
-      },
-      {
-        "lineNumber": 40,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "                        String.format(MESSAGE_INVALID_COMMAND_FORMAT, SetCommand.MESSAGE_USAGE));"
-      },
-      {
-        "lineNumber": 41,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "            }"
-      },
-      {
-        "lineNumber": 42,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "            return new SetCommand(tag, colour);"
-      },
-      {
-        "lineNumber": 43,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        } catch (IllegalValueException ive) {"
-      },
-      {
-        "lineNumber": 44,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "            throw new ParseException("
-      },
-      {
-        "lineNumber": 45,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, SetCommand.MESSAGE_USAGE));"
-      },
-      {
-        "lineNumber": 46,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        }"
-      },
-      {
-        "lineNumber": 47,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 48,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 49,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    /**"
-      },
-      {
-        "lineNumber": 50,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "     * Returns true if none of the prefixes contains empty {@code Optional} values in the given"
-      },
-      {
-        "lineNumber": 51,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "     * {@code ArgumentMultimap}."
-      },
-      {
-        "lineNumber": 52,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "     */"
-      },
-      {
-        "lineNumber": 53,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {"
-      },
-      {
-        "lineNumber": 54,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        return Stream.of(prefixes).allMatch(prefix -\u003e argumentMultimap.getValue(prefix).isPresent());"
-      },
-      {
-        "lineNumber": 55,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 56,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "}"
-      }
-    ],
-    "authorContributionMap": {
-      "codeeong": 40,
-      "-": 16
-    }
-  },
-  {
     "path": "src/main/java/seedu/address/logic/parser/SortCommandParser.java",
     "lines": [
       {
@@ -53389,71 +48277,68 @@
       {
         "lineNumber": 190,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    /** @@author Codee */"
       },
       {
         "lineNumber": 191,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    public void setTagColour(Tag tag, String colour) {"
       },
       {
         "lineNumber": 192,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        for (Tag t : tags) {"
       },
       {
         "lineNumber": 193,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "            if (t.getTagName().equals(tag.getTagName())) {"
       },
       {
         "lineNumber": 194,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "                t.changeTagColour(colour);"
       },
       {
         "lineNumber": 195,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "            }"
       },
       {
         "lineNumber": 196,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        }"
       },
       {
         "lineNumber": 197,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    }"
       },
       {
         "lineNumber": 198,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 199,
-        "author": {
-          "gitId": "codeeong"
-        },
         "content": "    //@@author"
       },
       {
@@ -55222,10 +50107,10 @@
       }
     ],
     "authorContributionMap": {
+      "null": 1,
       "lohtianwei": 7,
       "jordancjq": 240,
-      "codeeong": 10,
-      "-": 194
+      "-": 203
     }
   },
   {
@@ -57050,141 +51935,138 @@
       {
         "lineNumber": 158,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    //@@author Codee"
       },
       {
         "lineNumber": 159,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    @Override"
       },
       {
         "lineNumber": 160,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    public boolean setTagColour(Tag tag, String colour) {"
       },
       {
         "lineNumber": 161,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        ObservableList\u003cTag\u003e allTags \u003d addressBook.getTagList();"
       },
       {
         "lineNumber": 162,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        boolean isTagValid \u003d false;"
       },
       {
         "lineNumber": 163,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        for (Tag t : allTags) {"
       },
       {
         "lineNumber": 164,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "            if (t.getTagName().equals(tag.getTagName())) {"
       },
       {
         "lineNumber": 165,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "                isTagValid \u003d true;"
       },
       {
         "lineNumber": 166,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "                break;"
       },
       {
         "lineNumber": 167,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "            }"
       },
       {
         "lineNumber": 168,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        }"
       },
       {
         "lineNumber": 169,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        if (!isTagValid) {"
       },
       {
         "lineNumber": 170,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "            return false;"
       },
       {
         "lineNumber": 171,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        }"
       },
       {
         "lineNumber": 172,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        addressBook.setTagColour(tag, colour);"
       },
       {
         "lineNumber": 173,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        indicateAddressBookChanged();"
       },
       {
         "lineNumber": 174,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        return isTagValid;"
       },
       {
         "lineNumber": 175,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    }"
       },
       {
         "lineNumber": 176,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 177,
-        "author": {
-          "gitId": "codeeong"
-        },
         "content": "    //@@author"
       },
       {
@@ -57574,10 +52456,10 @@
       }
     ],
     "authorContributionMap": {
+      "null": 1,
       "lohtianwei": 28,
       "jordancjq": 60,
-      "codeeong": 20,
-      "-": 124
+      "-": 143
     }
   },
   {
@@ -58281,64 +53163,61 @@
       {
         "lineNumber": 69,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    //@@author Codee"
       },
       {
         "lineNumber": 70,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    public void setAddressBookName(String addressBookName) {"
       },
       {
         "lineNumber": 71,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        this.addressBookName \u003d addressBookName;"
       },
       {
         "lineNumber": 72,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    }"
       },
       {
         "lineNumber": 73,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 74,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    public String getAddressBookTheme() {"
       },
       {
         "lineNumber": 75,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        return addressBookTheme;"
       },
       {
         "lineNumber": 76,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    }"
       },
       {
         "lineNumber": 77,
-        "author": {
-          "gitId": "codeeong"
-        },
         "content": "    //@@author"
       },
       {
@@ -58623,9 +53502,9 @@
       }
     ],
     "authorContributionMap": {
+      "null": 1,
       "lohtianwei": 28,
-      "codeeong": 9,
-      "-": 80
+      "-": 88
     }
   },
   {
@@ -59203,785 +54082,6 @@
       "lohtianwei": 22,
       "jordancjq": 2,
       "-": 57
-    }
-  },
-  {
-    "path": "src/main/java/seedu/address/model/person/Avatar.java",
-    "lines": [
-      {
-        "lineNumber": 1,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "package seedu.address.model.person;"
-      },
-      {
-        "lineNumber": 2,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 3,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static java.util.Objects.requireNonNull;"
-      },
-      {
-        "lineNumber": 4,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static seedu.address.commons.util.AppUtil.checkArgument;"
-      },
-      {
-        "lineNumber": 5,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static seedu.address.logic.parser.ParserUtil.UNSPECIFIED_FIELD;"
-      },
-      {
-        "lineNumber": 6,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 7,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import java.io.File;"
-      },
-      {
-        "lineNumber": 8,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import java.io.IOException;"
-      },
-      {
-        "lineNumber": 9,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import java.nio.file.Files;"
-      },
-      {
-        "lineNumber": 10,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import java.nio.file.Path;"
-      },
-      {
-        "lineNumber": 11,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import java.nio.file.Paths;"
-      },
-      {
-        "lineNumber": 12,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import java.nio.file.StandardCopyOption;"
-      },
-      {
-        "lineNumber": 13,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import java.util.regex.Matcher;"
-      },
-      {
-        "lineNumber": 14,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import java.util.regex.Pattern;"
-      },
-      {
-        "lineNumber": 15,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 16,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.commons.core.LogsCenter;"
-      },
-      {
-        "lineNumber": 17,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 18,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "//@@author lithiumlkid"
-      },
-      {
-        "lineNumber": 19,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "/**"
-      },
-      {
-        "lineNumber": 20,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": " * Represents a Player\u0027s avatar in the address book. Contains filepath to avatar image file."
-      },
-      {
-        "lineNumber": 21,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": " * Guarantees: immutable; is valid as declared in {@link #isValidAvatar(String)}"
-      },
-      {
-        "lineNumber": 22,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": " */"
-      },
-      {
-        "lineNumber": 23,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "public class Avatar {"
-      },
-      {
-        "lineNumber": 24,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 25,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    public static final String MESSAGE_AVATAR_CONSTRAINTS \u003d"
-      },
-      {
-        "lineNumber": 26,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "            \"Please specify the absolute filepath for the avatar image eg. av/C:\\\\image.png\\n (for Windows), \""
-      },
-      {
-        "lineNumber": 27,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "            + \"av//User/username/path/to/image.jpg (for MacOS). \""
-      },
-      {
-        "lineNumber": 28,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "            + \"Image file should be 200x200 and in jpg or png format\";"
-      },
-      {
-        "lineNumber": 29,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 30,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    public static final String AVATAR_VALIDATION_PATTERN \u003d \"([^\\\\s]+(\\\\.(?i)(jpg|png))$)\";"
-      },
-      {
-        "lineNumber": 31,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 32,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    private String value;"
-      },
-      {
-        "lineNumber": 33,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 34,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    /**"
-      },
-      {
-        "lineNumber": 35,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "     * Constructs an {@code Avatar}."
-      },
-      {
-        "lineNumber": 36,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "     *"
-      },
-      {
-        "lineNumber": 37,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "     * @param avatar A valid avatar."
-      },
-      {
-        "lineNumber": 38,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "     */"
-      },
-      {
-        "lineNumber": 39,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    public Avatar(String avatar) {"
-      },
-      {
-        "lineNumber": 40,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        requireNonNull(avatar);"
-      },
-      {
-        "lineNumber": 41,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        checkArgument(isValidAvatar(avatar), MESSAGE_AVATAR_CONSTRAINTS);"
-      },
-      {
-        "lineNumber": 42,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        this.value \u003d avatar;"
-      },
-      {
-        "lineNumber": 43,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 44,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 45,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    /**"
-      },
-      {
-        "lineNumber": 46,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "     * Returns true if a given string is a valid player\u0027s avatar."
-      },
-      {
-        "lineNumber": 47,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "     */"
-      },
-      {
-        "lineNumber": 48,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    public static boolean isValidAvatar(String test) {"
-      },
-      {
-        "lineNumber": 49,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        Pattern pattern \u003d Pattern.compile(AVATAR_VALIDATION_PATTERN);"
-      },
-      {
-        "lineNumber": 50,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        Matcher matcher \u003d pattern.matcher(test);"
-      },
-      {
-        "lineNumber": 51,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        return matcher.matches() || test.equals(UNSPECIFIED_FIELD);"
-      },
-      {
-        "lineNumber": 52,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 53,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 54,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    @Override"
-      },
-      {
-        "lineNumber": 55,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    public String toString() {"
-      },
-      {
-        "lineNumber": 56,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        return value;"
-      },
-      {
-        "lineNumber": 57,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 58,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 59,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    /*"
-      },
-      {
-        "lineNumber": 60,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    @Override"
-      },
-      {
-        "lineNumber": 61,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    public boolean equals(Object other) {"
-      },
-      {
-        "lineNumber": 62,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        return other \u003d\u003d this // short circuit if same object"
-      },
-      {
-        "lineNumber": 63,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "                || (other instanceof Avatar // instanceof handles nulls"
-      },
-      {
-        "lineNumber": 64,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "                \u0026\u0026 this.value.equals(((Avatar) other).value)); // state check"
-      },
-      {
-        "lineNumber": 65,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 66,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    */"
-      },
-      {
-        "lineNumber": 67,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 68,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    /**"
-      },
-      {
-        "lineNumber": 69,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "     * Copies the image file from file path entered into images/ and renames it as [name].png"
-      },
-      {
-        "lineNumber": 70,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "     * and saves the file path in value"
-      },
-      {
-        "lineNumber": 71,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "     * @param player player\u0027s avatar image filepath string"
-      },
-      {
-        "lineNumber": 72,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "     * @throws IOException  thrown when file not found"
-      },
-      {
-        "lineNumber": 73,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "     */"
-      },
-      {
-        "lineNumber": 74,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    public void setFilePath(String player) throws IOException {"
-      },
-      {
-        "lineNumber": 75,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        if (value.equals(\"\u003cUNSPECIFIED\u003e\")) {"
-      },
-      {
-        "lineNumber": 76,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "            return;"
-      },
-      {
-        "lineNumber": 77,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        }"
-      },
-      {
-        "lineNumber": 78,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        final File file \u003d new File(value);"
-      },
-      {
-        "lineNumber": 79,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 80,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        Path dest \u003d new File(\"images/\" + player.replaceAll(\"\\\\s+\", \"\") + \".png\").toPath();"
-      },
-      {
-        "lineNumber": 81,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        Files.createDirectories(Paths.get(\"images\")); // Creates missing directories if any"
-      },
-      {
-        "lineNumber": 82,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        Files.copy(file.toPath(), dest, StandardCopyOption.REPLACE_EXISTING);"
-      },
-      {
-        "lineNumber": 83,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        this.value \u003d dest.toString();"
-      },
-      {
-        "lineNumber": 84,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 85,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 86,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    public String getValue() {"
-      },
-      {
-        "lineNumber": 87,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        return value;"
-      },
-      {
-        "lineNumber": 88,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 89,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 90,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    public static void setUpPlaceholderForTest() {"
-      },
-      {
-        "lineNumber": 91,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        try {"
-      },
-      {
-        "lineNumber": 92,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "            Files.copy(Avatar.class.getResourceAsStream(\"/images/placeholder_test.png\"),"
-      },
-      {
-        "lineNumber": 93,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "                    Paths.get(\"images/placeholder_test.png\"), StandardCopyOption.REPLACE_EXISTING);"
-      },
-      {
-        "lineNumber": 94,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        } catch (IOException e) {"
-      },
-      {
-        "lineNumber": 95,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "            LogsCenter.getLogger(Avatar.class).warning(\"placeholder image file missing\");"
-      },
-      {
-        "lineNumber": 96,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        }"
-      },
-      {
-        "lineNumber": 97,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 98,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 99,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    @Override"
-      },
-      {
-        "lineNumber": 100,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    public boolean equals(Object other) {"
-      },
-      {
-        "lineNumber": 101,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        return other \u003d\u003d this // short circuit if same object"
-      },
-      {
-        "lineNumber": 102,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "                || (other instanceof Avatar // instanceof handles nulls"
-      },
-      {
-        "lineNumber": 103,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "                \u0026\u0026 this.value.equals(((Avatar) other).value)); // state check"
-      },
-      {
-        "lineNumber": 104,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 105,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 106,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    @Override"
-      },
-      {
-        "lineNumber": 107,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    public int hashCode() {"
-      },
-      {
-        "lineNumber": 108,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        return value.hashCode();"
-      },
-      {
-        "lineNumber": 109,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 110,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "}"
-      }
-    ],
-    "authorContributionMap": {
-      "lithiumlkid": 93,
-      "-": 17
     }
   },
   {
@@ -60614,414 +54714,6 @@
     "authorContributionMap": {
       "lohtianwei": 22,
       "-": 67
-    }
-  },
-  {
-    "path": "src/main/java/seedu/address/model/person/JerseyNumber.java",
-    "lines": [
-      {
-        "lineNumber": 1,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "package seedu.address.model.person;"
-      },
-      {
-        "lineNumber": 2,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 3,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static java.util.Objects.requireNonNull;"
-      },
-      {
-        "lineNumber": 4,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static seedu.address.commons.util.AppUtil.checkArgument;"
-      },
-      {
-        "lineNumber": 5,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static seedu.address.logic.parser.ParserUtil.UNSPECIFIED_FIELD;"
-      },
-      {
-        "lineNumber": 6,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 7,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "//@@author lithiumlkid"
-      },
-      {
-        "lineNumber": 8,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "/**"
-      },
-      {
-        "lineNumber": 9,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": " * Represents a Player\u0027s jersey number in the address book."
-      },
-      {
-        "lineNumber": 10,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": " * Guarantees: immutable; is valid as declared in {@link #isValidJerseyNumber(String)}"
-      },
-      {
-        "lineNumber": 11,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": " */"
-      },
-      {
-        "lineNumber": 12,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "public class JerseyNumber {"
-      },
-      {
-        "lineNumber": 13,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 14,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    public static final String MESSAGE_JERSEY_NUMBER_CONSTRAINTS \u003d"
-      },
-      {
-        "lineNumber": 15,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "            \"Player\u0027s jersey number should be an integer from 0 - 99.\";"
-      },
-      {
-        "lineNumber": 16,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 17,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 18,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    public static final String RATING_VALIDATION_REGEX \u003d \"[0-9]|[1-8][0-9]|9[0-9]\";"
-      },
-      {
-        "lineNumber": 19,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 20,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    public final String value;"
-      },
-      {
-        "lineNumber": 21,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 22,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    /**"
-      },
-      {
-        "lineNumber": 23,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "     * Constructs an {@code JerseyNumber}."
-      },
-      {
-        "lineNumber": 24,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "     *"
-      },
-      {
-        "lineNumber": 25,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "     * @param jerseyNumber A valid jersey number."
-      },
-      {
-        "lineNumber": 26,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "     */"
-      },
-      {
-        "lineNumber": 27,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    public JerseyNumber(String jerseyNumber) {"
-      },
-      {
-        "lineNumber": 28,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        requireNonNull(jerseyNumber);"
-      },
-      {
-        "lineNumber": 29,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        checkArgument(isValidJerseyNumber(jerseyNumber), MESSAGE_JERSEY_NUMBER_CONSTRAINTS);"
-      },
-      {
-        "lineNumber": 30,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        this.value \u003d jerseyNumber;"
-      },
-      {
-        "lineNumber": 31,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 32,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 33,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    /**"
-      },
-      {
-        "lineNumber": 34,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "     * Returns true if a given string is a valid player\u0027s jersey number."
-      },
-      {
-        "lineNumber": 35,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "     */"
-      },
-      {
-        "lineNumber": 36,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    public static boolean isValidJerseyNumber(String test) {"
-      },
-      {
-        "lineNumber": 37,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        return test.matches(RATING_VALIDATION_REGEX) || test.equals(UNSPECIFIED_FIELD);"
-      },
-      {
-        "lineNumber": 38,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 39,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 40,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    @Override"
-      },
-      {
-        "lineNumber": 41,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    public String toString() {"
-      },
-      {
-        "lineNumber": 42,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        return value;"
-      },
-      {
-        "lineNumber": 43,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 44,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 45,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    @Override"
-      },
-      {
-        "lineNumber": 46,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    public boolean equals(Object other) {"
-      },
-      {
-        "lineNumber": 47,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        return other \u003d\u003d this // short circuit if same object"
-      },
-      {
-        "lineNumber": 48,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "                || (other instanceof JerseyNumber // instanceof handles nulls"
-      },
-      {
-        "lineNumber": 49,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "                \u0026\u0026 this.value.equals(((JerseyNumber) other).value)); // state check"
-      },
-      {
-        "lineNumber": 50,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 51,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 52,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    @Override"
-      },
-      {
-        "lineNumber": 53,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    public int hashCode() {"
-      },
-      {
-        "lineNumber": 54,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        return value.hashCode();"
-      },
-      {
-        "lineNumber": 55,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 56,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 57,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "}"
-      }
-    ],
-    "authorContributionMap": {
-      "lithiumlkid": 51,
-      "-": 6
     }
   },
   {
@@ -62633,547 +56325,6 @@
     }
   },
   {
-    "path": "src/main/java/seedu/address/model/person/Position.java",
-    "lines": [
-      {
-        "lineNumber": 1,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "package seedu.address.model.person;"
-      },
-      {
-        "lineNumber": 2,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 3,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static java.util.Objects.requireNonNull;"
-      },
-      {
-        "lineNumber": 4,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static seedu.address.commons.util.AppUtil.checkArgument;"
-      },
-      {
-        "lineNumber": 5,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static seedu.address.logic.parser.ParserUtil.UNSPECIFIED_FIELD;"
-      },
-      {
-        "lineNumber": 6,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 7,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import java.util.Collections;"
-      },
-      {
-        "lineNumber": 8,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import java.util.HashMap;"
-      },
-      {
-        "lineNumber": 9,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import java.util.Map;"
-      },
-      {
-        "lineNumber": 10,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 11,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "//@@author lithiumlkid"
-      },
-      {
-        "lineNumber": 12,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "/**"
-      },
-      {
-        "lineNumber": 13,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": " * Represents a Player\u0027s position in the address book."
-      },
-      {
-        "lineNumber": 14,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": " * Guarantees: immutable; is valid as declared in {@link #isValidPosition(String)}"
-      },
-      {
-        "lineNumber": 15,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": " */"
-      },
-      {
-        "lineNumber": 16,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "public class Position {"
-      },
-      {
-        "lineNumber": 17,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 18,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    public static final String MESSAGE_POSITION_CONSTRAINTS \u003d"
-      },
-      {
-        "lineNumber": 19,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "            \"Player\u0027s position should be an integer from 1 - 4 where 1 - Striker, 2 - Midfield, 3 - Defender, \""
-      },
-      {
-        "lineNumber": 20,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "                   + \"and 4 - Goalkeeper.\";"
-      },
-      {
-        "lineNumber": 21,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 22,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    public static final String RATING_VALIDATION_REGEX \u003d \"[1-4]\";"
-      },
-      {
-        "lineNumber": 23,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    private static final Map\u003cString, String\u003e myMap;"
-      },
-      {
-        "lineNumber": 24,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    static {"
-      },
-      {
-        "lineNumber": 25,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        Map\u003cString, String\u003e aMap \u003d new HashMap\u003c\u003e();"
-      },
-      {
-        "lineNumber": 26,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        aMap.put(\"1\", \"Striker\");"
-      },
-      {
-        "lineNumber": 27,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        aMap.put(\"2\", \"Midfielder\");"
-      },
-      {
-        "lineNumber": 28,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        aMap.put(\"3\", \"Defender\");"
-      },
-      {
-        "lineNumber": 29,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        aMap.put(\"4\", \"Goalkeeper\");"
-      },
-      {
-        "lineNumber": 30,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        myMap \u003d Collections.unmodifiableMap(aMap);"
-      },
-      {
-        "lineNumber": 31,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 32,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    public final String value;"
-      },
-      {
-        "lineNumber": 33,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    /**"
-      },
-      {
-        "lineNumber": 34,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "     * Constructs an {@code Position}."
-      },
-      {
-        "lineNumber": 35,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "     *"
-      },
-      {
-        "lineNumber": 36,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "     * @param position A valid position."
-      },
-      {
-        "lineNumber": 37,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "     */"
-      },
-      {
-        "lineNumber": 38,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    public Position(String position) {"
-      },
-      {
-        "lineNumber": 39,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        requireNonNull(position);"
-      },
-      {
-        "lineNumber": 40,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        checkArgument(isValidPosition(position), MESSAGE_POSITION_CONSTRAINTS);"
-      },
-      {
-        "lineNumber": 41,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        this.value \u003d position;"
-      },
-      {
-        "lineNumber": 42,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 43,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 44,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    /**"
-      },
-      {
-        "lineNumber": 45,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "     * Returns true if a given string is a valid player\u0027s position."
-      },
-      {
-        "lineNumber": 46,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "     */"
-      },
-      {
-        "lineNumber": 47,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    public static boolean isValidPosition(String test) {"
-      },
-      {
-        "lineNumber": 48,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        return test.matches(RATING_VALIDATION_REGEX) || test.equals(UNSPECIFIED_FIELD);"
-      },
-      {
-        "lineNumber": 49,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 50,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 51,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    /**"
-      },
-      {
-        "lineNumber": 52,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "     * Returns position name according to value"
-      },
-      {
-        "lineNumber": 53,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "     * @return position name"
-      },
-      {
-        "lineNumber": 54,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "     */"
-      },
-      {
-        "lineNumber": 55,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    public String getPositionName() {"
-      },
-      {
-        "lineNumber": 56,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        return myMap.get(value);"
-      },
-      {
-        "lineNumber": 57,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 58,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 59,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    @Override"
-      },
-      {
-        "lineNumber": 60,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    public String toString() {"
-      },
-      {
-        "lineNumber": 61,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        return getPositionName();"
-      },
-      {
-        "lineNumber": 62,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 63,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 64,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    @Override"
-      },
-      {
-        "lineNumber": 65,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    public boolean equals(Object other) {"
-      },
-      {
-        "lineNumber": 66,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        return other \u003d\u003d this // short circuit if same object"
-      },
-      {
-        "lineNumber": 67,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "                || (other instanceof Position // instanceof handles nulls"
-      },
-      {
-        "lineNumber": 68,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "                \u0026\u0026 this.value.equals(((Position) other).value)); // state check"
-      },
-      {
-        "lineNumber": 69,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 70,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 71,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    @Override"
-      },
-      {
-        "lineNumber": 72,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    public int hashCode() {"
-      },
-      {
-        "lineNumber": 73,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        return value.hashCode();"
-      },
-      {
-        "lineNumber": 74,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 75,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 76,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "}"
-      }
-    ],
-    "authorContributionMap": {
-      "lithiumlkid": 66,
-      "-": 10
-    }
-  },
-  {
     "path": "src/main/java/seedu/address/model/person/Rating.java",
     "lines": [
       {
@@ -63221,504 +56372,504 @@
       {
         "lineNumber": 7,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "//@@author lithiumlkid"
       },
       {
         "lineNumber": 8,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "/**"
       },
       {
         "lineNumber": 9,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": " * Represents a Player\u0027s rating in the address book."
       },
       {
         "lineNumber": 10,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": " * Guarantees: immutable; is valid as declared in {@link #isValidRating(String)}"
       },
       {
         "lineNumber": 11,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": " */"
       },
       {
         "lineNumber": 12,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "public class Rating {"
       },
       {
         "lineNumber": 13,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 14,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    public static final String MESSAGE_RATING_CONSTRAINTS \u003d"
       },
       {
         "lineNumber": 15,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "            \"Player\u0027s rating should be an integer from 0 - 5.\";"
       },
       {
         "lineNumber": 16,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 17,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    public static final String RATING_VALIDATION_REGEX \u003d \"[0-5]\";"
       },
       {
         "lineNumber": 18,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 19,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    public final String value;"
       },
       {
         "lineNumber": 20,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "lohtianwei"
         },
         "content": "    private boolean isPrivate;"
       },
       {
         "lineNumber": 21,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 22,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    /**"
       },
       {
         "lineNumber": 23,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "     * Constructs an {@code Rating}."
       },
       {
         "lineNumber": 24,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "     *"
       },
       {
         "lineNumber": 25,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "     * @param rating A valid rating."
       },
       {
         "lineNumber": 26,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "     */"
       },
       {
         "lineNumber": 27,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    public Rating(String rating) {"
       },
       {
         "lineNumber": 28,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        requireNonNull(rating);"
       },
       {
         "lineNumber": 29,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        checkArgument(isValidRating(rating), MESSAGE_RATING_CONSTRAINTS);"
       },
       {
         "lineNumber": 30,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        this.value \u003d rating;"
       },
       {
         "lineNumber": 31,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    }"
       },
       {
         "lineNumber": 32,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 33,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "lohtianwei"
         },
         "content": "    public Rating(String rating, boolean isPrivate) {"
       },
       {
         "lineNumber": 34,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "lohtianwei"
         },
         "content": "        this(rating);"
       },
       {
         "lineNumber": 35,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "lohtianwei"
         },
         "content": "        this.setPrivate(isPrivate);"
       },
       {
         "lineNumber": 36,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "lohtianwei"
         },
         "content": "    }"
       },
       {
         "lineNumber": 37,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "lohtianwei"
         },
         "content": ""
       },
       {
         "lineNumber": 38,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    /**"
       },
       {
         "lineNumber": 39,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "     * Returns true if a given string is a valid player\u0027s rating."
       },
       {
         "lineNumber": 40,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "     */"
       },
       {
         "lineNumber": 41,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    public static boolean isValidRating(String test) {"
       },
       {
         "lineNumber": 42,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        return test.matches(RATING_VALIDATION_REGEX) || test.equals(UNSPECIFIED_FIELD);"
       },
       {
         "lineNumber": 43,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    }"
       },
       {
         "lineNumber": 44,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 45,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    @Override"
       },
       {
         "lineNumber": 46,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    public String toString() {"
       },
       {
         "lineNumber": 47,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "lohtianwei"
         },
         "content": "        if (isPrivate) {"
       },
       {
         "lineNumber": 48,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "lohtianwei"
         },
         "content": "            return \"\u003cPrivate Rating\u003e\";"
       },
       {
         "lineNumber": 49,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "lohtianwei"
         },
         "content": "        }"
       },
       {
         "lineNumber": 50,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        return value;"
       },
       {
         "lineNumber": 51,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    }"
       },
       {
         "lineNumber": 52,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 53,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "lohtianwei"
         },
         "content": "    public boolean isPrivate() {"
       },
       {
         "lineNumber": 54,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "lohtianwei"
         },
         "content": "        return isPrivate;"
       },
       {
         "lineNumber": 55,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "lohtianwei"
         },
         "content": "    }"
       },
       {
         "lineNumber": 56,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "lohtianwei"
         },
         "content": ""
       },
       {
         "lineNumber": 57,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "lohtianwei"
         },
         "content": "    public void togglePrivacy() {"
       },
       {
         "lineNumber": 58,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "lohtianwei"
         },
         "content": "        this.isPrivate \u003d isPrivate ? false : true;"
       },
       {
         "lineNumber": 59,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "lohtianwei"
         },
         "content": "    }"
       },
       {
         "lineNumber": 60,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "lohtianwei"
         },
         "content": ""
       },
       {
         "lineNumber": 61,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "lohtianwei"
         },
         "content": "    public void setPrivate(boolean isPrivate) {"
       },
       {
         "lineNumber": 62,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "lohtianwei"
         },
         "content": "        this.isPrivate \u003d isPrivate;"
       },
       {
         "lineNumber": 63,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "lohtianwei"
         },
         "content": "    }"
       },
       {
         "lineNumber": 64,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "lohtianwei"
         },
         "content": ""
       },
       {
         "lineNumber": 65,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    @Override"
       },
       {
         "lineNumber": 66,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    public boolean equals(Object other) {"
       },
       {
         "lineNumber": 67,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        return other \u003d\u003d this // short circuit if same object"
       },
       {
         "lineNumber": 68,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "                || (other instanceof Rating // instanceof handles nulls"
       },
       {
         "lineNumber": 69,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "                \u0026\u0026 this.value.equals(((Rating) other).value)); // state check"
       },
       {
         "lineNumber": 70,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    }"
       },
       {
         "lineNumber": 71,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 72,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    @Override"
       },
       {
         "lineNumber": 73,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    public int hashCode() {"
       },
       {
         "lineNumber": 74,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        return value.hashCode();"
       },
       {
         "lineNumber": 75,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    }"
       },
       {
         "lineNumber": 76,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 77,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "}"
       }
     ],
     "authorContributionMap": {
-      "lithiumlkid": 71,
-      "-": 6
+      "lohtianwei": 21,
+      "-": 56
     }
   },
   {
@@ -65937,736 +59088,6 @@
     ],
     "authorContributionMap": {
       "lohtianwei": 7
-    }
-  },
-  {
-    "path": "src/main/java/seedu/address/model/tag/Tag.java",
-    "lines": [
-      {
-        "lineNumber": 1,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "package seedu.address.model.tag;"
-      },
-      {
-        "lineNumber": 2,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 3,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static java.util.Objects.requireNonNull;"
-      },
-      {
-        "lineNumber": 4,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static seedu.address.commons.util.AppUtil.checkArgument;"
-      },
-      {
-        "lineNumber": 5,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 6,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "/**"
-      },
-      {
-        "lineNumber": 7,
-        "author": {
-          "gitId": "-"
-        },
-        "content": " * Represents a Tag in the address book."
-      },
-      {
-        "lineNumber": 8,
-        "author": {
-          "gitId": "-"
-        },
-        "content": " * Guarantees: immutable; name is valid as declared in {@link #isValidTagName(String)}"
-      },
-      {
-        "lineNumber": 9,
-        "author": {
-          "gitId": "-"
-        },
-        "content": " */"
-      },
-      {
-        "lineNumber": 10,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "public class Tag {"
-      },
-      {
-        "lineNumber": 11,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 12,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public static final String MESSAGE_TAG_CONSTRAINTS \u003d \"Tags names should be a string\";"
-      },
-      {
-        "lineNumber": 13,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public static final String MESSAGE_TAG_COLOUR_CONSTRAINTS \u003d \"Tag colours should be one of these colours:\""
-      },
-      {
-        "lineNumber": 14,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        + \"teal, red, yellow, blue, orange, brown, green, pink, black, grey\";"
-      },
-      {
-        "lineNumber": 15,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public static final String TAG_VALIDATION_REGEX \u003d \"\\\\p{Alnum}+\";"
-      },
-      {
-        "lineNumber": 16,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    private static final String[] TAG_COLOR_STYLES \u003d"
-      },
-      {
-        "lineNumber": 17,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        { \"teal\", \"red\", \"yellow\", \"blue\", \"orange\", \"brown\", \"green\", \"pink\", \"black\", \"grey\" };"
-      },
-      {
-        "lineNumber": 18,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 19,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public final String tagName;"
-      },
-      {
-        "lineNumber": 20,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    private String tagColour;"
-      },
-      {
-        "lineNumber": 21,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 22,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    /**"
-      },
-      {
-        "lineNumber": 23,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     * Constructs a {@code Tag}."
-      },
-      {
-        "lineNumber": 24,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     *"
-      },
-      {
-        "lineNumber": 25,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     * @param tagName A valid tag name."
-      },
-      {
-        "lineNumber": 26,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     */"
-      },
-      {
-        "lineNumber": 27,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public Tag(String tagName) {"
-      },
-      {
-        "lineNumber": 28,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        requireNonNull(tagName);"
-      },
-      {
-        "lineNumber": 29,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        checkArgument(isValidTagName(tagName), MESSAGE_TAG_CONSTRAINTS);"
-      },
-      {
-        "lineNumber": 30,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        this.tagName \u003d tagName;"
-      },
-      {
-        "lineNumber": 31,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        this.tagColour \u003d \"teal\";"
-      },
-      {
-        "lineNumber": 32,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 33,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 34,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    /**"
-      },
-      {
-        "lineNumber": 35,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     * Overloaded constructor for a {@code Tag}."
-      },
-      {
-        "lineNumber": 36,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     *"
-      },
-      {
-        "lineNumber": 37,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     * @param tagName A valid tag name"
-      },
-      {
-        "lineNumber": 38,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     * @param tagColour A valid tag colour."
-      },
-      {
-        "lineNumber": 39,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     */"
-      },
-      {
-        "lineNumber": 40,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public Tag(String tagName, String tagColour) {"
-      },
-      {
-        "lineNumber": 41,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        requireNonNull(tagName);"
-      },
-      {
-        "lineNumber": 42,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        checkArgument(isValidTagName(tagName), MESSAGE_TAG_CONSTRAINTS);"
-      },
-      {
-        "lineNumber": 43,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        this.tagName \u003d tagName;"
-      },
-      {
-        "lineNumber": 44,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        this.tagColour \u003d tagColour;"
-      },
-      {
-        "lineNumber": 45,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 46,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 47,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public String getTagName() {"
-      },
-      {
-        "lineNumber": 48,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        return this.tagName;"
-      },
-      {
-        "lineNumber": 49,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 50,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 51,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    /**"
-      },
-      {
-        "lineNumber": 52,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     * Returns true if a given string is a valid tag name."
-      },
-      {
-        "lineNumber": 53,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     */"
-      },
-      {
-        "lineNumber": 54,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public static boolean isValidTagName(String test) {"
-      },
-      {
-        "lineNumber": 55,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        return test.matches(TAG_VALIDATION_REGEX);"
-      },
-      {
-        "lineNumber": 56,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 57,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 58,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    /** @@author Codee */"
-      },
-      {
-        "lineNumber": 59,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    public String getTagColour() {"
-      },
-      {
-        "lineNumber": 60,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        return this.tagColour;"
-      },
-      {
-        "lineNumber": 61,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 62,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 63,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    /**"
-      },
-      {
-        "lineNumber": 64,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "     * Changes the {@code tagColour} for {@code tagName}\u0027s label"
-      },
-      {
-        "lineNumber": 65,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "     */"
-      },
-      {
-        "lineNumber": 66,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    public void changeTagColour(String colour) {"
-      },
-      {
-        "lineNumber": 67,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        this.tagColour \u003d colour;"
-      },
-      {
-        "lineNumber": 68,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 69,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 70,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 71,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    /**"
-      },
-      {
-        "lineNumber": 72,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "     * Returns true if a given string is a valid tag colour."
-      },
-      {
-        "lineNumber": 73,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "     */"
-      },
-      {
-        "lineNumber": 74,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    public static boolean isValidTagColour(String testColour) {"
-      },
-      {
-        "lineNumber": 75,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        for (String tcs : TAG_COLOR_STYLES) {"
-      },
-      {
-        "lineNumber": 76,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "            if (testColour.equals(tcs)) {"
-      },
-      {
-        "lineNumber": 77,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "                return true;"
-      },
-      {
-        "lineNumber": 78,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "            }"
-      },
-      {
-        "lineNumber": 79,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        }"
-      },
-      {
-        "lineNumber": 80,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        return false;"
-      },
-      {
-        "lineNumber": 81,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 82,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    //@@author"
-      },
-      {
-        "lineNumber": 83,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 84,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    @Override"
-      },
-      {
-        "lineNumber": 85,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public boolean equals(Object other) {"
-      },
-      {
-        "lineNumber": 86,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        return other \u003d\u003d this // short circuit if same object"
-      },
-      {
-        "lineNumber": 87,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "                || (other instanceof Tag // instanceof handles nulls"
-      },
-      {
-        "lineNumber": 88,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "                \u0026\u0026 this.tagName.equals(((Tag) other).tagName)); // state check"
-      },
-      {
-        "lineNumber": 89,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 90,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 91,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    @Override"
-      },
-      {
-        "lineNumber": 92,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public int hashCode() {"
-      },
-      {
-        "lineNumber": 93,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        return tagName.hashCode();"
-      },
-      {
-        "lineNumber": 94,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 95,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 96,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    /**"
-      },
-      {
-        "lineNumber": 97,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     * Format state as text for viewing."
-      },
-      {
-        "lineNumber": 98,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     */"
-      },
-      {
-        "lineNumber": 99,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public String toString() {"
-      },
-      {
-        "lineNumber": 100,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        return \u0027[\u0027 + tagName + \u0027]\u0027;"
-      },
-      {
-        "lineNumber": 101,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 102,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 103,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "}"
-      }
-    ],
-    "authorContributionMap": {
-      "codeeong": 25,
-      "-": 78
     }
   },
   {
@@ -69886,57 +62307,54 @@
       {
         "lineNumber": 128,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    //@@author Codee"
       },
       {
         "lineNumber": 129,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    public static Team[] getSampleTeams()  {"
       },
       {
         "lineNumber": 130,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        return new Team[] {"
       },
       {
         "lineNumber": 131,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "            new Team(new TeamName(\"Arsenal\")),"
       },
       {
         "lineNumber": 132,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "            new Team(new TeamName(\"Chelsea\"))"
       },
       {
         "lineNumber": 133,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        };"
       },
       {
         "lineNumber": 134,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    }"
       },
       {
         "lineNumber": 135,
-        "author": {
-          "gitId": "codeeong"
-        },
         "content": "    //@@author"
       },
       {
@@ -69970,36 +62388,33 @@
       {
         "lineNumber": 140,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "            //@@author Codee"
       },
       {
         "lineNumber": 141,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "            for (Team sampleTeam : getSampleTeams()) {"
       },
       {
         "lineNumber": 142,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "                sampleAb.createTeam(sampleTeam);"
       },
       {
         "lineNumber": 143,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "            }"
       },
       {
         "lineNumber": 144,
-        "author": {
-          "gitId": "codeeong"
-        },
         "content": "            //@@author"
       },
       {
@@ -70179,9 +62594,9 @@
       }
     ],
     "authorContributionMap": {
+      "null": 2,
       "jordancjq": 9,
-      "codeeong": 13,
-      "-": 147
+      "-": 158
     }
   },
   {
@@ -71896,582 +64311,6 @@
     }
   },
   {
-    "path": "src/main/java/seedu/address/storage/XmlAdaptedTag.java",
-    "lines": [
-      {
-        "lineNumber": 1,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "package seedu.address.storage;"
-      },
-      {
-        "lineNumber": 2,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 3,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import javax.xml.bind.annotation.XmlElement;"
-      },
-      {
-        "lineNumber": 4,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 5,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.commons.exceptions.IllegalValueException;"
-      },
-      {
-        "lineNumber": 6,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.model.tag.Tag;"
-      },
-      {
-        "lineNumber": 7,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 8,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "/**"
-      },
-      {
-        "lineNumber": 9,
-        "author": {
-          "gitId": "-"
-        },
-        "content": " * JAXB-friendly adapted version of the Tag."
-      },
-      {
-        "lineNumber": 10,
-        "author": {
-          "gitId": "-"
-        },
-        "content": " */"
-      },
-      {
-        "lineNumber": 11,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "public class XmlAdaptedTag {"
-      },
-      {
-        "lineNumber": 12,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 13,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    @XmlElement"
-      },
-      {
-        "lineNumber": 14,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    private String tagName;"
-      },
-      {
-        "lineNumber": 15,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 16,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    @XmlElement"
-      },
-      {
-        "lineNumber": 17,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    private String tagColour;"
-      },
-      {
-        "lineNumber": 18,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 19,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    /**"
-      },
-      {
-        "lineNumber": 20,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     * Constructs an XmlAdaptedTag."
-      },
-      {
-        "lineNumber": 21,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     * This is the no-arg constructor that is required by JAXB."
-      },
-      {
-        "lineNumber": 22,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     */"
-      },
-      {
-        "lineNumber": 23,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public XmlAdaptedTag() {}"
-      },
-      {
-        "lineNumber": 24,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 25,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    /**"
-      },
-      {
-        "lineNumber": 26,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     * Constructs a {@code XmlAdaptedTag} with the given {@code tagName}."
-      },
-      {
-        "lineNumber": 27,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 28,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     */"
-      },
-      {
-        "lineNumber": 29,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public XmlAdaptedTag(String tagName) {"
-      },
-      {
-        "lineNumber": 30,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        this.tagName \u003d tagName;"
-      },
-      {
-        "lineNumber": 31,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        this.tagColour \u003d \"teal\";"
-      },
-      {
-        "lineNumber": 32,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 33,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 34,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    /**"
-      },
-      {
-        "lineNumber": 35,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     * Constructs a {@code XmlAdaptedTag} with the given {@code tagName} and {@code tagColour}."
-      },
-      {
-        "lineNumber": 36,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     */"
-      },
-      {
-        "lineNumber": 37,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    /** @@author Codee */"
-      },
-      {
-        "lineNumber": 38,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    public XmlAdaptedTag(String tagName, String tagColour) {"
-      },
-      {
-        "lineNumber": 39,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        this.tagName \u003d tagName;"
-      },
-      {
-        "lineNumber": 40,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        this.tagColour \u003d tagColour;"
-      },
-      {
-        "lineNumber": 41,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 42,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 43,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    /**"
-      },
-      {
-        "lineNumber": 44,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "     * Converts a given Tag into this class for JAXB use."
-      },
-      {
-        "lineNumber": 45,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "     *"
-      },
-      {
-        "lineNumber": 46,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "     * @param source future changes to this will not affect the created"
-      },
-      {
-        "lineNumber": 47,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "     */"
-      },
-      {
-        "lineNumber": 48,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    public XmlAdaptedTag(Tag source) {"
-      },
-      {
-        "lineNumber": 49,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        tagName \u003d source.tagName;"
-      },
-      {
-        "lineNumber": 50,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        tagColour \u003d source.getTagColour();"
-      },
-      {
-        "lineNumber": 51,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 52,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 53,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    /**"
-      },
-      {
-        "lineNumber": 54,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "     * Converts this jaxb-friendly adapted tag object into the model\u0027s Tag object."
-      },
-      {
-        "lineNumber": 55,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "     *"
-      },
-      {
-        "lineNumber": 56,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "     * @throws IllegalValueException if there were any data constraints violated in the adapted person"
-      },
-      {
-        "lineNumber": 57,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "     */"
-      },
-      {
-        "lineNumber": 58,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    public Tag toModelType() throws IllegalValueException {"
-      },
-      {
-        "lineNumber": 59,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        if (!Tag.isValidTagName(tagName)) {"
-      },
-      {
-        "lineNumber": 60,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "            throw new IllegalValueException(Tag.MESSAGE_TAG_CONSTRAINTS);"
-      },
-      {
-        "lineNumber": 61,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        }"
-      },
-      {
-        "lineNumber": 62,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        if (!Tag.isValidTagColour(tagColour)) {"
-      },
-      {
-        "lineNumber": 63,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "            throw new IllegalValueException(Tag.MESSAGE_TAG_COLOUR_CONSTRAINTS);"
-      },
-      {
-        "lineNumber": 64,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        }"
-      },
-      {
-        "lineNumber": 65,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        return new Tag(tagName, tagColour);"
-      },
-      {
-        "lineNumber": 66,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 67,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    //@@author"
-      },
-      {
-        "lineNumber": 68,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 69,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    @Override"
-      },
-      {
-        "lineNumber": 70,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public boolean equals(Object other) {"
-      },
-      {
-        "lineNumber": 71,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        if (other \u003d\u003d this) {"
-      },
-      {
-        "lineNumber": 72,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "            return true;"
-      },
-      {
-        "lineNumber": 73,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        }"
-      },
-      {
-        "lineNumber": 74,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 75,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        if (!(other instanceof XmlAdaptedTag)) {"
-      },
-      {
-        "lineNumber": 76,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "            return false;"
-      },
-      {
-        "lineNumber": 77,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        }"
-      },
-      {
-        "lineNumber": 78,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 79,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        return tagName.equals(((XmlAdaptedTag) other).tagName);"
-      },
-      {
-        "lineNumber": 80,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 81,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "}"
-      }
-    ],
-    "authorContributionMap": {
-      "codeeong": 31,
-      "-": 50
-    }
-  },
-  {
     "path": "src/main/java/seedu/address/storage/XmlAdaptedTeam.java",
     "lines": [
       {
@@ -72589,547 +64428,546 @@
       {
         "lineNumber": 17,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "/** @@author Codee */"
       },
       {
         "lineNumber": 18,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "public class XmlAdaptedTeam {"
       },
       {
         "lineNumber": 19,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 20,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "jordancjq"
         },
         "content": "    public static final String MISSING_FIELD_MESSAGE_FORMAT \u003d \"Team\u0027s %s field is missing!\";"
       },
       {
         "lineNumber": 21,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 22,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "jordancjq"
         },
         "content": "    @XmlElement(required \u003d true)"
       },
       {
         "lineNumber": 23,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    private String teamName;"
       },
       {
         "lineNumber": 24,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    @XmlElement"
       },
       {
         "lineNumber": 25,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "jordancjq"
         },
         "content": "    private List\u003cXmlAdaptedPerson\u003e players \u003d new ArrayList\u003c\u003e();"
       },
       {
         "lineNumber": 26,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 27,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    /**"
       },
       {
         "lineNumber": 28,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "     * Constructs an XmlAdaptedTeam."
       },
       {
         "lineNumber": 29,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "     * This is the no-arg constructor that is required by JAXB."
       },
       {
         "lineNumber": 30,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "     */"
       },
       {
         "lineNumber": 31,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    public XmlAdaptedTeam() {}"
       },
       {
         "lineNumber": 32,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 33,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    /**"
       },
       {
         "lineNumber": 34,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "     * Constructs a {@code XmlAdaptedTeam} with the given {@code teamName}."
       },
       {
         "lineNumber": 35,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "     */"
       },
       {
         "lineNumber": 36,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "jordancjq"
         },
         "content": "    public XmlAdaptedTeam(String teamName, List\u003cXmlAdaptedPerson\u003e persons) {"
       },
       {
         "lineNumber": 37,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        this.teamName \u003d teamName;"
       },
       {
         "lineNumber": 38,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "jordancjq"
         },
         "content": "        if (persons !\u003d null) {"
       },
       {
         "lineNumber": 39,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "jordancjq"
         },
         "content": "            this.players \u003d new ArrayList\u003c\u003e(persons);"
       },
       {
         "lineNumber": 40,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "jordancjq"
         },
         "content": "        }"
       },
       {
         "lineNumber": 41,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    }"
       },
       {
         "lineNumber": 42,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 43,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    /**"
       },
       {
         "lineNumber": 44,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "     * Converts a given Team into this class for JAXB use."
       },
       {
         "lineNumber": 45,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "     *"
       },
       {
         "lineNumber": 46,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "jordancjq"
         },
         "content": "     * @param source future changes to this will not affect the created XmlAdaptedTeam"
       },
       {
         "lineNumber": 47,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "     */"
       },
       {
         "lineNumber": 48,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    public XmlAdaptedTeam(Team source) {"
       },
       {
         "lineNumber": 49,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        teamName \u003d source.getTeamName().toString();"
       },
       {
         "lineNumber": 50,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "jordancjq"
         },
         "content": "        players \u003d new ArrayList\u003c\u003e();"
       },
       {
         "lineNumber": 51,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "jordancjq"
         },
         "content": "        for (Person person : source.getTeamPlayers()) {"
       },
       {
         "lineNumber": 52,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "jordancjq"
         },
         "content": "            players.add(new XmlAdaptedPerson(person));"
       },
       {
         "lineNumber": 53,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "jordancjq"
         },
         "content": "        }"
       },
       {
         "lineNumber": 54,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    }"
       },
       {
         "lineNumber": 55,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 56,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    /**"
       },
       {
         "lineNumber": 57,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "jordancjq"
         },
         "content": "     * Converts this jaxb-friendly adapted tag object into the model\u0027s Team object."
       },
       {
         "lineNumber": 58,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "     *"
       },
       {
         "lineNumber": 59,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "     * @throws IllegalValueException if there were any data constraints violated in the adapted person"
       },
       {
         "lineNumber": 60,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "     */"
       },
       {
         "lineNumber": 61,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    public Team toModelType() throws IllegalValueException {"
       },
       {
         "lineNumber": 62,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "jordancjq"
         },
         "content": "        if (this.teamName \u003d\u003d null) {"
       },
       {
         "lineNumber": 63,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "jordancjq"
         },
         "content": "            throw new IllegalValueException((String.format(MISSING_FIELD_MESSAGE_FORMAT,"
       },
       {
         "lineNumber": 64,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "jordancjq"
         },
         "content": "                    TeamName.class.getSimpleName())));"
       },
       {
         "lineNumber": 65,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "jordancjq"
         },
         "content": "        }"
       },
       {
         "lineNumber": 66,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "jordancjq"
         },
         "content": "        if (!TeamName.isValidName(this.teamName)) {"
       },
       {
         "lineNumber": 67,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "jordancjq"
         },
         "content": "            throw new IllegalValueException(TeamName.MESSAGE_TEAM_NAME_CONSTRAINTS);"
       },
       {
         "lineNumber": 68,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        }"
       },
       {
         "lineNumber": 69,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "jordancjq"
         },
         "content": "        final TeamName teamName \u003d new TeamName(this.teamName);"
       },
       {
         "lineNumber": 70,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "jordancjq"
         },
         "content": ""
       },
       {
         "lineNumber": 71,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "jordancjq"
         },
         "content": "        final List\u003cPerson\u003e teamPlayers \u003d new ArrayList\u003c\u003e();"
       },
       {
         "lineNumber": 72,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "jordancjq"
         },
         "content": "        for (XmlAdaptedPerson player : players) {"
       },
       {
         "lineNumber": 73,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "jordancjq"
         },
         "content": "            teamPlayers.add(player.toModelType());"
       },
       {
         "lineNumber": 74,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "jordancjq"
         },
         "content": "        }"
       },
       {
         "lineNumber": 75,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "jordancjq"
         },
         "content": ""
       },
       {
         "lineNumber": 76,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "jordancjq"
         },
         "content": "        return new Team(teamName, teamPlayers);"
       },
       {
         "lineNumber": 77,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    }"
       },
       {
         "lineNumber": 78,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 79,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    @Override"
       },
       {
         "lineNumber": 80,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    public boolean equals(Object other) {"
       },
       {
         "lineNumber": 81,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        if (other \u003d\u003d this) {"
       },
       {
         "lineNumber": 82,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "            return true;"
       },
       {
         "lineNumber": 83,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        }"
       },
       {
         "lineNumber": 84,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 85,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        if (!(other instanceof XmlAdaptedTeam)) {"
       },
       {
         "lineNumber": 86,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "            return false;"
       },
       {
         "lineNumber": 87,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        }"
       },
       {
         "lineNumber": 88,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "jordancjq"
         },
         "content": "        XmlAdaptedTeam otherTeam \u003d (XmlAdaptedTeam) other;"
       },
       {
         "lineNumber": 89,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "jordancjq"
         },
         "content": "        return Objects.equals(teamName, otherTeam.teamName)"
       },
       {
         "lineNumber": 90,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "jordancjq"
         },
         "content": "                \u0026\u0026 players.equals(otherTeam.players);"
       },
       {
         "lineNumber": 91,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 92,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    }"
       },
       {
         "lineNumber": 93,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "}"
       }
     ],
     "authorContributionMap": {
-      "jordancjq": 3,
-      "codeeong": 77,
-      "-": 13
+      "jordancjq": 33,
+      "-": 60
     }
   },
   {
@@ -73278,43 +65116,40 @@
       {
         "lineNumber": 21,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    /** @@author Codee */"
       },
       {
         "lineNumber": 22,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    @XmlElement"
       },
       {
         "lineNumber": 23,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "jordancjq"
         },
         "content": "    private List\u003cXmlAdaptedTeam\u003e teams;"
       },
       {
         "lineNumber": 24,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    @XmlElement"
       },
       {
         "lineNumber": 25,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    private List\u003cXmlAdaptedPerson\u003e persons;"
       },
       {
         "lineNumber": 26,
-        "author": {
-          "gitId": "codeeong"
-        },
         "content": "    //@@author"
       },
       {
@@ -73432,197 +65267,194 @@
       {
         "lineNumber": 43,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    /** @@author Codee */"
       },
       {
         "lineNumber": 44,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    public XmlSerializableAddressBook(ReadOnlyAddressBook src) {"
       },
       {
         "lineNumber": 45,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        this();"
       },
       {
         "lineNumber": 46,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        persons.addAll(src.getPersonList().stream().map(XmlAdaptedPerson::new).collect(Collectors.toList()));"
       },
       {
         "lineNumber": 47,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        tags.addAll(src.getTagList().stream().map(XmlAdaptedTag::new).collect(Collectors.toList()));"
       },
       {
         "lineNumber": 48,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "jordancjq"
         },
         "content": "        teams.addAll(src.getTeamList().stream().map(XmlAdaptedTeam::new).collect(Collectors.toList()));"
       },
       {
         "lineNumber": 49,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    }"
       },
       {
         "lineNumber": 50,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 51,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    /**"
       },
       {
         "lineNumber": 52,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "     * Converts this addressbook into the model\u0027s {@code AddressBook} object."
       },
       {
         "lineNumber": 53,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "     *"
       },
       {
         "lineNumber": 54,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "     * @throws IllegalValueException if there were any data constraints violated or duplicates in the"
       },
       {
         "lineNumber": 55,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "     * {@code XmlAdaptedPerson} or {@code XmlAdaptedTag}."
       },
       {
         "lineNumber": 56,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "     */"
       },
       {
         "lineNumber": 57,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    public AddressBook toModelType() throws IllegalValueException {"
       },
       {
         "lineNumber": 58,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        AddressBook addressBook \u003d new AddressBook();"
       },
       {
         "lineNumber": 59,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        for (XmlAdaptedTag t : tags) {"
       },
       {
         "lineNumber": 60,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "            addressBook.addTag(t.toModelType());"
       },
       {
         "lineNumber": 61,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        }"
       },
       {
         "lineNumber": 62,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        for (XmlAdaptedPerson p : persons) {"
       },
       {
         "lineNumber": 63,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "            addressBook.addPerson(p.toModelType());"
       },
       {
         "lineNumber": 64,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        }"
       },
       {
         "lineNumber": 65,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "jordancjq"
         },
         "content": "        for (XmlAdaptedTeam tm : teams) {"
       },
       {
         "lineNumber": 66,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "jordancjq"
         },
         "content": "            addressBook.createTeam(tm.toModelType());"
       },
       {
         "lineNumber": 67,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        }"
       },
       {
         "lineNumber": 68,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        return addressBook;"
       },
       {
         "lineNumber": 69,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    }"
       },
       {
         "lineNumber": 70,
-        "author": {
-          "gitId": "codeeong"
-        },
         "content": "    //@@author"
       },
       {
@@ -73732,3142 +65564,9 @@
       }
     ],
     "authorContributionMap": {
-      "codeeong": 34,
-      "jordancjq": 2,
-      "-": 49
-    }
-  },
-  {
-    "path": "src/main/java/seedu/address/ui/CommandBox.java",
-    "lines": [
-      {
-        "lineNumber": 1,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "package seedu.address.ui;"
-      },
-      {
-        "lineNumber": 2,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 3,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import java.util.List;"
-      },
-      {
-        "lineNumber": 4,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import java.util.Set;"
-      },
-      {
-        "lineNumber": 5,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import java.util.logging.Logger;"
-      },
-      {
-        "lineNumber": 6,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 7,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import javafx.collections.ObservableList;"
-      },
-      {
-        "lineNumber": 8,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import javafx.fxml.FXML;"
-      },
-      {
-        "lineNumber": 9,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import javafx.geometry.Side;"
-      },
-      {
-        "lineNumber": 10,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import javafx.scene.control.ContextMenu;"
-      },
-      {
-        "lineNumber": 11,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import javafx.scene.control.MenuItem;"
-      },
-      {
-        "lineNumber": 12,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import javafx.scene.control.TextField;"
-      },
-      {
-        "lineNumber": 13,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import javafx.scene.input.KeyEvent;"
-      },
-      {
-        "lineNumber": 14,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import javafx.scene.layout.Region;"
-      },
-      {
-        "lineNumber": 15,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.commons.core.LogsCenter;"
-      },
-      {
-        "lineNumber": 16,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.commons.events.ui.NewResultAvailableEvent;"
-      },
-      {
-        "lineNumber": 17,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.logic.ListElementPointer;"
-      },
-      {
-        "lineNumber": 18,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.logic.Logic;"
-      },
-      {
-        "lineNumber": 19,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.logic.commands.CommandResult;"
-      },
-      {
-        "lineNumber": 20,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.logic.commands.CommandTrie;"
-      },
-      {
-        "lineNumber": 21,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.logic.commands.exceptions.CommandException;"
-      },
-      {
-        "lineNumber": 22,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.logic.parser.exceptions.ParseException;"
-      },
-      {
-        "lineNumber": 23,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 24,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "/**"
-      },
-      {
-        "lineNumber": 25,
-        "author": {
-          "gitId": "-"
-        },
-        "content": " * The UI component that is responsible for receiving user command inputs."
-      },
-      {
-        "lineNumber": 26,
-        "author": {
-          "gitId": "-"
-        },
-        "content": " */"
-      },
-      {
-        "lineNumber": 27,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "public class CommandBox extends UiPart\u003cRegion\u003e {"
-      },
-      {
-        "lineNumber": 28,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 29,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public static final String ERROR_STYLE_CLASS \u003d \"error\";"
-      },
-      {
-        "lineNumber": 30,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    private static final String FXML \u003d \"CommandBox.fxml\";"
-      },
-      {
-        "lineNumber": 31,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 32,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    private CommandTrie commandTrie;"
-      },
-      {
-        "lineNumber": 33,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    private Set\u003cString\u003e commandSet;"
-      },
-      {
-        "lineNumber": 34,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    private final Logger logger \u003d LogsCenter.getLogger(CommandBox.class);"
-      },
-      {
-        "lineNumber": 35,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    private final Logic logic;"
-      },
-      {
-        "lineNumber": 36,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    private ListElementPointer historySnapshot;"
-      },
-      {
-        "lineNumber": 37,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    private final ContextMenu suggestions;"
-      },
-      {
-        "lineNumber": 38,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 39,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 40,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    @FXML"
-      },
-      {
-        "lineNumber": 41,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    private TextField commandTextField;"
-      },
-      {
-        "lineNumber": 42,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 43,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    //@@author lithiumlkid"
-      },
-      {
-        "lineNumber": 44,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    CommandBox(Logic logic) {"
-      },
-      {
-        "lineNumber": 45,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        super(FXML);"
-      },
-      {
-        "lineNumber": 46,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        this.logic \u003d logic;"
-      },
-      {
-        "lineNumber": 47,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        commandTrie \u003d logic.getCommandTrie();"
-      },
-      {
-        "lineNumber": 48,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        commandSet \u003d commandTrie.getCommandSet();"
-      },
-      {
-        "lineNumber": 49,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        // calls #setStyleToDefault() whenever there is a change to the text of the command box."
-      },
-      {
-        "lineNumber": 50,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        commandTextField.textProperty().addListener((unused1, unused2, unused3) -\u003e setStyleToDefault());"
-      },
-      {
-        "lineNumber": 51,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        historySnapshot \u003d logic.getHistorySnapshot();"
-      },
-      {
-        "lineNumber": 52,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        suggestions \u003d new ContextMenu();"
-      },
-      {
-        "lineNumber": 53,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        commandTextField.setContextMenu(suggestions);"
-      },
-      {
-        "lineNumber": 54,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 55,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 56,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    /**"
-      },
-      {
-        "lineNumber": 57,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "     *"
-      },
-      {
-        "lineNumber": 58,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "     * Handles the key press event, {@code keyEvent}."
-      },
-      {
-        "lineNumber": 59,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "     */"
-      },
-      {
-        "lineNumber": 60,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    @FXML"
-      },
-      {
-        "lineNumber": 61,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    private void handleKeyPress(KeyEvent keyEvent) {"
-      },
-      {
-        "lineNumber": 62,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        switch (keyEvent.getCode()) {"
-      },
-      {
-        "lineNumber": 63,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        case UP:"
-      },
-      {
-        "lineNumber": 64,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "            // As up and down buttons will alter the position of the caret,"
-      },
-      {
-        "lineNumber": 65,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "            // consuming it causes the caret\u0027s position to remain unchanged"
-      },
-      {
-        "lineNumber": 66,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "            keyEvent.consume();"
-      },
-      {
-        "lineNumber": 67,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 68,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "            navigateToPreviousInput();"
-      },
-      {
-        "lineNumber": 69,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "            break;"
-      },
-      {
-        "lineNumber": 70,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        case DOWN:"
-      },
-      {
-        "lineNumber": 71,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "            keyEvent.consume();"
-      },
-      {
-        "lineNumber": 72,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "            navigateToNextInput();"
-      },
-      {
-        "lineNumber": 73,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "            break;"
-      },
-      {
-        "lineNumber": 74,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        case TAB:"
-      },
-      {
-        "lineNumber": 75,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "            keyEvent.consume();"
-      },
-      {
-        "lineNumber": 76,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "            handleAutoComplete();"
-      },
-      {
-        "lineNumber": 77,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "            break;"
-      },
-      {
-        "lineNumber": 78,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        default:"
-      },
-      {
-        "lineNumber": 79,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "            if (suggestions.isShowing()) {"
-      },
-      {
-        "lineNumber": 80,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "                suggestions.hide();"
-      },
-      {
-        "lineNumber": 81,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "            }"
-      },
-      {
-        "lineNumber": 82,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "            // let JavaFx handle the keypress"
-      },
-      {
-        "lineNumber": 83,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        }"
-      },
-      {
-        "lineNumber": 84,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 85,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 86,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    /**"
-      },
-      {
-        "lineNumber": 87,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "     * Updates the text field with the previous input in {@code historySnapshot},"
-      },
-      {
-        "lineNumber": 88,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "     * if there exists a previous input in {@code historySnapshot}"
-      },
-      {
-        "lineNumber": 89,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "     */"
-      },
-      {
-        "lineNumber": 90,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    private void navigateToPreviousInput() {"
-      },
-      {
-        "lineNumber": 91,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        assert historySnapshot !\u003d null;"
-      },
-      {
-        "lineNumber": 92,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        if (!historySnapshot.hasPrevious()) {"
-      },
-      {
-        "lineNumber": 93,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "            return;"
-      },
-      {
-        "lineNumber": 94,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        }"
-      },
-      {
-        "lineNumber": 95,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 96,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        replaceText(historySnapshot.previous());"
-      },
-      {
-        "lineNumber": 97,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 98,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 99,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    /**"
-      },
-      {
-        "lineNumber": 100,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "     * Updates the text field with the next input in {@code historySnapshot},"
-      },
-      {
-        "lineNumber": 101,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "     * if there exists a next input in {@code historySnapshot}"
-      },
-      {
-        "lineNumber": 102,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "     */"
-      },
-      {
-        "lineNumber": 103,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    private void navigateToNextInput() {"
-      },
-      {
-        "lineNumber": 104,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        assert historySnapshot !\u003d null;"
-      },
-      {
-        "lineNumber": 105,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        if (!historySnapshot.hasNext()) {"
-      },
-      {
-        "lineNumber": 106,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "            return;"
-      },
-      {
-        "lineNumber": 107,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        }"
-      },
-      {
-        "lineNumber": 108,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 109,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        replaceText(historySnapshot.next());"
-      },
-      {
-        "lineNumber": 110,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 111,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 112,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    /**"
-      },
-      {
-        "lineNumber": 113,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "     * Sets {@code CommandBox}\u0027s text field with {@code text} and"
-      },
-      {
-        "lineNumber": 114,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "     * positions the caret to the end of the {@code text}."
-      },
-      {
-        "lineNumber": 115,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "     */"
-      },
-      {
-        "lineNumber": 116,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    private void replaceText(String text) {"
-      },
-      {
-        "lineNumber": 117,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        commandTextField.setText(text);"
-      },
-      {
-        "lineNumber": 118,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        commandTextField.positionCaret(commandTextField.getText().length());"
-      },
-      {
-        "lineNumber": 119,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 120,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 121,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    /**"
-      },
-      {
-        "lineNumber": 122,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "     * Handles the Enter button pressed event."
-      },
-      {
-        "lineNumber": 123,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "     */"
-      },
-      {
-        "lineNumber": 124,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    @FXML"
-      },
-      {
-        "lineNumber": 125,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    private void handleCommandInputChanged() {"
-      },
-      {
-        "lineNumber": 126,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        try {"
-      },
-      {
-        "lineNumber": 127,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "            CommandResult commandResult \u003d logic.execute(commandTextField.getText());"
-      },
-      {
-        "lineNumber": 128,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "            initHistory();"
-      },
-      {
-        "lineNumber": 129,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "            historySnapshot.next();"
-      },
-      {
-        "lineNumber": 130,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "            // process result of the command"
-      },
-      {
-        "lineNumber": 131,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "            commandTextField.setText(\"\");"
-      },
-      {
-        "lineNumber": 132,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "            logger.info(\"Result: \" + commandResult.feedbackToUser);"
-      },
-      {
-        "lineNumber": 133,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "            raise(new NewResultAvailableEvent(commandResult.feedbackToUser));"
-      },
-      {
-        "lineNumber": 134,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 135,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        } catch (CommandException | ParseException e) {"
-      },
-      {
-        "lineNumber": 136,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "            initHistory();"
-      },
-      {
-        "lineNumber": 137,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "            // handle command failure"
-      },
-      {
-        "lineNumber": 138,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "            setStyleToIndicateCommandFailure();"
-      },
-      {
-        "lineNumber": 139,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "            logger.info(\"Invalid command: \" + commandTextField.getText());"
-      },
-      {
-        "lineNumber": 140,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "            raise(new NewResultAvailableEvent(e.getMessage()));"
-      },
-      {
-        "lineNumber": 141,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        }"
-      },
-      {
-        "lineNumber": 142,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 143,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 144,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    /**"
-      },
-      {
-        "lineNumber": 145,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "     * Initializes the history snapshot."
-      },
-      {
-        "lineNumber": 146,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "     */"
-      },
-      {
-        "lineNumber": 147,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    private void initHistory() {"
-      },
-      {
-        "lineNumber": 148,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        historySnapshot \u003d logic.getHistorySnapshot();"
-      },
-      {
-        "lineNumber": 149,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        // add an empty string to represent the most-recent end of historySnapshot, to be shown to"
-      },
-      {
-        "lineNumber": 150,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        // the user if she tries to navigate past the most-recent end of the historySnapshot."
-      },
-      {
-        "lineNumber": 151,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        historySnapshot.add(\"\");"
-      },
-      {
-        "lineNumber": 152,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 153,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 154,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    /**"
-      },
-      {
-        "lineNumber": 155,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "     * Sets the command box style to use the default style."
-      },
-      {
-        "lineNumber": 156,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "     */"
-      },
-      {
-        "lineNumber": 157,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    private void setStyleToDefault() {"
-      },
-      {
-        "lineNumber": 158,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        commandTextField.getStyleClass().remove(ERROR_STYLE_CLASS);"
-      },
-      {
-        "lineNumber": 159,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 160,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 161,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    /**"
-      },
-      {
-        "lineNumber": 162,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "     * Sets the command box style to indicate a failed command."
-      },
-      {
-        "lineNumber": 163,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "     */"
-      },
-      {
-        "lineNumber": 164,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    private void setStyleToIndicateCommandFailure() {"
-      },
-      {
-        "lineNumber": 165,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        ObservableList\u003cString\u003e styleClass \u003d commandTextField.getStyleClass();"
-      },
-      {
-        "lineNumber": 166,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 167,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        if (styleClass.contains(ERROR_STYLE_CLASS)) {"
-      },
-      {
-        "lineNumber": 168,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "            return;"
-      },
-      {
-        "lineNumber": 169,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        }"
-      },
-      {
-        "lineNumber": 170,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 171,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        styleClass.add(ERROR_STYLE_CLASS);"
-      },
-      {
-        "lineNumber": 172,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 173,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 174,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    //@@author lithiumlkid"
-      },
-      {
-        "lineNumber": 175,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    /**"
-      },
-      {
-        "lineNumber": 176,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "     * Handles the Tab button pressed event. Attempts to autocomplete current input."
-      },
-      {
-        "lineNumber": 177,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "     */"
-      },
-      {
-        "lineNumber": 178,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    private void handleAutoComplete() {"
-      },
-      {
-        "lineNumber": 179,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        String input \u003d commandTextField.getText();"
-      },
-      {
-        "lineNumber": 180,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        try {"
-      },
-      {
-        "lineNumber": 181,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "            String command \u003d commandTrie.attemptAutoComplete(input);"
-      },
-      {
-        "lineNumber": 182,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "            if (input.equals(command)) {"
-      },
-      {
-        "lineNumber": 183,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "                setStyleToIndicateCommandFailure();"
-      },
-      {
-        "lineNumber": 184,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "                showSuggestions(commandTrie.getOptions(input));"
-      },
-      {
-        "lineNumber": 185,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "            } else if (commandSet.contains(command)) {"
-      },
-      {
-        "lineNumber": 186,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "                this.replaceText(command);"
-      },
-      {
-        "lineNumber": 187,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "            } else if (commandSet.contains(input)) {"
-      },
-      {
-        "lineNumber": 188,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "                setStyleToIndicateCommandFailure();"
-      },
-      {
-        "lineNumber": 189,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "                this.replaceText(input + command);"
-      },
-      {
-        "lineNumber": 190,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "            }"
-      },
-      {
-        "lineNumber": 191,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        } catch (NullPointerException e) {"
-      },
-      {
-        "lineNumber": 192,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "            setStyleToIndicateCommandFailure();"
-      },
-      {
-        "lineNumber": 193,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        }"
-      },
-      {
-        "lineNumber": 194,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 195,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 196,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    /**"
-      },
-      {
-        "lineNumber": 197,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "     * Populates ContextMenu and shows it to user"
-      },
-      {
-        "lineNumber": 198,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "     * @param options the options with matching prefix found in Command Trie"
-      },
-      {
-        "lineNumber": 199,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "     */"
-      },
-      {
-        "lineNumber": 200,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    private void showSuggestions(List\u003cString\u003e options) {"
-      },
-      {
-        "lineNumber": 201,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        suggestions.getItems().clear();"
-      },
-      {
-        "lineNumber": 202,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        for (String option : options) {"
-      },
-      {
-        "lineNumber": 203,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "            MenuItem item \u003d new MenuItem(option);"
-      },
-      {
-        "lineNumber": 204,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "            item.setOnAction(event -\u003e replaceText(item.getText()));"
-      },
-      {
-        "lineNumber": 205,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "            suggestions.getItems().add(item);"
-      },
-      {
-        "lineNumber": 206,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        }"
-      },
-      {
-        "lineNumber": 207,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        suggestions.show(commandTextField, Side.BOTTOM, 0.0, 0.0);"
-      },
-      {
-        "lineNumber": 208,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 209,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "}"
-      }
-    ],
-    "authorContributionMap": {
-      "lithiumlkid": 167,
-      "-": 42
-    }
-  },
-  {
-    "path": "src/main/java/seedu/address/ui/MainWindow.java",
-    "lines": [
-      {
-        "lineNumber": 1,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "package seedu.address.ui;"
-      },
-      {
-        "lineNumber": 2,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 3,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import java.util.logging.Logger;"
-      },
-      {
-        "lineNumber": 4,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 5,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import com.google.common.eventbus.Subscribe;"
-      },
-      {
-        "lineNumber": 6,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 7,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import javafx.event.ActionEvent;"
-      },
-      {
-        "lineNumber": 8,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import javafx.fxml.FXML;"
-      },
-      {
-        "lineNumber": 9,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import javafx.scene.control.Menu;"
-      },
-      {
-        "lineNumber": 10,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import javafx.scene.control.MenuItem;"
-      },
-      {
-        "lineNumber": 11,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import javafx.scene.control.TextInputControl;"
-      },
-      {
-        "lineNumber": 12,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import javafx.scene.image.Image;"
-      },
-      {
-        "lineNumber": 13,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import javafx.scene.image.ImageView;"
-      },
-      {
-        "lineNumber": 14,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import javafx.scene.input.KeyCombination;"
-      },
-      {
-        "lineNumber": 15,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import javafx.scene.input.KeyEvent;"
-      },
-      {
-        "lineNumber": 16,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import javafx.scene.layout.StackPane;"
-      },
-      {
-        "lineNumber": 17,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import javafx.scene.layout.VBox;"
-      },
-      {
-        "lineNumber": 18,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import javafx.stage.Stage;"
-      },
-      {
-        "lineNumber": 19,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.commons.core.Config;"
-      },
-      {
-        "lineNumber": 20,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.commons.core.GuiSettings;"
-      },
-      {
-        "lineNumber": 21,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.commons.core.LogsCenter;"
-      },
-      {
-        "lineNumber": 22,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.commons.events.ui.ChangeThemeEvent;"
-      },
-      {
-        "lineNumber": 23,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.commons.events.ui.ExitAppRequestEvent;"
-      },
-      {
-        "lineNumber": 24,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.commons.events.ui.ShowHelpRequestEvent;"
-      },
-      {
-        "lineNumber": 25,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.logic.Logic;"
-      },
-      {
-        "lineNumber": 26,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.logic.commands.exceptions.CommandException;"
-      },
-      {
-        "lineNumber": 27,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.model.UserPrefs;"
-      },
-      {
-        "lineNumber": 28,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 29,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "/**"
-      },
-      {
-        "lineNumber": 30,
-        "author": {
-          "gitId": "-"
-        },
-        "content": " * The Main Window. Provides the basic application layout containing"
-      },
-      {
-        "lineNumber": 31,
-        "author": {
-          "gitId": "-"
-        },
-        "content": " * a menu bar and space where other JavaFX elements can be placed."
-      },
-      {
-        "lineNumber": 32,
-        "author": {
-          "gitId": "-"
-        },
-        "content": " */"
-      },
-      {
-        "lineNumber": 33,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "public class MainWindow extends UiPart\u003cStage\u003e {"
-      },
-      {
-        "lineNumber": 34,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 35,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    private static final String FXML \u003d \"MainWindow.fxml\";"
-      },
-      {
-        "lineNumber": 36,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    private static String currentTheme \u003d \"view/DarkTheme.css\";"
-      },
-      {
-        "lineNumber": 37,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 38,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    private final Logger logger \u003d LogsCenter.getLogger(this.getClass());"
-      },
-      {
-        "lineNumber": 39,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 40,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    private Stage primaryStage;"
-      },
-      {
-        "lineNumber": 41,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    private Logic logic;"
-      },
-      {
-        "lineNumber": 42,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 43,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    // Independent Ui parts residing in this Ui container"
-      },
-      {
-        "lineNumber": 44,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    private PersonListPanel personListPanel;"
-      },
-      {
-        "lineNumber": 45,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    private Config config;"
-      },
-      {
-        "lineNumber": 46,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    private UserPrefs prefs;"
-      },
-      {
-        "lineNumber": 47,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    private HelpWindow helpWindow;"
-      },
-      {
-        "lineNumber": 48,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 49,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    @FXML"
-      },
-      {
-        "lineNumber": 50,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    private Menu mtmLogo;"
-      },
-      {
-        "lineNumber": 51,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 52,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    @FXML"
-      },
-      {
-        "lineNumber": 53,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    private StackPane commandBoxPlaceholder;"
-      },
-      {
-        "lineNumber": 54,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 55,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    @FXML"
-      },
-      {
-        "lineNumber": 56,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    private MenuItem helpMenuItem;"
-      },
-      {
-        "lineNumber": 57,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 58,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    @FXML"
-      },
-      {
-        "lineNumber": 59,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    private StackPane personListPanelPlaceholder;"
-      },
-      {
-        "lineNumber": 60,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 61,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    @FXML"
-      },
-      {
-        "lineNumber": 62,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    private StackPane resultDisplayPlaceholder;"
-      },
-      {
-        "lineNumber": 63,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 64,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    @FXML"
-      },
-      {
-        "lineNumber": 65,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    private StackPane teamDisplayPlaceholder;"
-      },
-      {
-        "lineNumber": 66,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 67,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    @FXML"
-      },
-      {
-        "lineNumber": 68,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    private StackPane statusbarPlaceholder;"
-      },
-      {
-        "lineNumber": 69,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 70,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    @FXML"
-      },
-      {
-        "lineNumber": 71,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    private VBox mainWindow;"
-      },
-      {
-        "lineNumber": 72,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 73,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public MainWindow(Stage primaryStage, Config config, UserPrefs prefs, Logic logic) {"
-      },
-      {
-        "lineNumber": 74,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        super(FXML, primaryStage);"
-      },
-      {
-        "lineNumber": 75,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 76,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        // Set dependencies"
-      },
-      {
-        "lineNumber": 77,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        this.primaryStage \u003d primaryStage;"
-      },
-      {
-        "lineNumber": 78,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        this.logic \u003d logic;"
-      },
-      {
-        "lineNumber": 79,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        this.config \u003d config;"
-      },
-      {
-        "lineNumber": 80,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        this.prefs \u003d prefs;"
-      },
-      {
-        "lineNumber": 81,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 82,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        // Configure the UI"
-      },
-      {
-        "lineNumber": 83,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        setTitle(config.getAppTitle());"
-      },
-      {
-        "lineNumber": 84,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        setWindowDefaultSize(prefs);"
-      },
-      {
-        "lineNumber": 85,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 86,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        setAccelerators();"
-      },
-      {
-        "lineNumber": 87,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        registerAsAnEventHandler(this);"
-      },
-      {
-        "lineNumber": 88,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 89,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 90,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public Stage getPrimaryStage() {"
-      },
-      {
-        "lineNumber": 91,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        return primaryStage;"
-      },
-      {
-        "lineNumber": 92,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 93,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 94,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    private void setAccelerators() {"
-      },
-      {
-        "lineNumber": 95,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        setAccelerator(helpMenuItem, KeyCombination.valueOf(\"F1\"));"
-      },
-      {
-        "lineNumber": 96,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 97,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 98,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    /**"
-      },
-      {
-        "lineNumber": 99,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     * Sets the accelerator of a MenuItem."
-      },
-      {
-        "lineNumber": 100,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     * @param keyCombination the KeyCombination value of the accelerator"
-      },
-      {
-        "lineNumber": 101,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     */"
-      },
-      {
-        "lineNumber": 102,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    private void setAccelerator(MenuItem menuItem, KeyCombination keyCombination) {"
-      },
-      {
-        "lineNumber": 103,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        menuItem.setAccelerator(keyCombination);"
-      },
-      {
-        "lineNumber": 104,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 105,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        /*"
-      },
-      {
-        "lineNumber": 106,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "         * TODO: the code below can be removed once the bug reported here"
-      },
-      {
-        "lineNumber": 107,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "         * https://bugs.openjdk.java.net/browse/JDK-8131666"
-      },
-      {
-        "lineNumber": 108,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "         * is fixed in later version of SDK."
-      },
-      {
-        "lineNumber": 109,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "         *"
-      },
-      {
-        "lineNumber": 110,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "         * According to the bug report, TextInputControl (TextField, TextArea) will"
-      },
-      {
-        "lineNumber": 111,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "         * consume function-key events. Because CommandBox contains a TextField, and"
-      },
-      {
-        "lineNumber": 112,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "         * ResultDisplay contains a TextArea, thus some accelerators (e.g F1) will"
-      },
-      {
-        "lineNumber": 113,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "         * not work when the focus is in them because the key event is consumed by"
-      },
-      {
-        "lineNumber": 114,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "         * the TextInputControl(s)."
-      },
-      {
-        "lineNumber": 115,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "         *"
-      },
-      {
-        "lineNumber": 116,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "         * For now, we add following event filter to capture such key events and open"
-      },
-      {
-        "lineNumber": 117,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "         * help window purposely so to support accelerators even when focus is"
-      },
-      {
-        "lineNumber": 118,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "         * in CommandBox or ResultDisplay."
-      },
-      {
-        "lineNumber": 119,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "         */"
-      },
-      {
-        "lineNumber": 120,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        getRoot().addEventFilter(KeyEvent.KEY_PRESSED, event -\u003e {"
-      },
-      {
-        "lineNumber": 121,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "            if (event.getTarget() instanceof TextInputControl \u0026\u0026 keyCombination.match(event)) {"
-      },
-      {
-        "lineNumber": 122,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "                menuItem.getOnAction().handle(new ActionEvent());"
-      },
-      {
-        "lineNumber": 123,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "                event.consume();"
-      },
-      {
-        "lineNumber": 124,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "            }"
-      },
-      {
-        "lineNumber": 125,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        });"
-      },
-      {
-        "lineNumber": 126,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 127,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 128,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    /**"
-      },
-      {
-        "lineNumber": 129,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     * Fills up all the placeholders of this window."
-      },
-      {
-        "lineNumber": 130,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     */"
-      },
-      {
-        "lineNumber": 131,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    void fillInnerParts() {"
-      },
-      {
-        "lineNumber": 132,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        //@@author Codee"
-      },
-      {
-        "lineNumber": 133,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        currentTheme \u003d \"view/\" + prefs.getAddressBookTheme();"
-      },
-      {
-        "lineNumber": 134,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        mainWindow.getStylesheets().add(currentTheme);"
-      },
-      {
-        "lineNumber": 135,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        mainWindow.getStylesheets().add(\"view/Extensions.css\");"
-      },
-      {
-        "lineNumber": 136,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 137,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        final Image image \u003d new Image(\"images/MyTeamManagerLogo.png\", true);"
-      },
-      {
-        "lineNumber": 138,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        mtmLogo.setGraphic(new ImageView(image));"
-      },
-      {
-        "lineNumber": 139,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        mtmLogo.setDisable(true);"
-      },
-      {
-        "lineNumber": 140,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 141,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        //@@author"
-      },
-      {
-        "lineNumber": 142,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        personListPanel \u003d new PersonListPanel(logic.getFilteredPersonList());"
-      },
-      {
-        "lineNumber": 143,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        personListPanelPlaceholder.getChildren().add(personListPanel.getRoot());"
-      },
-      {
-        "lineNumber": 144,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 145,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        ResultDisplay resultDisplay \u003d new ResultDisplay();"
-      },
-      {
-        "lineNumber": 146,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        resultDisplayPlaceholder.getChildren().add(resultDisplay.getRoot());"
-      },
-      {
-        "lineNumber": 147,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 148,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        TeamDisplay teamDisplay \u003d new TeamDisplay(logic.getInitTeamList());"
-      },
-      {
-        "lineNumber": 149,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        teamDisplayPlaceholder.getChildren().add(teamDisplay.getRoot());"
-      },
-      {
-        "lineNumber": 150,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 151,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        StatusBarFooter statusBarFooter \u003d new StatusBarFooter(prefs.getAddressBookFilePath());"
-      },
-      {
-        "lineNumber": 152,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        statusbarPlaceholder.getChildren().add(statusBarFooter.getRoot());"
-      },
-      {
-        "lineNumber": 153,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 154,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        CommandBox commandBox \u003d new CommandBox(logic);"
-      },
-      {
-        "lineNumber": 155,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        commandBoxPlaceholder.getChildren().add(commandBox.getRoot());"
-      },
-      {
-        "lineNumber": 156,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 157,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 158,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    void hide() {"
-      },
-      {
-        "lineNumber": 159,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        primaryStage.hide();"
-      },
-      {
-        "lineNumber": 160,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 161,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 162,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    private void setTitle(String appTitle) {"
-      },
-      {
-        "lineNumber": 163,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        primaryStage.setTitle(appTitle);"
-      },
-      {
-        "lineNumber": 164,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 165,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 166,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    /**"
-      },
-      {
-        "lineNumber": 167,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     * Sets the default size based on user preferences."
-      },
-      {
-        "lineNumber": 168,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     */"
-      },
-      {
-        "lineNumber": 169,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    private void setWindowDefaultSize(UserPrefs prefs) {"
-      },
-      {
-        "lineNumber": 170,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        primaryStage.setHeight(prefs.getGuiSettings().getWindowHeight());"
-      },
-      {
-        "lineNumber": 171,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        primaryStage.setWidth(prefs.getGuiSettings().getWindowWidth());"
-      },
-      {
-        "lineNumber": 172,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        if (prefs.getGuiSettings().getWindowCoordinates() !\u003d null) {"
-      },
-      {
-        "lineNumber": 173,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "            primaryStage.setX(prefs.getGuiSettings().getWindowCoordinates().getX());"
-      },
-      {
-        "lineNumber": 174,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "            primaryStage.setY(prefs.getGuiSettings().getWindowCoordinates().getY());"
-      },
-      {
-        "lineNumber": 175,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        }"
-      },
-      {
-        "lineNumber": 176,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 177,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 178,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    /** @@author Codee */"
-      },
-      {
-        "lineNumber": 179,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    /**"
-      },
-      {
-        "lineNumber": 180,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "     * @returns the {@code currentTheme}."
-      },
-      {
-        "lineNumber": 181,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "     */"
-      },
-      {
-        "lineNumber": 182,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    public static String getCurrentTheme() {"
-      },
-      {
-        "lineNumber": 183,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        return currentTheme;"
-      },
-      {
-        "lineNumber": 184,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 185,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 186,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    @Subscribe"
-      },
-      {
-        "lineNumber": 187,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    public void handleChangeThemeRequestEvent(ChangeThemeEvent event) throws CommandException {"
-      },
-      {
-        "lineNumber": 188,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        logger.info(LogsCenter.getEventHandlingLogMessage(event));"
-      },
-      {
-        "lineNumber": 189,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        mainWindow.getStylesheets().remove(currentTheme);"
-      },
-      {
-        "lineNumber": 190,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        prefs.setAddressBookTheme(event.theme + \"Theme.css\");"
-      },
-      {
-        "lineNumber": 191,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        currentTheme \u003d \"view/\" + prefs.getAddressBookTheme();"
-      },
-      {
-        "lineNumber": 192,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        mainWindow.getStylesheets().add(currentTheme);"
-      },
-      {
-        "lineNumber": 193,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 194,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    //@@author"
-      },
-      {
-        "lineNumber": 195,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 196,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    /**"
-      },
-      {
-        "lineNumber": 197,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     * Returns the current size and the position of the main Window."
-      },
-      {
-        "lineNumber": 198,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     */"
-      },
-      {
-        "lineNumber": 199,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    GuiSettings getCurrentGuiSetting() {"
-      },
-      {
-        "lineNumber": 200,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        return new GuiSettings(primaryStage.getWidth(), primaryStage.getHeight(),"
-      },
-      {
-        "lineNumber": 201,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "                (int) primaryStage.getX(), (int) primaryStage.getY());"
-      },
-      {
-        "lineNumber": 202,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 203,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 204,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    /**"
-      },
-      {
-        "lineNumber": 205,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     * Opens the help window."
-      },
-      {
-        "lineNumber": 206,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     */"
-      },
-      {
-        "lineNumber": 207,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    @FXML"
-      },
-      {
-        "lineNumber": 208,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public void handleHelp() {"
-      },
-      {
-        "lineNumber": 209,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        if (helpWindow \u003d\u003d null) {"
-      },
-      {
-        "lineNumber": 210,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "            helpWindow \u003d new HelpWindow();"
-      },
-      {
-        "lineNumber": 211,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        }"
-      },
-      {
-        "lineNumber": 212,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        helpWindow.show();"
-      },
-      {
-        "lineNumber": 213,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 214,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 215,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    void show() {"
-      },
-      {
-        "lineNumber": 216,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        primaryStage.show();"
-      },
-      {
-        "lineNumber": 217,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 218,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 219,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    /**"
-      },
-      {
-        "lineNumber": 220,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     * Closes the application."
-      },
-      {
-        "lineNumber": 221,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     */"
-      },
-      {
-        "lineNumber": 222,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    @FXML"
-      },
-      {
-        "lineNumber": 223,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    private void handleExit() {"
-      },
-      {
-        "lineNumber": 224,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        raise(new ExitAppRequestEvent());"
-      },
-      {
-        "lineNumber": 225,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 226,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 227,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public PersonListPanel getPersonListPanel() {"
-      },
-      {
-        "lineNumber": 228,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        return this.personListPanel;"
-      },
-      {
-        "lineNumber": 229,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 230,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 231,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    @Subscribe"
-      },
-      {
-        "lineNumber": 232,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    private void handleShowHelpEvent(ShowHelpRequestEvent event) {"
-      },
-      {
-        "lineNumber": 233,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        logger.info(LogsCenter.getEventHandlingLogMessage(event));"
-      },
-      {
-        "lineNumber": 234,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        handleHelp();"
-      },
-      {
-        "lineNumber": 235,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 236,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "}"
-      }
-    ],
-    "authorContributionMap": {
-      "codeeong": 27,
-      "-": 209
+      "null": 2,
+      "jordancjq": 6,
+      "-": 77
     }
   },
   {
@@ -77758,126 +66457,126 @@
       {
         "lineNumber": 127,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    /** @@author Codee */"
       },
       {
         "lineNumber": 128,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    @Subscribe"
       },
       {
         "lineNumber": 129,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    public void handleColourChangeEvent(ChangeTagColourEvent event) {"
       },
       {
         "lineNumber": 130,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        logger.info(LogsCenter.getEventHandlingLogMessage(event));"
       },
       {
         "lineNumber": 131,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        Set\u003cTag\u003e tagSet \u003d person.getTags();"
       },
       {
         "lineNumber": 132,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        int i \u003d 0;"
       },
       {
         "lineNumber": 133,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        for (Iterator\u003cTag\u003e it \u003d tagSet.iterator(); it.hasNext();) {"
       },
       {
         "lineNumber": 134,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "            Tag tag \u003d it.next();"
       },
       {
         "lineNumber": 135,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "            if (tag.getTagName().equals(event.tagName)) {"
       },
       {
         "lineNumber": 136,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "                tags.getChildren().remove(i);"
       },
       {
         "lineNumber": 137,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "                Label newTagLabel \u003d new Label(event.tagName);"
       },
       {
         "lineNumber": 138,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "                newTagLabel.getStyleClass().add(event.tagColour);"
       },
       {
         "lineNumber": 139,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "                tags.getChildren().add(i, newTagLabel);"
       },
       {
         "lineNumber": 140,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "            }"
       },
       {
         "lineNumber": 141,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "            i++;"
       },
       {
         "lineNumber": 142,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        }"
       },
       {
         "lineNumber": 143,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    }"
       },
       {
         "lineNumber": 144,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "}"
       }
@@ -77885,787 +66584,7 @@
     "authorContributionMap": {
       "lohtianwei": 5,
       "jordancjq": 2,
-      "codeeong": 18,
-      "-": 119
-    }
-  },
-  {
-    "path": "src/main/java/seedu/address/ui/PersonListPanel.java",
-    "lines": [
-      {
-        "lineNumber": 1,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "package seedu.address.ui;"
-      },
-      {
-        "lineNumber": 2,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 3,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import java.util.logging.Logger;"
-      },
-      {
-        "lineNumber": 4,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 5,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import org.fxmisc.easybind.EasyBind;"
-      },
-      {
-        "lineNumber": 6,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 7,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import com.google.common.eventbus.Subscribe;"
-      },
-      {
-        "lineNumber": 8,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 9,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import javafx.application.Platform;"
-      },
-      {
-        "lineNumber": 10,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import javafx.collections.ObservableList;"
-      },
-      {
-        "lineNumber": 11,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import javafx.fxml.FXML;"
-      },
-      {
-        "lineNumber": 12,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import javafx.scene.control.ListCell;"
-      },
-      {
-        "lineNumber": 13,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import javafx.scene.control.ListView;"
-      },
-      {
-        "lineNumber": 14,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import javafx.scene.layout.Region;"
-      },
-      {
-        "lineNumber": 15,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import javafx.scene.layout.StackPane;"
-      },
-      {
-        "lineNumber": 16,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.commons.core.LogsCenter;"
-      },
-      {
-        "lineNumber": 17,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.commons.events.ui.JumpToListRequestEvent;"
-      },
-      {
-        "lineNumber": 18,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.commons.events.ui.PersonDetailsChangedNoParamEvent;"
-      },
-      {
-        "lineNumber": 19,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.commons.events.ui.PersonPanelSelectionChangedEvent;"
-      },
-      {
-        "lineNumber": 20,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.model.person.Person;"
-      },
-      {
-        "lineNumber": 21,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 22,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "/**"
-      },
-      {
-        "lineNumber": 23,
-        "author": {
-          "gitId": "-"
-        },
-        "content": " * Panel containing the list of persons."
-      },
-      {
-        "lineNumber": 24,
-        "author": {
-          "gitId": "-"
-        },
-        "content": " */"
-      },
-      {
-        "lineNumber": 25,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "public class PersonListPanel extends UiPart\u003cRegion\u003e {"
-      },
-      {
-        "lineNumber": 26,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    private static final String FXML \u003d \"PersonListPanel.fxml\";"
-      },
-      {
-        "lineNumber": 27,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    private final Logger logger \u003d LogsCenter.getLogger(PersonListPanel.class);"
-      },
-      {
-        "lineNumber": 28,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 29,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    private PlayerDetails playerDetails;"
-      },
-      {
-        "lineNumber": 30,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    private Integer selectedCardIndex;"
-      },
-      {
-        "lineNumber": 31,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 32,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    @FXML"
-      },
-      {
-        "lineNumber": 33,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    private ListView\u003cPersonCard\u003e personListView;"
-      },
-      {
-        "lineNumber": 34,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 35,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    @FXML"
-      },
-      {
-        "lineNumber": 36,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    private StackPane playerDetailsPlaceholder;"
-      },
-      {
-        "lineNumber": 37,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 38,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public PersonListPanel(ObservableList\u003cPerson\u003e personList) {"
-      },
-      {
-        "lineNumber": 39,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        super(FXML);"
-      },
-      {
-        "lineNumber": 40,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        setConnections(personList);"
-      },
-      {
-        "lineNumber": 41,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        registerAsAnEventHandler(this);"
-      },
-      {
-        "lineNumber": 42,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 43,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 44,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    private void setConnections(ObservableList\u003cPerson\u003e personList) {"
-      },
-      {
-        "lineNumber": 45,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        ObservableList\u003cPersonCard\u003e mappedList \u003d EasyBind.map("
-      },
-      {
-        "lineNumber": 46,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "                personList, (person) -\u003e new PersonCard(person, personList.indexOf(person) + 1));"
-      },
-      {
-        "lineNumber": 47,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        personListView.setItems(mappedList);"
-      },
-      {
-        "lineNumber": 48,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        personListView.setCellFactory(listView -\u003e new PersonListViewCell());"
-      },
-      {
-        "lineNumber": 49,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        setEventHandlerForSelectionChangeEvent();"
-      },
-      {
-        "lineNumber": 50,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 51,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 52,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    private void setEventHandlerForSelectionChangeEvent() {"
-      },
-      {
-        "lineNumber": 53,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        personListView.getSelectionModel().selectedItemProperty()"
-      },
-      {
-        "lineNumber": 54,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "                .addListener((observable, oldValue, newValue) -\u003e {"
-      },
-      {
-        "lineNumber": 55,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "                    if (newValue !\u003d null) {"
-      },
-      {
-        "lineNumber": 56,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "                        playerDetailsPlaceholder.getChildren().clear();"
-      },
-      {
-        "lineNumber": 57,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "                        logger.fine(\"Selection in person list panel changed to : \u0027\" + newValue + \"\u0027\");"
-      },
-      {
-        "lineNumber": 58,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "                        raise(new PersonPanelSelectionChangedEvent(newValue));"
-      },
-      {
-        "lineNumber": 59,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "                        playerDetails \u003d new PlayerDetails(newValue.person);"
-      },
-      {
-        "lineNumber": 60,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "                        playerDetailsPlaceholder.getChildren().add(playerDetails.getRoot());"
-      },
-      {
-        "lineNumber": 61,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "                    }"
-      },
-      {
-        "lineNumber": 62,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "                });"
-      },
-      {
-        "lineNumber": 63,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 64,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 65,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    /**"
-      },
-      {
-        "lineNumber": 66,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     * Scrolls to the {@code PersonCard} at the {@code index} and selects it."
-      },
-      {
-        "lineNumber": 67,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     */"
-      },
-      {
-        "lineNumber": 68,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    private void scrollTo(int index) {"
-      },
-      {
-        "lineNumber": 69,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        Platform.runLater(() -\u003e {"
-      },
-      {
-        "lineNumber": 70,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "            personListView.scrollTo(index);"
-      },
-      {
-        "lineNumber": 71,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "            personListView.getSelectionModel().clearAndSelect(index);"
-      },
-      {
-        "lineNumber": 72,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "            this.selectedCardIndex \u003d index;"
-      },
-      {
-        "lineNumber": 73,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        });"
-      },
-      {
-        "lineNumber": 74,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 75,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 76,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    @Subscribe"
-      },
-      {
-        "lineNumber": 77,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    private void handleJumpToListRequestEvent(JumpToListRequestEvent event) {"
-      },
-      {
-        "lineNumber": 78,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        logger.info(LogsCenter.getEventHandlingLogMessage(event));"
-      },
-      {
-        "lineNumber": 79,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        scrollTo(event.targetIndex);"
-      },
-      {
-        "lineNumber": 80,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 81,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 82,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    //@@author Codee"
-      },
-      {
-        "lineNumber": 83,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    @Subscribe"
-      },
-      {
-        "lineNumber": 84,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    private void handlePersonDetailsChangedNoParamEvent(PersonDetailsChangedNoParamEvent event) {"
-      },
-      {
-        "lineNumber": 85,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        logger.info(LogsCenter.getEventHandlingLogMessage(event));"
-      },
-      {
-        "lineNumber": 86,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        PersonCard newPersonCard \u003d personListView.getItems().get(selectedCardIndex);"
-      },
-      {
-        "lineNumber": 87,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        playerDetailsPlaceholder.getChildren().clear();"
-      },
-      {
-        "lineNumber": 88,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        playerDetails \u003d new PlayerDetails(newPersonCard.person);"
-      },
-      {
-        "lineNumber": 89,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        playerDetailsPlaceholder.getChildren().add(playerDetails.getRoot());"
-      },
-      {
-        "lineNumber": 90,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 91,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    //@author"
-      },
-      {
-        "lineNumber": 92,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 93,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    /**"
-      },
-      {
-        "lineNumber": 94,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "     * Custom {@code ListCell} that displays the graphics of a {@code PersonCard}."
-      },
-      {
-        "lineNumber": 95,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "     */"
-      },
-      {
-        "lineNumber": 96,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    class PersonListViewCell extends ListCell\u003cPersonCard\u003e {"
-      },
-      {
-        "lineNumber": 97,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 98,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        @Override"
-      },
-      {
-        "lineNumber": 99,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        protected void updateItem(PersonCard person, boolean empty) {"
-      },
-      {
-        "lineNumber": 100,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "            super.updateItem(person, empty);"
-      },
-      {
-        "lineNumber": 101,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 102,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "            if (empty || person \u003d\u003d null) {"
-      },
-      {
-        "lineNumber": 103,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "                setGraphic(null);"
-      },
-      {
-        "lineNumber": 104,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "                setText(null);"
-      },
-      {
-        "lineNumber": 105,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "            } else {"
-      },
-      {
-        "lineNumber": 106,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "                setGraphic(person.getRoot());"
-      },
-      {
-        "lineNumber": 107,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "            }"
-      },
-      {
-        "lineNumber": 108,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        }"
-      },
-      {
-        "lineNumber": 109,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 110,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "}"
-      }
-    ],
-    "authorContributionMap": {
-      "codeeong": 29,
-      "-": 81
+      "-": 137
     }
   },
   {
@@ -78779,217 +66698,217 @@
       {
         "lineNumber": 16,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "/** @@author Codee */"
       },
       {
         "lineNumber": 17,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "public class PlayerDetails extends UiPart\u003cRegion\u003e {"
       },
       {
         "lineNumber": 18,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 19,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    private static final String FXML \u003d \"PlayerDetails.fxml\";"
       },
       {
         "lineNumber": 20,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 21,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    /**"
       },
       {
         "lineNumber": 22,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "     * Note: Certain keywords such as \"location\" and \"resources\" are reserved keywords in JavaFX."
       },
       {
         "lineNumber": 23,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "     * As a consequence, UI elements\u0027 variable names cannot be set to such keywords"
       },
       {
         "lineNumber": 24,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "     * or an exception will be thrown by JavaFX during runtime."
       },
       {
         "lineNumber": 25,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "     *"
       },
       {
         "lineNumber": 26,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "     * @see \u003ca href\u003d\"https://github.com/se-edu/addressbook-level4/issues/336\"\u003eThe issue on AddressBook level 4\u003c/a\u003e"
       },
       {
         "lineNumber": 27,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "     */"
       },
       {
         "lineNumber": 28,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 29,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    public final Person person;"
       },
       {
         "lineNumber": 30,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    private Person personBeforeChange;"
       },
       {
         "lineNumber": 31,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 32,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    @FXML"
       },
       {
         "lineNumber": 33,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    private HBox cardPane;"
       },
       {
         "lineNumber": 34,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    @FXML"
       },
       {
         "lineNumber": 35,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    private Label name;"
       },
       {
         "lineNumber": 36,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    @FXML"
       },
       {
         "lineNumber": 37,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    private Label phone;"
       },
       {
         "lineNumber": 38,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    @FXML"
       },
       {
         "lineNumber": 39,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    private Label address;"
       },
       {
         "lineNumber": 40,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    @FXML"
       },
       {
         "lineNumber": 41,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    private Label email;"
       },
       {
         "lineNumber": 42,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    @FXML"
       },
       {
         "lineNumber": 43,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    private Label jerseyNumber;"
       },
       {
         "lineNumber": 44,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    @FXML"
       },
       {
         "lineNumber": 45,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    private Label remark;"
       },
       {
         "lineNumber": 46,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -79234,106 +67153,105 @@
       {
         "lineNumber": 81,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    //@@author Codee"
       },
       {
         "lineNumber": 82,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    @Subscribe"
       },
       {
         "lineNumber": 83,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    private void handlePersonDetailsChangedEvent(PersonDetailsChangedEvent event) {"
       },
       {
         "lineNumber": 84,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        if (event.getPerson().getName().fullName.equals(person.getName().fullName)) {"
       },
       {
         "lineNumber": 85,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "            name.setText((event.getPerson().getName().toString()));"
       },
       {
         "lineNumber": 86,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "            phone.setText(event.getPerson().getPhone().toString());"
       },
       {
         "lineNumber": 87,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "            jerseyNumber.setText(\"Jersey Number: \" + event.getPerson().getJerseyNumber().toString());"
       },
       {
         "lineNumber": 88,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "            address.setText(event.getPerson().getAddress().toString());"
       },
       {
         "lineNumber": 89,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "            email.setText(event.getPerson().getEmail().toString());"
       },
       {
         "lineNumber": 90,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "            remark.setText(\"Remarks: \" + event.getPerson().getRemark().toString());"
       },
       {
         "lineNumber": 91,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        }"
       },
       {
         "lineNumber": 92,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    }"
       },
       {
         "lineNumber": 93,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "}"
       },
       {
         "lineNumber": 94,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       }
     ],
     "authorContributionMap": {
       "lohtianwei": 34,
-      "codeeong": 45,
-      "-": 15
+      "-": 60
     }
   },
   {
@@ -79524,694 +67442,693 @@
       {
         "lineNumber": 27,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "/** @@author Codee */"
       },
       {
         "lineNumber": 28,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "public class TeamDisplay extends UiPart\u003cRegion\u003e {"
       },
       {
         "lineNumber": 29,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 30,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "jordancjq"
         },
         "content": "    private static final Logger logger \u003d LogsCenter.getLogger(TeamDisplay.class);"
       },
       {
         "lineNumber": 31,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    private static final String FXML \u003d \"TeamDisplay.fxml\";"
       },
       {
         "lineNumber": 32,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "jordancjq"
         },
         "content": ""
       },
       {
         "lineNumber": 33,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    private ObservableList\u003cTeam\u003e teamList;"
       },
       {
         "lineNumber": 34,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 35,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    @FXML"
       },
       {
         "lineNumber": 36,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    private FlowPane teams;"
       },
       {
         "lineNumber": 37,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 38,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    public TeamDisplay(ObservableList\u003cTeam\u003e teamList) {"
       },
       {
         "lineNumber": 39,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        super(FXML);"
       },
       {
         "lineNumber": 40,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        this.teamList \u003d teamList;"
       },
       {
         "lineNumber": 41,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        initTeams();"
       },
       {
         "lineNumber": 42,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        getTeams();"
       },
       {
         "lineNumber": 43,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        registerAsAnEventHandler(this);"
       },
       {
         "lineNumber": 44,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    }"
       },
       {
         "lineNumber": 45,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 46,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    /**"
       },
       {
         "lineNumber": 47,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "     * Creates the tag labels for {@code person}."
       },
       {
         "lineNumber": 48,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "     */"
       },
       {
         "lineNumber": 49,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    private void initTeams() {"
       },
       {
         "lineNumber": 50,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        for (Team t: this.teamList) {"
       },
       {
         "lineNumber": 51,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "            Label teamLabel \u003d new Label(t.getTeamName().toString());"
       },
       {
         "lineNumber": 52,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "            teamLabel.setStyle(\"-fx-text-fill: #3f7bbf\");"
       },
       {
         "lineNumber": 53,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "            teams.getChildren().add(teamLabel);"
       },
       {
         "lineNumber": 54,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "            teams.setHgap(10);"
       },
       {
         "lineNumber": 55,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        }"
       },
       {
         "lineNumber": 56,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    }"
       },
       {
         "lineNumber": 57,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 58,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    public List\u003cString\u003e getTeams() {"
       },
       {
         "lineNumber": 59,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        List\u003cString\u003e listOfTeams \u003d FXCollections.observableArrayList();"
       },
       {
         "lineNumber": 60,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        for (Team t: teamList) {"
       },
       {
         "lineNumber": 61,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "            listOfTeams.add(t.getTeamName().toString());"
       },
       {
         "lineNumber": 62,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        }"
       },
       {
         "lineNumber": 63,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        return listOfTeams;"
       },
       {
         "lineNumber": 64,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    }"
       },
       {
         "lineNumber": 65,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 66,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    @Subscribe"
       },
       {
         "lineNumber": 67,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    private void handleShowNewTeamEvent(ShowNewTeamNameEvent event) {"
       },
       {
         "lineNumber": 68,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        Label newTeamLabel \u003d new Label(event.teamName);"
       },
       {
         "lineNumber": 69,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        newTeamLabel.getStyleClass();"
       },
       {
         "lineNumber": 70,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        teams.getChildren().add(newTeamLabel);"
       },
       {
         "lineNumber": 71,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    }"
       },
       {
         "lineNumber": 72,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 73,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    @Subscribe"
       },
       {
         "lineNumber": 74,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    private void handleHighlightSelectedTeamEvent(HighlightSelectedTeamEvent event) {"
       },
       {
         "lineNumber": 75,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        for (int i \u003d 0; i \u003c teamList.size(); i++) {"
       },
       {
         "lineNumber": 76,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "            if (event.teamName.equals(teamList.get(i).getTeamName().toString())) {"
       },
       {
         "lineNumber": 77,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "                teams.getChildren().remove(i);"
       },
       {
         "lineNumber": 78,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "                Label newTeamLabel \u003d new Label(event.teamName);"
       },
       {
         "lineNumber": 79,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "                newTeamLabel.getStyleClass().add(\"selected\");"
       },
       {
         "lineNumber": 80,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "                teams.getChildren().add(i, newTeamLabel);"
       },
       {
         "lineNumber": 81,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "            } else {"
       },
       {
         "lineNumber": 82,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "                teams.getChildren().remove(i);"
       },
       {
         "lineNumber": 83,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "                Label newTeamLabel \u003d new Label(teamList.get(i).getTeamName().toString());"
       },
       {
         "lineNumber": 84,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "                newTeamLabel.getStyleClass();"
       },
       {
         "lineNumber": 85,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "                teams.getChildren().add(i, newTeamLabel);"
       },
       {
         "lineNumber": 86,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "            }"
       },
       {
         "lineNumber": 87,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        }"
       },
       {
         "lineNumber": 88,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    }"
       },
       {
         "lineNumber": 89,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 90,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    @Subscribe"
       },
       {
         "lineNumber": 91,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    private void handleDeselectTeamEvent(DeselectTeamEvent event) {"
       },
       {
         "lineNumber": 92,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        for (int i \u003d 0; i \u003c teamList.size(); i++) {"
       },
       {
         "lineNumber": 93,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "            teams.getChildren().remove(i);"
       },
       {
         "lineNumber": 94,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "            Label newTeamLabel \u003d new Label(teamList.get(i).getTeamName().toString());"
       },
       {
         "lineNumber": 95,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "            newTeamLabel.getStyleClass();"
       },
       {
         "lineNumber": 96,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "            teams.getChildren().add(i, newTeamLabel);"
       },
       {
         "lineNumber": 97,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        }"
       },
       {
         "lineNumber": 98,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    }"
       },
       {
         "lineNumber": 99,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "jordancjq"
         },
         "content": ""
       },
       {
         "lineNumber": 100,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "jordancjq"
         },
         "content": "    @Subscribe"
       },
       {
         "lineNumber": 101,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "jordancjq"
         },
         "content": "    private void handleRemoveSelectedTeamEvent(RemoveSelectedTeamEvent event) {"
       },
       {
         "lineNumber": 102,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "jordancjq"
         },
         "content": "        logger.info(LogsCenter.getEventHandlingLogMessage(event));"
       },
       {
         "lineNumber": 103,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "jordancjq"
         },
         "content": "        for (int i \u003d 0; i \u003c teams.getChildren().size(); i++) {"
       },
       {
         "lineNumber": 104,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "jordancjq"
         },
         "content": "            if (teamList.get(i).getTeamName().equals(event.teamName)) {"
       },
       {
         "lineNumber": 105,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "jordancjq"
         },
         "content": "                teams.getChildren().remove(i);"
       },
       {
         "lineNumber": 106,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "jordancjq"
         },
         "content": "            }"
       },
       {
         "lineNumber": 107,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "jordancjq"
         },
         "content": "        }"
       },
       {
         "lineNumber": 108,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "jordancjq"
         },
         "content": "    }"
       },
       {
         "lineNumber": 109,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 110,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    @Subscribe"
       },
       {
         "lineNumber": 111,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    private void handleClearTeamsEvent(ClearTeamsEvent event) {"
       },
       {
         "lineNumber": 112,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        logger.info(LogsCenter.getEventHandlingLogMessage(event));"
       },
       {
         "lineNumber": 113,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        teams.getChildren().clear();"
       },
       {
         "lineNumber": 114,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    }"
       },
       {
         "lineNumber": 115,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 116,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    @Subscribe"
       },
       {
         "lineNumber": 117,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    private void handleUndoTeamsEvent(UndoTeamsEvent event) {"
       },
       {
         "lineNumber": 118,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        logger.info(LogsCenter.getEventHandlingLogMessage(event));"
       },
       {
         "lineNumber": 119,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        teams.getChildren().clear();"
       },
       {
         "lineNumber": 120,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        initTeams();"
       },
       {
         "lineNumber": 121,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        getTeams();"
       },
       {
         "lineNumber": 122,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    }"
       },
       {
         "lineNumber": 123,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "}"
       },
       {
         "lineNumber": 124,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       }
     ],
     "authorContributionMap": {
-      "jordancjq": 3,
-      "codeeong": 98,
-      "-": 23
+      "jordancjq": 15,
+      "-": 109
     }
   },
   {
@@ -80788,985 +68705,6 @@
     "authorContributionMap": {
       "jordancjq": 2,
       "-": 79
-    }
-  },
-  {
-    "path": "src/test/java/guitests/guihandles/PlayerDetailsHandle.java",
-    "lines": [
-      {
-        "lineNumber": 1,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "package guitests.guihandles;"
-      },
-      {
-        "lineNumber": 2,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 3,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import javafx.scene.Node;"
-      },
-      {
-        "lineNumber": 4,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import javafx.scene.control.Label;"
-      },
-      {
-        "lineNumber": 5,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 6,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "/**"
-      },
-      {
-        "lineNumber": 7,
-        "author": {
-          "gitId": "-"
-        },
-        "content": " * Provides a handle to a player details pane."
-      },
-      {
-        "lineNumber": 8,
-        "author": {
-          "gitId": "-"
-        },
-        "content": " */"
-      },
-      {
-        "lineNumber": 9,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "//@@author Codee"
-      },
-      {
-        "lineNumber": 10,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "public class PlayerDetailsHandle extends NodeHandle\u003cNode\u003e {"
-      },
-      {
-        "lineNumber": 11,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 12,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    public static final String PLAYER_DETAILS_DISPLAY_ID \u003d \"#playerDetails\";"
-      },
-      {
-        "lineNumber": 13,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 14,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    private static final String NAME_FIELD_ID \u003d \"#name\";"
-      },
-      {
-        "lineNumber": 15,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    private static final String JERSEY_FIELD_ID \u003d \"#jerseyNumber\";"
-      },
-      {
-        "lineNumber": 16,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    private static final String PHONE_FIELD_ID \u003d \"#phone\";"
-      },
-      {
-        "lineNumber": 17,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    private static final String EMAIL_FIELD_ID \u003d \"#email\";"
-      },
-      {
-        "lineNumber": 18,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    private static final String ADDRESS_FIELD_ID \u003d \"#address\";"
-      },
-      {
-        "lineNumber": 19,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    private static final String REMARK_FIELD_ID \u003d \"#remark\";"
-      },
-      {
-        "lineNumber": 20,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 21,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    private final Label nameLabel;"
-      },
-      {
-        "lineNumber": 22,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    private final Label jerseyLabel;"
-      },
-      {
-        "lineNumber": 23,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    private final Label addressLabel;"
-      },
-      {
-        "lineNumber": 24,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    private final Label phoneLabel;"
-      },
-      {
-        "lineNumber": 25,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    private final Label emailLabel;"
-      },
-      {
-        "lineNumber": 26,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    private final Label remarkLabel;"
-      },
-      {
-        "lineNumber": 27,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 28,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    public PlayerDetailsHandle(Node cardNode) {"
-      },
-      {
-        "lineNumber": 29,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        super(cardNode);"
-      },
-      {
-        "lineNumber": 30,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 31,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        this.nameLabel \u003d getChildNode(NAME_FIELD_ID);"
-      },
-      {
-        "lineNumber": 32,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        this.phoneLabel \u003d getChildNode(PHONE_FIELD_ID);"
-      },
-      {
-        "lineNumber": 33,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        this.addressLabel \u003d getChildNode(ADDRESS_FIELD_ID);"
-      },
-      {
-        "lineNumber": 34,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        this.emailLabel \u003d getChildNode(EMAIL_FIELD_ID);"
-      },
-      {
-        "lineNumber": 35,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        this.remarkLabel \u003d getChildNode(REMARK_FIELD_ID);"
-      },
-      {
-        "lineNumber": 36,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        this.jerseyLabel \u003d getChildNode(JERSEY_FIELD_ID);"
-      },
-      {
-        "lineNumber": 37,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 38,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 39,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 40,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    public String getPhone() {"
-      },
-      {
-        "lineNumber": 41,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        return phoneLabel.getText();"
-      },
-      {
-        "lineNumber": 42,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 43,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 44,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    public String getName() {"
-      },
-      {
-        "lineNumber": 45,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        return nameLabel.getText();"
-      },
-      {
-        "lineNumber": 46,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 47,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 48,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    public String getAddress() {"
-      },
-      {
-        "lineNumber": 49,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        return addressLabel.getText();"
-      },
-      {
-        "lineNumber": 50,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 51,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 52,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    public String getJerseyNumber() {"
-      },
-      {
-        "lineNumber": 53,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        return jerseyLabel.getText().substring(15);"
-      },
-      {
-        "lineNumber": 54,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 55,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 56,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    public String getRemarks() {"
-      },
-      {
-        "lineNumber": 57,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        return remarkLabel.getText().substring(9);"
-      },
-      {
-        "lineNumber": 58,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 59,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 60,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    public String getEmail() {"
-      },
-      {
-        "lineNumber": 61,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        return emailLabel.getText();"
-      },
-      {
-        "lineNumber": 62,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 63,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 64,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "}"
-      }
-    ],
-    "authorContributionMap": {
-      "codeeong": 56,
-      "-": 8
-    }
-  },
-  {
-    "path": "src/test/java/guitests/guihandles/TeamDisplayHandle.java",
-    "lines": [
-      {
-        "lineNumber": 1,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "package guitests.guihandles;"
-      },
-      {
-        "lineNumber": 2,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 3,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import java.util.List;"
-      },
-      {
-        "lineNumber": 4,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import java.util.stream.Collectors;"
-      },
-      {
-        "lineNumber": 5,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 6,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import javafx.scene.Node;"
-      },
-      {
-        "lineNumber": 7,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import javafx.scene.control.Label;"
-      },
-      {
-        "lineNumber": 8,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import javafx.scene.layout.Region;"
-      },
-      {
-        "lineNumber": 9,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 10,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "/**"
-      },
-      {
-        "lineNumber": 11,
-        "author": {
-          "gitId": "-"
-        },
-        "content": " * Provides a handle for {@code TeamDisplayHandle} containing the list of {@code Teams}."
-      },
-      {
-        "lineNumber": 12,
-        "author": {
-          "gitId": "-"
-        },
-        "content": " */"
-      },
-      {
-        "lineNumber": 13,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "/** @@author Codee */"
-      },
-      {
-        "lineNumber": 14,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "public class TeamDisplayHandle extends NodeHandle\u003cNode\u003e {"
-      },
-      {
-        "lineNumber": 15,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    public static final String TEAM_DISPLAY_ID \u003d \"#teams\";"
-      },
-      {
-        "lineNumber": 16,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 17,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    private final List\u003cLabel\u003e teamLabels;"
-      },
-      {
-        "lineNumber": 18,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 19,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    public TeamDisplayHandle(Node teamDisplayNode) {"
-      },
-      {
-        "lineNumber": 20,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        super(teamDisplayNode);"
-      },
-      {
-        "lineNumber": 21,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 22,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        Region teamContainer \u003d getChildNode(TEAM_DISPLAY_ID);"
-      },
-      {
-        "lineNumber": 23,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        this.teamLabels \u003d teamContainer"
-      },
-      {
-        "lineNumber": 24,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "                .getChildrenUnmodifiable()"
-      },
-      {
-        "lineNumber": 25,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "                .stream()"
-      },
-      {
-        "lineNumber": 26,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "                .map(Label.class::cast)"
-      },
-      {
-        "lineNumber": 27,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "                .collect(Collectors.toList());"
-      },
-      {
-        "lineNumber": 28,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 29,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 30,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    public List\u003cString\u003e getTeams() {"
-      },
-      {
-        "lineNumber": 31,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        return teamLabels"
-      },
-      {
-        "lineNumber": 32,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "                .stream()"
-      },
-      {
-        "lineNumber": 33,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "                .map(Label::getText)"
-      },
-      {
-        "lineNumber": 34,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "                .collect(Collectors.toList());"
-      },
-      {
-        "lineNumber": 35,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 36,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 37,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "}"
-      }
-    ],
-    "authorContributionMap": {
-      "codeeong": 25,
-      "-": 12
-    }
-  },
-  {
-    "path": "src/test/java/seedu/address/logic/AutocompleteTest.java",
-    "lines": [
-      {
-        "lineNumber": 1,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "package seedu.address.logic;"
-      },
-      {
-        "lineNumber": 2,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 3,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "//@@author lithiumlkid"
-      },
-      {
-        "lineNumber": 4,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "import org.junit.Before;"
-      },
-      {
-        "lineNumber": 5,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "import org.junit.Test;"
-      },
-      {
-        "lineNumber": 6,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 7,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "import seedu.address.logic.commands.CommandTrie;"
-      },
-      {
-        "lineNumber": 8,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 9,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "public class AutocompleteTest {"
-      },
-      {
-        "lineNumber": 10,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 11,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    private CommandTrie commandTrie;"
-      },
-      {
-        "lineNumber": 12,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 13,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    @Before"
-      },
-      {
-        "lineNumber": 14,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    public void setup() {"
-      },
-      {
-        "lineNumber": 15,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        commandTrie \u003d new CommandTrie();"
-      },
-      {
-        "lineNumber": 16,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 17,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 18,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    @Test"
-      },
-      {
-        "lineNumber": 19,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    public void autocomplete_unique_prefix() {"
-      },
-      {
-        "lineNumber": 20,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        assert commandTrie.attemptAutoComplete(\"l\").equals(\"list\");"
-      },
-      {
-        "lineNumber": 21,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        assert commandTrie.attemptAutoComplete(\"he\").equals(\"help\");"
-      },
-      {
-        "lineNumber": 22,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 23,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 24,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    @Test"
-      },
-      {
-        "lineNumber": 25,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    public void autocomplete_multiple_prefix() {"
-      },
-      {
-        "lineNumber": 26,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        assert commandTrie.attemptAutoComplete(\"e\").equals(\"e\");"
-      },
-      {
-        "lineNumber": 27,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        assert commandTrie.attemptAutoComplete(\"H\").equals(\"H\");"
-      },
-      {
-        "lineNumber": 28,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 29,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 30,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 31,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    @Test"
-      },
-      {
-        "lineNumber": 32,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    public void autocomplete_mix_case() {"
-      },
-      {
-        "lineNumber": 33,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        assert commandTrie.attemptAutoComplete(\"setT\").equals(\"setTagColour\");"
-      },
-      {
-        "lineNumber": 34,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 35,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "}"
-      }
-    ],
-    "authorContributionMap": {
-      "lithiumlkid": 33,
-      "-": 2
     }
   },
   {
@@ -85546,638 +72484,6 @@
     ],
     "authorContributionMap": {
       "jordancjq": 223
-    }
-  },
-  {
-    "path": "src/test/java/seedu/address/logic/commands/ChangeThemeCommandTest.java",
-    "lines": [
-      {
-        "lineNumber": 1,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "package seedu.address.logic.commands;"
-      },
-      {
-        "lineNumber": 2,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 3,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static org.junit.Assert.assertEquals;"
-      },
-      {
-        "lineNumber": 4,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static org.junit.Assert.assertFalse;"
-      },
-      {
-        "lineNumber": 5,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static org.junit.Assert.assertTrue;"
-      },
-      {
-        "lineNumber": 6,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static org.junit.Assert.fail;"
-      },
-      {
-        "lineNumber": 7,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 8,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import org.junit.Test;"
-      },
-      {
-        "lineNumber": 9,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 10,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.commons.core.Messages;"
-      },
-      {
-        "lineNumber": 11,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.logic.commands.exceptions.CommandException;"
-      },
-      {
-        "lineNumber": 12,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 13,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "/** @@author Codee */"
-      },
-      {
-        "lineNumber": 14,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "public class ChangeThemeCommandTest {"
-      },
-      {
-        "lineNumber": 15,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 16,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    private String[] listThemes \u003d { \"Light\", \"Dark\" };"
-      },
-      {
-        "lineNumber": 17,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 18,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    @Test"
-      },
-      {
-        "lineNumber": 19,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    public void execute_validTheme_success() {"
-      },
-      {
-        "lineNumber": 20,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        assertExecutionSuccess(listThemes[0]);"
-      },
-      {
-        "lineNumber": 21,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 22,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 23,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    @Test"
-      },
-      {
-        "lineNumber": 24,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    public void execute_invalidTheme_failure() {"
-      },
-      {
-        "lineNumber": 25,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        assertExecutionFailure(\"FakeTheme\", Messages.MESSAGE_INVALID_THEME);"
-      },
-      {
-        "lineNumber": 26,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 27,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 28,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    @Test"
-      },
-      {
-        "lineNumber": 29,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    public void equals() {"
-      },
-      {
-        "lineNumber": 30,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        ChangeThemeCommand[] listThemeCommands \u003d new ChangeThemeCommand[2];"
-      },
-      {
-        "lineNumber": 31,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        for (int i \u003d 0; i \u003c 2; i++) {"
-      },
-      {
-        "lineNumber": 32,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "            listThemeCommands[i] \u003d new ChangeThemeCommand(listThemes[i]);"
-      },
-      {
-        "lineNumber": 33,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        }"
-      },
-      {
-        "lineNumber": 34,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 35,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        // same object -\u003e returns true"
-      },
-      {
-        "lineNumber": 36,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        for (int i \u003d 0; i \u003c 2; i++) {"
-      },
-      {
-        "lineNumber": 37,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "            assertTrue(listThemeCommands[i].equals(new ChangeThemeCommand(listThemes[i])));"
-      },
-      {
-        "lineNumber": 38,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        }"
-      },
-      {
-        "lineNumber": 39,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 40,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        // different types -\u003e returns false"
-      },
-      {
-        "lineNumber": 41,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        for (int i \u003d 0; i \u003c 2; i++) {"
-      },
-      {
-        "lineNumber": 42,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "            assertFalse(listThemeCommands[i].equals(1));"
-      },
-      {
-        "lineNumber": 43,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        }"
-      },
-      {
-        "lineNumber": 44,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 45,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        // null -\u003e returns false"
-      },
-      {
-        "lineNumber": 46,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        for (int i \u003d 0; i \u003c 2; i++) {"
-      },
-      {
-        "lineNumber": 47,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "            assertFalse(listThemeCommands[i].equals(null));"
-      },
-      {
-        "lineNumber": 48,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        }"
-      },
-      {
-        "lineNumber": 49,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 50,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        // different theme -\u003e returns false"
-      },
-      {
-        "lineNumber": 51,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        int j \u003d 1;"
-      },
-      {
-        "lineNumber": 52,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 53,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        for (int i \u003d 0; i \u003c 2; i++) {"
-      },
-      {
-        "lineNumber": 54,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "            if (i !\u003d j) {"
-      },
-      {
-        "lineNumber": 55,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "                assertFalse(listThemeCommands[i].equals(listThemeCommands[j]));"
-      },
-      {
-        "lineNumber": 56,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "            }"
-      },
-      {
-        "lineNumber": 57,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "            j--;"
-      },
-      {
-        "lineNumber": 58,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        }"
-      },
-      {
-        "lineNumber": 59,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 60,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 61,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    /**"
-      },
-      {
-        "lineNumber": 62,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "     * Executes a {@code ChangeThemeCommand} with the given {@code theme}."
-      },
-      {
-        "lineNumber": 63,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "     */"
-      },
-      {
-        "lineNumber": 64,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    private void assertExecutionSuccess(String theme) {"
-      },
-      {
-        "lineNumber": 65,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        ChangeThemeCommand changethemeCommand \u003d new ChangeThemeCommand(theme);"
-      },
-      {
-        "lineNumber": 66,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        try {"
-      },
-      {
-        "lineNumber": 67,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "            CommandResult commandResult \u003d changethemeCommand.execute();"
-      },
-      {
-        "lineNumber": 68,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "            assertEquals(String.format(ChangeThemeCommand.MESSAGE_THEME_SUCCESS, theme),"
-      },
-      {
-        "lineNumber": 69,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "                    commandResult.feedbackToUser);"
-      },
-      {
-        "lineNumber": 70,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        } catch (CommandException ce) {"
-      },
-      {
-        "lineNumber": 71,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "            throw new IllegalArgumentException(\"Execution of command should not fail.\", ce);"
-      },
-      {
-        "lineNumber": 72,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        }"
-      },
-      {
-        "lineNumber": 73,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 74,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 75,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 76,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    /**"
-      },
-      {
-        "lineNumber": 77,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "     * Executes a {@code ChangeThemeCommand} with the given {@code theme}."
-      },
-      {
-        "lineNumber": 78,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "     */"
-      },
-      {
-        "lineNumber": 79,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    private void assertExecutionFailure(String theme, String expectedMessage) {"
-      },
-      {
-        "lineNumber": 80,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        ChangeThemeCommand changethemeCommand \u003d new ChangeThemeCommand(theme);"
-      },
-      {
-        "lineNumber": 81,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 82,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        try {"
-      },
-      {
-        "lineNumber": 83,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "            changethemeCommand.execute();"
-      },
-      {
-        "lineNumber": 84,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "            fail(\"The expected CommandException was not thrown.\");"
-      },
-      {
-        "lineNumber": 85,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        } catch (CommandException ce) {"
-      },
-      {
-        "lineNumber": 86,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "            assertEquals(expectedMessage, ce.getMessage());"
-      },
-      {
-        "lineNumber": 87,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        }"
-      },
-      {
-        "lineNumber": 88,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 89,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "}"
-      }
-    ],
-    "authorContributionMap": {
-      "codeeong": 77,
-      "-": 12
     }
   },
   {
@@ -91785,715 +78091,6 @@
     ],
     "authorContributionMap": {
       "jordancjq": 123
-    }
-  },
-  {
-    "path": "src/test/java/seedu/address/logic/commands/SetCommandTest.java",
-    "lines": [
-      {
-        "lineNumber": 1,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "package seedu.address.logic.commands;"
-      },
-      {
-        "lineNumber": 2,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 3,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static org.junit.Assert.assertFalse;"
-      },
-      {
-        "lineNumber": 4,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static org.junit.Assert.assertTrue;"
-      },
-      {
-        "lineNumber": 5,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static seedu.address.logic.commands.CommandTestUtil.DESC_AMY;"
-      },
-      {
-        "lineNumber": 6,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;"
-      },
-      {
-        "lineNumber": 7,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static seedu.address.testutil.TypicalPersons.CARL;"
-      },
-      {
-        "lineNumber": 8,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;"
-      },
-      {
-        "lineNumber": 9,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 10,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import org.junit.Before;"
-      },
-      {
-        "lineNumber": 11,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import org.junit.Test;"
-      },
-      {
-        "lineNumber": 12,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 13,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import javafx.collections.ObservableList;"
-      },
-      {
-        "lineNumber": 14,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 15,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.logic.CommandHistory;"
-      },
-      {
-        "lineNumber": 16,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.logic.UndoRedoStack;"
-      },
-      {
-        "lineNumber": 17,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.logic.commands.exceptions.CommandException;"
-      },
-      {
-        "lineNumber": 18,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.model.Model;"
-      },
-      {
-        "lineNumber": 19,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.model.ModelManager;"
-      },
-      {
-        "lineNumber": 20,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.model.UserPrefs;"
-      },
-      {
-        "lineNumber": 21,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.model.tag.Tag;"
-      },
-      {
-        "lineNumber": 22,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 23,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "/**"
-      },
-      {
-        "lineNumber": 24,
-        "author": {
-          "gitId": "-"
-        },
-        "content": " * This is the unit test for {@code SetCommand}."
-      },
-      {
-        "lineNumber": 25,
-        "author": {
-          "gitId": "-"
-        },
-        "content": " */"
-      },
-      {
-        "lineNumber": 26,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "/** @@author Codee */"
-      },
-      {
-        "lineNumber": 27,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "public class SetCommandTest {"
-      },
-      {
-        "lineNumber": 28,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 29,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    private Model model;"
-      },
-      {
-        "lineNumber": 30,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    private Tag tagOne \u003d new Tag(\"testTagOne\");"
-      },
-      {
-        "lineNumber": 31,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    private Tag tagTwo \u003d new Tag(\"testTagTwo\");"
-      },
-      {
-        "lineNumber": 32,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 33,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    @Before"
-      },
-      {
-        "lineNumber": 34,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    public void setUp() {"
-      },
-      {
-        "lineNumber": 35,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        model \u003d new ModelManager(getTypicalAddressBook(), new UserPrefs());"
-      },
-      {
-        "lineNumber": 36,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 37,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 38,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    @Test"
-      },
-      {
-        "lineNumber": 39,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    public void equals() {"
-      },
-      {
-        "lineNumber": 40,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 41,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        SetCommand testCommand \u003d new SetCommand(tagOne, \"teal\");"
-      },
-      {
-        "lineNumber": 42,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        SetCommand testCommandTwo \u003d new SetCommand(tagOne, \"teal\");"
-      },
-      {
-        "lineNumber": 43,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        //Test to ensure command is strictly a SetCommand"
-      },
-      {
-        "lineNumber": 44,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        assertFalse(testCommand.equals(new AddCommand(CARL)));"
-      },
-      {
-        "lineNumber": 45,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        assertFalse(testCommand.equals(new ClearCommand()));"
-      },
-      {
-        "lineNumber": 46,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        assertFalse(testCommand.equals(new DeleteCommand(INDEX_FIRST_PERSON)));"
-      },
-      {
-        "lineNumber": 47,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        assertFalse(testCommand.equals(new HistoryCommand()));"
-      },
-      {
-        "lineNumber": 48,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        assertFalse(testCommand.equals(new HelpCommand()));"
-      },
-      {
-        "lineNumber": 49,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        assertFalse(testCommand.equals(new RedoCommand()));"
-      },
-      {
-        "lineNumber": 50,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        assertFalse(testCommand.equals(new UndoCommand()));"
-      },
-      {
-        "lineNumber": 51,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        assertFalse(testCommand.equals(new ListCommand()));"
-      },
-      {
-        "lineNumber": 52,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        assertFalse(testCommand.equals(new EditCommand(INDEX_FIRST_PERSON, DESC_AMY)));"
-      },
-      {
-        "lineNumber": 53,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 54,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 55,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        //Test to check that different tag string returns false"
-      },
-      {
-        "lineNumber": 56,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        assertFalse(testCommand.equals(new SetCommand(tagTwo, \"teal\")));"
-      },
-      {
-        "lineNumber": 57,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        assertFalse(testCommandTwo.equals(new SetCommand(tagTwo, \"teal\")));"
-      },
-      {
-        "lineNumber": 58,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 59,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        //Test to check that different color strings returns false"
-      },
-      {
-        "lineNumber": 60,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        assertFalse(testCommand.equals(new SetCommand(tagOne, \"red\")));"
-      },
-      {
-        "lineNumber": 61,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        assertFalse(testCommandTwo.equals(new SetCommand(tagTwo, \"red\")));"
-      },
-      {
-        "lineNumber": 62,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 63,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 64,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    @Test"
-      },
-      {
-        "lineNumber": 65,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    public void checkCommandResult() throws CommandException {"
-      },
-      {
-        "lineNumber": 66,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 67,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        //Check if the result message is correct when there is no tags found"
-      },
-      {
-        "lineNumber": 68,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        SetCommand command \u003d new SetCommand(new Tag(\"blablabla\"), \"teal\");"
-      },
-      {
-        "lineNumber": 69,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        command.setData(model, new CommandHistory(), new UndoRedoStack());"
-      },
-      {
-        "lineNumber": 70,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        assertTrue(command.execute().feedbackToUser.equals(\"tag is invalid! Please input a valid tag name!\"));"
-      },
-      {
-        "lineNumber": 71,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 72,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        //When tags is present"
-      },
-      {
-        "lineNumber": 73,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        command \u003d new SetCommand(new Tag(\"friends\"), \"red\");"
-      },
-      {
-        "lineNumber": 74,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        command.setData(model, new CommandHistory(), new UndoRedoStack());"
-      },
-      {
-        "lineNumber": 75,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        assertFalse(command.execute().feedbackToUser.equals(\"No such tag\"));"
-      },
-      {
-        "lineNumber": 76,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        assertTrue(command.execute().feedbackToUser.equals(\"tag [friends] colour changed to red\"));"
-      },
-      {
-        "lineNumber": 77,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 78,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        //Check if friends tags are set to color"
-      },
-      {
-        "lineNumber": 79,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        command \u003d new SetCommand(new Tag(\"friends\"), \"teal\");"
-      },
-      {
-        "lineNumber": 80,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        command.setData(model, new CommandHistory(), new UndoRedoStack());"
-      },
-      {
-        "lineNumber": 81,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        assertTrue(command.execute().feedbackToUser.equals(\"tag [friends] colour changed to teal\"));"
-      },
-      {
-        "lineNumber": 82,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        for (Tag tag : model.getAddressBook().getTagList()) {"
-      },
-      {
-        "lineNumber": 83,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "            if (\"friends\".equals(tag.tagName)) {"
-      },
-      {
-        "lineNumber": 84,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "                assertTrue(tag.getTagColour().equals(\"teal\"));"
-      },
-      {
-        "lineNumber": 85,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "                assertFalse(tag.getTagColour().equals(\"pink\"));"
-      },
-      {
-        "lineNumber": 86,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "            }"
-      },
-      {
-        "lineNumber": 87,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        }"
-      },
-      {
-        "lineNumber": 88,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        resetAllTagsToDefault();"
-      },
-      {
-        "lineNumber": 89,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 90,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 91,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    /**"
-      },
-      {
-        "lineNumber": 92,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "     * This method allows all tags to be set to the default colour \"teal\""
-      },
-      {
-        "lineNumber": 93,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "     */"
-      },
-      {
-        "lineNumber": 94,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    public void resetAllTagsToDefault() {"
-      },
-      {
-        "lineNumber": 95,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        ObservableList\u003cTag\u003e allTags \u003d model.getAddressBook().getTagList();"
-      },
-      {
-        "lineNumber": 96,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        for (Tag t : allTags) {"
-      },
-      {
-        "lineNumber": 97,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "            t.changeTagColour(\"teal\");"
-      },
-      {
-        "lineNumber": 98,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        }"
-      },
-      {
-        "lineNumber": 99,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 100,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "}"
-      }
-    ],
-    "authorContributionMap": {
-      "codeeong": 75,
-      "-": 25
     }
   },
   {
@@ -98979,225 +84576,6 @@
     }
   },
   {
-    "path": "src/test/java/seedu/address/logic/parser/ChangeThemeCommandParserTest.java",
-    "lines": [
-      {
-        "lineNumber": 1,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "package seedu.address.logic.parser;"
-      },
-      {
-        "lineNumber": 2,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 3,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;"
-      },
-      {
-        "lineNumber": 4,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;"
-      },
-      {
-        "lineNumber": 5,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;"
-      },
-      {
-        "lineNumber": 6,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 7,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import org.junit.Test;"
-      },
-      {
-        "lineNumber": 8,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 9,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.logic.commands.ChangeThemeCommand;"
-      },
-      {
-        "lineNumber": 10,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 11,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "/** @@author Codee */"
-      },
-      {
-        "lineNumber": 12,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "public class ChangeThemeCommandParserTest {"
-      },
-      {
-        "lineNumber": 13,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 14,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    private ChangeThemeCommandParser parser \u003d new ChangeThemeCommandParser();"
-      },
-      {
-        "lineNumber": 15,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    private String[] listThemes \u003d { \"Light\", \"Dark\" };"
-      },
-      {
-        "lineNumber": 16,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 17,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    @Test"
-      },
-      {
-        "lineNumber": 18,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    public void parse_validArgs_returnsThemeCommand() {"
-      },
-      {
-        "lineNumber": 19,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        for (int i \u003d 0; i \u003c 2; i++) {"
-      },
-      {
-        "lineNumber": 20,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "            assertParseSuccess(parser, listThemes[i], new ChangeThemeCommand(listThemes[i]));"
-      },
-      {
-        "lineNumber": 21,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        }"
-      },
-      {
-        "lineNumber": 22,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 23,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 24,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    @Test"
-      },
-      {
-        "lineNumber": 25,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    public void parse_invalidArgs_throwsParseException() {"
-      },
-      {
-        "lineNumber": 26,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        // Empty Argument"
-      },
-      {
-        "lineNumber": 27,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        assertParseFailure(parser, \"\","
-      },
-      {
-        "lineNumber": 28,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "                String.format(MESSAGE_INVALID_COMMAND_FORMAT, ChangeThemeCommand.MESSAGE_USAGE));"
-      },
-      {
-        "lineNumber": 29,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 30,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "}"
-      }
-    ],
-    "authorContributionMap": {
-      "codeeong": 20,
-      "-": 10
-    }
-  },
-  {
     "path": "src/test/java/seedu/address/logic/parser/CreateCommandParserTest.java",
     "lines": [
       {
@@ -102865,176 +88243,6 @@
     }
   },
   {
-    "path": "src/test/java/seedu/address/logic/parser/SetCommandParserTest.java",
-    "lines": [
-      {
-        "lineNumber": 1,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "package seedu.address.logic.parser;"
-      },
-      {
-        "lineNumber": 2,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 3,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;"
-      },
-      {
-        "lineNumber": 4,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG_COLOUR;"
-      },
-      {
-        "lineNumber": 5,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;"
-      },
-      {
-        "lineNumber": 6,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static seedu.address.testutil.TypicalTags.FRIEND;"
-      },
-      {
-        "lineNumber": 7,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 8,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import org.junit.Test;"
-      },
-      {
-        "lineNumber": 9,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 10,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.logic.commands.SetCommand;"
-      },
-      {
-        "lineNumber": 11,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 12,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "/** @@author Codee */"
-      },
-      {
-        "lineNumber": 13,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "public class SetCommandParserTest {"
-      },
-      {
-        "lineNumber": 14,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 15,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    private SetCommandParser parser \u003d new SetCommandParser();"
-      },
-      {
-        "lineNumber": 16,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 17,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    @Test"
-      },
-      {
-        "lineNumber": 18,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    public void parse_validArgs_returnsSetCommand() {"
-      },
-      {
-        "lineNumber": 19,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        String userInput \u003d \" \" + PREFIX_TAG + FRIEND.getTagName() + \" \" + PREFIX_TAG_COLOUR + \"green\";"
-      },
-      {
-        "lineNumber": 20,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        assertParseSuccess(parser, userInput, new SetCommand(FRIEND, \"green\"));"
-      },
-      {
-        "lineNumber": 21,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 22,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 23,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "}"
-      }
-    ],
-    "authorContributionMap": {
-      "codeeong": 12,
-      "-": 11
-    }
-  },
-  {
     "path": "src/test/java/seedu/address/logic/parser/SortCommandParserTest.java",
     "lines": [
       {
@@ -106634,1435 +91842,6 @@
     }
   },
   {
-    "path": "src/test/java/seedu/address/model/person/AvatarTest.java",
-    "lines": [
-      {
-        "lineNumber": 1,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "package seedu.address.model.person;"
-      },
-      {
-        "lineNumber": 2,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 3,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static org.junit.Assert.assertFalse;"
-      },
-      {
-        "lineNumber": 4,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static org.junit.Assert.assertTrue;"
-      },
-      {
-        "lineNumber": 5,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 6,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import org.junit.Test;"
-      },
-      {
-        "lineNumber": 7,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 8,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.testutil.Assert;"
-      },
-      {
-        "lineNumber": 9,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 10,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "//@@author lithiumlkid"
-      },
-      {
-        "lineNumber": 11,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "public class AvatarTest {"
-      },
-      {
-        "lineNumber": 12,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 13,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    @Test"
-      },
-      {
-        "lineNumber": 14,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    public void constructor_null_throwsNullPointerException() {"
-      },
-      {
-        "lineNumber": 15,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        Assert.assertThrows(NullPointerException.class, () -\u003e new Avatar(null));"
-      },
-      {
-        "lineNumber": 16,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 17,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 18,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    @Test"
-      },
-      {
-        "lineNumber": 19,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    public void constructor_invalidAvatar_throwsIllegalArgumentException() {"
-      },
-      {
-        "lineNumber": 20,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        String invalidAvatar \u003d \"\";"
-      },
-      {
-        "lineNumber": 21,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        Assert.assertThrows(IllegalArgumentException.class, () -\u003e new Avatar(invalidAvatar));"
-      },
-      {
-        "lineNumber": 22,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 23,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 24,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    @Test"
-      },
-      {
-        "lineNumber": 25,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    public void isValidAvatar() {"
-      },
-      {
-        "lineNumber": 26,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        // null avatar number"
-      },
-      {
-        "lineNumber": 27,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        Assert.assertThrows(NullPointerException.class, () -\u003e Avatar.isValidAvatar(null));"
-      },
-      {
-        "lineNumber": 28,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 29,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        // invalid avatar numbers"
-      },
-      {
-        "lineNumber": 30,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        assertFalse(Avatar.isValidAvatar(\"\")); // empty string"
-      },
-      {
-        "lineNumber": 31,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        assertFalse(Avatar.isValidAvatar(\" \")); // spaces only"
-      },
-      {
-        "lineNumber": 32,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        assertFalse(Avatar.isValidAvatar(\"avatar.gif\")); // invalid filtype"
-      },
-      {
-        "lineNumber": 33,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        assertFalse(Avatar.isValidAvatar(\"avatar\")); // no file type"
-      },
-      {
-        "lineNumber": 34,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        assertFalse(Avatar.isValidAvatar(\"a a\")); // spaces within digits"
-      },
-      {
-        "lineNumber": 35,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 36,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        // valid avatar numbers"
-      },
-      {
-        "lineNumber": 37,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        assertTrue(Avatar.isValidAvatar(\"avatar.png\")); // png file"
-      },
-      {
-        "lineNumber": 38,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        assertTrue(Avatar.isValidAvatar(\"/file/path/to/avatar.png\")); //mac file path"
-      },
-      {
-        "lineNumber": 39,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        assertTrue(Avatar.isValidAvatar(\"C:\\\\file\\\\path\\\\avatar.png\")); // windows file path"
-      },
-      {
-        "lineNumber": 40,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 41,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 42,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    @Test"
-      },
-      {
-        "lineNumber": 43,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    public void isEqualAvatar() {"
-      },
-      {
-        "lineNumber": 44,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        Avatar x  \u003d new Avatar(\"avatar.png\");"
-      },
-      {
-        "lineNumber": 45,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        Avatar y \u003d new Avatar(\"avatar.png\");"
-      },
-      {
-        "lineNumber": 46,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        assertTrue(x.equals(y) \u0026\u0026 y.equals(x));"
-      },
-      {
-        "lineNumber": 47,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        assertTrue(x.hashCode() \u003d\u003d y.hashCode());"
-      },
-      {
-        "lineNumber": 48,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 49,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 50,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "}"
-      }
-    ],
-    "authorContributionMap": {
-      "lithiumlkid": 41,
-      "-": 9
-    }
-  },
-  {
-    "path": "src/test/java/seedu/address/model/person/JerseyNumberTest.java",
-    "lines": [
-      {
-        "lineNumber": 1,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "package seedu.address.model.person;"
-      },
-      {
-        "lineNumber": 2,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 3,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static org.junit.Assert.assertFalse;"
-      },
-      {
-        "lineNumber": 4,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static org.junit.Assert.assertTrue;"
-      },
-      {
-        "lineNumber": 5,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 6,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import org.junit.Test;"
-      },
-      {
-        "lineNumber": 7,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 8,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.testutil.Assert;"
-      },
-      {
-        "lineNumber": 9,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 10,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "//@@author lithiumlkid"
-      },
-      {
-        "lineNumber": 11,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "public class JerseyNumberTest {"
-      },
-      {
-        "lineNumber": 12,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 13,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    @Test"
-      },
-      {
-        "lineNumber": 14,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    public void constructor_null_throwsNullPointerException() {"
-      },
-      {
-        "lineNumber": 15,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        Assert.assertThrows(NullPointerException.class, () -\u003e new JerseyNumber(null));"
-      },
-      {
-        "lineNumber": 16,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 17,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 18,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    @Test"
-      },
-      {
-        "lineNumber": 19,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    public void constructor_invalidJerseyNumber_throwsIllegalArgumentException() {"
-      },
-      {
-        "lineNumber": 20,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        String invalidJerseyNumber \u003d \"\";"
-      },
-      {
-        "lineNumber": 21,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        Assert.assertThrows(IllegalArgumentException.class, () -\u003e new JerseyNumber(invalidJerseyNumber));"
-      },
-      {
-        "lineNumber": 22,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 23,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 24,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    @Test"
-      },
-      {
-        "lineNumber": 25,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    public void isValidJerseyNumber() {"
-      },
-      {
-        "lineNumber": 26,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        // null jerseyNumber number"
-      },
-      {
-        "lineNumber": 27,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        Assert.assertThrows(NullPointerException.class, () -\u003e JerseyNumber.isValidJerseyNumber(null));"
-      },
-      {
-        "lineNumber": 28,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 29,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        // invalid jerseyNumber numbers"
-      },
-      {
-        "lineNumber": 30,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        assertFalse(JerseyNumber.isValidJerseyNumber(\"\")); // empty string"
-      },
-      {
-        "lineNumber": 31,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        assertFalse(JerseyNumber.isValidJerseyNumber(\" \")); // spaces only"
-      },
-      {
-        "lineNumber": 32,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        assertFalse(JerseyNumber.isValidJerseyNumber(\"-1\")); // less than 0"
-      },
-      {
-        "lineNumber": 33,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        assertFalse(JerseyNumber.isValidJerseyNumber(\"100\")); // larger than 99"
-      },
-      {
-        "lineNumber": 34,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        assertFalse(JerseyNumber.isValidJerseyNumber(\"1a\")); // alphabets with digits"
-      },
-      {
-        "lineNumber": 35,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        assertFalse(JerseyNumber.isValidJerseyNumber(\"1 1\")); // spaces within digits"
-      },
-      {
-        "lineNumber": 36,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 37,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        // valid jerseyNumber numbers"
-      },
-      {
-        "lineNumber": 38,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        assertTrue(JerseyNumber.isValidJerseyNumber(\"0\")); // within 0 - 99"
-      },
-      {
-        "lineNumber": 39,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        assertTrue(JerseyNumber.isValidJerseyNumber(\"99\"));"
-      },
-      {
-        "lineNumber": 40,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 41,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 42,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    @Test"
-      },
-      {
-        "lineNumber": 43,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    public void isEqualJerseyNumber() {"
-      },
-      {
-        "lineNumber": 44,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        JerseyNumber x  \u003d new JerseyNumber(\"0\");"
-      },
-      {
-        "lineNumber": 45,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        JerseyNumber y \u003d new JerseyNumber(\"0\");"
-      },
-      {
-        "lineNumber": 46,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        assertTrue(x.equals(y) \u0026\u0026 y.equals(x));"
-      },
-      {
-        "lineNumber": 47,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        assertTrue(x.hashCode() \u003d\u003d y.hashCode());"
-      },
-      {
-        "lineNumber": 48,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 49,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "}"
-      },
-      {
-        "lineNumber": 50,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": ""
-      }
-    ],
-    "authorContributionMap": {
-      "lithiumlkid": 41,
-      "-": 9
-    }
-  },
-  {
-    "path": "src/test/java/seedu/address/model/person/PositionTest.java",
-    "lines": [
-      {
-        "lineNumber": 1,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "package seedu.address.model.person;"
-      },
-      {
-        "lineNumber": 2,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 3,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static org.junit.Assert.assertFalse;"
-      },
-      {
-        "lineNumber": 4,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static org.junit.Assert.assertTrue;"
-      },
-      {
-        "lineNumber": 5,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 6,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import org.junit.Test;"
-      },
-      {
-        "lineNumber": 7,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 8,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.testutil.Assert;"
-      },
-      {
-        "lineNumber": 9,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 10,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "//@@author lithiumlkid"
-      },
-      {
-        "lineNumber": 11,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "public class PositionTest {"
-      },
-      {
-        "lineNumber": 12,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 13,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    @Test"
-      },
-      {
-        "lineNumber": 14,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    public void constructor_null_throwsNullPointerException() {"
-      },
-      {
-        "lineNumber": 15,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        Assert.assertThrows(NullPointerException.class, () -\u003e new Position(null));"
-      },
-      {
-        "lineNumber": 16,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 17,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 18,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    @Test"
-      },
-      {
-        "lineNumber": 19,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    public void constructor_invalidPosition_throwsIllegalArgumentException() {"
-      },
-      {
-        "lineNumber": 20,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        String invalidPosition \u003d \"\";"
-      },
-      {
-        "lineNumber": 21,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        Assert.assertThrows(IllegalArgumentException.class, () -\u003e new Position(invalidPosition));"
-      },
-      {
-        "lineNumber": 22,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 23,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 24,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    @Test"
-      },
-      {
-        "lineNumber": 25,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    public void isValidPosition() {"
-      },
-      {
-        "lineNumber": 26,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        // null position number"
-      },
-      {
-        "lineNumber": 27,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        Assert.assertThrows(NullPointerException.class, () -\u003e Position.isValidPosition(null));"
-      },
-      {
-        "lineNumber": 28,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 29,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        // invalid position numbers"
-      },
-      {
-        "lineNumber": 30,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        assertFalse(Position.isValidPosition(\"\")); // empty string"
-      },
-      {
-        "lineNumber": 31,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        assertFalse(Position.isValidPosition(\" \")); // spaces only"
-      },
-      {
-        "lineNumber": 32,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        assertFalse(Position.isValidPosition(\"0\")); // less than 1"
-      },
-      {
-        "lineNumber": 33,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        assertFalse(Position.isValidPosition(\"-1\")); // negative"
-      },
-      {
-        "lineNumber": 34,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        assertFalse(Position.isValidPosition(\"position\")); // non-numeric"
-      },
-      {
-        "lineNumber": 35,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        assertFalse(Position.isValidPosition(\"1a\")); // alphabets within digits"
-      },
-      {
-        "lineNumber": 36,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        assertFalse(Position.isValidPosition(\"1 1\")); // spaces within digits"
-      },
-      {
-        "lineNumber": 37,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 38,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        // valid position numbers"
-      },
-      {
-        "lineNumber": 39,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        assertTrue(Position.isValidPosition(\"1\")); // within range"
-      },
-      {
-        "lineNumber": 40,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        assertTrue(Position.isValidPosition(\"4\"));"
-      },
-      {
-        "lineNumber": 41,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 42,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 43,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    @Test"
-      },
-      {
-        "lineNumber": 44,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    public void isEqualPosition() {"
-      },
-      {
-        "lineNumber": 45,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        Position x  \u003d new Position(\"1\");"
-      },
-      {
-        "lineNumber": 46,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        Position y \u003d new Position(\"1\");"
-      },
-      {
-        "lineNumber": 47,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        assertTrue(x.equals(y) \u0026\u0026 y.equals(x));"
-      },
-      {
-        "lineNumber": 48,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        assertTrue(x.hashCode() \u003d\u003d y.hashCode());"
-      },
-      {
-        "lineNumber": 49,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 50,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "}"
-      }
-    ],
-    "authorContributionMap": {
-      "lithiumlkid": 41,
-      "-": 9
-    }
-  },
-  {
-    "path": "src/test/java/seedu/address/model/person/RatingTest.java",
-    "lines": [
-      {
-        "lineNumber": 1,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "package seedu.address.model.person;"
-      },
-      {
-        "lineNumber": 2,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 3,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static org.junit.Assert.assertFalse;"
-      },
-      {
-        "lineNumber": 4,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static org.junit.Assert.assertTrue;"
-      },
-      {
-        "lineNumber": 5,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 6,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import org.junit.Test;"
-      },
-      {
-        "lineNumber": 7,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 8,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.testutil.Assert;"
-      },
-      {
-        "lineNumber": 9,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 10,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "//@@author lithiumlkid"
-      },
-      {
-        "lineNumber": 11,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "public class RatingTest {"
-      },
-      {
-        "lineNumber": 12,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 13,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    @Test"
-      },
-      {
-        "lineNumber": 14,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    public void constructor_null_throwsNullPointerException() {"
-      },
-      {
-        "lineNumber": 15,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        Assert.assertThrows(NullPointerException.class, () -\u003e new Rating(null));"
-      },
-      {
-        "lineNumber": 16,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 17,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 18,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    @Test"
-      },
-      {
-        "lineNumber": 19,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    public void constructor_invalidRating_throwsIllegalArgumentException() {"
-      },
-      {
-        "lineNumber": 20,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        String invalidRating \u003d \"\";"
-      },
-      {
-        "lineNumber": 21,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        Assert.assertThrows(IllegalArgumentException.class, () -\u003e new Rating(invalidRating));"
-      },
-      {
-        "lineNumber": 22,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 23,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 24,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    @Test"
-      },
-      {
-        "lineNumber": 25,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    public void isValidRating() {"
-      },
-      {
-        "lineNumber": 26,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        // null rating number"
-      },
-      {
-        "lineNumber": 27,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        Assert.assertThrows(NullPointerException.class, () -\u003e Rating.isValidRating(null));"
-      },
-      {
-        "lineNumber": 28,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 29,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        // invalid rating numbers"
-      },
-      {
-        "lineNumber": 30,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        assertFalse(Rating.isValidRating(\"\")); // empty string"
-      },
-      {
-        "lineNumber": 31,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        assertFalse(Rating.isValidRating(\" \")); // spaces only"
-      },
-      {
-        "lineNumber": 32,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        assertFalse(Rating.isValidRating(\"-1\")); // negative"
-      },
-      {
-        "lineNumber": 33,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        assertFalse(Rating.isValidRating(\"rating\")); // non-numeric"
-      },
-      {
-        "lineNumber": 34,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        assertFalse(Rating.isValidRating(\"1a\")); // alphabets within digits"
-      },
-      {
-        "lineNumber": 35,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        assertFalse(Rating.isValidRating(\"1 1\")); // spaces within digits"
-      },
-      {
-        "lineNumber": 36,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 37,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        // valid rating numbers"
-      },
-      {
-        "lineNumber": 38,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        assertTrue(Rating.isValidRating(\"1\")); // within range"
-      },
-      {
-        "lineNumber": 39,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        assertTrue(Rating.isValidRating(\"5\"));"
-      },
-      {
-        "lineNumber": 40,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 41,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 42,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    @Test"
-      },
-      {
-        "lineNumber": 43,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    public void isEqualRating() {"
-      },
-      {
-        "lineNumber": 44,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        Rating x  \u003d new Rating(\"1\");"
-      },
-      {
-        "lineNumber": 45,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        Rating y \u003d new Rating(\"1\");"
-      },
-      {
-        "lineNumber": 46,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        assertTrue(x.equals(y) \u0026\u0026 y.equals(x));"
-      },
-      {
-        "lineNumber": 47,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        assertTrue(x.hashCode() \u003d\u003d y.hashCode());"
-      },
-      {
-        "lineNumber": 48,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 49,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "}"
-      }
-    ],
-    "authorContributionMap": {
-      "lithiumlkid": 40,
-      "-": 9
-    }
-  },
-  {
     "path": "src/test/java/seedu/address/model/person/RemarkTest.java",
     "lines": [
       {
@@ -110663,224 +94442,224 @@
       {
         "lineNumber": 9,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "jordancjq"
         },
         "content": "//@@author Codee"
       },
       {
         "lineNumber": 10,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "public class TeamBuilder {"
       },
       {
         "lineNumber": 11,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 12,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "jordancjq"
         },
         "content": "    public static final String DEFAULT_TEAM_NAME \u003d \"Arsenal\";"
       },
       {
         "lineNumber": 13,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 14,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "jordancjq"
         },
         "content": "    private TeamName teamName;"
       },
       {
         "lineNumber": 15,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 16,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 17,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    public TeamBuilder() {"
       },
       {
         "lineNumber": 18,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "jordancjq"
         },
         "content": "        teamName \u003d new TeamName(DEFAULT_TEAM_NAME);"
       },
       {
         "lineNumber": 19,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    }"
       },
       {
         "lineNumber": 20,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 21,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "jordancjq"
         },
         "content": "    /**"
       },
       {
         "lineNumber": 22,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "jordancjq"
         },
         "content": "     * Initializes the TeamBuilder with the data of {@code teamToCopy}."
       },
       {
         "lineNumber": 23,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "jordancjq"
         },
         "content": "     */"
       },
       {
         "lineNumber": 24,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "jordancjq"
         },
         "content": "    public TeamBuilder(Team teamToCopy) {"
       },
       {
         "lineNumber": 25,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "jordancjq"
         },
         "content": "        teamName \u003d teamToCopy.getTeamName();"
       },
       {
         "lineNumber": 26,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    }"
       },
       {
         "lineNumber": 27,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 28,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "jordancjq"
         },
         "content": "    /**"
       },
       {
         "lineNumber": 29,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "jordancjq"
         },
         "content": "     * Sets the {@code TeamName} of the {@code Team} that we are building."
       },
       {
         "lineNumber": 30,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "jordancjq"
         },
         "content": "     */"
       },
       {
         "lineNumber": 31,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "jordancjq"
         },
         "content": "    public TeamBuilder withTeamName(String teamName) {"
       },
       {
         "lineNumber": 32,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "jordancjq"
         },
         "content": "        this.teamName \u003d new TeamName(teamName);"
       },
       {
         "lineNumber": 33,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "jordancjq"
         },
         "content": "        return this;"
       },
       {
         "lineNumber": 34,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "jordancjq"
         },
         "content": "    }"
       },
       {
         "lineNumber": 35,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 36,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "jordancjq"
         },
         "content": "    public Team build() {"
       },
       {
         "lineNumber": 37,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "jordancjq"
         },
         "content": "        return new Team(teamName);"
       },
       {
         "lineNumber": 38,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "jordancjq"
         },
         "content": "    }"
       },
       {
         "lineNumber": 39,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "}"
       }
     ],
     "authorContributionMap": {
-      "codeeong": 31,
-      "-": 8
+      "jordancjq": 19,
+      "-": 20
     }
   },
   {
@@ -112057,316 +95836,6 @@
     }
   },
   {
-    "path": "src/test/java/seedu/address/testutil/TypicalTags.java",
-    "lines": [
-      {
-        "lineNumber": 1,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "package seedu.address.testutil;"
-      },
-      {
-        "lineNumber": 2,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 3,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import java.util.ArrayList;"
-      },
-      {
-        "lineNumber": 4,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import java.util.Arrays;"
-      },
-      {
-        "lineNumber": 5,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import java.util.List;"
-      },
-      {
-        "lineNumber": 6,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 7,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.model.AddressBook;"
-      },
-      {
-        "lineNumber": 8,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.model.tag.Tag;"
-      },
-      {
-        "lineNumber": 9,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.model.tag.UniqueTagList;"
-      },
-      {
-        "lineNumber": 10,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 11,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 12,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "/**"
-      },
-      {
-        "lineNumber": 13,
-        "author": {
-          "gitId": "-"
-        },
-        "content": " * A utility class containing a list of {@code Tag} objects to be used in tests."
-      },
-      {
-        "lineNumber": 14,
-        "author": {
-          "gitId": "-"
-        },
-        "content": " */"
-      },
-      {
-        "lineNumber": 15,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "/** @@author Codee */"
-      },
-      {
-        "lineNumber": 16,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "public class TypicalTags {"
-      },
-      {
-        "lineNumber": 17,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 18,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    public static final Tag GOOD_ATTITUDE \u003d new Tag(\"goodAttitude\", \"teal\");"
-      },
-      {
-        "lineNumber": 19,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    public static final Tag FRIEND \u003d new Tag(\"friends\", \"teal\");"
-      },
-      {
-        "lineNumber": 20,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 21,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    private TypicalTags() {} //prevents instantiation"
-      },
-      {
-        "lineNumber": 22,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 23,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 24,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    /**"
-      },
-      {
-        "lineNumber": 25,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "     * Returns an {@code AddressBook} with all the typical teams."
-      },
-      {
-        "lineNumber": 26,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "     */"
-      },
-      {
-        "lineNumber": 27,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    public static AddressBook getTypicalAddressBook() {"
-      },
-      {
-        "lineNumber": 28,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        AddressBook ab \u003d new AddressBook();"
-      },
-      {
-        "lineNumber": 29,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        for (Tag tag : getTypicalTags()) {"
-      },
-      {
-        "lineNumber": 30,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "            try {"
-      },
-      {
-        "lineNumber": 31,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "                ab.addTag(tag);"
-      },
-      {
-        "lineNumber": 32,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "            } catch (UniqueTagList.DuplicateTagException e) {"
-      },
-      {
-        "lineNumber": 33,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "                throw new AssertionError(\"not possible\");"
-      },
-      {
-        "lineNumber": 34,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "            }"
-      },
-      {
-        "lineNumber": 35,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        }"
-      },
-      {
-        "lineNumber": 36,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        return ab;"
-      },
-      {
-        "lineNumber": 37,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 38,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 39,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    public static List\u003cTag\u003e getTypicalTags() {"
-      },
-      {
-        "lineNumber": 40,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        return new ArrayList\u003c\u003e(Arrays.asList(GOOD_ATTITUDE, FRIEND));"
-      },
-      {
-        "lineNumber": 41,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 42,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 43,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "}"
-      }
-    ],
-    "authorContributionMap": {
-      "codeeong": 29,
-      "-": 14
-    }
-  },
-  {
     "path": "src/test/java/seedu/address/testutil/TypicalTeams.java",
     "lines": [
       {
@@ -112865,1662 +96334,6 @@
     }
   },
   {
-    "path": "src/test/java/seedu/address/ui/CommandBoxTest.java",
-    "lines": [
-      {
-        "lineNumber": 1,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "package seedu.address.ui;"
-      },
-      {
-        "lineNumber": 2,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 3,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static org.junit.Assert.assertEquals;"
-      },
-      {
-        "lineNumber": 4,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 5,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import java.util.ArrayList;"
-      },
-      {
-        "lineNumber": 6,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 7,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import org.junit.Before;"
-      },
-      {
-        "lineNumber": 8,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import org.junit.Test;"
-      },
-      {
-        "lineNumber": 9,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 10,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import guitests.guihandles.CommandBoxHandle;"
-      },
-      {
-        "lineNumber": 11,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import javafx.scene.input.KeyCode;"
-      },
-      {
-        "lineNumber": 12,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.logic.Logic;"
-      },
-      {
-        "lineNumber": 13,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.logic.LogicManager;"
-      },
-      {
-        "lineNumber": 14,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.logic.commands.ExitCommand;"
-      },
-      {
-        "lineNumber": 15,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.logic.commands.ListCommand;"
-      },
-      {
-        "lineNumber": 16,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.logic.commands.ViewCommand;"
-      },
-      {
-        "lineNumber": 17,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.model.Model;"
-      },
-      {
-        "lineNumber": 18,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.model.ModelManager;"
-      },
-      {
-        "lineNumber": 19,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 20,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "//@@author lithiumlkid"
-      },
-      {
-        "lineNumber": 21,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "public class CommandBoxTest extends GuiUnitTest {"
-      },
-      {
-        "lineNumber": 22,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 23,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    private static final String COMMAND_THAT_SUCCEEDS \u003d ListCommand.COMMAND_WORD;"
-      },
-      {
-        "lineNumber": 24,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    private static final String COMMAND_THAT_FAILS \u003d \"invalid command\";"
-      },
-      {
-        "lineNumber": 25,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 26,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    private ArrayList\u003cString\u003e defaultStyleOfCommandBox;"
-      },
-      {
-        "lineNumber": 27,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    private ArrayList\u003cString\u003e errorStyleOfCommandBox;"
-      },
-      {
-        "lineNumber": 28,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 29,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    private CommandBoxHandle commandBoxHandle;"
-      },
-      {
-        "lineNumber": 30,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 31,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    @Before"
-      },
-      {
-        "lineNumber": 32,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    public void setUp() {"
-      },
-      {
-        "lineNumber": 33,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        Model model \u003d new ModelManager();"
-      },
-      {
-        "lineNumber": 34,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        Logic logic \u003d new LogicManager(model);"
-      },
-      {
-        "lineNumber": 35,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 36,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        CommandBox commandBox \u003d new CommandBox(logic);"
-      },
-      {
-        "lineNumber": 37,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        commandBoxHandle \u003d new CommandBoxHandle(getChildNode(commandBox.getRoot(),"
-      },
-      {
-        "lineNumber": 38,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "                CommandBoxHandle.COMMAND_INPUT_FIELD_ID));"
-      },
-      {
-        "lineNumber": 39,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        uiPartRule.setUiPart(commandBox);"
-      },
-      {
-        "lineNumber": 40,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 41,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        defaultStyleOfCommandBox \u003d new ArrayList\u003c\u003e(commandBoxHandle.getStyleClass());"
-      },
-      {
-        "lineNumber": 42,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 43,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        errorStyleOfCommandBox \u003d new ArrayList\u003c\u003e(defaultStyleOfCommandBox);"
-      },
-      {
-        "lineNumber": 44,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        errorStyleOfCommandBox.add(CommandBox.ERROR_STYLE_CLASS);"
-      },
-      {
-        "lineNumber": 45,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 46,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 47,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    @Test"
-      },
-      {
-        "lineNumber": 48,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    public void commandBox_startingWithSuccessfulCommand() {"
-      },
-      {
-        "lineNumber": 49,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        assertBehaviorForSuccessfulCommand();"
-      },
-      {
-        "lineNumber": 50,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        assertBehaviorForFailedCommand();"
-      },
-      {
-        "lineNumber": 51,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 52,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 53,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    @Test"
-      },
-      {
-        "lineNumber": 54,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    public void commandBox_startingWithFailedCommand() {"
-      },
-      {
-        "lineNumber": 55,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        assertBehaviorForFailedCommand();"
-      },
-      {
-        "lineNumber": 56,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        assertBehaviorForSuccessfulCommand();"
-      },
-      {
-        "lineNumber": 57,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 58,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        // verify that style is changed correctly even after multiple consecutive failed commands"
-      },
-      {
-        "lineNumber": 59,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        assertBehaviorForSuccessfulCommand();"
-      },
-      {
-        "lineNumber": 60,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        assertBehaviorForFailedCommand();"
-      },
-      {
-        "lineNumber": 61,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        assertBehaviorForFailedCommand();"
-      },
-      {
-        "lineNumber": 62,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 63,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 64,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    @Test"
-      },
-      {
-        "lineNumber": 65,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    public void commandBox_handleKeyPress() {"
-      },
-      {
-        "lineNumber": 66,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        commandBoxHandle.run(COMMAND_THAT_FAILS);"
-      },
-      {
-        "lineNumber": 67,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        assertEquals(errorStyleOfCommandBox, commandBoxHandle.getStyleClass());"
-      },
-      {
-        "lineNumber": 68,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        guiRobot.push(KeyCode.ESCAPE);"
-      },
-      {
-        "lineNumber": 69,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        assertEquals(errorStyleOfCommandBox, commandBoxHandle.getStyleClass());"
-      },
-      {
-        "lineNumber": 70,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        guiRobot.push(KeyCode.A);"
-      },
-      {
-        "lineNumber": 71,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        assertEquals(defaultStyleOfCommandBox, commandBoxHandle.getStyleClass());"
-      },
-      {
-        "lineNumber": 72,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        assertBehaviorForSuccessfulCommand();"
-      },
-      {
-        "lineNumber": 73,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        guiRobot.push(KeyCode.V);"
-      },
-      {
-        "lineNumber": 74,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        guiRobot.push(KeyCode.TAB);"
-      },
-      {
-        "lineNumber": 75,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        assertEquals(ViewCommand.COMMAND_WORD, commandBoxHandle.getInput());"
-      },
-      {
-        "lineNumber": 76,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        guiRobot.push(KeyCode.TAB);"
-      },
-      {
-        "lineNumber": 77,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        assertEquals(ViewCommand.COMMAND_WORD + \" \" + ViewCommand.MESSAGE_PARAMETERS, commandBoxHandle.getInput());"
-      },
-      {
-        "lineNumber": 78,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        guiRobot.push(KeyCode.TAB);"
-      },
-      {
-        "lineNumber": 79,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        assertEquals(ViewCommand.COMMAND_WORD, commandBoxHandle.getInput());"
-      },
-      {
-        "lineNumber": 80,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        commandBoxHandle.run(COMMAND_THAT_FAILS);"
-      },
-      {
-        "lineNumber": 81,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        guiRobot.push(KeyCode.TAB);"
-      },
-      {
-        "lineNumber": 82,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        assertEquals(errorStyleOfCommandBox, commandBoxHandle.getStyleClass());"
-      },
-      {
-        "lineNumber": 83,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        commandBoxHandle.run(\"e\");"
-      },
-      {
-        "lineNumber": 84,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        guiRobot.push(KeyCode.TAB);"
-      },
-      {
-        "lineNumber": 85,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        guiRobot.push(KeyCode.TAB);"
-      },
-      {
-        "lineNumber": 86,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        guiRobot.push(KeyCode.ENTER);"
-      },
-      {
-        "lineNumber": 87,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        assertEquals(ExitCommand.COMMAND_WORD, commandBoxHandle.getInput());"
-      },
-      {
-        "lineNumber": 88,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 89,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 90,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 91,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 92,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    @Test"
-      },
-      {
-        "lineNumber": 93,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    public void handleKeyPress_startingWithUp() {"
-      },
-      {
-        "lineNumber": 94,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        // empty history"
-      },
-      {
-        "lineNumber": 95,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        assertInputHistory(KeyCode.UP, \"\");"
-      },
-      {
-        "lineNumber": 96,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        assertInputHistory(KeyCode.DOWN, \"\");"
-      },
-      {
-        "lineNumber": 97,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 98,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        // one command"
-      },
-      {
-        "lineNumber": 99,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        commandBoxHandle.run(COMMAND_THAT_SUCCEEDS);"
-      },
-      {
-        "lineNumber": 100,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        assertInputHistory(KeyCode.UP, COMMAND_THAT_SUCCEEDS);"
-      },
-      {
-        "lineNumber": 101,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        assertInputHistory(KeyCode.DOWN, \"\");"
-      },
-      {
-        "lineNumber": 102,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 103,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        // two commands (latest command is failure)"
-      },
-      {
-        "lineNumber": 104,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        commandBoxHandle.run(COMMAND_THAT_FAILS);"
-      },
-      {
-        "lineNumber": 105,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        assertInputHistory(KeyCode.UP, COMMAND_THAT_SUCCEEDS);"
-      },
-      {
-        "lineNumber": 106,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        assertInputHistory(KeyCode.UP, COMMAND_THAT_SUCCEEDS);"
-      },
-      {
-        "lineNumber": 107,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        assertInputHistory(KeyCode.DOWN, COMMAND_THAT_FAILS);"
-      },
-      {
-        "lineNumber": 108,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        assertInputHistory(KeyCode.DOWN, \"\");"
-      },
-      {
-        "lineNumber": 109,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        assertInputHistory(KeyCode.DOWN, \"\");"
-      },
-      {
-        "lineNumber": 110,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        assertInputHistory(KeyCode.UP, COMMAND_THAT_FAILS);"
-      },
-      {
-        "lineNumber": 111,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 112,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        // insert command in the middle of retrieving previous commands"
-      },
-      {
-        "lineNumber": 113,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        guiRobot.push(KeyCode.UP);"
-      },
-      {
-        "lineNumber": 114,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        String thirdCommand \u003d \"list\";"
-      },
-      {
-        "lineNumber": 115,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        commandBoxHandle.run(thirdCommand);"
-      },
-      {
-        "lineNumber": 116,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        assertInputHistory(KeyCode.UP, thirdCommand);"
-      },
-      {
-        "lineNumber": 117,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        assertInputHistory(KeyCode.UP, COMMAND_THAT_FAILS);"
-      },
-      {
-        "lineNumber": 118,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        assertInputHistory(KeyCode.UP, COMMAND_THAT_SUCCEEDS);"
-      },
-      {
-        "lineNumber": 119,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        assertInputHistory(KeyCode.DOWN, COMMAND_THAT_FAILS);"
-      },
-      {
-        "lineNumber": 120,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        assertInputHistory(KeyCode.DOWN, thirdCommand);"
-      },
-      {
-        "lineNumber": 121,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        assertInputHistory(KeyCode.DOWN, \"\");"
-      },
-      {
-        "lineNumber": 122,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 123,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 124,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    @Test"
-      },
-      {
-        "lineNumber": 125,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    public void handleKeyPress_startingWithDown() {"
-      },
-      {
-        "lineNumber": 126,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        // empty history"
-      },
-      {
-        "lineNumber": 127,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        assertInputHistory(KeyCode.DOWN, \"\");"
-      },
-      {
-        "lineNumber": 128,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        assertInputHistory(KeyCode.UP, \"\");"
-      },
-      {
-        "lineNumber": 129,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 130,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        // one command"
-      },
-      {
-        "lineNumber": 131,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        commandBoxHandle.run(COMMAND_THAT_SUCCEEDS);"
-      },
-      {
-        "lineNumber": 132,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        assertInputHistory(KeyCode.DOWN, \"\");"
-      },
-      {
-        "lineNumber": 133,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        assertInputHistory(KeyCode.UP, COMMAND_THAT_SUCCEEDS);"
-      },
-      {
-        "lineNumber": 134,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 135,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        // two commands"
-      },
-      {
-        "lineNumber": 136,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        commandBoxHandle.run(COMMAND_THAT_FAILS);"
-      },
-      {
-        "lineNumber": 137,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        assertInputHistory(KeyCode.DOWN, \"\");"
-      },
-      {
-        "lineNumber": 138,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        assertInputHistory(KeyCode.UP, COMMAND_THAT_FAILS);"
-      },
-      {
-        "lineNumber": 139,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 140,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        // insert command in the middle of retrieving previous commands"
-      },
-      {
-        "lineNumber": 141,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        guiRobot.push(KeyCode.UP);"
-      },
-      {
-        "lineNumber": 142,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        String thirdCommand \u003d \"list\";"
-      },
-      {
-        "lineNumber": 143,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        commandBoxHandle.run(thirdCommand);"
-      },
-      {
-        "lineNumber": 144,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        assertInputHistory(KeyCode.DOWN, \"\");"
-      },
-      {
-        "lineNumber": 145,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        assertInputHistory(KeyCode.UP, thirdCommand);"
-      },
-      {
-        "lineNumber": 146,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 147,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 148,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    /**"
-      },
-      {
-        "lineNumber": 149,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "     * Runs a command that fails, then verifies that \u003cbr\u003e"
-      },
-      {
-        "lineNumber": 150,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "     *      - the text remains \u003cbr\u003e"
-      },
-      {
-        "lineNumber": 151,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "     *      - the command box\u0027s style is the same as {@code errorStyleOfCommandBox}."
-      },
-      {
-        "lineNumber": 152,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "     */"
-      },
-      {
-        "lineNumber": 153,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    private void assertBehaviorForFailedCommand() {"
-      },
-      {
-        "lineNumber": 154,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        commandBoxHandle.run(COMMAND_THAT_FAILS);"
-      },
-      {
-        "lineNumber": 155,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        assertEquals(COMMAND_THAT_FAILS, commandBoxHandle.getInput());"
-      },
-      {
-        "lineNumber": 156,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        assertEquals(errorStyleOfCommandBox, commandBoxHandle.getStyleClass());"
-      },
-      {
-        "lineNumber": 157,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 158,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 159,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    /**"
-      },
-      {
-        "lineNumber": 160,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "     * Runs a command that succeeds, then verifies that \u003cbr\u003e"
-      },
-      {
-        "lineNumber": 161,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "     *      - the text is cleared \u003cbr\u003e"
-      },
-      {
-        "lineNumber": 162,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "     *      - the command box\u0027s style is the same as {@code defaultStyleOfCommandBox}."
-      },
-      {
-        "lineNumber": 163,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "     */"
-      },
-      {
-        "lineNumber": 164,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    private void assertBehaviorForSuccessfulCommand() {"
-      },
-      {
-        "lineNumber": 165,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        commandBoxHandle.run(COMMAND_THAT_SUCCEEDS);"
-      },
-      {
-        "lineNumber": 166,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        assertEquals(\"\", commandBoxHandle.getInput());"
-      },
-      {
-        "lineNumber": 167,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        assertEquals(defaultStyleOfCommandBox, commandBoxHandle.getStyleClass());"
-      },
-      {
-        "lineNumber": 168,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 169,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 170,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    /**"
-      },
-      {
-        "lineNumber": 171,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "     * Pushes {@code keycode} and checks that the input in the {@code commandBox} equals to {@code expectedCommand}."
-      },
-      {
-        "lineNumber": 172,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "     */"
-      },
-      {
-        "lineNumber": 173,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    private void assertInputHistory(KeyCode keycode, String expectedCommand) {"
-      },
-      {
-        "lineNumber": 174,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        guiRobot.push(keycode);"
-      },
-      {
-        "lineNumber": 175,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "        assertEquals(expectedCommand, commandBoxHandle.getInput());"
-      },
-      {
-        "lineNumber": 176,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 177,
-        "author": {
-          "gitId": "lithiumlkid"
-        },
-        "content": "}"
-      }
-    ],
-    "authorContributionMap": {
-      "lithiumlkid": 158,
-      "-": 19
-    }
-  },
-  {
-    "path": "src/test/java/seedu/address/ui/PlayerDetailsTest.java",
-    "lines": [
-      {
-        "lineNumber": 1,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "package seedu.address.ui;"
-      },
-      {
-        "lineNumber": 2,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 3,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static org.junit.Assert.assertFalse;"
-      },
-      {
-        "lineNumber": 4,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static org.junit.Assert.assertTrue;"
-      },
-      {
-        "lineNumber": 5,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static seedu.address.ui.testutil.GuiTestAssert.assertPlayerDetailsDisplaysPerson;"
-      },
-      {
-        "lineNumber": 6,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 7,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import org.junit.Test;"
-      },
-      {
-        "lineNumber": 8,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 9,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import guitests.guihandles.PlayerDetailsHandle;"
-      },
-      {
-        "lineNumber": 10,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 11,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.model.person.Person;"
-      },
-      {
-        "lineNumber": 12,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.testutil.PersonBuilder;"
-      },
-      {
-        "lineNumber": 13,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 14,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "//@@author Codee"
-      },
-      {
-        "lineNumber": 15,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "public class PlayerDetailsTest extends GuiUnitTest {"
-      },
-      {
-        "lineNumber": 16,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 17,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    @Test"
-      },
-      {
-        "lineNumber": 18,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    public void display() {"
-      },
-      {
-        "lineNumber": 19,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        // no tags"
-      },
-      {
-        "lineNumber": 20,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        Person personWithNoTags \u003d new PersonBuilder().withTags(new String[0]).build();"
-      },
-      {
-        "lineNumber": 21,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        PlayerDetails playerDetails \u003d new PlayerDetails(personWithNoTags);"
-      },
-      {
-        "lineNumber": 22,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        uiPartRule.setUiPart(playerDetails);"
-      },
-      {
-        "lineNumber": 23,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        assertCardDisplay(playerDetails, personWithNoTags);"
-      },
-      {
-        "lineNumber": 24,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 25,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 26,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 27,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    @Test"
-      },
-      {
-        "lineNumber": 28,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    public void equals() {"
-      },
-      {
-        "lineNumber": 29,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        Person person \u003d new PersonBuilder().build();"
-      },
-      {
-        "lineNumber": 30,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        PlayerDetails playerDetails \u003d new PlayerDetails(person);"
-      },
-      {
-        "lineNumber": 31,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 32,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        // same object -\u003e returns true"
-      },
-      {
-        "lineNumber": 33,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        assertTrue(playerDetails.equals(playerDetails));"
-      },
-      {
-        "lineNumber": 34,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 35,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        // null -\u003e returns false"
-      },
-      {
-        "lineNumber": 36,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        assertFalse(playerDetails.equals(null));"
-      },
-      {
-        "lineNumber": 37,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 38,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        // different types -\u003e returns false"
-      },
-      {
-        "lineNumber": 39,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        assertFalse(playerDetails.equals(0));"
-      },
-      {
-        "lineNumber": 40,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 41,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        // different person, same index -\u003e returns false"
-      },
-      {
-        "lineNumber": 42,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        Person differentPerson \u003d new PersonBuilder().withName(\"differentName\").build();"
-      },
-      {
-        "lineNumber": 43,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        assertFalse(playerDetails.equals(new PlayerDetails(differentPerson)));"
-      },
-      {
-        "lineNumber": 44,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 45,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 46,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    /**"
-      },
-      {
-        "lineNumber": 47,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "     * Asserts that {@code playerDetails} displays the details of {@code expectedPerson} correctly"
-      },
-      {
-        "lineNumber": 48,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "     */"
-      },
-      {
-        "lineNumber": 49,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    private void assertCardDisplay(PlayerDetails playerDetails, Person expectedPerson) {"
-      },
-      {
-        "lineNumber": 50,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        guiRobot.pauseForHuman();"
-      },
-      {
-        "lineNumber": 51,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 52,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        PlayerDetailsHandle playerDetailsHandle \u003d new PlayerDetailsHandle(playerDetails.getRoot());"
-      },
-      {
-        "lineNumber": 53,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 54,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        // verify player details are displayed correctly"
-      },
-      {
-        "lineNumber": 55,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        assertPlayerDetailsDisplaysPerson(expectedPerson, playerDetailsHandle);"
-      },
-      {
-        "lineNumber": 56,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 57,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "}"
-      }
-    ],
-    "authorContributionMap": {
-      "codeeong": 44,
-      "-": 13
-    }
-  },
-  {
     "path": "src/test/java/seedu/address/ui/TeamDisplayTest.java",
     "lines": [
       {
@@ -114666,1408 +96479,341 @@
       {
         "lineNumber": 21,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "/** @@author Codee */"
       },
       {
         "lineNumber": 22,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "public class TeamDisplayTest extends GuiUnitTest {"
       },
       {
         "lineNumber": 23,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 24,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    private static final String NEW_TEAM_NAME \u003d \"myTeam\";"
       },
       {
         "lineNumber": 25,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    private static final ShowNewTeamNameEvent SHOW_NEW_TEAM_NAME_EVENT \u003d new ShowNewTeamNameEvent(NEW_TEAM_NAME);"
       },
       {
         "lineNumber": 26,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 27,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    private TeamDisplay teamDisplay;"
       },
       {
         "lineNumber": 28,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    private TeamDisplayHandle teamDisplayHandle;"
       },
       {
         "lineNumber": 29,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    private ObservableList\u003cTeam\u003e teamList;"
       },
       {
         "lineNumber": 30,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 31,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    @Before"
       },
       {
         "lineNumber": 32,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    public void setUp() {"
       },
       {
         "lineNumber": 33,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "jordancjq"
         },
         "content": "        teamList \u003d FXCollections.observableArrayList();"
       },
       {
         "lineNumber": 34,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "jordancjq"
         },
         "content": "        teamList.add(new TeamBuilder().withTeamName(\"Arsenal\").build());"
       },
       {
         "lineNumber": 35,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "jordancjq"
         },
         "content": "        teamList.add(new TeamBuilder().withTeamName(\"Chelsea\").build());"
       },
       {
         "lineNumber": 36,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        teamDisplay \u003d new TeamDisplay(teamList);"
       },
       {
         "lineNumber": 37,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        uiPartRule.setUiPart(teamDisplay);"
       },
       {
         "lineNumber": 38,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        teamDisplayHandle \u003d new TeamDisplayHandle(teamDisplay.getRoot());"
       },
       {
         "lineNumber": 39,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    }"
       },
       {
         "lineNumber": 40,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 41,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    @Test"
       },
       {
         "lineNumber": 42,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    public void display() {"
       },
       {
         "lineNumber": 43,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        assertTeamDisplay(teamDisplay, teamList);"
       },
       {
         "lineNumber": 44,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    }"
       },
       {
         "lineNumber": 45,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    /**"
       },
       {
         "lineNumber": 46,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "     * Asserts that {@code personCard} displays the details of {@code expectedPerson} correctly and matches"
       },
       {
         "lineNumber": 47,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "     * {@code expectedId}."
       },
       {
         "lineNumber": 48,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "     */"
       },
       {
         "lineNumber": 49,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    private void assertTeamDisplay(TeamDisplay teamDisplay, ObservableList\u003cTeam\u003e teamlist) {"
       },
       {
         "lineNumber": 50,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        guiRobot.pauseForHuman();"
       },
       {
         "lineNumber": 51,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 52,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        // verify team names are displayed correctly"
       },
       {
         "lineNumber": 53,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        assertTeamDisplayEquals(teamDisplay, teamDisplayHandle);"
       },
       {
         "lineNumber": 54,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    }"
       },
       {
         "lineNumber": 55,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 56,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    @Test"
       },
       {
         "lineNumber": 57,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    public void handleShowNewTeamNameEvent() {"
       },
       {
         "lineNumber": 58,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        postNow(SHOW_NEW_TEAM_NAME_EVENT);"
       },
       {
         "lineNumber": 59,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 60,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        // verify team names are displayed correctly after event"
       },
       {
         "lineNumber": 61,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        guiRobot.pauseForHuman();"
       },
       {
         "lineNumber": 62,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 63,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        teamList.add(new Team(new TeamName(NEW_TEAM_NAME)));"
       },
       {
         "lineNumber": 64,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        TeamDisplay expectedTeamDisplay \u003d new TeamDisplay(teamList);"
       },
       {
         "lineNumber": 65,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        teamDisplayHandle \u003d new TeamDisplayHandle(teamDisplay.getRoot());"
       },
       {
         "lineNumber": 66,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        // verify team names are displayed correctly"
       },
       {
         "lineNumber": 67,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "        assertTeamDisplayEquals(expectedTeamDisplay, teamDisplayHandle);"
       },
       {
         "lineNumber": 68,
         "author": {
-          "gitId": "codeeong"
+          "gitId": "-"
         },
         "content": "    }"
       },
       {
         "lineNumber": 69,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "}"
-      }
-    ],
-    "authorContributionMap": {
-      "jordancjq": 1,
-      "codeeong": 49,
-      "-": 19
-    }
-  },
-  {
-    "path": "src/test/java/seedu/address/ui/testutil/GuiTestAssert.java",
-    "lines": [
-      {
-        "lineNumber": 1,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "package seedu.address.ui.testutil;"
-      },
-      {
-        "lineNumber": 2,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 3,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static org.junit.Assert.assertEquals;"
-      },
-      {
-        "lineNumber": 4,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import static org.junit.Assert.fail;"
-      },
-      {
-        "lineNumber": 5,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 6,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import java.util.Arrays;"
-      },
-      {
-        "lineNumber": 7,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import java.util.List;"
-      },
-      {
-        "lineNumber": 8,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import java.util.stream.Collectors;"
-      },
-      {
-        "lineNumber": 9,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 10,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import guitests.guihandles.PersonCardHandle;"
-      },
-      {
-        "lineNumber": 11,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import guitests.guihandles.PersonListPanelHandle;"
-      },
-      {
-        "lineNumber": 12,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import guitests.guihandles.PlayerDetailsHandle;"
-      },
-      {
-        "lineNumber": 13,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import guitests.guihandles.ResultDisplayHandle;"
-      },
-      {
-        "lineNumber": 14,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import guitests.guihandles.TeamDisplayHandle;"
-      },
-      {
-        "lineNumber": 15,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.model.person.Person;"
-      },
-      {
-        "lineNumber": 16,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.ui.PersonCard;"
-      },
-      {
-        "lineNumber": 17,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "import seedu.address.ui.TeamDisplay;"
-      },
-      {
-        "lineNumber": 18,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 19,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "/**"
-      },
-      {
-        "lineNumber": 20,
-        "author": {
-          "gitId": "-"
-        },
-        "content": " * A set of assertion methods useful for writing GUI tests."
-      },
-      {
-        "lineNumber": 21,
-        "author": {
-          "gitId": "-"
-        },
-        "content": " */"
-      },
-      {
-        "lineNumber": 22,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "public class GuiTestAssert {"
-      },
-      {
-        "lineNumber": 23,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    private static final String LABEL_DEFAULT_STYLE \u003d \"label\";"
-      },
-      {
-        "lineNumber": 24,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 25,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    /**"
-      },
-      {
-        "lineNumber": 26,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     * Asserts that {@code actualCard} displays the same values as {@code expectedCard}."
-      },
-      {
-        "lineNumber": 27,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     */"
-      },
-      {
-        "lineNumber": 28,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public static void assertCardEquals(PersonCardHandle expectedCard, PersonCardHandle actualCard) {"
-      },
-      {
-        "lineNumber": 29,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertEquals(expectedCard.getId(), actualCard.getId());"
-      },
-      {
-        "lineNumber": 30,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertEquals(expectedCard.getPosition(), actualCard.getPosition());"
-      },
-      {
-        "lineNumber": 31,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertEquals(expectedCard.getRating(), actualCard.getRating());"
-      },
-      {
-        "lineNumber": 32,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertEquals(expectedCard.getName(), actualCard.getName());"
-      },
-      {
-        "lineNumber": 33,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertEquals(expectedCard.getTeamName(), actualCard.getTeamName());"
-      },
-      {
-        "lineNumber": 34,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertEquals(expectedCard.getTags(), actualCard.getTags());"
-      },
-      {
-        "lineNumber": 35,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 36,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        expectedCard.getTags().forEach(tag -\u003e"
-      },
-      {
-        "lineNumber": 37,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "                assertEquals(expectedCard.getTagStyleClasses(tag), actualCard.getTagStyleClasses(tag)));"
-      },
-      {
-        "lineNumber": 38,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 39,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 40,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    /**"
-      },
-      {
-        "lineNumber": 41,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     * Asserts that {@code actualTeamDisplay} displays the details of {@code expectedTeamDisplay}."
-      },
-      {
-        "lineNumber": 42,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     */"
-      },
-      {
-        "lineNumber": 43,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    //@@author Codee"
-      },
-      {
-        "lineNumber": 44,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    public static void assertTeamDisplayEquals(TeamDisplay expectedTeamDisplay, TeamDisplayHandle actualTeamDisplay) {"
-      },
-      {
-        "lineNumber": 45,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        expectedTeamDisplay.getTeams().forEach(team -\u003e"
-      },
-      {
-        "lineNumber": 46,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "                assertEquals(expectedTeamDisplay.getTeams().toString(), actualTeamDisplay.getTeams().toString()));"
-      },
-      {
-        "lineNumber": 47,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 48,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    //@@author"
-      },
-      {
-        "lineNumber": 49,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 50,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    /**"
-      },
-      {
-        "lineNumber": 51,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     * Asserts that {@code actualCard} displays the details of {@code expectedPerson}."
-      },
-      {
-        "lineNumber": 52,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     */"
-      },
-      {
-        "lineNumber": 53,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public static void assertCardDisplaysPerson(Person expectedPerson, PersonCardHandle actualCard) {"
-      },
-      {
-        "lineNumber": 54,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertEquals(expectedPerson.getName().fullName, actualCard.getName());"
-      },
-      {
-        "lineNumber": 55,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertEquals(expectedPerson.getTeamName().toString(), actualCard.getTeamName());"
-      },
-      {
-        "lineNumber": 56,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertEquals(expectedPerson.getRating().value, actualCard.getRating());"
-      },
-      {
-        "lineNumber": 57,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertEquals(expectedPerson.getPosition().getPositionName(), actualCard.getPosition());"
-      },
-      {
-        "lineNumber": 58,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 59,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertTagsEqual(expectedPerson, actualCard);"
-      },
-      {
-        "lineNumber": 60,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 61,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 62,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    /**"
-      },
-      {
-        "lineNumber": 63,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     * Asserts that {@code actualPlayerDetails} displays the details of {@code expectedPerson}."
-      },
-      {
-        "lineNumber": 64,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     */"
-      },
-      {
-        "lineNumber": 65,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    //@@author Codee"
-      },
-      {
-        "lineNumber": 66,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    public static void assertPlayerDetailsDisplaysPerson(Person expectedPerson, PlayerDetailsHandle actualPlayerPanel) {"
-      },
-      {
-        "lineNumber": 67,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        assertEquals(expectedPerson.getName().fullName, actualPlayerPanel.getName());"
-      },
-      {
-        "lineNumber": 68,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        assertEquals(expectedPerson.getAddress().toString(), actualPlayerPanel.getAddress());"
-      },
-      {
-        "lineNumber": 69,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        assertEquals(expectedPerson.getEmail().value, actualPlayerPanel.getEmail());"
-      },
-      {
-        "lineNumber": 70,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        assertEquals(expectedPerson.getJerseyNumber().value, actualPlayerPanel.getJerseyNumber());"
-      },
-      {
-        "lineNumber": 71,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        assertEquals(expectedPerson.getPhone().value, actualPlayerPanel.getPhone());"
-      },
-      {
-        "lineNumber": 72,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "        assertEquals(expectedPerson.getRemark().toString(), actualPlayerPanel.getRemarks());"
-      },
-      {
-        "lineNumber": 73,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 74,
-        "author": {
-          "gitId": "codeeong"
-        },
-        "content": "    //@@author"
-      },
-      {
-        "lineNumber": 75,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 76,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    /**"
-      },
-      {
-        "lineNumber": 77,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     * Returns the color style for {@code tagName}\u0027s label. The tag\u0027s color is determined by looking up the color"
-      },
-      {
-        "lineNumber": 78,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     * of {@tagColour}"
-      },
-      {
-        "lineNumber": 79,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     *"
-      },
-      {
-        "lineNumber": 80,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     * @see PersonCard getTagColorStyleFor(String)"
-      },
-      {
-        "lineNumber": 81,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     */"
-      },
-      {
-        "lineNumber": 82,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    private static String getTagColorStyleFor(String tagName) {"
-      },
-      {
-        "lineNumber": 83,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        switch (tagName) {"
-      },
-      {
-        "lineNumber": 84,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        case \"classmates\":"
-      },
-      {
-        "lineNumber": 85,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        case \"owesMoney\":"
-      },
-      {
-        "lineNumber": 86,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        case \"colleagues\":"
-      },
-      {
-        "lineNumber": 87,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        case \"neighbours\":"
-      },
-      {
-        "lineNumber": 88,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        case \"family\":"
-      },
-      {
-        "lineNumber": 89,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        case \"friend\":"
-      },
-      {
-        "lineNumber": 90,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        case \"friends\":"
-      },
-      {
-        "lineNumber": 91,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        case \"husband\":"
-      },
-      {
-        "lineNumber": 92,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        case \"redCard\":"
-      },
-      {
-        "lineNumber": 93,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        case \"yellowCard\":"
-      },
-      {
-        "lineNumber": 94,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        case \"goodAttitude\":"
-      },
-      {
-        "lineNumber": 95,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        case \"badAttitude\":"
-      },
-      {
-        "lineNumber": 96,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        case \"injured\":"
-      },
-      {
-        "lineNumber": 97,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        case \"fastRunner\":"
-      },
-      {
-        "lineNumber": 98,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "            return \"teal\";"
-      },
-      {
-        "lineNumber": 99,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 100,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        default:"
-      },
-      {
-        "lineNumber": 101,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "            fail(tagName + \" does not have a color assigned.\");"
-      },
-      {
-        "lineNumber": 102,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "            return \"\";"
-      },
-      {
-        "lineNumber": 103,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        }"
-      },
-      {
-        "lineNumber": 104,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 105,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 106,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    /**"
-      },
-      {
-        "lineNumber": 107,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     * Asserts that the tags in {@code actualCard} matches all the tags in {@code expectedPerson} with the correct"
-      },
-      {
-        "lineNumber": 108,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     * color."
-      },
-      {
-        "lineNumber": 109,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     */"
-      },
-      {
-        "lineNumber": 110,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    private static void assertTagsEqual(Person expectedPerson, PersonCardHandle actualCard) {"
-      },
-      {
-        "lineNumber": 111,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        List\u003cString\u003e expectedTags \u003d expectedPerson.getTags().stream()"
-      },
-      {
-        "lineNumber": 112,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "                .map(tag -\u003e tag.tagName).collect(Collectors.toList());"
-      },
-      {
-        "lineNumber": 113,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertEquals(expectedTags, actualCard.getTags());"
-      },
-      {
-        "lineNumber": 114,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        expectedTags.forEach(tag -\u003e"
-      },
-      {
-        "lineNumber": 115,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "                assertEquals(Arrays.asList(LABEL_DEFAULT_STYLE, getTagColorStyleFor(tag)),"
-      },
-      {
-        "lineNumber": 116,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "                        actualCard.getTagStyleClasses(tag)));"
-      },
-      {
-        "lineNumber": 117,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 118,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 119,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    /**"
-      },
-      {
-        "lineNumber": 120,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     * Asserts that the list in {@code personListPanelHandle} displays the details of {@code persons} correctly and"
-      },
-      {
-        "lineNumber": 121,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     * in the correct order."
-      },
-      {
-        "lineNumber": 122,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     */"
-      },
-      {
-        "lineNumber": 123,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public static void assertListMatching(PersonListPanelHandle personListPanelHandle, Person... persons) {"
-      },
-      {
-        "lineNumber": 124,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        for (int i \u003d 0; i \u003c persons.length; i++) {"
-      },
-      {
-        "lineNumber": 125,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "            assertCardDisplaysPerson(persons[i], personListPanelHandle.getPersonCardHandle(i));"
-      },
-      {
-        "lineNumber": 126,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        }"
-      },
-      {
-        "lineNumber": 127,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 128,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 129,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    /**"
-      },
-      {
-        "lineNumber": 130,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     * Asserts that the list in {@code personListPanelHandle} displays the details of {@code persons} correctly and"
-      },
-      {
-        "lineNumber": 131,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     * in the correct order."
-      },
-      {
-        "lineNumber": 132,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     */"
-      },
-      {
-        "lineNumber": 133,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public static void assertListMatching(PersonListPanelHandle personListPanelHandle, List\u003cPerson\u003e persons) {"
-      },
-      {
-        "lineNumber": 134,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertListMatching(personListPanelHandle, persons.toArray(new Person[0]));"
-      },
-      {
-        "lineNumber": 135,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 136,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 137,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    /**"
-      },
-      {
-        "lineNumber": 138,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     * Asserts the size of the list in {@code personListPanelHandle} equals to {@code size}."
-      },
-      {
-        "lineNumber": 139,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     */"
-      },
-      {
-        "lineNumber": 140,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public static void assertListSize(PersonListPanelHandle personListPanelHandle, int size) {"
-      },
-      {
-        "lineNumber": 141,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        int numberOfPeople \u003d personListPanelHandle.getListSize();"
-      },
-      {
-        "lineNumber": 142,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertEquals(size, numberOfPeople);"
-      },
-      {
-        "lineNumber": 143,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 144,
-        "author": {
-          "gitId": "-"
-        },
-        "content": ""
-      },
-      {
-        "lineNumber": 145,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    /**"
-      },
-      {
-        "lineNumber": 146,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     * Asserts the message shown in {@code resultDisplayHandle} equals to {@code expected}."
-      },
-      {
-        "lineNumber": 147,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "     */"
-      },
-      {
-        "lineNumber": 148,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    public static void assertResultMessage(ResultDisplayHandle resultDisplayHandle, String expected) {"
-      },
-      {
-        "lineNumber": 149,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "        assertEquals(expected, resultDisplayHandle.getText());"
-      },
-      {
-        "lineNumber": 150,
-        "author": {
-          "gitId": "-"
-        },
-        "content": "    }"
-      },
-      {
-        "lineNumber": 151,
         "author": {
           "gitId": "-"
         },
@@ -116075,8 +96821,8 @@
       }
     ],
     "authorContributionMap": {
-      "codeeong": 16,
-      "-": 135
+      "jordancjq": 4,
+      "-": 65
     }
   },
   {
@@ -117933,708 +98679,707 @@
       {
         "lineNumber": 265,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        //@@author lithiumlkid"
       },
       {
         "lineNumber": 266,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        /* Case: invalid rating -\u003e rejected */"
       },
       {
         "lineNumber": 267,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        command \u003d AddCommand.COMMAND_WORD + NAME_DESC_AMY + PHONE_DESC_AMY + EMAIL_DESC_AMY + ADDRESS_DESC_AMY"
       },
       {
         "lineNumber": 268,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "                 + INVALID_RATING_DESC + POSITION_DESC_STRIKER + JERSEY_NUMBER_DESC_2;"
       },
       {
         "lineNumber": 269,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        assertCommandFailure(command, Rating.MESSAGE_RATING_CONSTRAINTS);"
       },
       {
         "lineNumber": 270,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 271,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        /* Case: invalid position -\u003e rejected */"
       },
       {
         "lineNumber": 272,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        command \u003d AddCommand.COMMAND_WORD + NAME_DESC_AMY + PHONE_DESC_AMY + EMAIL_DESC_AMY + ADDRESS_DESC_AMY"
       },
       {
         "lineNumber": 273,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "                 + RATING_DESC_0 + INVALID_POSITION_DESC + JERSEY_NUMBER_DESC_2;"
       },
       {
         "lineNumber": 274,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        assertCommandFailure(command, Position.MESSAGE_POSITION_CONSTRAINTS);"
       },
       {
         "lineNumber": 275,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 276,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        /* Case: invalid jersey number -\u003e rejected */"
       },
       {
         "lineNumber": 277,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        command \u003d AddCommand.COMMAND_WORD + NAME_DESC_AMY + PHONE_DESC_AMY + EMAIL_DESC_AMY + ADDRESS_DESC_AMY"
       },
       {
         "lineNumber": 278,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "                 + RATING_DESC_0 + POSITION_DESC_STRIKER + INVALID_JERSEY_NUMBER_DESC;"
       },
       {
         "lineNumber": 279,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        assertCommandFailure(command, JerseyNumber.MESSAGE_JERSEY_NUMBER_CONSTRAINTS);"
       },
       {
         "lineNumber": 280,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 281,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        /* Case: invalid jersey avatar -\u003e rejected */"
       },
       {
         "lineNumber": 282,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        command \u003d AddCommand.COMMAND_WORD + NAME_DESC_AMY + PHONE_DESC_AMY + EMAIL_DESC_AMY + ADDRESS_DESC_AMY"
       },
       {
         "lineNumber": 283,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "                + RATING_DESC_0 + POSITION_DESC_STRIKER + JERSEY_NUMBER_DESC_2 + INVALID_AVATAR_NO_FILE;"
       },
       {
         "lineNumber": 284,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        assertCommandFailure(command, AddCommand.MESSAGE_FILE_NOT_FOUND);"
       },
       {
         "lineNumber": 285,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 286,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        /* Case: invalid jersey avatar -\u003e rejected */"
       },
       {
         "lineNumber": 287,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        command \u003d AddCommand.COMMAND_WORD + NAME_DESC_AMY + PHONE_DESC_AMY + EMAIL_DESC_AMY + ADDRESS_DESC_AMY"
       },
       {
         "lineNumber": 288,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "                + RATING_DESC_0 + POSITION_DESC_STRIKER + JERSEY_NUMBER_DESC_2 + INVALID_AVATAR_TYPE;"
       },
       {
         "lineNumber": 289,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        assertCommandFailure(command, Avatar.MESSAGE_AVATAR_CONSTRAINTS);"
       },
       {
         "lineNumber": 290,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    }"
       },
       {
         "lineNumber": 291,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 292,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    /**"
       },
       {
         "lineNumber": 293,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "     * Executes the {@code AddCommand} that adds {@code toAdd} to the model and asserts that the,\u003cbr\u003e"
       },
       {
         "lineNumber": 294,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "     * 1. Command box displays an empty string.\u003cbr\u003e"
       },
       {
         "lineNumber": 295,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "     * 2. Command box has the default style class.\u003cbr\u003e"
       },
       {
         "lineNumber": 296,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "     * 3. Result display box displays the success message of executing {@code AddCommand} with the details of"
       },
       {
         "lineNumber": 297,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "     * {@code toAdd}.\u003cbr\u003e"
       },
       {
         "lineNumber": 298,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "     * 4. {@code Model}, {@code Storage} and {@code PersonListPanel} equal to the corresponding components in"
       },
       {
         "lineNumber": 299,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "     * the current model added with {@code toAdd}.\u003cbr\u003e"
       },
       {
         "lineNumber": 300,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "     * 5. Browser url and selected card remain unchanged.\u003cbr\u003e"
       },
       {
         "lineNumber": 301,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "     * 6. Status bar\u0027s sync status changes.\u003cbr\u003e"
       },
       {
         "lineNumber": 302,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "     * Verifications 1, 3 and 4 are performed by"
       },
       {
         "lineNumber": 303,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "     * {@code AddressBookSystemTest#assertApplicationDisplaysExpected(String, String, Model)}.\u003cbr\u003e"
       },
       {
         "lineNumber": 304,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "     * @see AddressBookSystemTest#assertApplicationDisplaysExpected(String, String, Model)"
       },
       {
         "lineNumber": 305,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "     */"
       },
       {
         "lineNumber": 306,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    private void assertCommandSuccess(Person toAdd) {"
       },
       {
         "lineNumber": 307,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        assertCommandSuccess(PersonUtil.getAddCommand(toAdd), toAdd);"
       },
       {
         "lineNumber": 308,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    }"
       },
       {
         "lineNumber": 309,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 310,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    /**"
       },
       {
         "lineNumber": 311,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "     * Performs the same verification as {@code assertCommandSuccess(Person)}. Executes {@code command}"
       },
       {
         "lineNumber": 312,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "     * instead."
       },
       {
         "lineNumber": 313,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "     * @see AddCommandSystemTest#assertCommandSuccess(Person)"
       },
       {
         "lineNumber": 314,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "     */"
       },
       {
         "lineNumber": 315,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    private void assertCommandSuccess(String command, Person toAdd) {"
       },
       {
         "lineNumber": 316,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        Model expectedModel \u003d getModel();"
       },
       {
         "lineNumber": 317,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        try {"
       },
       {
         "lineNumber": 318,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "            expectedModel.addPerson(toAdd);"
       },
       {
         "lineNumber": 319,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        } catch (DuplicatePersonException dpe) {"
       },
       {
         "lineNumber": 320,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "            throw new IllegalArgumentException(\"toAdd already exists in the model.\");"
       },
       {
         "lineNumber": 321,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        }"
       },
       {
         "lineNumber": 322,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "jordancjq"
         },
         "content": "        // TODO: place holder for success message, change to proper assert method"
       },
       {
         "lineNumber": 323,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "jordancjq"
         },
         "content": "        String expectedResultMessage \u003d String.format(AddCommand.MESSAGE_SUCCESS, toAdd);"
       },
       {
         "lineNumber": 324,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 325,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        assertCommandSuccess(command, expectedModel, expectedResultMessage);"
       },
       {
         "lineNumber": 326,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    }"
       },
       {
         "lineNumber": 327,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 328,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    /**"
       },
       {
         "lineNumber": 329,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "     * Performs the same verification as {@code assertCommandSuccess(String, Person)} except asserts that"
       },
       {
         "lineNumber": 330,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "     * the,\u003cbr\u003e"
       },
       {
         "lineNumber": 331,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "     * 1. Result display box displays {@code expectedResultMessage}.\u003cbr\u003e"
       },
       {
         "lineNumber": 332,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "     * 2. {@code Model}, {@code Storage} and {@code PersonListPanel} equal to the corresponding components in"
       },
       {
         "lineNumber": 333,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "     * {@code expectedModel}.\u003cbr\u003e"
       },
       {
         "lineNumber": 334,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "     * @see AddCommandSystemTest#assertCommandSuccess(String, Person)"
       },
       {
         "lineNumber": 335,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "     */"
       },
       {
         "lineNumber": 336,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    private void assertCommandSuccess(String command, Model expectedModel, String expectedResultMessage) {"
       },
       {
         "lineNumber": 337,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        executeCommand(command);"
       },
       {
         "lineNumber": 338,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        assertApplicationDisplaysExpected(\"\", expectedResultMessage, expectedModel);"
       },
       {
         "lineNumber": 339,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        assertSelectedCardUnchanged();"
       },
       {
         "lineNumber": 340,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        assertCommandBoxShowsDefaultStyle();"
       },
       {
         "lineNumber": 341,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        assertStatusBarUnchangedExceptSyncStatus();"
       },
       {
         "lineNumber": 342,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    }"
       },
       {
         "lineNumber": 343,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 344,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    /**"
       },
       {
         "lineNumber": 345,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "     * Executes {@code command} and asserts that the,\u003cbr\u003e"
       },
       {
         "lineNumber": 346,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "     * 1. Command box displays {@code command}.\u003cbr\u003e"
       },
       {
         "lineNumber": 347,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "     * 2. Command box has the error style class.\u003cbr\u003e"
       },
       {
         "lineNumber": 348,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "     * 3. Result display box displays {@code expectedResultMessage}.\u003cbr\u003e"
       },
       {
         "lineNumber": 349,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "     * 4. {@code Model}, {@code Storage} and {@code PersonListPanel} remain unchanged.\u003cbr\u003e"
       },
       {
         "lineNumber": 350,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "     * 5. Browser url, selected card and status bar remain unchanged.\u003cbr\u003e"
       },
       {
         "lineNumber": 351,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "     * Verifications 1, 3 and 4 are performed by"
       },
       {
         "lineNumber": 352,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "     * {@code AddressBookSystemTest#assertApplicationDisplaysExpected(String, String, Model)}.\u003cbr\u003e"
       },
       {
         "lineNumber": 353,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "     * @see AddressBookSystemTest#assertApplicationDisplaysExpected(String, String, Model)"
       },
       {
         "lineNumber": 354,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "     */"
       },
       {
         "lineNumber": 355,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    private void assertCommandFailure(String command, String expectedResultMessage) {"
       },
       {
         "lineNumber": 356,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        Model expectedModel \u003d getModel();"
       },
       {
         "lineNumber": 357,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 358,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        executeCommand(command);"
       },
       {
         "lineNumber": 359,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        assertApplicationDisplaysExpected(command, expectedResultMessage, expectedModel);"
       },
       {
         "lineNumber": 360,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        assertSelectedCardUnchanged();"
       },
       {
         "lineNumber": 361,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        assertCommandBoxShowsErrorStyle();"
       },
       {
         "lineNumber": 362,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "        assertStatusBarUnchanged();"
       },
       {
         "lineNumber": 363,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "    }"
       },
       {
         "lineNumber": 364,
         "author": {
-          "gitId": "lithiumlkid"
+          "gitId": "-"
         },
         "content": "}"
       }
     ],
     "authorContributionMap": {
-      "lithiumlkid": 100,
-      "jordancjq": 9,
-      "-": 255
+      "jordancjq": 11,
+      "-": 353
     }
   }
 ]

--- a/src/functional/resources/noDateRange/expected/reposense_testrepo-Delta_master/commits.json
+++ b/src/functional/resources/noDateRange/expected/reposense_testrepo-Delta_master/commits.json
@@ -1292,10 +1292,10 @@
     ]
   },
   "authorFinalContributionMap": {
-    "lithiumlkid": 1782,
-    "lohtianwei": 2164,
-    "codeeong": 1159,
-    "jordancjq": 5321
+    "lithiumlkid": 360,
+    "lohtianwei": 2187,
+    "codeeong": 0,
+    "jordancjq": 5427
   },
   "authorContributionVariance": {
     "lithiumlkid": 1465.0459,

--- a/src/main/java/reposense/authorship/FileInfoAnalyzer.java
+++ b/src/main/java/reposense/authorship/FileInfoAnalyzer.java
@@ -78,13 +78,14 @@ public class FileInfoAnalyzer {
 
         String blameResults = getGitBlameResult(config, fileInfo.getPath());
         String[] blameResultLines = blameResults.split("\n");
+        Path filePath = Paths.get(fileInfo.getPath());
         int lineCount = 0;
 
         for (String line : blameResultLines) {
             String authorRawName = line.substring(AUTHOR_NAME_OFFSET);
             Author author = authorAliasMap.getOrDefault(authorRawName, new Author(Author.UNKNOWN_AUTHOR_GIT_ID));
 
-            if (!fileInfo.isFileLineTracked(lineCount) || isAuthorIgnoringFile(author, fileInfo)) {
+            if (!fileInfo.isFileLineTracked(lineCount) || isAuthorIgnoringFile(author, filePath)) {
                 author = new Author(Author.UNKNOWN_AUTHOR_GIT_ID);
             }
 
@@ -116,10 +117,10 @@ public class FileInfoAnalyzer {
     }
 
     /**
-     * Returns true if the {@code author} is ignoring the file path of {@code fileInfo} based on its ignore glob list.
+     * Returns true if the {@code author} is ignoring the {@code filePath} based on its ignore glob list.
      */
-    private static boolean isAuthorIgnoringFile(Author author, FileInfo fileinfo) {
+    private static boolean isAuthorIgnoringFile(Author author, Path filePath) {
         PathMatcher ignoreGlobMatcher = author.getIgnoreGlobMatcher();
-        return ignoreGlobMatcher.matches(Paths.get(fileinfo.getPath()));
+        return ignoreGlobMatcher.matches(filePath);
     }
 }

--- a/src/main/java/reposense/authorship/analyzer/AnnotatorAnalyzer.java
+++ b/src/main/java/reposense/authorship/analyzer/AnnotatorAnalyzer.java
@@ -1,5 +1,7 @@
 package reposense.authorship.analyzer;
 
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -22,13 +24,18 @@ public class AnnotatorAnalyzer {
      */
     public static void aggregateAnnotationAuthorInfo(FileInfo fileInfo, Map<String, Author> authorAliasMap) {
         Author currentAuthor = null;
+        Path filePath = Paths.get(fileInfo.getPath());
         for (LineInfo lineInfo : fileInfo.getLines()) {
             if (lineInfo.getContent().contains(AUTHOR_TAG)) {
                 Author newAuthor = findAuthorInLine(lineInfo.getContent(), authorAliasMap);
+
                 if (newAuthor == null) {
                     //end of an author tag should belong to this author too.
                     lineInfo.setAuthor(currentAuthor);
+                } else if (newAuthor.getIgnoreGlobMatcher().matches(filePath)) {
+                    newAuthor = null;
                 }
+
                 //set a new author
                 currentAuthor = newAuthor;
             }


### PR DESCRIPTION
Fixes #262 
```
Each author has their own ignoreGlobList, which should ignore
any of their contributions to any files within that glob list.

However, while the commits information are correctly ignored,
the authorship information is not, as some files that should be
in the glob list still appeared for the author's contribution.
This is due to AnnotatorAnalyzer not ignoring the files in the
glob list, and overriding the original git blame results.

Let's resolve this by updating AnnotatorAnalyzer to remove
author contribution if the file being analyzed is inside their
glob list.
```