### PR TITLE
Hotfix for recent outburst of RuntimeException

### DIFF
--- a/src/main/java/reposense/report/ReportGenerator.java
+++ b/src/main/java/reposense/report/ReportGenerator.java
@@ -56,13 +56,18 @@ public class ReportGenerator {
                 repoReportDirectory = Paths.get(outputPath, config.getDisplayName());
                 FileUtil.createDirectory(repoReportDirectory);
             } catch (GitDownloaderException gde) {
-                logger.log(Level.WARNING, "Exception met while trying to clone the repo, will skip this one", gde);
+                logger.log(Level.WARNING,
+                        "Exception met while trying to clone the repo, will skip this repo.", gde);
                 repoReportDirectory = Paths.get(outputPath, config.getDisplayName());
                 FileUtil.createDirectory(repoReportDirectory);
                 generateEmptyRepoReport(repoReportDirectory.toString());
                 continue;
             } catch (IOException ioe) {
-                logger.log(Level.WARNING, "Error while creating repo directory, will skip this repo.", ioe);
+                logger.log(Level.WARNING,
+                        "Error has occurred while creating repo directory, will skip this repo.", ioe);
+                continue;
+            } catch (RuntimeException rte) {
+                logger.log(Level.SEVERE, "Error has occurred during analysis, will skip this repo.", rte);
                 continue;
             }
 


### PR DESCRIPTION
Temporarily fix for #391 #398 #399  
```
Due to the nature of our application, and the lack of simpler
alternatives, our application heavily relies on the external command
line utility, `git`. To make use of the tool, we employed a
CommandRunner class which starts a separate process to execute various
operations.

This, however, encourages the outbreak of RuntimeException as numerous
factors can cause `git` to return a non-zero status code and
CommandRunner allows these exceptions to go unchecked.

To prevent RuntimeException from interrupting the analysis of multiple
repos, let's skip the repo under analysis whenever a RunTimeException
occurs.
``` 