### PR TITLE
Code view: add controls to expand/collapse all files #36

### DIFF
--- a/frontend/src/index.jade
+++ b/frontend/src/index.jade
@@ -28,13 +28,10 @@ html
           .tab-content
             .tab-panes
               #tab-authorship.tab-pane(v-if="isTabAuthorship")
-                ul.authorship__toolbar
-                  li.dropdown
-                    a.dropdown-button
-                      i.fas.fa-lg.fa-bars
-                    .dropdown-content
-                      a(onclick="expandAll()") Expand all
-                      a(onclick="collapseAll()") Collapse all
+                .toolbar
+                  a(onclick="expandAll()") Expand all
+                  label &nbsp;/&nbsp;
+                  a(onclick="collapseAll()") Collapse all
                 v_authorship(
                   v-bind:key="generateKey(tabInfo.tabAuthorship)",
                   v-bind:info="tabInfo.tabAuthorship")

--- a/frontend/src/index.jade
+++ b/frontend/src/index.jade
@@ -28,6 +28,13 @@ html
           .tab-content
             .tab-panes
               #tab-authorship.tab-pane(v-if="isTabAuthorship")
+                ul.authorship__toolbar
+                  li.dropdown
+                    a.dropdown-button
+                      i.fas.fa-lg.fa-bars
+                    .dropdown-content
+                      a Expand all
+                      a Collapse all
                 v_authorship(
                   v-bind:key="generateKey(tabInfo.tabAuthorship)",
                   v-bind:info="tabInfo.tabAuthorship")

--- a/frontend/src/index.jade
+++ b/frontend/src/index.jade
@@ -33,8 +33,8 @@ html
                     a.dropdown-button
                       i.fas.fa-lg.fa-bars
                     .dropdown-content
-                      a Expand all
-                      a Collapse all
+                      a(onclick="expandAll()") Expand all
+                      a(onclick="collapseAll()") Collapse all
                 v_authorship(
                   v-bind:key="generateKey(tabInfo.tabAuthorship)",
                   v-bind:info="tabInfo.tabAuthorship")

--- a/frontend/src/index.jade
+++ b/frontend/src/index.jade
@@ -30,7 +30,7 @@ html
               #tab-authorship.tab-pane(v-if="isTabAuthorship")
                 .toolbar
                   a(onclick="expandAll(true)") Expand all
