### PR TITLE
 granularity#week: fix url not using correct time gap #354

### DIFF
--- a/frontend/src/static/js/v_summary.js
+++ b/frontend/src/static/js/v_summary.js
@@ -34,6 +34,11 @@ function dateRounding(datestr, roundDown) {
   return getDateStr(datems);
 }
 
+function addDays(dateStr, numDays) {
+  const date = new Date(dateStr);
+  return getDateStr(date.getTime() + numDays * DAY_IN_MS);
+}
+
 window.vSummary = {
   props: ['repos'],
   template: window.$('v_summary').innerHTML,
@@ -122,6 +127,7 @@ window.vSummary = {
     },
     getSliceLink(user, slice) {
       const { REPOS } = window;
+      const untilDate = this.filterTimeFrame === 'week' ? addDays(slice.sinceDate, 6): slice.sinceDate;
 
       return `http://github.com/${
         REPOS[user.repoId].organization}/${
@@ -129,7 +135,7 @@ window.vSummary = {
         REPOS[user.repoId].branch}?`
                 + `author=${user.name}&`
                 + `since=${slice.sinceDate}'T'00:00:00+08:00&`
-                + `until=${slice.sinceDate}'T'23:59:59+08:00`;
+                + `until=${untilDate}'T'23:59:59+08:00`;
     },
     getContributionBars(totalContribution) {
       const res = [];


### PR DESCRIPTION
Fix #354 

```
When the granularity is set to week in report, the url link is still
using a single day time gap.

This should be updated accordingly to show users the commits that were
done in the week.

Let's update the url function to do a conditional check prior to the
generation of hyper link.
```