### PR TITLE
code view: differentiate untouched code more #311

### DIFF
--- a/frontend/src/static/css/style.scss
+++ b/frontend/src/static/css/style.scss
@@ -252,7 +252,11 @@ header{
 
             &.active{
                 pre{
-                    display:block;
+                    display:grid;
+                    .hljs{
+                        // overwrite hljs library
+                        display:inherit;
+                    }
                 }
             }
         }
@@ -271,14 +275,16 @@ header{
         .code{
             padding-left:1rem;
             border-left:0.25rem solid mui-color('green');
+            background-color:mui-color('green', '50');
         }
 
         .untouched{
-            $gray: mui-color('grey', '400');
+            $grey:mui-color('grey', '400');
 
             &.active{
                 .code{
-                    display:block;
+                    display:inherit;
+                    background-color:mui-color('white');
                 }
 
                 .closer{
@@ -295,7 +301,8 @@ header{
 
             .code{
                 display:none;
-                border-left:0.25rem solid $gray;
+                border-left:0.25rem solid $grey;
+                background-color:mui-color('white');
             }
 
             .closer{
@@ -303,7 +310,7 @@ header{
                 padding:0.5rem 1rem;
 
                 .icon{
-                    background-color:$gray;
+                    background-color:$grey;
                     color:mui-color('white');
 
                     width:2.2rem;


### PR DESCRIPTION
Fix #311 

```
Untouched code uses the same background and font color as written
code.

This allows the possibility of it being passed off as written code
(i.e., give the viewer an impression that the author changed more code
than she actually did) because the only way to differentiate the two
types of code is the color of the line in the gutter.

Let's differentiate the two code types more by adding a light green 
background to written code.
```