### PR TITLE
Make branch an optional field #323

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -252,7 +252,7 @@ Repository's Location|Branch|File formats|Ignore Glob List|Ignore standalone con
 Column Name | Explanation
 ----------- | -----------
 Repository's Location | The `GitHub URL` or `Disk Path` to the git repository e.g., `https://github.com/foo/bar.git` or `C:\Users\user\Desktop\GitHub\foo\bar`
-Branch | The branch to analyze in the target repository e.g., `master`. Default: the default branch of the repo
+[Optional] Branch | The branch to analyze in the target repository e.g., `master`. Default: the default branch of the repo
 [Optional] File formats<sup>*</sup> | The file extensions to analyze. Default: `adoc;cs;css;fxml;gradle;html;java;js;json;jsp;md;py;tag;xml`
 [Optional] Ignore Glob List<sup>*</sup> | The list of file path globs to ignore during analysis for each author. e.g., `test/**;temp/**`
 [Optional] Ignore standalone config | To ignore the standalone config file (if any) in target repository, enter **`yes`**. If the cell is empty, the standalone config file in the repo (if any) will take precedence over configurations provided in the csv files.
@@ -267,7 +267,7 @@ Optionally, you can use a `author-config.csv` (which should be in the same direc
 Column Name | Explanation
 ----------- | -----------
 Repository's Location | Same as `repo-config.csv`
-Branch | The branch to analyze for this author
+[Optional] Branch | The branch to analyze for this author e.g., `master`. Default: the default branch of the repo
 Author's GitHub ID | GitHub username of the target author e.g., `JohnDoe`
 [Optional] Author's Display Name | The name to display for the author. Default: author's GitHub username.
 [Optional] Author's Git Author Name<sup>*</sup> | The meaning of _Git Author Name_ is explained in [_A Note About Git Author Name_](#a-note-about-git-author-name).

--- a/src/main/java/reposense/git/GitDownloader.java
+++ b/src/main/java/reposense/git/GitDownloader.java
@@ -33,6 +33,10 @@ public class GitDownloader {
         }
 
         try {
+            if (repoConfig.getBranch().equals(RepoConfiguration.DEFAULT_BRANCH)) {
+                String currentBranch = CommandRunner.getCurrentBranch(repoConfig.getRepoRoot());
+                repoConfig.setBranch(currentBranch);
+            }
             GitChecker.checkout(repoConfig.getRepoRoot(), repoConfig.getBranch());
         } catch (RuntimeException e) {
             logger.log(Level.SEVERE, "Branch does not exist! Analyze terminated.", e);

--- a/src/main/java/reposense/git/GitDownloader.java
+++ b/src/main/java/reposense/git/GitDownloader.java
@@ -21,7 +21,7 @@ public class GitDownloader {
         try {
             FileUtil.deleteDirectory(repoConfig.getRepoRoot());
             logger.info("Cloning " + repoConfig.getLocation() + "...");
-            CommandRunner.cloneRepo(repoConfig.getLocation(), repoConfig.getDisplayName());
+            CommandRunner.cloneRepo(repoConfig.getLocation(), repoConfig.getRepoName());
             logger.info("Cloning completed!");
         } catch (RuntimeException rte) {
             logger.log(Level.SEVERE, "Error encountered in Git Cloning, will attempt to continue analyzing", rte);

--- a/src/main/java/reposense/model/RepoConfiguration.java
+++ b/src/main/java/reposense/model/RepoConfiguration.java
@@ -26,6 +26,7 @@ import reposense.system.LogsManager;
 import reposense.util.FileUtil;
 
 public class RepoConfiguration {
+    public static final String DEFAULT_BRANCH = "HEAD";
     private static final Logger logger = LogsManager.getLogger(RepoConfiguration.class);
     private static final String MESSAGE_ILLEGAL_FORMATS = "The provided formats, %s, contains illegal characters.";
     private static final String FORMAT_VALIDATION_REGEX = "[A-Za-z0-9]+";
@@ -33,7 +34,6 @@ public class RepoConfiguration {
     private static final String GIT_LINK_SUFFIX = ".git";
     private static final Pattern GIT_REPOSITORY_LOCATION_PATTERN =
             Pattern.compile("^.*github.com\\/(?<org>.+?)\\/(?<repoName>.+?)\\.git$");
-    private static final String DEFAULT_BRANCH = "master";
     private static final String COMMIT_HASH_REGEX = "^[0-9a-f]+$";
     private static final String INVALID_COMMIT_HASH_MESSAGE =
             "The provided commit hash, %s, contains illegal characters.";

--- a/src/main/java/reposense/model/RepoConfiguration.java
+++ b/src/main/java/reposense/model/RepoConfiguration.java
@@ -162,7 +162,7 @@ public class RepoConfiguration {
     }
 
     public String getRepoRoot() {
-        String path = FileUtil.REPOS_ADDRESS + File.separator + displayName + File.separator;
+        String path = FileUtil.REPOS_ADDRESS + File.separator + repoName + File.separator;
 
         if (!repoName.isEmpty()) {
             path += repoName + File.separator;
@@ -219,7 +219,12 @@ public class RepoConfiguration {
     }
 
     public void setBranch(String branch) {
+        updateDisplayName(branch);
         this.branch = branch;
+    }
+
+    public void updateDisplayName(String branch) {
+        this.displayName = displayName.substring(0, displayName.lastIndexOf('_') + 1) + branch;
     }
 
     public boolean isAnnotationOverwrite() {

--- a/src/main/java/reposense/parser/AuthorConfigCsvParser.java
+++ b/src/main/java/reposense/parser/AuthorConfigCsvParser.java
@@ -32,7 +32,6 @@ public class AuthorConfigCsvParser extends CsvParser<RepoConfiguration> {
     protected int[] mandatoryPositions() {
         return new int[] {
             LOCATION_POSITION,
-            BRANCH_POSITION,
             GITHUB_ID_POSITION,
         };
     }

--- a/src/main/java/reposense/parser/AuthorConfigCsvParser.java
+++ b/src/main/java/reposense/parser/AuthorConfigCsvParser.java
@@ -45,7 +45,7 @@ public class AuthorConfigCsvParser extends CsvParser<RepoConfiguration> {
     protected void processLine(List<RepoConfiguration> results, String[] elements)
             throws ParseException {
         String location = getValueInElement(elements, LOCATION_POSITION);
-        String branch = getValueInElement(elements, BRANCH_POSITION);
+        String branch = getValueInElement(elements, BRANCH_POSITION, RepoConfiguration.DEFAULT_BRANCH);
         String gitHubId = getValueInElement(elements, GITHUB_ID_POSITION);
         String displayName = getValueInElement(elements, DISPLAY_NAME_POSITION);
         List<String> aliases = getManyValueInElement(elements, ALIAS_POSITION);

--- a/src/main/java/reposense/parser/CsvParser.java
+++ b/src/main/java/reposense/parser/CsvParser.java
@@ -99,6 +99,15 @@ public abstract class CsvParser<T> {
 
     /**
      * Gets the value of {@code position} in {@code elements}.
+     * Returns the value of {@code position} if it is in {@code element} and not empty.
+     * Otherwise returns the {@code defaultValue}.
+     */
+    protected String getValueInElement(final String[] elements, int position, String defaultValue) {
+        return (containsValueAtPosition(elements, position)) ? elements[position] : defaultValue;
+    }
+
+    /**
+     * Gets the value of {@code position} in {@code elements}.
      * Returns the value of {@code element} at {@code position} as a {@code List},
      * delimited by {@code COLUMN_VALUES_SEPARATOR} if it is in {@code element} and not empty.
      * Otherwise returns an empty {@code List}.

--- a/src/main/java/reposense/parser/RepoConfigCsvParser.java
+++ b/src/main/java/reposense/parser/RepoConfigCsvParser.java
@@ -31,7 +31,6 @@ public class RepoConfigCsvParser extends CsvParser<RepoConfiguration> {
     protected int[] mandatoryPositions() {
         return new int[] {
             LOCATION_POSITION,
-            BRANCH_POSITION
         };
     }
 

--- a/src/main/java/reposense/parser/RepoConfigCsvParser.java
+++ b/src/main/java/reposense/parser/RepoConfigCsvParser.java
@@ -42,7 +42,7 @@ public class RepoConfigCsvParser extends CsvParser<RepoConfiguration> {
     @Override
     protected void processLine(List<RepoConfiguration> results, String[] elements) throws InvalidLocationException {
         String location = getValueInElement(elements, LOCATION_POSITION);
-        String branch = getValueInElement(elements, BRANCH_POSITION);
+        String branch = getValueInElement(elements, BRANCH_POSITION, RepoConfiguration.DEFAULT_BRANCH);
         List<String> formats = getManyValueInElement(elements, FILE_FORMATS_POSITION);
         List<String> ignoreGlobList = getManyValueInElement(elements, IGNORE_GLOB_LIST_POSITION);
         String ignoreStandaloneConfig = getValueInElement(elements, IGNORE_STANDALONE_CONFIG_POSITION);

--- a/src/main/java/reposense/report/ReportGenerator.java
+++ b/src/main/java/reposense/report/ReportGenerator.java
@@ -48,12 +48,15 @@ public class ReportGenerator {
         FileUtil.copyTemplate(is, outputPath);
 
         for (RepoConfiguration config : configs) {
-            Path repoReportDirectory = Paths.get(outputPath, config.getDisplayName());
+            Path repoReportDirectory;
             try {
-                FileUtil.createDirectory(repoReportDirectory);
                 GitDownloader.downloadRepo(config);
+                repoReportDirectory = Paths.get(outputPath, config.getDisplayName());
+                FileUtil.createDirectory(repoReportDirectory);
             } catch (GitDownloaderException gde) {
                 logger.log(Level.WARNING, "Exception met while trying to clone the repo, will skip this one", gde);
+                repoReportDirectory = Paths.get(outputPath, config.getDisplayName());
+                FileUtil.createDirectory(repoReportDirectory);
                 generateEmptyRepoReport(repoReportDirectory.toString());
                 continue;
             } catch (IOException ioe) {

--- a/src/main/java/reposense/system/CommandRunner.java
+++ b/src/main/java/reposense/system/CommandRunner.java
@@ -105,6 +105,16 @@ public class CommandRunner {
         return runCommand(rootPath, revListCommand);
     }
 
+    /**
+     * Returns the current working branch.
+     */
+    public static String getCurrentBranch(String root) {
+        Path rootPath = Paths.get(root);
+        String gitBranchCommand = "git branch";
+
+        return StringsUtil.filterText(runCommand(rootPath, gitBranchCommand), "\\* (.*)").split("\\*")[1].trim();
+    }
+
     public static String getShortlogSummary(String root, Date sinceDate, Date untilDate) {
         Path rootPath = Paths.get(root);
         String command = "git log --pretty=short";

--- a/src/main/java/reposense/system/CommandRunner.java
+++ b/src/main/java/reposense/system/CommandRunner.java
@@ -124,8 +124,8 @@ public class CommandRunner {
         return runCommand(rootPath, command);
     }
 
-    public static String cloneRepo(String location, String displayName) throws IOException {
-        Path rootPath = Paths.get(FileUtil.REPOS_ADDRESS, displayName);
+    public static String cloneRepo(String location, String repoName) throws IOException {
+        Path rootPath = Paths.get(FileUtil.REPOS_ADDRESS, repoName);
         Files.createDirectories(rootPath);
         return runCommand(rootPath, "git clone " + addQuote(location));
     }

--- a/src/systemtest/resources/author-config.csv
+++ b/src/systemtest/resources/author-config.csv
@@ -1,9 +1,9 @@
 Repository's Location,Branch,Author's GitHub ID,Author's Display Name,Author's Git Author Name,Ignore Glob List
-https://github.com/reposense/testrepo-Beta.git,master,nbriannl,Nbr,,
-https://github.com/reposense/testrepo-Beta.git,master,zacharytang,Zac,Zachary Tang,src/main**
-https://github.com/reposense/testrepo-Beta.git,master,April0616,Fan,LAPTOP-7KFM2KSP\User;Fan Yuting,
-https://github.com/reposense/testrepo-Beta.git,master,CindyTsai1,Cin,YuHsuan,src/test**
-https://github.com/reposense/testrepo-Charlie.git,master,charlesgoh,Cha,Charles Goh,
-https://github.com/reposense/testrepo-Charlie.git,master,Esilocke,Esi,,
-https://github.com/reposense/testrepo-Charlie.git,master,jeffreygohkw,Jef,Jeffrey Goh,
-https://github.com/reposense/testrepo-Charlie.git,master,wangyiming1019,Wan,ACER\kyle;Wang Yiming,**.adoc
+https://github.com/reposense/testrepo-Beta.git,,nbriannl,Nbr,,
+https://github.com/reposense/testrepo-Beta.git,,zacharytang,Zac,Zachary Tang,src/main**
+https://github.com/reposense/testrepo-Beta.git,,April0616,Fan,LAPTOP-7KFM2KSP\User;Fan Yuting,
+https://github.com/reposense/testrepo-Beta.git,,CindyTsai1,Cin,YuHsuan,src/test**
+https://github.com/reposense/testrepo-Charlie.git,,charlesgoh,Cha,Charles Goh,
+https://github.com/reposense/testrepo-Charlie.git,,Esilocke,Esi,,
+https://github.com/reposense/testrepo-Charlie.git,,jeffreygohkw,Jef,Jeffrey Goh,
+https://github.com/reposense/testrepo-Charlie.git,,wangyiming1019,Wan,ACER\kyle;Wang Yiming,**.adoc

--- a/src/systemtest/resources/repo-config.csv
+++ b/src/systemtest/resources/repo-config.csv
@@ -1,6 +1,6 @@
 Repository's Location,Branch,File formats,Ignore Glob List,Ignore standalone config,Ignore Commits List
-https://github.com/reposense/testrepo-Alpha.git,master,,,,2fb6b9b2dd9fa40bf0f9815da2cb0ae8731436c7;c5a6dc774e22099cd9ddeb0faff1e75f9cf4f151;cd7f610e0becbdf331d5231887d8010a689f87c7;768015345e70f06add2a8b7d1f901dc07bf70582
-https://github.com/reposense/testrepo-Beta.git,master,fxml,docs**,yes,
-https://github.com/reposense/testrepo-Charlie.git,master,,,,9859b492760ca3a04432fcecc3ad64302a00689f;95aec8300a020c775d272d4f230d4ff5409793ef;b4b671e671ad3d917328322884c0e643b5b4d47d;80b2c05fcd8145df4301d6e57f89374c5e07cd28
-https://github.com/reposense/testrepo-Delta.git,master,,,,
+https://github.com/reposense/testrepo-Alpha.git,,,,,2fb6b9b2dd9fa40bf0f9815da2cb0ae8731436c7;c5a6dc774e22099cd9ddeb0faff1e75f9cf4f151;cd7f610e0becbdf331d5231887d8010a689f87c7;768015345e70f06add2a8b7d1f901dc07bf70582
+https://github.com/reposense/testrepo-Beta.git,,fxml,docs**,yes,
+https://github.com/reposense/testrepo-Charlie.git,,,,,9859b492760ca3a04432fcecc3ad64302a00689f;95aec8300a020c775d272d4f230d4ff5409793ef;b4b671e671ad3d917328322884c0e643b5b4d47d;80b2c05fcd8145df4301d6e57f89374c5e07cd28
+https://github.com/reposense/testrepo-Delta.git,,,,,
 https://github.com/reposense/testrepo-Delta.git,nonExistentBranch,,,,

--- a/src/test/java/reposense/git/GitCheckerTest.java
+++ b/src/test/java/reposense/git/GitCheckerTest.java
@@ -1,6 +1,5 @@
 package reposense.git;
 
-import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -10,24 +9,11 @@ import java.util.Date;
 import org.junit.Assert;
 import org.junit.Test;
 
-import reposense.model.RepoConfiguration;
-import reposense.parser.InvalidLocationException;
 import reposense.template.GitTestTemplate;
-import reposense.util.FileUtil;
 import reposense.util.TestUtil;
 
 
 public class GitCheckerTest extends GitTestTemplate {
-    @Test
-    public void checkout_fromDiskLocation_success() throws GitDownloaderException, IOException,
-            InvalidLocationException {
-        Path diskLocation = Paths.get(config.getRepoRoot()).toAbsolutePath();
-        RepoConfiguration diskConfig = new RepoConfiguration(diskLocation.toString(), "master");
-        GitDownloader.downloadRepo(diskConfig);
-        Path clonedDiskLocation = Paths.get(FileUtil.REPOS_ADDRESS, DISK_REPO_DISPLAY_NAME).toAbsolutePath();
-        TestUtil.compareDirectories(diskLocation, clonedDiskLocation);
-    }
-
     @Test
     public void checkoutBranchTest() {
         Path branchFile = Paths.get(config.getRepoRoot(), "inTestBranch.java");

--- a/src/test/java/reposense/parser/CsvParserTest.java
+++ b/src/test/java/reposense/parser/CsvParserTest.java
@@ -20,6 +20,8 @@ import reposense.model.RepoConfiguration;
 public class CsvParserTest {
     private static final Path TEST_CONFIG_FOLDER = new File(CsvParserTest.class.getClassLoader()
             .getResource("repoconfig_merge_test").getFile()).toPath();
+    private static final Path TEST_EMPTY_BRANCH_CONFIG_FOLDER = new File(CsvParserTest.class.getClassLoader()
+            .getResource("repoconfig_empty_branch_test").getFile()).toPath();
     private static final Path REPO_CONFIG_NO_SPECIAL_CHARACTER_FILE = new File(CsvParserTest.class.getClassLoader()
             .getResource("CsvParserTest/repoconfig_noSpecialCharacter_test.csv").getFile()).toPath();
     private static final Path AUTHOR_CONFIG_NO_SPECIAL_CHARACTER_FILE = new File(CsvParserTest.class.getClassLoader()
@@ -131,5 +133,24 @@ public class CsvParserTest {
         Assert.assertEquals(expectedConfig.getAuthorAliasMap().hashCode(),
                 actualConfigs.get(0).getAuthorAliasMap().hashCode());
         Assert.assertEquals(REPO_LEVEL_GLOB_LIST, actualConfigs.get(0).getIgnoreGlobList());
+    }
+
+    @Test
+    public void repoConfig_defaultBranch_success() throws ParseException, IOException {
+        RepoConfiguration expectedConfig = new RepoConfiguration(TEST_REPO_BETA_LOCATION,
+                RepoConfiguration.DEFAULT_BRANCH);
+
+        String input = String.format("-config %s", TEST_EMPTY_BRANCH_CONFIG_FOLDER);
+        CliArguments cliArguments = ArgsParser.parse(translateCommandline(input));
+
+        List<RepoConfiguration> actualConfigs =
+                new RepoConfigCsvParser(((ConfigCliArguments) cliArguments).getRepoConfigFilePath()).parse();
+        List<RepoConfiguration> authorConfigs =
+                new AuthorConfigCsvParser(((ConfigCliArguments) cliArguments).getAuthorConfigFilePath()).parse();
+        RepoConfiguration.merge(actualConfigs, authorConfigs);
+
+        Assert.assertEquals(1, actualConfigs.size());
+        Assert.assertEquals(expectedConfig.getBranch(), actualConfigs.get(0).getBranch());
+        Assert.assertEquals(expectedConfig.getBranch(), authorConfigs.get(0).getBranch());
     }
 }

--- a/src/test/java/reposense/system/CommandRunnerTest.java
+++ b/src/test/java/reposense/system/CommandRunnerTest.java
@@ -10,11 +10,19 @@ import java.util.Date;
 import org.junit.Assert;
 import org.junit.Test;
 
+import reposense.git.GitDownloader;
+import reposense.git.GitDownloaderException;
 import reposense.model.Author;
+import reposense.model.RepoConfiguration;
+import reposense.parser.ArgsParser;
+import reposense.parser.InvalidLocationException;
 import reposense.template.GitTestTemplate;
 import reposense.util.TestUtil;
 
 public class CommandRunnerTest extends GitTestTemplate {
+    protected static final String TEST_REPO_UNCOMMON_DEFAULT_GIT_LOCATION =
+            "https://github.com/reposense/testrepo-UncommonDefaultBranch.git";
+    protected static RepoConfiguration uncommonDefaultConfig;
 
     @Test
     public void cloneTest() {
@@ -214,5 +222,23 @@ public class CommandRunnerTest extends GitTestTemplate {
         String result = CommandRunner.getShortlogSummary(config.getRepoRoot(), sinceDate, untilDate);
 
         Assert.assertTrue(result.isEmpty());
+    }
+
+    @Test
+    public void getCurrentBranch_masterBranch_success() {
+        String currentBranch = CommandRunner.getCurrentBranch(config.getRepoRoot());
+        Assert.assertEquals("master", currentBranch);
+    }
+
+    @Test
+    public void getCurrentBranch_uncommonDefaultBranch_success() throws GitDownloaderException,
+            InvalidLocationException {
+        uncommonDefaultConfig = new RepoConfiguration(TEST_REPO_UNCOMMON_DEFAULT_GIT_LOCATION,
+                RepoConfiguration.DEFAULT_BRANCH);
+        uncommonDefaultConfig.setFormats(ArgsParser.DEFAULT_FORMATS);
+
+        GitDownloader.downloadRepo(uncommonDefaultConfig);
+        String currentBranch = CommandRunner.getCurrentBranch(uncommonDefaultConfig.getRepoRoot());
+        Assert.assertEquals("uncommon", currentBranch);
     }
 }

--- a/src/test/resources/cli_location_test/repo-config.csv
+++ b/src/test/resources/cli_location_test/repo-config.csv
@@ -1,4 +1,4 @@
 Repository's Location,Branch,File formats,Ignore Glob List,Ignore standalone config,Ignore Commits List
-https://github.com/reposense/testrepo-Beta.git,master,,,,
-https://github.com/reposense/testrepo-Charlie.git,master,,,,
-https://github.com/reposense/testrepo-Delta.git,master,,,,
+https://github.com/reposense/testrepo-Beta.git,,,,,
+https://github.com/reposense/testrepo-Charlie.git,,,,,
+https://github.com/reposense/testrepo-Delta.git,,,,,

--- a/src/test/resources/repoconfig_empty_branch_test/author-config.csv
+++ b/src/test/resources/repoconfig_empty_branch_test/author-config.csv
@@ -1,0 +1,2 @@
+Repository's Location,Branch,Author's GitHub ID,Author's Display Name,Author's Git Author Name,Ignore Glob List
+https://github.com/reposense/testrepo-Beta.git,,nbriannl,Nbr,,

--- a/src/test/resources/repoconfig_empty_branch_test/repo-config.csv
+++ b/src/test/resources/repoconfig_empty_branch_test/repo-config.csv
@@ -1,0 +1,2 @@
+Repository's Location,Branch,File formats,Ignore Glob List,Ignore standalone config,Ignore Commits List
+https://github.com/reposense/testrepo-Beta.git,,fxml,docs**,yes,


### PR DESCRIPTION
Fixes #323 

```
Make branch an optional field.

Checking out to master is a redundant step as it doesn't guarantee that 
we are analysing the current working branch.

Let's,
* Remove branch as a mandatory field when parsing a CSV file
* Set default branch as HEAD
* Retrieve name of current working branch
* Update system and unit tests
* Update User Guide
```


