### PR TITLE
Make the commits info analysis case insensitive #363

### DIFF
--- a/src/main/java/reposense/system/CommandRunner.java
+++ b/src/main/java/reposense/system/CommandRunner.java
@@ -28,7 +28,7 @@ public class CommandRunner {
     public static String gitLog(RepoConfiguration config, Author author) {
         Path rootPath = Paths.get(config.getRepoRoot());
 
-        String command = "git log --no-merges ";
+        String command = "git log --no-merges -i ";
         command += convertToGitDateRangeArgs(config.getSinceDate(), config.getUntilDate());
         command += " --pretty=format:\"%H|%aN|%ad|%s\" --date=iso --shortstat";
         command += convertToFilterAuthorArgs(author);

--- a/src/test/java/reposense/system/CommandRunnerTest.java
+++ b/src/test/java/reposense/system/CommandRunnerTest.java
@@ -58,6 +58,14 @@ public class CommandRunnerTest extends GitTestTemplate {
     }
 
     @Test
+    public void gitLog_authorNameIncorrectCase_success() {
+        Author fakeAuthorName = new Author(FAKE_AUTHOR_NAME.toUpperCase());
+
+        String content = CommandRunner.gitLog(config, fakeAuthorName);
+        Assert.assertTrue(TestUtil.compareNumberExpectedCommitsToGitLogLines(4, content));
+    }
+
+    @Test
     public void gitLog_fakeAuthorNameWithSpecialCharacter_success() {
         Author fakeAuthorWithSpecialCharacter = new Author(FAKE_AUTHOR_NAME.replace("fake", "#()!"));
 


### PR DESCRIPTION
Fix #363 

```
CommitInfoExtractor uses git log to extract users' commits info.
However, by default, the author matching pattern used in git log is
case sensitive.

This can cause the CommitInfoAnalyzer to miss out some or all their
commits in the analysis. As a result, some authors do not have any
ramps shown in their ramp chart, even though their code view shows line
contributions.

To resolve this problem, let's set the git log regex patterns to be
case insensitive.
```