### PR TITLE
Split repo configuration #316

### DIFF
--- a/src/main/java/reposense/model/FormatList.java
+++ b/src/main/java/reposense/model/FormatList.java
@@ -1,0 +1,60 @@
+package reposense.model;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class FormatList {
+    private static final String FORMAT_VALIDATION_REGEX = "[A-Za-z0-9]+";
+    private static final String MESSAGE_ILLEGAL_FORMATS = "The provided formats, %s, contains illegal characters.";
+
+    private List<String> formats = new ArrayList<>();
+
+    public List<String> getFormats() {
+        return formats;
+    }
+
+    public void setFormats(List<String> formats) {
+        validateFormats(formats);
+        this.formats = formats;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        // short circuit if same object
+        if (this == other) {
+            return true;
+        }
+
+        // instanceof handles null
+        if (!(other instanceof FormatList)) {
+            return false;
+        }
+
+        FormatList otherList = (FormatList) other;
+        return this.formats.equals(otherList.formats);
+    }
+
+    @Override
+    public int hashCode() {
+        return formats.hashCode();
+    }
+
+    /**
+     * Checks that all the strings in the {@code formats} are in valid formats.
+     * @throws IllegalArgumentException if any of the values do not meet the criteria.
+     */
+    public static void validateFormats(List<String> formats) throws IllegalArgumentException {
+        for (String format: formats) {
+            if (!isValidFormat(format)) {
+                throw new IllegalArgumentException(String.format(MESSAGE_ILLEGAL_FORMATS, format));
+            }
+        }
+    }
+
+    /**
+     * Returns true if the given {@code value} is a valid format.
+     */
+    private static boolean isValidFormat(String value) throws IllegalArgumentException {
+        return value.matches(FORMAT_VALIDATION_REGEX);
+    }
+}

--- a/src/main/java/reposense/model/IgnoreCommitsList.java
+++ b/src/main/java/reposense/model/IgnoreCommitsList.java
@@ -1,0 +1,54 @@
+package reposense.model;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class IgnoreCommitsList {
+    private static final String COMMIT_HASH_REGEX = "^[0-9a-f]+$";
+    private static final String INVALID_COMMIT_HASH_MESSAGE =
+            "The provided commit hash, %s, contains illegal characters.";
+
+    private List<String> ignoreCommits = new ArrayList<>();
+
+    public List<String> getIgnoreCommitsList() {
+        return ignoreCommits;
+    }
+
+    public void setIgnoreCommitsList(List<String> formats) {
+        validateIgnoreCommits(formats);
+        this.ignoreCommits = formats;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        // short circuit if same object
+        if (this == other) {
+            return true;
+        }
+
+        // instanceof handles null
+        if (!(other instanceof IgnoreCommitsList)) {
+            return false;
+        }
+
+        IgnoreCommitsList otherList = (IgnoreCommitsList) other;
+        return this.ignoreCommits.equals(otherList.ignoreCommits);
+    }
+
+    @Override
+    public int hashCode() {
+        return ignoreCommits.hashCode();
+    }
+
+    /**
+     * Checks that all the strings in the {@code ignoreCommitList} are in valid formats.
+     * @throws IllegalArgumentException if any of the values do not meet the criteria.
+     */
+    public static void validateIgnoreCommits(List<String> ignoreCommitList) throws IllegalArgumentException {
+        for (String commitHash : ignoreCommitList) {
+            if (!commitHash.matches(COMMIT_HASH_REGEX)) {
+                throw new IllegalArgumentException(String.format(INVALID_COMMIT_HASH_MESSAGE, commitHash));
+            }
+        }
+    }
+}

