### PR TITLE
Gradle task npmRunSpuild is not working as intended #409

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "homepage": "https://github.com/reposense/RepoSense#readme",
   "dependencies": {
-    "spuild": "^1.0.2"
+    "spuild": "1.0.2"
   },
   "devDependencies": {
     "eslint": "^4.19.1",


### PR DESCRIPTION
```
seems like after the recent update on the spuild library, the npmRunSpuild
task in gradle is not working the same as before.

Let's fix the version of spuild to use for the rendering of the dashboard.
```