### PR TITLE
-output param does not allow nonexistent folder #345

### DIFF
--- a/src/main/java/reposense/parser/OutputFolderArgumentType.java
+++ b/src/main/java/reposense/parser/OutputFolderArgumentType.java
@@ -13,7 +13,9 @@ public class OutputFolderArgumentType implements ArgumentType<Path> {
     @Override
     public Path convert(ArgumentParser parser, Argument arg, String value) throws ArgumentParserException {
         // Piggyback on library methods to do file existence checks
-        Arguments.fileType().verifyExists().verifyIsDirectory().verifyCanWrite().convert(parser, arg, value);
+        Arguments.fileType().verifyExists().verifyIsDirectory().verifyCanWrite()
+                .or()
+                .verifyNotExists().convert(parser, arg, value);
         return Paths.get(value).resolve(ArgsParser.DEFAULT_REPORT_NAME);
     }
 }

--- a/src/test/java/reposense/parser/ArgsParserTest.java
+++ b/src/test/java/reposense/parser/ArgsParserTest.java
@@ -267,18 +267,16 @@ public class ArgsParserTest {
         ArgsParser.parse(translateCommandline(input));
     }
 
-    @Test(expected = ParseException.class)
-    public void file_forOutputDirectory_throwsParseException() throws ParseException {
-        String file = PROJECT_DIRECTORY.resolve("parser_test.csv").toString();
-        String input = DEFAULT_MANDATORY_ARGS + String.format("-output %s", file);
-        ArgsParser.parse(translateCommandline(input));
-    }
-
-    @Test(expected = ParseException.class)
-    public void nonExistentDirectory_forOutputDirectory_throwsParseException() throws ParseException {
+    @Test
+    public void outputPath_nonExistentDirectory_success() throws ParseException, IOException {
         String nonExistentDirectory = PROJECT_DIRECTORY.resolve("some_non_existent_dir/").toString();
+        Path expectedRelativeOutputDirectoryPath = Paths.get(nonExistentDirectory)
+                .resolve(ArgsParser.DEFAULT_REPORT_NAME);
         String input = DEFAULT_MANDATORY_ARGS + String.format("-output %s", nonExistentDirectory);
-        ArgsParser.parse(translateCommandline(input));
+        CliArguments cliArguments = ArgsParser.parse(translateCommandline(input));
+        Assert.assertTrue(cliArguments instanceof ConfigCliArguments);
+        Assert.assertTrue(Files.isSameFile(
+                expectedRelativeOutputDirectoryPath, cliArguments.getOutputFilePath()));
     }
 
     @Test(expected = ParseException.class)


### PR DESCRIPTION
Fixes #345

```
If the output path specified by the user does not exist, the program
exits with a 'folder not found' error message.

Let's automatically create the output folder for such cases
as it is more convenient to the user and is the norm in most software.
```