### PR TITLE
README: update url to UserGuide

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The features of the report includes:
 * Filtering and sorting of authors
 
 ## Documentations
-* [**User Guide**](docs/UserGuide.md)
+* [**User Guide**](https://github.com/reposense/RepoSense/blob/release/docs/UserGuide.md)
 * [**Developer Guide**](docs/DeveloperGuide.md)
 
 ## About Us


### PR DESCRIPTION
```
Documentation link in landing page points to the User Guide in
production.

This can result in users reading the User Guide that is ahead of
release, looking at features irrelevant to the jar they are using.

As users may not how to look for user guide pertaining to their
downloaded version, let's have the url in README to redirect user to
the latest released User Guide. 