### PR TITLE
Fix unhandled IllegalArgumentException in RepoConfiguration#update #395

### DIFF
--- a/src/main/java/reposense/model/RepoConfiguration.java
+++ b/src/main/java/reposense/model/RepoConfiguration.java
@@ -159,6 +159,7 @@ public class RepoConfiguration {
         validateFormats(standaloneConfig.getFormats());
         validateIgnoreCommits(standaloneConfig.getIgnoreCommitList());
 
+        // only assign the new values when all the fields in {@code standaloneConfig} pass the validations.
         authorList = newAuthorList;
         authorAliasMap = newAuthorAliasMap;
         authorDisplayNameMap = newAuthorDisplayNameMap;

--- a/src/main/java/reposense/model/RepoConfiguration.java
+++ b/src/main/java/reposense/model/RepoConfiguration.java
@@ -377,7 +377,7 @@ public class RepoConfiguration {
      * Checks that all the strings in the {@code formats} are in valid formats.
      * @throws IllegalArgumentException if any of the values do not meet the criteria.
      */
-    private static void validateFormats(List<String> formats) {
+    private static void validateFormats(List<String> formats) throws IllegalArgumentException {
         for (String format: formats) {
             if (!isValidFormat(format)) {
                 throw new IllegalArgumentException(String.format(MESSAGE_ILLEGAL_FORMATS, format));
@@ -389,7 +389,7 @@ public class RepoConfiguration {
      * Checks that all the strings in the {@code ignoreCommitList} are in valid formats.
      * @throws IllegalArgumentException if any of the values do not meet the criteria.
      */
-    private static void validateIgnoreCommits(List<String> ignoreCommitList) {
+    private static void validateIgnoreCommits(List<String> ignoreCommitList) throws IllegalArgumentException {
         for (String commitHash : ignoreCommitList) {
             if (!commitHash.matches(COMMIT_HASH_REGEX)) {
                 throw new IllegalArgumentException(String.format(INVALID_COMMIT_HASH_MESSAGE, commitHash));

--- a/src/main/java/reposense/model/RepoConfiguration.java
+++ b/src/main/java/reposense/model/RepoConfiguration.java
@@ -141,24 +141,30 @@ public class RepoConfiguration {
      * Clears authors information and use the information provided from {@code standaloneConfig}.
      */
     public void update(StandaloneConfig standaloneConfig) {
-        authorList = new ArrayList<>();
-        authorAliasMap.clear();
-        authorDisplayNameMap.clear();
-        ignoreGlobList = standaloneConfig.getIgnoreGlobList();
-
-        this.setFormats(standaloneConfig.getFormats());
+        List<Author> newAuthorList = new ArrayList<>();
+        TreeMap<String, Author> newAuthorAliasMap = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+        Map<Author, String> newAuthorDisplayNameMap = new HashMap<>();
+        List<String> newIgnoreGlobList = standaloneConfig.getIgnoreGlobList();
 
         for (StandaloneAuthor sa : standaloneConfig.getAuthors()) {
             Author author = new Author(sa);
-            author.appendIgnoreGlobList(ignoreGlobList);
+            author.appendIgnoreGlobList(newIgnoreGlobList);
 
-            this.authorList.add(author);
-            this.setAuthorDisplayName(author, author.getDisplayName());
-            this.addAuthorAliases(author, Arrays.asList(author.getGitId()));
-            this.addAuthorAliases(author, author.getAuthorAliases());
+            newAuthorList.add(author);
+            newAuthorDisplayNameMap.put(author, author.getDisplayName());
+            List<String> aliases = new ArrayList<>(author.getAuthorAliases());
+            aliases.add(author.getGitId());
+            aliases.forEach(alias -> newAuthorAliasMap.put(alias, author));
         }
+        validateFormats(standaloneConfig.getFormats());
+        validateIgnoreCommits(standaloneConfig.getIgnoreCommitList());
 
-        setIgnoreCommitList(standaloneConfig.getIgnoreCommitList());
+        authorList = newAuthorList;
+        authorAliasMap = newAuthorAliasMap;
+        authorDisplayNameMap = newAuthorDisplayNameMap;
+        ignoreGlobList = newIgnoreGlobList;
+        formats = standaloneConfig.getFormats();
+        ignoreCommitList = standaloneConfig.getIgnoreCommitList();
     }
 
     public String getRepoRoot() {
@@ -248,7 +254,6 @@ public class RepoConfiguration {
     }
 
     public void setIgnoreCommitList(List<String> ignoreCommitList) {
-        validateIgnoreCommits(ignoreCommitList);
         this.ignoreCommitList = ignoreCommitList;
     }
 
@@ -307,7 +312,6 @@ public class RepoConfiguration {
     }
 
     public void setFormats(List<String> formats) {
-        validateFormats(formats);
         this.formats = formats;
     }
 
@@ -381,7 +385,11 @@ public class RepoConfiguration {
         }
     }
 
-    private void validateIgnoreCommits(List<String> ignoreCommitList) {
+    /**
+     * Checks that all the strings in the {@code ignoreCommitList} are in valid formats.
+     * @throws IllegalArgumentException if any of the values do not meet the criteria.
+     */
+    private static void validateIgnoreCommits(List<String> ignoreCommitList) {
         for (String commitHash : ignoreCommitList) {
             if (!commitHash.matches(COMMIT_HASH_REGEX)) {
                 throw new IllegalArgumentException(String.format(INVALID_COMMIT_HASH_MESSAGE, commitHash));

--- a/src/main/java/reposense/report/ReportGenerator.java
+++ b/src/main/java/reposense/report/ReportGenerator.java
@@ -36,6 +36,8 @@ public class ReportGenerator {
     // zip file which contains all the dashboard template files
     private static final String TEMPLATE_FILE = "/templateZip.zip";
 
+    private static final String MESSAGE_INVALID_CONFIG_JSON = "%s Ignoring the config provided by this repository.";
+
     /**
      * Generates the authorship and commits JSON file for each repo in {@code configs} at {@code outputPath}, as
      * well as the summary JSON file of all the repos.
@@ -99,6 +101,8 @@ public class ReportGenerator {
         } catch (JsonSyntaxException jse) {
             logger.warning(String.format("%s/%s/%s is malformed.",
                     config.getDisplayName(), REPOSENSE_CONFIG_FOLDER, REPOSENSE_CONFIG_FILE));
+        } catch (IllegalArgumentException iae) {
+            logger.warning(String.format(MESSAGE_INVALID_CONFIG_JSON, iae.getMessage()));
         } catch (IOException ioe) {
             throw new AssertionError(
                     "This exception should not happen as we have performed the file existence check.");

--- a/src/test/java/reposense/authorship/FileInfoExtractorTest.java
+++ b/src/test/java/reposense/authorship/FileInfoExtractorTest.java
@@ -48,7 +48,7 @@ public class FileInfoExtractorTest extends GitTestTemplate {
         config.setSinceDate(date);
 
         List<FileInfo> files = FileInfoExtractor.extractFileInfos(config);
-        Assert.assertEquals(3, files.size());
+        Assert.assertEquals(4, files.size());
 
         // files edited within commit range
         Assert.assertTrue(isFileExistence(Paths.get("README.md"), files));

--- a/src/test/java/reposense/parser/RepoConfigurationTest.java
+++ b/src/test/java/reposense/parser/RepoConfigurationTest.java
@@ -4,6 +4,8 @@ import static org.apache.tools.ant.types.Commandline.translateCommandline;
 
 import java.io.File;
 import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -97,15 +99,22 @@ public class RepoConfigurationTest {
     }
 
     @Test
-    public void setFormats_alphaNumeric_success() throws InvalidLocationException {
-        RepoConfiguration actualConfig = new RepoConfiguration(TEST_REPO_DELTA, "master");
-        actualConfig.setFormats(Arrays.asList("java", "7z"));
+    public void validateFormats_alphaNumeric_success()
+            throws InvalidLocationException, NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+        Method m = RepoConfiguration.class.getDeclaredMethod("validateFormats", List.class);
+        m.setAccessible(true);
+        m.invoke(null, Arrays.asList("java", "7z"));
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void setFormats_nonAlphaNumeric_throwIllegalArgumentException() throws InvalidLocationException {
-        RepoConfiguration actualConfig = new RepoConfiguration(TEST_REPO_DELTA, "master");
-        actualConfig.setFormats(Arrays.asList(".java"));
+    public void validateFormats_nonAlphaNumeric_throwIllegalArgumentException() throws Throwable {
+        try {
+            Method m = RepoConfiguration.class.getDeclaredMethod("validateFormats", List.class);
+            m.setAccessible(true);
+            m.invoke(null, Arrays.asList(".java"));
+        } catch (InvocationTargetException ite) {
+            throw ite.getCause();
+        }
     }
 
     @Test

--- a/src/test/java/reposense/template/GitTestTemplate.java
+++ b/src/test/java/reposense/template/GitTestTemplate.java
@@ -32,7 +32,7 @@ public class GitTestTemplate {
     protected static final String MAIN_AUTHOR_NAME = "harryggg";
     protected static final String FAKE_AUTHOR_NAME = "fakeAuthor";
     protected static final String EUGENE_AUTHOR_NAME = "eugenepeh";
-    protected static final String LATEST_COMMIT_HASH = "b28dfac5bd449825c1a372e58485833b35fdbd50";
+    protected static final String LATEST_COMMIT_HASH = "136c6713fc00cfe79a1598e8ce83c6ef3b878660";
     protected static final String EUGENE_AUTHOR_README_FILE_COMMIT_07052018 =
             "2d87a431fcbb8f73a731b6df0fcbee962c85c250";
     protected static final String FAKE_AUTHOR_BLAME_TEST_FILE_COMMIT_08022018 =


### PR DESCRIPTION
Fix #395 

```
Standalone config goes through validation check before being utilized
for analysis. In the event where standalone configs contain invalid
value(s), RepoSense will indicate it by throwing an
IllegalArgumentException.

However, in #395, a standalone config with invalid `ignoreCommitList`
was found in one of the repositories which has caused an intermediate
crash during the analysis. This is due to the IllegalArgumentException
not being properly handled.

Let's handle the IllegalArgumentException by ignoring the standalone
config, also, ensure that none of the fields prior to validation.
```

EDIT: invalid config.json file added to testrepo-Alpha.