### PR TITLE
[#394] Search bar allows lower case only

### DIFF
--- a/frontend/src/static/css/style.scss
+++ b/frontend/src/static/css/style.scss
@@ -122,10 +122,6 @@ header{
         flex:0 0 auto;
     }
 
-    &__search{
-        text-transform:lowercase;
-    }
-
     &__checkboxes{
         label{ margin-left:0.5rem; }
         span{ margin-left:0.25rem; }


### PR DESCRIPTION
Delete the default translation of case in style.scss
Will keep work on for the auto-change of case after return key is entered