--- a/src/main/java/reposense/model/Location.java
+++ b/src/main/java/reposense/model/Location.java
@@ -1,0 +1,78 @@
+package reposense.model;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.InvalidPathException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import reposense.parser.InvalidLocationException;
+
+/**
+ * Represents a repository location.
+ */
+public class Location {
+    private String location;
+
+    /**
+     * @throws InvalidLocationException if {@code location} cannot be represented by a {@code URL} or {@code Path}.
+     */
+    public Location(String location) throws InvalidLocationException {
+        verifyLocation(location);
+        this.location = location;
+    }
+
+    /**
+     * Verifies {@code location} can be presented as a {@code URL} or {@code Path}.
+     * @throws InvalidLocationException if otherwise.
+     */
+    private void verifyLocation(String location) throws InvalidLocationException {
+        boolean isValidPathLocation = false;
+        boolean isValidGitUrl = false;
+
+        try {
+            Path pathLocation = Paths.get(location);
+            isValidPathLocation = Files.exists(pathLocation);
+        } catch (InvalidPathException ipe) {
+            // Ignore exception
+        }
+
+        try {
+            new URL(location);
+            isValidGitUrl = location.endsWith(RepoConfiguration.GIT_LINK_SUFFIX);
+        } catch (MalformedURLException mue) {
+            // Ignore exception
+        }
+
+        if (!isValidPathLocation && !isValidGitUrl) {
+            throw new InvalidLocationException(location + " is an invalid location.");
+        }
+    }
+
+    @Override
+    public String toString() {
+        return location;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        // short circuit if same object
+        if (this == other) {
+            return true;
+        }
+
+        // instanceof handles null
+        if (!(other instanceof Location)) {
+            return false;
+        }
+
+        Location otherLocation = (Location) other;
+        return this.location.equals(otherLocation.location);
+    }
+
+    @Override
+    public int hashCode() {
+        return location.hashCode();
+    }
+}

