### PR TITLE
Add total number of lines contributed in code panel #264

### DIFF
--- a/frontend/src/index.jade
+++ b/frontend/src/index.jade
@@ -111,7 +111,7 @@ html
 
         .files(v-if="isLoaded")
           .file(v-for="file in files")
-            .title(onclick="toggleNext(this)") {{ file.path }} ({{ file.lineCount }} LOC)
+            .title(onclick="toggleNext(this)") {{ file.path }} ({{ file.lineCount }} lines)
             pre.hljs.java
               code
                 template(v-for="segment in file.segments")

--- a/frontend/src/index.jade
+++ b/frontend/src/index.jade
@@ -111,7 +111,7 @@ html
 
         .files(v-if="isLoaded")
           .file(v-for="file in files")
-            .title(onclick="toggleNext(this)") {{ file.path }}
+            .title(onclick="toggleNext(this)") {{ file.path }} ({{ file.lineCount }} LOC)
             pre.hljs.java
               code
                 template(v-for="segment in file.segments")

--- a/frontend/src/static/js/v_authorship.js
+++ b/frontend/src/static/js/v_authorship.js
@@ -137,6 +137,8 @@ window.vAuthorship = {
         }
       });
 
+      res.sort((a, b) => b.lineCount - a.lineCount);
+
       this.files = res;
       this.isLoaded = true;
     },

--- a/frontend/src/static/js/v_authorship.js
+++ b/frontend/src/static/js/v_authorship.js
@@ -121,9 +121,11 @@ window.vAuthorship = {
       const res = [];
 
       files.forEach((file) => {
-        if (file.authorContributionMap[this.info.author]) {
+        const lineCnt = file.authorContributionMap[this.info.author];
+        if (lineCnt) {
           const out = {};
           out.path = file.path;
+          out.lineCount = lineCnt;
 
           const segments = this.splitSegments(file.lines);
           const bigSegments = this.removeSmallUnauthored(segments);


### PR DESCRIPTION
fixes #264 

```
Code panel could use more useful information such as number of lines
contributed for each file. This would give the reviewer a rough idea
how many lines the author has contributed to each component.

Let's add the line of code information into the display.
```