### PR TITLE
InvalidPathException thrown during run time due to Illegal char <:> in file name #370

### DIFF
--- a/src/main/java/reposense/authorship/FileInfoExtractor.java
+++ b/src/main/java/reposense/authorship/FileInfoExtractor.java
@@ -106,17 +106,13 @@ public class FileInfoExtractor {
             }
 
             if (isFormatInsideWhiteList(filePath, config.getFormats())) {
-                FileInfo currentFileInfo;
-
                 try {
-                    currentFileInfo = generateFileInfo(config.getRepoRoot(), filePath);
+                    FileInfo currentFileInfo = generateFileInfo(config.getRepoRoot(), filePath);
+                    setLinesToTrack(currentFileInfo, fileDiffResult);
+                    fileInfos.add(currentFileInfo);
                 } catch (InvalidPathException ipe) {
                     logger.warning(String.format(INVALID_FILE_PATH_MESSAGE_FORMAT, filePath));
-                    continue;
                 }
-
-                setLinesToTrack(currentFileInfo, fileDiffResult);
-                fileInfos.add(currentFileInfo);
             }
         }
 

--- a/src/main/java/reposense/authorship/FileInfoExtractor.java
+++ b/src/main/java/reposense/authorship/FileInfoExtractor.java
@@ -38,8 +38,7 @@ public class FileInfoExtractor {
     private static final String FILE_CHANGED_GROUP_NAME = "filePath";
     private static final String FILE_DELETED_SYMBOL = "/dev/null";
     private static final String MATCH_GROUP_FAIL_MESSAGE_FORMAT = "Failed to match the %s group for:\n%s";
-    private static final String INVALID_FILE_PATH_MESSAGE_FORMAT =
-            "Invalid file path %s provided, skipping this file.";
+    private static final String INVALID_FILE_PATH_MESSAGE_FORMAT = "Invalid file path %s provided, skipping this file.";
 
     private static final int LINE_CHANGED_HEADER_INDEX = 0;
 

--- a/src/main/java/reposense/authorship/FileInfoExtractor.java
+++ b/src/main/java/reposense/authorship/FileInfoExtractor.java
@@ -4,6 +4,7 @@ import java.io.BufferedReader;
 import java.io.FileReader;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
@@ -37,6 +38,8 @@ public class FileInfoExtractor {
     private static final String FILE_CHANGED_GROUP_NAME = "filePath";
     private static final String FILE_DELETED_SYMBOL = "/dev/null";
     private static final String MATCH_GROUP_FAIL_MESSAGE_FORMAT = "Failed to match the %s group for:\n%s";
+    private static final String INVALID_FILE_PATH_MESSAGE_FORMAT =
+            "Invalid file path %s provided, skipping this file.";
 
     private static final int LINE_CHANGED_HEADER_INDEX = 0;
 
@@ -104,7 +107,15 @@ public class FileInfoExtractor {
             }
 
             if (isFormatInsideWhiteList(filePath, config.getFormats())) {
-                FileInfo currentFileInfo = generateFileInfo(config.getRepoRoot(), filePath);
+                FileInfo currentFileInfo;
+
+                try {
+                    currentFileInfo = generateFileInfo(config.getRepoRoot(), filePath);
+                } catch (InvalidPathException ipe) {
+                    logger.warning(String.format(INVALID_FILE_PATH_MESSAGE_FORMAT, filePath));
+                    continue;
+                }
+
                 setLinesToTrack(currentFileInfo, fileDiffResult);
                 fileInfos.add(currentFileInfo);
             }
@@ -162,7 +173,11 @@ public class FileInfoExtractor {
                 }
 
                 if (isFormatInsideWhiteList(relativePath, config.getFormats())) {
-                    fileInfos.add(generateFileInfo(config.getRepoRoot(), relativePath));
+                    try {
+                        fileInfos.add(generateFileInfo(config.getRepoRoot(), relativePath));
+                    } catch (InvalidPathException ipe) {
+                        logger.warning(String.format(INVALID_FILE_PATH_MESSAGE_FORMAT, filePath));
+                    }
                 }
             }
         } catch (IOException ioe) {

--- a/src/test/java/reposense/authorship/FileInfoExtractorTest.java
+++ b/src/test/java/reposense/authorship/FileInfoExtractorTest.java
@@ -145,6 +145,4 @@ public class FileInfoExtractorTest extends GitTestTemplate {
     private boolean isFileExistence(Path filePath, List<FileInfo> files) {
         return files.stream().anyMatch(file -> Paths.get(file.getPath()).equals(filePath));
     }
-
-
 }

--- a/src/test/java/reposense/authorship/FileInfoExtractorTest.java
+++ b/src/test/java/reposense/authorship/FileInfoExtractorTest.java
@@ -7,6 +7,7 @@ import java.util.Date;
 import java.util.List;
 
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.Test;
 
 import reposense.authorship.model.FileInfo;
@@ -21,9 +22,10 @@ public class FileInfoExtractorTest extends GitTestTemplate {
     private static final Path FILE_WITH_SPECIAL_CHARACTER = TEST_DATA_FOLDER.resolve("fileWithSpecialCharacters.txt");
     private static final Path FILE_WITHOUT_SPECIAL_CHARACTER = TEST_DATA_FOLDER
             .resolve("fileWithoutSpecialCharacters.txt");
+    private static final String FILE_NAME_WITH_ILLEGAL_WINDOW_CHARACTER = "windows:Illegal?Characters!File(Name).txt";
+
     private static final String EDITED_FILE_INFO_BRANCH = "getEditedFileInfos-test";
     private static final String FEBRUARY_EIGHT_COMMIT_HASH = "768015345e70f06add2a8b7d1f901dc07bf70582";
-
 
     @Test
     public void extractFileInfosTest() {
@@ -114,7 +116,17 @@ public class FileInfoExtractorTest extends GitTestTemplate {
         Assert.assertEquals(5, fileInfo.getLines().size());
     }
 
+    @Test
+    public void generateFileInfoOnNonWindows_fileNameWithIllegalCharactersForWindows_correctFileInfoGenerated() {
+        Assume.assumeFalse(TestUtil.isWindows());
+        Path testPath = TEST_DATA_FOLDER.resolve(FILE_NAME_WITH_ILLEGAL_WINDOW_CHARACTER);
+        FileInfo fileInfo = FileInfoExtractor.generateFileInfo(".", testPath.toString());
+        Assert.assertEquals(4, fileInfo.getLines().size());
+    }
+
     private boolean isFileExistence(Path filePath, List<FileInfo> files) {
         return files.stream().anyMatch(file -> Paths.get(file.getPath()).equals(filePath));
     }
+
+
 }

--- a/src/test/java/reposense/util/TestUtil.java
+++ b/src/test/java/reposense/util/TestUtil.java
@@ -148,4 +148,12 @@ public class TestUtil {
         // each commit has 2 lines of info, and a blank line in between each
         return expectedNumberCommits * 3 - 1 == gitLogResult.split("\n").length;
     }
+
+    /**
+     * Returns true if the test environment is on Windows OS.
+     */
+    public static boolean isWindows() {
+        return System.getProperty("os.name").toLowerCase().contains("win");
+    }
+
 }

--- a/src/test/resources/FileInfoExtractorTest/windows:Illegal?Characters!File(Name).txt
+++ b/src/test/resources/FileInfoExtractorTest/windows:Illegal?Characters!File(Name).txt
@@ -1,0 +1,4 @@
+windows
+illegal
+characters
+filename

--- a/src/test/resources/FileInfoExtractorTest/windows:Illegal?Characters!File(Name).txt
+++ b/src/test/resources/FileInfoExtractorTest/windows:Illegal?Characters!File(Name).txt
@@ -1,4 +1,0 @@
-windows
-illegal
-characters
-filename


### PR DESCRIPTION
Fixes #370 
```
Windows disallows certain characters for the file names, such as `/\:*?"<>|`,
while other OSes like Linux allows almost any characters for their file names.
This may result in some files with such `banned` characters in the repository
to not be copied/cloned into a local copy for Windows OS.

As we use the `git diff` command to find file differences for analyzing
repositories with a date range, such files with `banned` characters may appear
in the `git diff` result, which result in an InvalidPathException being thrown
when we try to create a Path to this file name, which is invalid in Windows.
This causes the program to crash as the exception is not handled anywhere.

Let's update FileInfoExtractor to handle files with invalid file names by
skipping those files.
```