### PR TITLE
 Add timezone to ramp's github redirect link #263 

### DIFF
--- a/frontend/src/static/js/v_summary.js
+++ b/frontend/src/static/js/v_summary.js
@@ -126,8 +126,8 @@ window.vSummary = {
         REPOS[user.repoId].repoName}/commits/${
         REPOS[user.repoId].branch}?`
                 + `author=${user.name}&`
-                + `since=${slice.sinceDate}&`
-                + `until=${slice.untilDate}`;
+                + `since=${slice.sinceDate}'T'00:00:00+08:00&`
+                + `until=${slice.untilDate}'T'23:59:59+08:00`;
     },
     getContributionBars(totalContribution) {
       const res = [];

--- a/frontend/src/static/js/v_summary.js
+++ b/frontend/src/static/js/v_summary.js
@@ -304,7 +304,7 @@ window.vSummary = {
 
       user.dailyCommits.forEach((commit) => {
         const date = commit.sinceDate;
-        if (date >= sinceDate && date < untilDate) {
+        if (date >= sinceDate && date <= untilDate) {
           user.commits.push(commit);
         }
       });

--- a/frontend/src/static/js/v_summary.js
+++ b/frontend/src/static/js/v_summary.js
@@ -127,7 +127,7 @@ window.vSummary = {
         REPOS[user.repoId].branch}?`
                 + `author=${user.name}&`
                 + `since=${slice.sinceDate}'T'00:00:00+08:00&`
-                + `until=${slice.untilDate}'T'23:59:59+08:00`;
+                + `until=${slice.sinceDate}'T'23:59:59+08:00`;
     },
     getContributionBars(totalContribution) {
       const res = [];


### PR DESCRIPTION
fixes #263 

```
Occasionally, clicking a ramp will show no commits found for the
specified user. This is because our git log command uses a constant
timezone (Singapore UTC+8) and this mis-align with the GitHub time
system.

Let's fix this by adding the timezone to the github redirect link as
well.
```