### PR TITLE
Reduce memory cache in code view #267

### DIFF
--- a/frontend/src/static/js/v_authorship.js
+++ b/frontend/src/static/js/v_authorship.js
@@ -37,7 +37,7 @@ window.vAuthorship = {
     initiate() {
       const repo = window.REPOS[this.info.repo];
 
-      if (repoCache.length === 5) {
+      if (repoCache.length === 3) {
         const toRemove = repoCache.shift();
         if (toRemove !== this.info.repo) {
           delete window.REPOS[toRemove].files;

--- a/frontend/src/static/js/v_authorship.js
+++ b/frontend/src/static/js/v_authorship.js
@@ -22,6 +22,7 @@ window.toggleNext = function toggleNext(ele) {
   }
 };
 
+const repoCache = [];
 window.vAuthorship = {
   props: ['info'],
   template: window.$('v_authorship').innerHTML,
@@ -35,6 +36,14 @@ window.vAuthorship = {
   methods: {
     initiate() {
       const repo = window.REPOS[this.info.repo];
+
+      if (repoCache.length === 5) {
+        const toRemove = repoCache.shift();
+        if (toRemove !== this.info.repo) {
+          delete window.REPOS[toRemove].files;
+        }
+      }
+      repoCache.push(this.info.repo);
 
       if (repo.files) {
         this.processFiles(repo.files);

--- a/frontend/src/static/js/v_authorship.js
+++ b/frontend/src/static/js/v_authorship.js
@@ -37,7 +37,7 @@ window.vAuthorship = {
     initiate() {
       const repo = window.REPOS[this.info.repo];
 
-      if (repoCache.length === 3) {
+      if (repoCache.length === 2) {
         const toRemove = repoCache.shift();
         if (toRemove !== this.info.repo) {
           delete window.REPOS[toRemove].files;


### PR DESCRIPTION
fixes #267 

```
Currently, the authorship data is cached in the `window.REPOS` to
reduce unnecessary loading because `authorship.json` is a very big
file. However, this causes the the browser memory keep increasing as a
user keeps going through code of various authors.

Let's limit the cache of code view data to a fixed number of authors to
5.
``