### PR TITLE
If author info is not specified, show only those who contributed during analysis period #341

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -275,7 +275,7 @@ Author's GitHub ID | GitHub username of the target author e.g., `JohnDoe`
 
 <sup>* **Multi-value column**: multiple values can be entered in this column using a semicolon `;` as the separator.</sup>
 
-If `author-config.csv` is not given and the repo has not provide author details in a standalone config file, all the authors of the repositories will be analyzed.
+If `author-config.csv` is not given and the repo has not provide author details in a standalone config file, all the authors of the repositories within the date range specified (if any) will be analyzed.
 
 <hr>
 

--- a/src/main/java/reposense/git/GitShortlog.java
+++ b/src/main/java/reposense/git/GitShortlog.java
@@ -1,8 +1,8 @@
 package reposense.git;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
 import java.util.stream.Collectors;
 
 import reposense.model.Author;
@@ -15,14 +15,19 @@ import reposense.system.CommandRunner;
 public class GitShortlog {
 
     /**
-     * Extracts all the author identities from the repository given in {@code config}.
+     * Extracts all the author identities from the repository and date range given in {@code config}.
      */
     public static List<Author> extractAuthorsFromLog(RepoConfiguration config) {
-        String summary = CommandRunner.getShortlogSummary(config);
+        String summary = CommandRunner.getShortlogSummary(
+                config.getRepoRoot(), config.getSinceDate(), config.getUntilDate());
+
+        if (summary.isEmpty()) {
+            return Collections.emptyList();
+        }
+
         String[] lines = summary.split("\n");
         return Arrays.stream(lines)
                 .map(line -> new Author(line.split("\t")[1]))
-                .filter(Objects::nonNull)
                 .collect(Collectors.toList());
     }
 }

--- a/src/main/java/reposense/system/CommandRunner.java
+++ b/src/main/java/reposense/system/CommandRunner.java
@@ -111,7 +111,6 @@ public class CommandRunner {
         command += convertToGitDateRangeArgs(sinceDate, untilDate);
         command += " | git shortlog --summary";
 
-        System.out.println(command);
         return runCommand(rootPath, command);
     }
 

--- a/src/main/java/reposense/system/CommandRunner.java
+++ b/src/main/java/reposense/system/CommandRunner.java
@@ -105,10 +105,13 @@ public class CommandRunner {
         return runCommand(rootPath, revListCommand);
     }
 
