### PR TITLE
Add clickable link to repository #226

### DIFF
--- a/frontend/src/index.jade
+++ b/frontend/src/index.jade
@@ -76,7 +76,10 @@ html
               span group by repo
         #summary-charts
           .summary-charts(v-for="repo of filtered", v-if="repo.length>0")
-            .summary-charts--title(v-if="filterGroupRepos") {{ repo[0].repoPath }}
+            a.summary-charts__title(
+              v-if="filterGroupRepos",
+              v-bind:href="repo[0].location", target="_blank"
+            ) {{ repo[0].repoPath }}
             .summary-chart(v-for="(user, i) in repo", v-bind:class="{indented:filterGroupRepos}")
               .summary-chart__title(
                 v-on:click="$emit('view-authorship', {author:user.name, repo:user.repoName, name:user.displayName})"

--- a/frontend/src/static/css/style.scss
+++ b/frontend/src/static/css/style.scss
@@ -165,7 +165,8 @@ header{
 .summary-charts{
     margin-bottom:3rem;
 
-    &--title{
+    &__title{
+        display:block;
         text-align:left;
         font-weight:bold;
     }

--- a/frontend/src/static/js/api.js
+++ b/frontend/src/static/js/api.js
@@ -66,6 +66,7 @@ window.api = {
           obj.searchPath = searchParams.join('_').toLowerCase();
           obj.repoPath = `${repo.displayName}`;
           obj.repoName = `${repo.displayName}`;
+          obj.location = `${repo.location}`;
 
           res.push(obj);
         }


### PR DESCRIPTION
Fix #226 

To view the repository, we need to manually open the link to navigate to it.

Let's simplify this by adding a redirect link to the remote repository in the 
dashboard itself.