-                  label &nbsp;/&nbsp;
+                  span &nbsp;/&nbsp;
                   a(onclick="expandAll(false)") Collapse all
                 v_authorship(
                   v-bind:key="generateKey(tabInfo.tabAuthorship)",

--- a/frontend/src/index.jade
+++ b/frontend/src/index.jade
@@ -29,9 +29,9 @@ html
             .tab-panes
               #tab-authorship.tab-pane(v-if="isTabAuthorship")
                 .toolbar
-                  a(onclick="expandAll()") Expand all
+                  a(onclick="expandAll(true)") Expand all
                   label &nbsp;/&nbsp;
-                  a(onclick="collapseAll()") Collapse all
+                  a(onclick="expandAll(false)") Collapse all
                 v_authorship(
                   v-bind:key="generateKey(tabInfo.tabAuthorship)",
                   v-bind:info="tabInfo.tabAuthorship")

--- a/frontend/src/static/css/style.scss
+++ b/frontend/src/static/css/style.scss
@@ -256,11 +256,11 @@ header{
             color: 	#7CFC00;
         }
 
-        li.dropdown {
+        li.dropdown{
             display: inline-block;
         }
 
-        .dropdown-content {
+        .dropdown-content{
             display: none;
             background-color: #333;
             min-width: 160px;
@@ -268,19 +268,20 @@ header{
             z-index: 1;
         }
 
-        .dropdown-content a {
+        .dropdown-content a{
             color: white;
             padding: 12px 16px;
             text-decoration: none;
             display: block;
             text-align: left;
+            cursor: pointer;
         }
 
-        .dropdown-content a:hover {
+        .dropdown-content a:hover{
             color: 	#7CFC00;
         }
 
-        .dropdown:hover .dropdown-content {
+        .dropdown:hover .dropdown-content{
             display: block;
         }
     }

--- a/frontend/src/static/css/style.scss
+++ b/frontend/src/static/css/style.scss
@@ -230,6 +230,61 @@ header{
 
 /* Authorship */
 #tab-authorship{
+    .authorship__toolbar{
+        list-style-type: none;
+        margin: 0;
+        padding: 0;
+        overflow: hidden;
+        background-color: #333;
+        position: -webkit-sticky;
+        position: sticky;
+        top: 0;
+
+        li{
+            float: left;
+        }
+
+        li a, .dropdown-button{
+            display: inline-block;
+            color: white;
+            text-align: center;
+            padding: 14px 16px;
+            text-decoration: none;
+        }
+
+        li a:hover, .dropdown:hover .dropdown-button{
+            color: 	#7CFC00;
+        }
+
+        li.dropdown {
+            display: inline-block;
+        }
+
+        .dropdown-content {
+            display: none;
+            background-color: #333;
+            min-width: 160px;
+            box-shadow: 0px 8px 16px 0px rgba(0,0,0,0.2);
+            z-index: 1;
+        }
+
+        .dropdown-content a {
+            color: white;
+            padding: 12px 16px;
+            text-decoration: none;
+            display: block;
+            text-align: left;
+        }
+
+        .dropdown-content a:hover {
+            color: 	#7CFC00;
+        }
+
+        .dropdown:hover .dropdown-content {
+            display: block;
+        }
+    }
+
     .title{
         .repoName{
             font-size:1.5rem;

--- a/frontend/src/static/css/style.scss
+++ b/frontend/src/static/css/style.scss
@@ -230,60 +230,9 @@ header{
 
 /* Authorship */
 #tab-authorship{
-    .authorship__toolbar{
-        list-style-type: none;
-        margin: 0;
-        padding: 0;
-        overflow: hidden;
-        background-color: #333;
-        position: -webkit-sticky;
-        position: sticky;
-        top: 0;
-
-        li{
-            float: left;
-        }
-
-        li a, .dropdown-button{
-            display: inline-block;
-            color: white;
-            text-align: center;
-            padding: 14px 16px;
-            text-decoration: none;
-        }
-
-        li a:hover, .dropdown:hover .dropdown-button{
-            color: 	#7CFC00;
-        }
-
-        li.dropdown{
-            display: inline-block;
-        }
-
-        .dropdown-content{
-            display: none;
-            background-color: #333;
-            min-width: 160px;
-            box-shadow: 0px 8px 16px 0px rgba(0,0,0,0.2);
-            z-index: 1;
-        }
-
-        .dropdown-content a{
-            color: white;
-            padding: 12px 16px;
-            text-decoration: none;
-            display: block;
-            text-align: left;
-            cursor: pointer;
-        }
-
-        .dropdown-content a:hover{
-            color: 	#7CFC00;
-        }
-
-        .dropdown:hover .dropdown-content{
-            display: block;
-        }
+    .toolbar{
+        float: right;
+        cursor: pointer;
     }
 
     .title{

--- a/frontend/src/static/js/v_authorship.js
+++ b/frontend/src/static/js/v_authorship.js
@@ -15,6 +15,28 @@ function toggleNext(ele) {
   parent.className = classes.join(' ');
 };
 
+function collapseAll() {
+  const targetClass = 'file active';
+  const renameValue = 'file';
+  
+  var files = document.getElementsByClassName(targetClass);
+  while (files.length) {
+    files[0].className = renameValue;
+  }
+}
+
+function expandAll() {
+  const targetClass = 'file';
+  const renameValue = 'file active';
+  
+  var files = document.getElementsByClassName(targetClass);
+  for (var i = 0; i < files.length; i++) {
+    if (files[i].className == targetClass) {
+      files[i].className = renameValue;
+    }
+  }
+}
+
 const repoCache = [];
 window.vAuthorship = {
   props: ['info'],

--- a/frontend/src/static/js/v_authorship.js
+++ b/frontend/src/static/js/v_authorship.js
@@ -15,26 +15,13 @@ function toggleNext(ele) {
   parent.className = classes.join(' ');
 };
 
-function collapseAll() {
-  const targetClass = 'file active';
-  const renameValue = 'file';
+function expandAll(isActive) {
+  const renameValue = isActive ? 'file active' : 'file';
 
-  var files = document.getElementsByClassName(targetClass);
-  while (files.length) {
-    files[0].className = renameValue;
-  }
-}
-
-function expandAll() {
-  const targetClass = 'file';
-  const renameValue = 'file active';
-
-  var files = document.getElementsByClassName(targetClass);
-  for (var i = 0; i < files.length; i++) {
-    if (files[i].className === targetClass) {
-      files[i].className = renameValue;
-    }
-  }
+  const files = document.getElementsByClassName('file');
+  Array.from(files).forEach((file) => {
+    file.className = renameValue;
+  });
 }
 
 const repoCache = [];

--- a/frontend/src/static/js/v_authorship.js
+++ b/frontend/src/static/js/v_authorship.js
@@ -31,7 +31,7 @@ function expandAll() {
   
   var files = document.getElementsByClassName(targetClass);
   for (var i = 0; i < files.length; i++) {
-    if (files[i].className == targetClass) {
+    if (files[i].className === targetClass) {
       files[i].className = renameValue;
     }
   }

--- a/frontend/src/static/js/v_authorship.js
+++ b/frontend/src/static/js/v_authorship.js
@@ -18,7 +18,7 @@ function toggleNext(ele) {
 function collapseAll() {
   const targetClass = 'file active';
   const renameValue = 'file';
-  
+
   var files = document.getElementsByClassName(targetClass);
   while (files.length) {
     files[0].className = renameValue;
@@ -28,7 +28,7 @@ function collapseAll() {
 function expandAll() {
   const targetClass = 'file';
   const renameValue = 'file active';
-  
+
   var files = document.getElementsByClassName(targetClass);
   for (var i = 0; i < files.length; i++) {
     if (files[i].className === targetClass) {


### PR DESCRIPTION
Fix #36 

```
Files in code view are shown in open state by default.

With the addition of #282, it can be useful to show only the file
headers as it provides a rough impression of the author's focus area
of contribution and pattern.

Let's add controls to allow user to expand or collapse all the files in
code view at their will.
```