-    public static String getShortlogSummary(RepoConfiguration config) {
-        Path rootPath = Paths.get(config.getRepoRoot());
-        String command = "git log --pretty=short | git shortlog --summary";
+    public static String getShortlogSummary(String root, Date sinceDate, Date untilDate) {
+        Path rootPath = Paths.get(root);
+        String command = "git log --pretty=short";
+        command += convertToGitDateRangeArgs(sinceDate, untilDate);
+        command += " | git shortlog --summary";
 
+        System.out.println(command);
         return runCommand(rootPath, command);
     }
 

--- a/src/systemtest/resources/dateRange/expected/reposense_testrepo-Alpha_master/commits.json
+++ b/src/systemtest/resources/dateRange/expected/reposense_testrepo-Alpha_master/commits.json
@@ -1,27 +1,7 @@
 {
-  "authorWeeklyIntervalContributions": {
-    "fakeAuthor": [],
-    "harryggg": [],
-    "eugenepeh": []
-  },
-  "authorDailyIntervalContributions": {
-    "fakeAuthor": [],
-    "harryggg": [],
-    "eugenepeh": []
-  },
-  "authorFinalContributionMap": {
-    "fakeAuthor": 0,
-    "harryggg": 0,
-    "eugenepeh": 0
-  },
-  "authorContributionVariance": {
-    "fakeAuthor": 0.0,
-    "harryggg": 0.0,
-    "eugenepeh": 0.0
-  },
-  "authorDisplayNameMap": {
-    "fakeAuthor": "fakeAuthor",
-    "harryggg": "harryggg",
-    "eugenepeh": "eugenepeh"
-  }
+  "authorWeeklyIntervalContributions": {},
+  "authorDailyIntervalContributions": {},
+  "authorFinalContributionMap": {},
+  "authorContributionVariance": {},
+  "authorDisplayNameMap": {}
 }

--- a/src/test/java/reposense/git/GitShortlogTest.java
+++ b/src/test/java/reposense/git/GitShortlogTest.java
@@ -3,27 +3,42 @@ package reposense.git;
 import static reposense.git.GitShortlog.extractAuthorsFromLog;
 
 import java.util.ArrayList;
+import java.util.Calendar;
 import java.util.List;
 
 import org.junit.Assert;
 import org.junit.Test;
 
 import reposense.model.Author;
-import reposense.parser.InvalidLocationException;
 import reposense.template.GitTestTemplate;
+import reposense.util.TestUtil;
 
 public class GitShortlogTest extends GitTestTemplate {
 
     @Test
-    public void extractAuthorsFromLog_validRepo_success() throws InvalidLocationException {
-        List<Author> expectedAuthorList = new ArrayList<Author>();
+    public void extractAuthorsFromLog_validRepoNoDateRange_success() {
+        List<Author> expectedAuthorList = new ArrayList<>();
         expectedAuthorList.add(new Author("eugenepeh"));
         expectedAuthorList.add(new Author("fakeAuthor"));
         expectedAuthorList.add(new Author("harryggg"));
 
         List<Author> actualAuthorList = extractAuthorsFromLog(config);
 
-        Assert.assertEquals(3, actualAuthorList.size());
+        Assert.assertEquals(expectedAuthorList.size(), actualAuthorList.size());
+        Assert.assertEquals(expectedAuthorList, actualAuthorList);
+    }
+
+    @Test
+    public void extractAuthorsFromLog_validRepoDateRange_success() {
+        List<Author> expectedAuthorList = new ArrayList<>();
+
+        expectedAuthorList.add(new Author("eugenepeh"));
+        config.setSinceDate(TestUtil.getDate(2018, Calendar.MAY, 5));
+        config.setUntilDate(TestUtil.getDate(2018, Calendar.MAY, 10));
+
+        List<Author> actualAuthorList = extractAuthorsFromLog(config);
+
+        Assert.assertEquals(expectedAuthorList.size(), actualAuthorList.size());
         Assert.assertEquals(expectedAuthorList, actualAuthorList);
     }
 }

--- a/src/test/java/reposense/git/GitShortlogTest.java
+++ b/src/test/java/reposense/git/GitShortlogTest.java
@@ -41,4 +41,14 @@ public class GitShortlogTest extends GitTestTemplate {
         Assert.assertEquals(expectedAuthorList.size(), actualAuthorList.size());
         Assert.assertEquals(expectedAuthorList, actualAuthorList);
     }
+
+    @Test
+    public void extractAuthorsFromLog_validRepoDateOutOfRange_success() {
+        config.setSinceDate(TestUtil.getDate(2018, Calendar.JUNE, 1));
+        config.setUntilDate(TestUtil.getDate(2018, Calendar.JUNE, 20));
+
+        List<Author> actualAuthorList = extractAuthorsFromLog(config);
+
+        Assert.assertTrue(actualAuthorList.isEmpty());
+    }
 }

--- a/src/test/java/reposense/system/CommandRunnerTest.java
+++ b/src/test/java/reposense/system/CommandRunnerTest.java
@@ -177,4 +177,34 @@ public class CommandRunnerTest extends GitTestTemplate {
         Date date = TestUtil.getDate(2018, Calendar.FEBRUARY, 9);
         CommandRunner.getCommitHashBeforeDate(config.getRepoRoot(), "invalidBranch", date);
     }
+
+    @Test
+    public void getShortlogSummary_noDateRange_success() {
+        String result = CommandRunner.getShortlogSummary(config.getRepoRoot(), null, null);
+
+        Assert.assertTrue(result.contains(EUGENE_AUTHOR_NAME));
+        Assert.assertTrue(result.contains(FAKE_AUTHOR_NAME));
+        Assert.assertTrue(result.contains(MAIN_AUTHOR_NAME));
+    }
+
+
+    @Test
+    public void getShortlogSummary_dateRange_success() {
+        Date sinceDate = TestUtil.getDate(2018, Calendar.MAY, 5);
+        Date untilDate = TestUtil.getDate(2018, Calendar.MAY, 10);
+
+        String result = CommandRunner.getShortlogSummary(config.getRepoRoot(), sinceDate, untilDate);
+
+        Assert.assertTrue(result.contains(EUGENE_AUTHOR_NAME));
+    }
+
+    @Test
+    public void getShortlogSummary_dateOutOfRange_emptyResult() {
+        Date sinceDate = TestUtil.getDate(2018, Calendar.JUNE, 1);
+        Date untilDate = TestUtil.getDate(2018, Calendar.JUNE, 10);
+
+        String result = CommandRunner.getShortlogSummary(config.getRepoRoot(), sinceDate, untilDate);
+
+        Assert.assertTrue(result.isEmpty());
+    }
 }


### PR DESCRIPTION
Fixes #341 
```
When no author details is specified for a repo to analyze, all authors who
have contributed to the repo will be analyzed by default, even if a date
range is specified where some of the authors did not contribute in.

As users are only interested in the analysis within that date range if they
specify one, having all the other authors who did not contribute in that
date range also listed out will lead to unnecessary usage of time generating
the report, and fill the dashboard with unnecessary information as those authors
will have zero contribution, increasing its memory usage.

Let's update the analysis to only consider the authors within date range
if no author details is specified.
```