### PR TITLE
Dashboard: add indication to empty state in code view

### DIFF
--- a/frontend/src/index.jade
+++ b/frontend/src/index.jade
@@ -113,6 +113,7 @@ html
           .author {{ info.name }} ({{ info.author }})
 
         .files(v-if="isLoaded")
+          .empty(v-if="files.length===0") nothing to see here :(
           .file(v-for="file in files")
             .title(onclick="toggleNext(this)") {{ file.path }}
             pre.hljs.java


### PR DESCRIPTION
```
Authorship tab currently lacks a empty state, which might be confusing
for users since they are unsure if the information is being loaded or
there is nothing to show.

Let's add a default empty state for the authorship tab.
```

Added by Eugene:
To preview this change, go to the repo `reposense_testrepo-Delta_master` open code view for `Cod`