### PR TITLE
error matching file path pattern inside file diff result #299

### DIFF
--- a/src/main/java/reposense/authorship/FileInfoExtractor.java
+++ b/src/main/java/reposense/authorship/FileInfoExtractor.java
@@ -34,6 +34,7 @@ public class FileInfoExtractor {
 
     private static final String DIFF_FILE_CHUNK_SEPARATOR = "\ndiff --git a/.*\n";
     private static final String BINARY_FILE_SYMBOL = "\nBinary files ";
+    private static final String SIMILAR_FILE_RENAMED_SYMBOL = "similarity index 100%\n";
     private static final String LINE_CHUNKS_SEPARATOR = "\n@@ ";
     private static final String LINE_INSERTED_SYMBOL = "+";
     private static final String STARTING_LINE_NUMBER_GROUP_NAME = "startingLineNumber";
@@ -96,9 +97,9 @@ public class FileInfoExtractor {
         String[] fileDiffResultList = fullDiffResult.split(DIFF_FILE_CHUNK_SEPARATOR);
 
         for (String fileDiffResult : fileDiffResultList) {
-            // file deleted, is binary file or is new and empty file, skip it
-            if (FILE_DELETED_PREDICATE.test(fileDiffResult) || fileDiffResult.contains(BINARY_FILE_SYMBOL)
-                    || NEW_EMPTY_FILE_PREDICATE.test(fileDiffResult)) {
+            // file deleted, renamed, is binary file or is new and empty file, skip it
+            if (fileDiffResult.contains(SIMILAR_FILE_RENAMED_SYMBOL) || fileDiffResult.contains(BINARY_FILE_SYMBOL)
+                    || FILE_DELETED_PREDICATE.test(fileDiffResult) || NEW_EMPTY_FILE_PREDICATE.test(fileDiffResult)) {
                 continue;
             }
 

--- a/src/test/java/reposense/authorship/FileInfoExtractorTest.java
+++ b/src/test/java/reposense/authorship/FileInfoExtractorTest.java
@@ -21,6 +21,9 @@ public class FileInfoExtractorTest extends GitTestTemplate {
     private static final Path FILE_WITH_SPECIAL_CHARACTER = TEST_DATA_FOLDER.resolve("fileWithSpecialCharacters.txt");
     private static final Path FILE_WITHOUT_SPECIAL_CHARACTER = TEST_DATA_FOLDER
             .resolve("fileWithoutSpecialCharacters.txt");
+    private static final String EDITED_FILE_INFO_BRANCH = "getEditedFileInfos-test";
+    private static final String FEBRUARY_EIGHT_COMMIT_HASH = "768015345e70f06add2a8b7d1f901dc07bf70582";
+
 
     @Test
     public void extractFileInfosTest() {
@@ -28,11 +31,13 @@ public class FileInfoExtractorTest extends GitTestTemplate {
         config.getAuthorAliasMap().put(FAKE_AUTHOR_NAME, new Author(FAKE_AUTHOR_NAME));
         GitChecker.checkout(config.getRepoRoot(), TEST_COMMIT_HASH);
         List<FileInfo> files = FileInfoExtractor.extractFileInfos(config);
-        Assert.assertEquals(files.size(), 6);
+        Assert.assertEquals(6, files.size());
+        Assert.assertTrue(isFileExistence(Paths.get("README.md"), files));
         Assert.assertTrue(isFileExistence(Paths.get("annotationTest.java"), files));
         Assert.assertTrue(isFileExistence(Paths.get("blameTest.java"), files));
         Assert.assertTrue(isFileExistence(Paths.get("newPos/movedFile.java"), files));
         Assert.assertTrue(isFileExistence(Paths.get("inMasterBranch.java"), files));
+        Assert.assertTrue(isFileExistence(Paths.get("newFile.java"), files));
     }
 
     @Test
@@ -70,6 +75,31 @@ public class FileInfoExtractorTest extends GitTestTemplate {
 
         List<FileInfo> files = FileInfoExtractor.extractFileInfos(config);
         Assert.assertTrue(files.isEmpty());
+    }
+
+    @Test
+    public void getEditedFileInfos_editFileInfoBranchSinceFebrauryEight_success() {
+        GitChecker.checkout(config.getRepoRoot(), EDITED_FILE_INFO_BRANCH);
+        List<FileInfo> files = FileInfoExtractor.getEditedFileInfos(config, FEBRUARY_EIGHT_COMMIT_HASH);
+
+        Assert.assertEquals(3, files.size());
+        Assert.assertTrue(isFileExistence(Paths.get("README.md"), files));
+        Assert.assertTrue(isFileExistence(Paths.get("annotationTest.java"), files));
+        Assert.assertTrue(isFileExistence(Paths.get("newPos/movedFile.java"), files));
+
+        // file renamed without changing content, not included
+        Assert.assertFalse(isFileExistence(Paths.get("renamedFile.java"), files));
+    }
+
+    @Test
+    public void getEditedFileInfos_editFileInfoBranchSinceFirstCommit_success() {
+        GitChecker.checkout(config.getRepoRoot(), EDITED_FILE_INFO_BRANCH);
+        List<FileInfo> files = FileInfoExtractor.getEditedFileInfos(config, FIRST_COMMIT_HASH);
+
+        Assert.assertEquals(5, files.size());
+
+        // empty file created, not included
+        Assert.assertFalse(isFileExistence(Paths.get("inMasterBranch.java"), files));
     }
 
     @Test


### PR DESCRIPTION
Fixes #299 
```
FileInfoExtractor#getFilePathFromDiffPattern(String) checks
for the group pattern '+++ b/path/to/file'
within the git diff result in order to get the file path.

However, when a file is renamed without changing any of its
content in between the commit range to analysis, the file will
appear in the git diff result, but since there are no lines to display,
the above group does not get printed, thus 
FileInfoExtractor#getFilePathFromDiffPattern(String) is unable
to match the pattern, causing the program to crash.

Let's add a check to skip these renamed but untouched files in 
the git diff result, since an untouched file has no lines to 
attribute any contribution.
```