--- a/src/main/java/reposense/model/RepoConfiguration.java
+++ b/src/main/java/reposense/model/RepoConfiguration.java
@@ -25,7 +25,6 @@ public class RepoConfiguration {
     public static final String GIT_LINK_SUFFIX = ".git";
     private static final Logger logger = LogsManager.getLogger(RepoConfiguration.class);
     private static final String MESSAGE_ILLEGAL_FORMATS = "The provided formats, %s, contains illegal characters.";
-    private static final String FORMAT_VALIDATION_REGEX = "[A-Za-z0-9]+";
 
     private static final Pattern GIT_REPOSITORY_LOCATION_PATTERN =
             Pattern.compile("^.*github.com\\/(?<org>.+?)\\/(?<repoName>.+?)\\.git$");
@@ -43,7 +42,7 @@ public class RepoConfiguration {
 
     private transient boolean needCheckStyle = false;
     private transient boolean annotationOverwrite = true;
-    private transient List<String> formats;
+    private final transient FormatList formats = new FormatList();
     private transient int commitNum = 1;
     private transient List<String> ignoreGlobList = new ArrayList<>();
     private transient List<Author> authorList = new ArrayList<>();
@@ -75,8 +74,8 @@ public class RepoConfiguration {
         this.branch = branch;
         this.ignoreGlobList = ignoreGlobList;
         this.isStandaloneConfigIgnored = isStandaloneConfigIgnored;
-        this.formats = formats;
 
+        this.formats.setFormats(formats);
         validateIgnoreCommits(ignoreCommitList);
         this.ignoreCommitList = ignoreCommitList;
 
@@ -149,7 +148,7 @@ public class RepoConfiguration {
             aliases.add(author.getGitId());
             aliases.forEach(alias -> newAuthorAliasMap.put(alias, author));
         }
-        validateFormats(standaloneConfig.getFormats());
+        FormatList.validateFormats(standaloneConfig.getFormats());
         validateIgnoreCommits(standaloneConfig.getIgnoreCommitList());
 
         // only assign the new values when all the fields in {@code standaloneConfig} pass the validations.
@@ -157,7 +156,7 @@ public class RepoConfiguration {
         authorAliasMap = newAuthorAliasMap;
         authorDisplayNameMap = newAuthorDisplayNameMap;
         ignoreGlobList = newIgnoreGlobList;
-        formats = standaloneConfig.getFormats();
+        formats.setFormats(standaloneConfig.getFormats());
         ignoreCommitList = standaloneConfig.getIgnoreCommitList();
     }
 
@@ -302,11 +301,11 @@ public class RepoConfiguration {
     }
 
     public List<String> getFormats() {
-        return formats;
+        return formats.getFormats();
     }
 
     public void setFormats(List<String> formats) {
-        this.formats = formats;
+        this.formats.setFormats(formats);
     }
 
     public void setAuthorDisplayName(Author author, String displayName) {
@@ -331,25 +330,6 @@ public class RepoConfiguration {
 
     public boolean isStandaloneConfigIgnored() {
         return isStandaloneConfigIgnored;
-    }
-
-    /**
-     * Returns true if the given {@code value} is a valid format.
-     */
-    private static boolean isValidFormat(String value) {
-        return value.matches(FORMAT_VALIDATION_REGEX);
-    }
-
-    /**
-     * Checks that all the strings in the {@code formats} are in valid formats.
-     * @throws IllegalArgumentException if any of the values do not meet the criteria.
-     */
-    private static void validateFormats(List<String> formats) throws IllegalArgumentException {
-        for (String format: formats) {
-            if (!isValidFormat(format)) {
-                throw new IllegalArgumentException(String.format(MESSAGE_ILLEGAL_FORMATS, format));
-            }
-        }
     }
 
     /**

--- a/src/main/java/reposense/model/RepoConfiguration.java
+++ b/src/main/java/reposense/model/RepoConfiguration.java
@@ -1,11 +1,6 @@
 package reposense.model;
 
 import java.io.File;
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.nio.file.Files;
-import java.nio.file.InvalidPathException;
-import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -27,19 +22,18 @@ import reposense.util.FileUtil;
 
 public class RepoConfiguration {
     public static final String DEFAULT_BRANCH = "HEAD";
+    public static final String GIT_LINK_SUFFIX = ".git";
     private static final Logger logger = LogsManager.getLogger(RepoConfiguration.class);
     private static final String MESSAGE_ILLEGAL_FORMATS = "The provided formats, %s, contains illegal characters.";
     private static final String FORMAT_VALIDATION_REGEX = "[A-Za-z0-9]+";
 
-    private static final String GIT_LINK_SUFFIX = ".git";
     private static final Pattern GIT_REPOSITORY_LOCATION_PATTERN =
             Pattern.compile("^.*github.com\\/(?<org>.+?)\\/(?<repoName>.+?)\\.git$");
     private static final String COMMIT_HASH_REGEX = "^[0-9a-f]+$";
     private static final String INVALID_COMMIT_HASH_MESSAGE =
             "The provided commit hash, %s, contains illegal characters.";
 
-
-    private String location;
+    private Location location;
     private String organization;
     private String repoName;
     private String branch;
@@ -77,7 +71,7 @@ public class RepoConfiguration {
      */
     public RepoConfiguration(String location, String branch, List<String> formats, List<String> ignoreGlobList,
             boolean isStandaloneConfigIgnored, List<String> ignoreCommitList) throws InvalidLocationException {
-        this.location = location;
+        this.location = new Location(location);
         this.branch = branch;
         this.ignoreGlobList = ignoreGlobList;
         this.isStandaloneConfigIgnored = isStandaloneConfigIgnored;
@@ -86,7 +80,6 @@ public class RepoConfiguration {
         validateIgnoreCommits(ignoreCommitList);
         this.ignoreCommitList = ignoreCommitList;
 
-        verifyLocation(location);
         Matcher matcher = GIT_REPOSITORY_LOCATION_PATTERN.matcher(location);
 
         if (matcher.matches()) {
@@ -328,43 +321,16 @@ public class RepoConfiguration {
         return displayName;
     }
 
-    public String getLocation() {
-        return location;
-    }
-
     public String getRepoName() {
         return repoName;
     }
 
-    public boolean isStandaloneConfigIgnored() {
-        return isStandaloneConfigIgnored;
+    public Location getLocation() {
+        return location;
     }
 
-    /**
-     * Verifies {@code location} can be presented as a {@code URL} or {@code Path}.
-     * @throws InvalidLocationException if otherwise.
-     */
-    private void verifyLocation(String location) throws InvalidLocationException {
-        boolean isValidPathLocation = false;
-        boolean isValidGitUrl = false;
-
-        try {
-            Path pathLocation = Paths.get(location);
-            isValidPathLocation = Files.exists(pathLocation);
-        } catch (InvalidPathException ipe) {
-            // Ignore exception
-        }
-
-        try {
-            new URL(location);
-            isValidGitUrl = location.endsWith(GIT_LINK_SUFFIX);
-        } catch (MalformedURLException mue) {
-            // Ignore exception
-        }
-
-        if (!isValidPathLocation && !isValidGitUrl) {
-            throw new InvalidLocationException(location + " is an invalid location.");
-        }
+    public boolean isStandaloneConfigIgnored() {
+        return isStandaloneConfigIgnored;
     }
 
     /**

--- a/src/main/java/reposense/system/CommandRunner.java
+++ b/src/main/java/reposense/system/CommandRunner.java
@@ -11,6 +11,7 @@ import java.util.List;
 
 import reposense.git.CommitNotFoundException;
 import reposense.model.Author;
+import reposense.model.Location;
 import reposense.model.RepoConfiguration;
 import reposense.util.FileUtil;
 import reposense.util.StringsUtil;
@@ -124,10 +125,10 @@ public class CommandRunner {
         return runCommand(rootPath, command);
     }
 
-    public static String cloneRepo(String location, String repoName) throws IOException {
+    public static String cloneRepo(Location location, String repoName) throws IOException {
         Path rootPath = Paths.get(FileUtil.REPOS_ADDRESS, repoName);
         Files.createDirectories(rootPath);
-        return runCommand(rootPath, "git clone " + addQuote(location));
+        return runCommand(rootPath, "git clone " + addQuote(location.toString()));
     }
 
     private static String runCommand(Path path, String command) {

--- a/src/test/java/reposense/model/FormatListTest.java
+++ b/src/test/java/reposense/model/FormatListTest.java
@@ -1,0 +1,28 @@
+package reposense.model;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.Test;
+
+public class FormatListTest {
+    @Test
+    public void validateFormats_alphaNumeric_success()
+            throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+        Method m = FormatList.class.getDeclaredMethod("validateFormats", List.class);
+        m.setAccessible(true);
+        m.invoke(null, Arrays.asList("java", "7z"));
+    }
+    @Test(expected = IllegalArgumentException.class)
+    public void validateFormats_nonAlphaNumeric_throwIllegalArgumentException() throws Throwable {
+        try {
+            Method m = FormatList.class.getDeclaredMethod("validateFormats", List.class);
+            m.setAccessible(true);
+            m.invoke(null, Arrays.asList(".java"));
+        } catch (InvocationTargetException ite) {
+            throw ite.getCause();
+        }
+    }
+}

--- a/src/test/java/reposense/parser/CsvParserTest.java
+++ b/src/test/java/reposense/parser/CsvParserTest.java
@@ -15,6 +15,7 @@ import org.junit.Test;
 import reposense.model.Author;
 import reposense.model.CliArguments;
 import reposense.model.ConfigCliArguments;
+import reposense.model.Location;
 import reposense.model.RepoConfiguration;
 
 public class CsvParserTest {
@@ -51,7 +52,7 @@ public class CsvParserTest {
     private static final List<String> FIRST_AUTHOR_GLOB_LIST = Arrays.asList("collated**", "**.java");
 
     @Test
-    public void repoConfig_noSpecialCharacter_success() throws IOException {
+    public void repoConfig_noSpecialCharacter_success() throws IOException, InvalidLocationException {
         RepoConfigCsvParser repoConfigCsvParser = new RepoConfigCsvParser(REPO_CONFIG_NO_SPECIAL_CHARACTER_FILE);
         List<RepoConfiguration> configs = repoConfigCsvParser.parse();
 
@@ -59,7 +60,7 @@ public class CsvParserTest {
 
         RepoConfiguration config = configs.get(0);
 
-        Assert.assertEquals(TEST_REPO_BETA_LOCATION, config.getLocation());
+        Assert.assertEquals(new Location(TEST_REPO_BETA_LOCATION), config.getLocation());
         Assert.assertEquals(TEST_REPO_BETA_BRANCH, config.getBranch());
 
         Assert.assertEquals(TEST_REPO_BETA_CONFIG_FORMATS, TEST_REPO_BETA_CONFIG_FORMATS);
@@ -70,7 +71,7 @@ public class CsvParserTest {
     }
 
     @Test
-    public void authorConfig_noSpecialCharacter_success() throws IOException {
+    public void authorConfig_noSpecialCharacter_success() throws IOException, InvalidLocationException {
         AuthorConfigCsvParser authorConfigCsvParser =
                 new AuthorConfigCsvParser(AUTHOR_CONFIG_NO_SPECIAL_CHARACTER_FILE);
         List<RepoConfiguration> configs = authorConfigCsvParser.parse();
@@ -79,14 +80,14 @@ public class CsvParserTest {
 
         RepoConfiguration config = configs.get(0);
 
-        Assert.assertEquals(TEST_REPO_BETA_LOCATION, config.getLocation());
+        Assert.assertEquals(new Location(TEST_REPO_BETA_LOCATION), config.getLocation());
         Assert.assertEquals(TEST_REPO_BETA_BRANCH, config.getBranch());
 
         Assert.assertEquals(AUTHOR_CONFIG_NO_SPECIAL_CHARACTER_AUTHORS, config.getAuthorList());
     }
 
     @Test
-    public void authorConfig_specialCharacter_success() throws IOException {
+    public void authorConfig_specialCharacter_success() throws IOException, InvalidLocationException {
         AuthorConfigCsvParser authorConfigCsvParser = new AuthorConfigCsvParser(AUTHOR_CONFIG_SPECIAL_CHARACTER_FILE);
         List<RepoConfiguration> configs = authorConfigCsvParser.parse();
 
@@ -94,7 +95,7 @@ public class CsvParserTest {
 
         RepoConfiguration config = configs.get(0);
 
-        Assert.assertEquals(TEST_REPO_BETA_LOCATION, config.getLocation());
+        Assert.assertEquals(new Location(TEST_REPO_BETA_LOCATION), config.getLocation());
         Assert.assertEquals(TEST_REPO_BETA_BRANCH, config.getBranch());
 
         Assert.assertEquals(AUTHOR_CONFIG_SPECIAL_CHARACTER_AUTHORS, config.getAuthorList());

--- a/src/test/java/reposense/parser/RepoConfigurationTest.java
+++ b/src/test/java/reposense/parser/RepoConfigurationTest.java
@@ -4,8 +4,6 @@ import static org.apache.tools.ant.types.Commandline.translateCommandline;
 
 import java.io.File;
 import java.io.IOException;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -96,25 +94,6 @@ public class RepoConfigurationTest {
     @Before
     public void cleanRepoDirectory() throws IOException {
         FileUtil.deleteDirectory(FileUtil.REPOS_ADDRESS);
-    }
-
-    @Test
-    public void validateFormats_alphaNumeric_success()
-            throws InvalidLocationException, NoSuchMethodException, InvocationTargetException, IllegalAccessException {
-        Method m = RepoConfiguration.class.getDeclaredMethod("validateFormats", List.class);
-        m.setAccessible(true);
-        m.invoke(null, Arrays.asList("java", "7z"));
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void validateFormats_nonAlphaNumeric_throwIllegalArgumentException() throws Throwable {
-        try {
-            Method m = RepoConfiguration.class.getDeclaredMethod("validateFormats", List.class);
-            m.setAccessible(true);
-            m.invoke(null, Arrays.asList(".java"));
-        } catch (InvocationTargetException ite) {
-            throw ite.getCause();
-        }
     }
 
     @Test


### PR DESCRIPTION
Fixes #316

RepoConfiguration has many analysis parameters and as more are added, 
it becomes larger and harder to maintain.

Let's delegate some of the parameters to their own classes, this includes 
Location, FormatList and IgnoreCommitsList. 

These parameters were delegated as currently only formats, ignored 
commits and location are being validated.
