### PR TITLE
FileInfoExtractor: explore cleaner alternative to extract code change #357

### DIFF
--- a/src/main/java/reposense/authorship/FileInfoExtractor.java
+++ b/src/main/java/reposense/authorship/FileInfoExtractor.java
@@ -36,13 +36,14 @@ public class FileInfoExtractor {
     private static final String LINE_INSERTED_SYMBOL = "+";
     private static final String STARTING_LINE_NUMBER_GROUP_NAME = "startingLineNumber";
     private static final String FILE_CHANGED_GROUP_NAME = "filePath";
+    private static final String FILE_DELETE_SYMBOL = "/dev/null";
     private static final String MATCH_GROUP_FAIL_MESSAGE_FORMAT = "Failed to match the %s group for:\n%s";
 
     private static final int LINE_CHANGED_HEADER_INDEX = 0;
 
     private static final Pattern STARTING_LINE_NUMBER_PATTERN = Pattern.compile(
             "-(\\d)+(,)?(\\d)* \\+(?<startingLineNumber>\\d+)(,)?(\\d)* @@");
-    private static final Pattern FILE_CHANGED_PATTERN = Pattern.compile("\n(\\+){3} (b/)?(?<filePath>.*)\n");
+    private static final Pattern FILE_CHANGED_PATTERN = Pattern.compile("\n(\\+){3} b?/(?<filePath>.*)\n");
 
     /**
      * Extracts a list of relevant files given in {@code config}.
@@ -95,7 +96,7 @@ public class FileInfoExtractor {
 
             String filePath = getFilePathFromDiffPattern(fileDiffResult);
 
-            if (filePath.equals("/dev/null")) {
+            if (filePath.equals(FILE_DELETE_SYMBOL)) {
                 continue;
             }
 


### PR DESCRIPTION
Fixes #357 
```
FileInfoExtractor#getEditedFileInfos(...) first checks for each file
whether they in a blacklist of 'uncommon' file changes which does not
follow the line patterns that we check for, and skips those files as they
are all unchanged files that does not have any difference to check for.

As there are many of such 'uncommon' file changes, some of these changes
may not have been added in our blacklist yet, which may cause the program
to crash unexpectedly, e.g #215 #300 #356.

Instead of trying to find out each of this 'uncommon' file changes and
blacklisting each 1 of them, it is easier and cleaner to whitelist only
those files that have valid diff file changes which follow the line patterns
we are checking for.

Let's change the blacklist for valid diff files to be a whitelist instead,
and check for the exception if this file is deleted.
```