### PR TITLE
Fix duplicate authors in underlying RepoConfig

### DIFF
--- a/src/main/java/reposense/parser/AuthorConfigCsvParser.java
+++ b/src/main/java/reposense/parser/AuthorConfigCsvParser.java
@@ -66,8 +66,6 @@ public class AuthorConfigCsvParser extends CsvParser<RepoConfiguration> {
         setDisplayName(config, author, displayName);
         setAliases(config, author, gitHubId, aliases);
         setAuthorIgnoreGlobList(author, ignoreGlobList);
-
-        results.add(config);
     }
 
 
@@ -82,7 +80,13 @@ public class AuthorConfigCsvParser extends CsvParser<RepoConfiguration> {
         RepoConfiguration config = new RepoConfiguration(location, branch);
         int index = results.indexOf(config);
 
-        return index != -1 ? results.get(index) : config;
+        if (index != -1) {
+            config = results.get(index);
+        } else {
+            results.add(config);
+        }
+
+        return config;
     }
 
     /**


### PR DESCRIPTION
```
AuthorConfigCsvParser#getRepoConfiguration should return existing
RepoConfiguration from a list of RepoConfigurations. Otherwise it adds
a newly created RepoConfigurtion into the list and returns it.

However, due to a bug, any RepoConfigurations existing or not are added
to the list of RepoConfigurations causing duplicates.

Let's only add newly created RepoConfigurtion to the list to prevent
duplications.
```
