### PR TITLE
Show analysis period in contribution bar tooltip #362

### DIFF
--- a/frontend/src/index.jade
+++ b/frontend/src/index.jade
@@ -109,7 +109,10 @@ html
                     right: (((user.commits.length-j-1)/user.commits.length) * 100) + '%'\
                   }"
                 )
-              .summary-chart__contrib(v-bind:title="'total contribution: '+user.totalCommits")
+              .summary-chart__contrib(
+                v-bind:title=
+                    "'Total contribution from ' + minDate + ' to ' + maxDate + ': ' + user.totalCommits + ' lines'"
+               )
                 .summary-chart__contrib--bar(
                   v-for="width in getContributionBars(user.totalCommits)",
                   v-bind:style="{ width: width+'%' }"


### PR DESCRIPTION
Fixes #362 
```
Tooltip shows only total contribution.

Let's include the analysis period for the total contribution in the
tooltip to make it more user-friendly.
```