### PR TITLE
Code panel: make the expand/collapse button a toggle button #376

### DIFF
--- a/frontend/src/index.jade
+++ b/frontend/src/index.jade
@@ -32,10 +32,9 @@ html
           .tab-content
             .tab-panes
               #tab-authorship.tab-pane(v-if="isTabAuthorship")
-                .toolbar
-                  a(onclick="expandAll(true)") Expand all
-                  span &nbsp;/&nbsp;
-                  a(onclick="expandAll(false)") Collapse all
+                .toolbar(v-if="tabInfo.tabAuthorship.totalCommits > 0")
+                    a(v-if="isCollapsed", v-on:click="expand(true)") Expand all
+                    a(v-else, v-on:click="expand(false)") Collapse all
                 v_authorship(
                   v-bind:key="generateKey(tabInfo.tabAuthorship)",
                   v-bind:info="tabInfo.tabAuthorship")
@@ -90,8 +89,9 @@ html
             .summary-chart(v-for="(user, i) in repo")
               .summary-chart__title(
                 title="click to view author's code",
-                v-on:click="$emit('view-authorship', "
-                    + "{author:user.name, repo:user.repoName, name:user.displayName, minDate:minDate, maxDate:maxDate})"
+                v-on:click="$emit('view-authorship', \
+                    {author:user.name, repo:user.repoName, name:user.displayName, \
+                        minDate:minDate, maxDate:maxDate, totalCommits:user.totalCommits})"
               )
                 .summary-chart__title--index {{ i+1 }}
                 .summary-chart__title--repo(v-if="!filterGroupRepos") {{ user.repoPath }}

--- a/frontend/src/static/js/main.js
+++ b/frontend/src/static/js/main.js
@@ -23,6 +23,7 @@ window.app = new window.Vue({
     loadedRepo: 0,
     userUpdated: false,
 
+    isCollapsed: false,
     isTabActive: false,
     isTabAuthorship: false,
     tabInfo: {},
@@ -82,6 +83,13 @@ window.app = new window.Vue({
 
       this.isTabActive = true;
       this.isTabAuthorship = true;
+      this.isCollapsed = false;
+    },
+
+    /*global expandAll*/
+    expand(isActive) {
+      this.isCollapsed = !isActive;
+      expandAll(isActive);
     },
 
     generateKey(dataObj) {


### PR DESCRIPTION
Fixes #376 

```
Code panel shows both Expand and Collapse buttons.

This is not consistent with how expand/collapse buttons normally work.

Let's make it a single link and only display the Expand or Collapse
button, whichever one is relevant.
```