### PR TITLE
Show breakdown of file type for total contribution in code panel #385

### DIFF
--- a/frontend/src/index.jade
+++ b/frontend/src/index.jade
@@ -124,7 +124,13 @@ html
         .title
           .repoName {{ info.repo }}
           .author {{ info.name }} ({{ info.author }}) contribution from {{ info.minDate }} to {{ info.maxDate }}
-          .contribution(v-if="isLoaded") Total contribution: {{ totalLineCount }} lines
+          .contribution(v-if="isLoaded")
+            span Total LoC contributed:&nbsp;
+            span.loc {{ totalLineCount }}
+            br
+            span.fileType(v-if="totalLineCount > 0") &rarr; &nbsp;
+                template(v-for="type in Object.keys(filesLinesObj)")
+                    span {{ type }}: {{ filesLinesObj[type] }}
 
         .files(v-if="isLoaded")
           .empty(v-if="files.length===0") nothing to see here :(

--- a/frontend/src/static/css/style.scss
+++ b/frontend/src/static/css/style.scss
@@ -237,7 +237,20 @@ header{
             margin-top:0.1rem;
             font-size:1.0rem;
             color:mui-color("red");
-            font-weight:bold;
+
+            .loc {
+              font-weight:bolder;
+            }
+
+            span.fileType {
+                span::after {
+                  content: ', ';
+                }
+
+                span:last-child::after {
+                  content:'';
+                }
+            }
         }
     }
 

--- a/frontend/src/static/js/v_authorship.js
+++ b/frontend/src/static/js/v_authorship.js
@@ -32,6 +32,7 @@ window.vAuthorship = {
     return {
       isLoaded: false,
       files: [],
+      filesLinesObj: {},
       totalLineCount: "",
     };
   },
@@ -84,6 +85,7 @@ window.vAuthorship = {
 
     processFiles(files) {
       const res = [];
+      let filesInfoObj = {};
       let totalLineCount = 0;
 
       files.forEach((file) => {
@@ -93,6 +95,7 @@ window.vAuthorship = {
           const out = {};
           out.path = file.path;
           out.lineCount = lineCnt;
+          this.addLineCountToFileType(file.path, lineCnt, filesInfoObj);
 
           const segments = this.splitSegments(file.lines);
           out.segments = segments;
@@ -103,8 +106,28 @@ window.vAuthorship = {
       this.totalLineCount = totalLineCount;
       res.sort((a, b) => b.lineCount - a.lineCount);
 
+      this.filesLinesObj = this.sortFileTypeAlphabetically(filesInfoObj);
       this.files = res;
       this.isLoaded = true;
+    },
+
+    addLineCountToFileType(path, lineCount, filesInfoObj) {
+      var fileType = path.split(".").pop();
+      fileType = (fileType.length === 0) ? "others" : fileType;
+
+      if (!filesInfoObj[fileType]) {
+        filesInfoObj[fileType] = 0;
+      }
+
+      filesInfoObj[fileType] += lineCount;
+    },
+
+    sortFileTypeAlphabetically(unsortedFilesInfoObj) {
+      return Object.keys(unsortedFilesInfoObj)
+          .sort()
+          .reduce((acc, key) => ({
+              ...acc, [key]: unsortedFilesInfoObj[key]
+          }), {});
     },
   },
 


### PR DESCRIPTION
Fixes #385 
```
With the addition of #372 and #388 , code view now shows the total LoCs
contribution and analysis period.

However, this does not provide any information on the LoC for each individual filetype. 

Let's show a breakdown of total contribution by filetype in the code view, and sort the file type displayed alphabetically to ensure that a certain file type always appears at the same place, giving predictability to the viewer.
```