### PR TITLE
Split repo configuration #316

### DIFF
--- a/frontend/src/static/js/api.js
+++ b/frontend/src/static/js/api.js
@@ -66,7 +66,7 @@ window.api = {
           obj.searchPath = searchParams.join('_').toLowerCase();
           obj.repoPath = `${repo.displayName}`;
           obj.repoName = `${repo.displayName}`;
-          obj.location = `${repo.location}`;
+          obj.location = `${repo.location.location}`;
 
           res.push(obj);
         }

--- a/src/main/java/reposense/RepoSense.java
+++ b/src/main/java/reposense/RepoSense.java
@@ -13,6 +13,7 @@ import reposense.model.CliArguments;
 import reposense.model.ConfigCliArguments;
 import reposense.model.LocationsCliArguments;
 import reposense.model.RepoConfiguration;
+import reposense.model.RepoLocation;
 import reposense.model.ViewCliArguments;
 import reposense.parser.ArgsParser;
 import reposense.parser.AuthorConfigCsvParser;
@@ -84,9 +85,9 @@ public class RepoSense {
      */
     public static List<RepoConfiguration> getRepoConfigurations(LocationsCliArguments cliArguments) {
         List<RepoConfiguration> configs = new ArrayList<>();
-        for (String location : cliArguments.getLocations()) {
+        for (String locationString : cliArguments.getLocations()) {
             try {
-                configs.add(new RepoConfiguration(location));
+                configs.add(new RepoConfiguration(new RepoLocation(locationString)));
             } catch (InvalidLocationException ile) {
                 logger.log(Level.WARNING, ile.getMessage(), ile);
             }

--- a/src/main/java/reposense/authorship/FileInfoAnalyzer.java
+++ b/src/main/java/reposense/authorship/FileInfoAnalyzer.java
@@ -7,7 +7,6 @@ import java.nio.file.Path;
 import java.nio.file.PathMatcher;
 import java.nio.file.Paths;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -19,6 +18,7 @@ import reposense.authorship.model.FileResult;
 import reposense.authorship.model.LineInfo;
 import reposense.git.GitBlame;
 import reposense.model.Author;
+import reposense.model.CommitHash;
 import reposense.model.RepoConfiguration;
 import reposense.system.LogsManager;
 
@@ -88,7 +88,7 @@ public class FileInfoAnalyzer {
             Author author = authorAliasMap.getOrDefault(authorRawName, new Author(Author.UNKNOWN_AUTHOR_GIT_ID));
 
             if (!fileInfo.isFileLineTracked(lineCount / 2) || isAuthorIgnoringFile(author, filePath)
-                    || isCommitHashWithinIgnoredCommitList(commitHash, config.getIgnoreCommitList())) {
+                    || CommitHash.isInsideCommitList(commitHash, config.getIgnoreCommitList())) {
                 author = new Author(Author.UNKNOWN_AUTHOR_GIT_ID);
             }
 
@@ -125,9 +125,5 @@ public class FileInfoAnalyzer {
     private static boolean isAuthorIgnoringFile(Author author, Path filePath) {
         PathMatcher ignoreGlobMatcher = author.getIgnoreGlobMatcher();
         return ignoreGlobMatcher.matches(filePath);
-    }
-
-    private static boolean isCommitHashWithinIgnoredCommitList(String commitHash, List<String> ignoreCommitList) {
-        return ignoreCommitList.stream().anyMatch(commitHash::startsWith);
     }
 }

--- a/src/main/java/reposense/authorship/FileInfoExtractor.java
+++ b/src/main/java/reposense/authorship/FileInfoExtractor.java
@@ -23,6 +23,7 @@ import reposense.git.CommitNotFoundException;
 import reposense.git.GitCheckout;
 import reposense.git.GitDiff;
 import reposense.git.GitRevList;
+import reposense.model.Format;
 import reposense.model.RepoConfiguration;
 import reposense.system.LogsManager;
 
@@ -106,7 +107,7 @@ public class FileInfoExtractor {
                 continue;
             }
 
-            if (isFormatInsideWhiteList(filePath, config.getFormats())) {
+            if (Format.isInsideWhiteList(filePath, config.getFormats())) {
                 try {
                     FileInfo currentFileInfo = generateFileInfo(config.getRepoRoot(), filePath);
                     setLinesToTrack(currentFileInfo, fileDiffResult);
@@ -168,7 +169,7 @@ public class FileInfoExtractor {
                     getAllFileInfo(config, filePath, fileInfos);
                 }
 
-                if (isFormatInsideWhiteList(relativePath, config.getFormats())) {
+                if (Format.isInsideWhiteList(relativePath, config.getFormats())) {
                     try {
                         fileInfos.add(generateFileInfo(config.getRepoRoot(), relativePath));
                     } catch (InvalidPathException ipe) {
@@ -199,13 +200,6 @@ public class FileInfoExtractor {
             logger.log(Level.SEVERE, ioe.getMessage(), ioe);
         }
         return fileInfo;
-    }
-
-    /**
-     * Returns true if the {@code relativePath}'s file type is inside {@code formatsWhiteList}.
-     */
-    private static boolean isFormatInsideWhiteList(String relativePath, List<String> formatsWhiteList) {
-        return formatsWhiteList.stream().anyMatch(format -> relativePath.endsWith("." + format));
     }
 
     /**

--- a/src/main/java/reposense/builder/ConfigurationBuilder.java
+++ b/src/main/java/reposense/builder/ConfigurationBuilder.java
@@ -4,13 +4,14 @@ import java.util.List;
 
 import reposense.model.Author;
 import reposense.model.RepoConfiguration;
+import reposense.model.RepoLocation;
 import reposense.parser.InvalidLocationException;
 
 public class ConfigurationBuilder {
     private RepoConfiguration config;
 
     public ConfigurationBuilder(String location, String branch) throws InvalidLocationException {
-        config = new RepoConfiguration(location, branch);
+        config = new RepoConfiguration(new RepoLocation(location), branch);
     }
 
     public ConfigurationBuilder needCheckStyle(boolean value) {

--- a/src/main/java/reposense/commits/CommitInfoAnalyzer.java
+++ b/src/main/java/reposense/commits/CommitInfoAnalyzer.java
@@ -16,6 +16,7 @@ import java.util.stream.Collectors;
 import reposense.commits.model.CommitInfo;
 import reposense.commits.model.CommitResult;
 import reposense.model.Author;
+import reposense.model.CommitHash;
 import reposense.model.RepoConfiguration;
 import reposense.system.LogsManager;
 
@@ -44,7 +45,7 @@ public class CommitInfoAnalyzer {
         return commitInfos.stream()
                 .map(commitInfo -> analyzeCommit(commitInfo, config.getAuthorAliasMap()))
                 .filter(commitResult -> !commitResult.getAuthor().equals(new Author(Author.UNKNOWN_AUTHOR_GIT_ID))
-                        && !isCommitHashWithinIgnoredCommitList(commitResult.getHash(), config.getIgnoreCommitList()))
+                        && !CommitHash.isInsideCommitList(commitResult.getHash(), config.getIgnoreCommitList()))
                 .sorted(Comparator.comparing(CommitResult::getTime))
                 .collect(Collectors.toList());
     }
@@ -71,10 +72,6 @@ public class CommitInfoAnalyzer {
         int insertion = getInsertion(statLine);
         int deletion = getDeletion(statLine);
         return new CommitResult(author, hash, date, message, insertion, deletion);
-    }
-
-    private static boolean isCommitHashWithinIgnoredCommitList(String commitHash, List<String> ignoreCommitList) {
-        return ignoreCommitList.stream().anyMatch(commitHash::startsWith);
     }
 
     private static int getInsertion(String raw) {

--- a/src/main/java/reposense/git/GitClone.java
+++ b/src/main/java/reposense/git/GitClone.java
@@ -11,6 +11,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import reposense.model.RepoConfiguration;
+import reposense.model.RepoLocation;
 import reposense.system.LogsManager;
 import reposense.util.FileUtil;
 
@@ -53,9 +54,9 @@ public class GitClone {
         }
     }
 
-    private static void clone(String location, String repoName) throws IOException {
+    private static void clone(RepoLocation location, String repoName) throws IOException {
         Path rootPath = Paths.get(FileUtil.REPOS_ADDRESS, repoName);
         Files.createDirectories(rootPath);
-        runCommand(rootPath, "git clone " + addQuote(location));
+        runCommand(rootPath, "git clone " + addQuote(location.toString()));
     }
 }

--- a/src/main/java/reposense/git/GitUtil.java
+++ b/src/main/java/reposense/git/GitUtil.java
@@ -8,6 +8,7 @@ import java.util.Date;
 import java.util.List;
 
 import reposense.model.Author;
+import reposense.model.Format;
 import reposense.util.StringsUtil;
 
 /**
@@ -58,11 +59,11 @@ class GitUtil {
     /**
      * Returns the {@code String} command to specify the file formats to analyze for `git` commands.
      */
-    static String convertToGitFormatsArgs(List<String> formats) {
+    static String convertToGitFormatsArgs(List<Format> formats) {
         StringBuilder gitFormatsArgsBuilder = new StringBuilder();
         final String cmdFormat = " -- " + addQuote("*.%s");
         formats.stream()
-                .map(format -> String.format(cmdFormat, format))
+                .map(format -> String.format(cmdFormat, format.toString()))
                 .forEach(gitFormatsArgsBuilder::append);
 
         return gitFormatsArgsBuilder.toString();

--- a/src/main/java/reposense/model/CliArguments.java
+++ b/src/main/java/reposense/model/CliArguments.java
@@ -12,7 +12,7 @@ public abstract class CliArguments {
     protected Path outputFilePath;
     protected Optional<Date> sinceDate;
     protected Optional<Date> untilDate;
-    protected List<String> formats;
+    protected List<Format> formats;
 
     public Path getOutputFilePath() {
         return outputFilePath;
@@ -26,7 +26,7 @@ public abstract class CliArguments {
         return untilDate;
     }
 
-    public List<String> getFormats() {
+    public List<Format> getFormats() {
         return formats;
     }
 

--- a/src/main/java/reposense/model/CommitHash.java
+++ b/src/main/java/reposense/model/CommitHash.java
@@ -1,0 +1,89 @@
+package reposense.model;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Represents a git commit hash in {@code RepoConfiguration}.
+ */
+public class CommitHash {
+    private static final String COMMIT_HASH_REGEX = "^[0-9a-f]+$";
+    private static final String INVALID_COMMIT_HASH_MESSAGE =
+            "The provided commit hash, %s, contains illegal characters.";
+
+    private String commit;
+
+    public CommitHash(String commit) {
+        validateCommit(commit);
+        this.commit = commit;
+    }
+
+    @Override
+    public String toString() {
+        return commit;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        // short circuit if same object
+        if (this == other) {
+            return true;
+        }
+
+        // instanceof handles null
+        if (!(other instanceof CommitHash)) {
+            return false;
+        }
+
+        CommitHash otherCommit = (CommitHash) other;
+        return this.commit.equals(otherCommit.commit);
+    }
+
+    @Override
+    public int hashCode() {
+        return commit.hashCode();
+    }
+
+    /**
+     * Converts all the strings in {@code commits} into {@code CommitHash} objects.
+     * Returns null if {@code commits} is null.
+     * @throws IllegalArgumentException if any of the strings are in invalid formats.
+     */
+    public static List<CommitHash> convertStringsToCommits(List<String> commits) throws IllegalArgumentException {
+        if (commits == null) {
+            return null;
+        }
+
+        return commits.stream()
+                .map(CommitHash::new)
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Checks if {@code commitList} contains {@code commitHash}
+     */
+    public static boolean isInsideCommitList(String commitHash, List<CommitHash> commitList) {
+        return commitList.stream().map(CommitHash::toString).anyMatch(commitHash::startsWith);
+    }
+
+    /**
+     * Checks that all the strings in the {@code ignoreCommitList} are in valid formats.
+     * @throws IllegalArgumentException if any of the values do not meet the criteria.
+     */
+    public static void validateCommits(List<String> commits) throws IllegalArgumentException {
+        for (String commitHash : commits) {
+            validateCommit(commitHash);
+        }
+    }
+
+    /**
+     * Checks that {@code commitHash} is in a valid format.
+     * @throws IllegalArgumentException if {@code commitHash} does not meet the criteria.
+     */
+    private static void validateCommit(String commitHash) throws IllegalArgumentException {
+        if (!commitHash.matches(COMMIT_HASH_REGEX)) {
+            throw new IllegalArgumentException(String.format(INVALID_COMMIT_HASH_MESSAGE, commitHash));
+        }
+    }
+}
+

--- a/src/main/java/reposense/model/ConfigCliArguments.java
+++ b/src/main/java/reposense/model/ConfigCliArguments.java
@@ -17,7 +17,7 @@ public class ConfigCliArguments extends CliArguments {
     private Path authorConfigFilePath;
 
     public ConfigCliArguments(Path configFolderPath,
-            Path outputFilePath, Optional<Date> sinceDate, Optional<Date> untilDate, List<String> formats) {
+            Path outputFilePath, Optional<Date> sinceDate, Optional<Date> untilDate, List<Format> formats) {
         this.configFolderPath = configFolderPath;
         this.repoConfigFilePath = configFolderPath.resolve(RepoConfigCsvParser.REPO_CONFIG_FILENAME);
         this.authorConfigFilePath = configFolderPath.resolve(AuthorConfigCsvParser.AUTHOR_CONFIG_FILENAME);

--- a/src/main/java/reposense/model/Format.java
+++ b/src/main/java/reposense/model/Format.java
@@ -1,0 +1,88 @@
+package reposense.model;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Represents a file format in {@code RepoConfiguration}.
+ */
+public class Format {
+    public static final List<String> DEFAULT_FORMAT_STRINGS = Arrays.asList(
+            "adoc", "cs", "css", "fxml", "gradle", "html", "java", "js", "json", "jsp", "md", "py", "tag", "xml");
+    public static final List<Format> DEFAULT_FORMATS = convertStringsToFormats(DEFAULT_FORMAT_STRINGS);
+    private static final String FORMAT_VALIDATION_REGEX = "[A-Za-z0-9]+";
+    private static final String MESSAGE_ILLEGAL_FORMATS = "The provided format, %s, contains illegal characters.";
+
+    private String format;
+
+    public Format(String format) {
+        validateFormat(format);
+        this.format = format;
+    }
+
+    @Override
+    public String toString() {
+        return format;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        // short circuit if same object
+        if (this == other) {
+            return true;
+        }
+
+        // instanceof handles null
+        if (!(other instanceof Format)) {
+            return false;
+        }
+
+        Format otherFormat = (Format) other;
+        return this.format.equals(otherFormat.format);
+    }
+
+    @Override
+    public int hashCode() {
+        return format.hashCode();
+    }
+
+    /**
+     * Checks that all the strings in the {@code formats} are in valid formats.
+     * @throws IllegalArgumentException if any of the values do not meet the criteria.
+     */
+    public static void validateFormats(List<String> formats) throws IllegalArgumentException {
+        formats.forEach(Format::validateFormat);
+    }
+
+    /**
+     * Converts all the strings in {@code formats} into {@code Format} objects. Returns null if {@code formats} is null.
+     * @throws IllegalArgumentException if any of the strings are in invalid formats.
+     */
+    public static List<Format> convertStringsToFormats(List<String> formats) throws IllegalArgumentException {
+        if (formats == null) {
+            return null;
+        }
+
+        return formats.stream()
+                .map(Format::new)
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Returns true if the {@code relativePath}'s file type is inside {@code formatsWhiteList}.
+     */
+    public static boolean isInsideWhiteList(String relativePath, List<Format> formatsWhiteList) {
+        return formatsWhiteList.stream().anyMatch(format -> relativePath.endsWith("." + format));
+    }
+
+    /**
+     * Checks that {@code value} is in a valid format.
+     * @throws IllegalArgumentException if {@code value} does not meet the criteria.
+     */
+    private static void validateFormat(String value) throws IllegalArgumentException {
+        if (!value.matches(FORMAT_VALIDATION_REGEX)) {
+            throw new IllegalArgumentException(String.format(MESSAGE_ILLEGAL_FORMATS, value));
+        }
+    }
+}

--- a/src/main/java/reposense/model/LocationsCliArguments.java
+++ b/src/main/java/reposense/model/LocationsCliArguments.java
@@ -12,7 +12,7 @@ public class LocationsCliArguments extends CliArguments {
     private List<String> locations;
 
     public LocationsCliArguments(List<String> locations,
-            Path outputFilePath, Optional<Date> sinceDate, Optional<Date> untilDate, List<String> formats) {
+            Path outputFilePath, Optional<Date> sinceDate, Optional<Date> untilDate, List<Format> formats) {
         this.locations = locations;
         this.outputFilePath = outputFilePath;
         this.sinceDate = sinceDate;

--- a/src/main/java/reposense/model/RepoConfiguration.java
+++ b/src/main/java/reposense/model/RepoConfiguration.java
@@ -19,8 +19,6 @@ import reposense.util.FileUtil;
 public class RepoConfiguration {
     public static final String DEFAULT_BRANCH = "HEAD";
     private static final Logger logger = LogsManager.getLogger(RepoConfiguration.class);
-    private static final String MESSAGE_ILLEGAL_FORMATS = "The provided formats, %s, contains illegal characters.";
-    private static final String FORMAT_VALIDATION_REGEX = "[A-Za-z0-9]+";
 
     private static final String COMMIT_HASH_REGEX = "^[0-9a-f]+$";
     private static final String INVALID_COMMIT_HASH_MESSAGE =
@@ -34,7 +32,7 @@ public class RepoConfiguration {
 
     private transient boolean needCheckStyle = false;
     private transient boolean annotationOverwrite = true;
-    private transient List<String> formats;
+    private transient List<Format> formats;
     private transient int commitNum = 1;
     private transient List<String> ignoreGlobList = new ArrayList<>();
     private transient List<Author> authorList = new ArrayList<>();
@@ -51,7 +49,7 @@ public class RepoConfiguration {
         this(location, branch, Collections.emptyList(), Collections.emptyList(), false, Collections.emptyList());
     }
 
-    public RepoConfiguration(RepoLocation location, String branch, List<String> formats, List<String> ignoreGlobList,
+    public RepoConfiguration(RepoLocation location, String branch, List<Format> formats, List<String> ignoreGlobList,
             boolean isStandaloneConfigIgnored, List<String> ignoreCommitList) {
         this.location = location;
         this.branch = branch;
@@ -105,7 +103,7 @@ public class RepoConfiguration {
     /**
      * Sets {@code formats} to {@code RepoConfiguration} in {@code configs} if its format list is empty.
      */
-    public static void setFormatsToRepoConfigs(List<RepoConfiguration> configs, List<String> formats) {
+    public static void setFormatsToRepoConfigs(List<RepoConfiguration> configs, List<Format> formats) {
         configs.stream().filter(config -> config.getFormats().isEmpty())
                         .forEach(config -> config.setFormats(formats));
     }
@@ -129,7 +127,7 @@ public class RepoConfiguration {
             aliases.add(author.getGitId());
             aliases.forEach(alias -> newAuthorAliasMap.put(alias, author));
         }
-        validateFormats(standaloneConfig.getFormats());
+        Format.validateFormats(standaloneConfig.getFormats());
         validateIgnoreCommits(standaloneConfig.getIgnoreCommitList());
 
         // only assign the new values when all the fields in {@code standaloneConfig} pass the validations.
@@ -137,7 +135,7 @@ public class RepoConfiguration {
         authorAliasMap = newAuthorAliasMap;
         authorDisplayNameMap = newAuthorDisplayNameMap;
         ignoreGlobList = newIgnoreGlobList;
-        formats = standaloneConfig.getFormats();
+        formats = Format.convertStringsToFormats(standaloneConfig.getFormats());
         ignoreCommitList = standaloneConfig.getIgnoreCommitList();
     }
 
@@ -281,11 +279,11 @@ public class RepoConfiguration {
         this.untilDate = untilDate;
     }
 
-    public List<String> getFormats() {
+    public List<Format> getFormats() {
         return formats;
     }
 
-    public void setFormats(List<String> formats) {
+    public void setFormats(List<Format> formats) {
         this.formats = formats;
     }
 
@@ -315,25 +313,6 @@ public class RepoConfiguration {
 
     public boolean isStandaloneConfigIgnored() {
         return isStandaloneConfigIgnored;
-    }
-
-    /**
-     * Returns true if the given {@code value} is a valid format.
-     */
-    private static boolean isValidFormat(String value) {
-        return value.matches(FORMAT_VALIDATION_REGEX);
-    }
-
-    /**
-     * Checks that all the strings in the {@code formats} are in valid formats.
-     * @throws IllegalArgumentException if any of the values do not meet the criteria.
-     */
-    private static void validateFormats(List<String> formats) throws IllegalArgumentException {
-        for (String format: formats) {
-            if (!isValidFormat(format)) {
-                throw new IllegalArgumentException(String.format(MESSAGE_ILLEGAL_FORMATS, format));
-            }
-        }
     }
 
     /**

--- a/src/main/java/reposense/model/RepoLocation.java
+++ b/src/main/java/reposense/model/RepoLocation.java
@@ -1,0 +1,122 @@
+package reposense.model;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.InvalidPathException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import reposense.parser.InvalidLocationException;
+
+/**
+ * Represents a repository location.
+ */
+public class RepoLocation {
+    private static final String GIT_LINK_SUFFIX = ".git";
+    private static final Pattern GIT_REPOSITORY_LOCATION_PATTERN =
+            Pattern.compile("^.*github.com\\/(?<org>.+?)\\/(?<repoName>.+?)\\.git$");
+
+    private final String location;
+    private final String repoName;
+    private String organization;
+
+    /**
+     * @throws InvalidLocationException if {@code location} cannot be represented by a {@code URL} or {@code Path}.
+     */
+    public RepoLocation(String location) throws InvalidLocationException {
+        verifyLocation(location);
+        this.location = location;
+        Matcher matcher = GIT_REPOSITORY_LOCATION_PATTERN.matcher(location);
+
+        if (matcher.matches()) {
+            organization = matcher.group("org");
+            repoName = matcher.group("repoName");
+        } else {
+            repoName = Paths.get(location).getFileName().toString().replace(GIT_LINK_SUFFIX, "");
+        }
+    }
+
+    public String getRepoName() {
+        return repoName;
+    }
+
+    public String getOrganization() {
+        return organization;
+    }
+
+    /**
+     * Verifies {@code location} can be presented as a {@code URL} or {@code Path}.
+     * @throws InvalidLocationException if otherwise.
+     */
+    private void verifyLocation(String location) throws InvalidLocationException {
+        boolean isValidPathLocation = false;
+        boolean isValidGitUrl = false;
+
+        try {
+            Path pathLocation = Paths.get(location);
+            isValidPathLocation = Files.exists(pathLocation);
+        } catch (InvalidPathException ipe) {
+            // Ignore exception
+        }
+
+        try {
+            new URL(location);
+            isValidGitUrl = location.endsWith(GIT_LINK_SUFFIX);
+        } catch (MalformedURLException mue) {
+            // Ignore exception
+        }
+
+        if (!isValidPathLocation && !isValidGitUrl) {
+            throw new InvalidLocationException(location + " is an invalid location.");
+        }
+    }
+
+    @Override
+    public String toString() {
+        return location;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        // short circuit if same object
+        if (this == other) {
+            return true;
+        }
+
+        // instanceof handles null
+        if (!(other instanceof RepoLocation)) {
+            return false;
+        }
+
+        RepoLocation otherLocation = (RepoLocation) other;
+        return this.location.equals(otherLocation.location);
+    }
+
+    @Override
+    public int hashCode() {
+        return location.hashCode();
+    }
+
+    /**
+     * Converts all the strings in {@code locations} into {@code RepoLocation} objects.
+     * Returns null if {@code locations} is null.
+     * @throws InvalidLocationException if any of the strings are in invalid formats.
+     */
+    public static List<RepoLocation> convertStringsToLocations(List<String> locations) throws InvalidLocationException {
+        if (locations == null) {
+            return null;
+        }
+
+        List<RepoLocation> convertedLocations = new ArrayList<>();
+        for (String location : locations) {
+            convertedLocations.add(new RepoLocation(location));
+        }
+
+        return convertedLocations;
+    }
+}

--- a/src/main/java/reposense/model/StandaloneConfig.java
+++ b/src/main/java/reposense/model/StandaloneConfig.java
@@ -4,8 +4,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
-import reposense.parser.ArgsParser;
-
 /**
  * Represents the structure of a config.json in _reposense folder.
  */
@@ -35,7 +33,7 @@ public class StandaloneConfig {
 
     public List<String> getFormats() {
         if (formats == null) {
-            return ArgsParser.DEFAULT_FORMATS;
+            return Format.DEFAULT_FORMAT_STRINGS;
         }
 
         formats.removeIf(Objects::isNull);

--- a/src/main/java/reposense/parser/ArgsParser.java
+++ b/src/main/java/reposense/parser/ArgsParser.java
@@ -2,7 +2,6 @@ package reposense.parser;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 import java.util.Optional;
@@ -15,6 +14,7 @@ import net.sourceforge.argparse4j.inf.MutuallyExclusiveGroup;
 import net.sourceforge.argparse4j.inf.Namespace;
 import reposense.model.CliArguments;
 import reposense.model.ConfigCliArguments;
+import reposense.model.Format;
 import reposense.model.LocationsCliArguments;
 import reposense.model.ViewCliArguments;
 
@@ -23,8 +23,6 @@ import reposense.model.ViewCliArguments;
  */
 public class ArgsParser {
     public static final String DEFAULT_REPORT_NAME = "reposense-report";
-    public static final List<String> DEFAULT_FORMATS = Arrays.asList(
-            "adoc", "cs", "css", "fxml", "gradle", "html", "java", "js", "json", "jsp", "md", "py", "tag", "xml");
     private static final String PROGRAM_USAGE = "java -jar RepoSense.jar";
     private static final String PROGRAM_DESCRIPTION =
             "RepoSense is a contribution analysis tool for Git repositories.";
@@ -87,7 +85,7 @@ public class ArgsParser {
                 .nargs("*")
                 .metavar("FORMAT")
                 .type(new AlphanumericArgumentType())
-                .setDefault(DEFAULT_FORMATS)
+                .setDefault(Format.DEFAULT_FORMAT_STRINGS)
                 .help("The alphanumeric file formats to process.\n"
                         + "If not provided, default file formats will be used.\n"
                         + "Please refer to userguide for more information.");
@@ -110,8 +108,8 @@ public class ArgsParser {
             Path outputFolderPath = results.get("output");
             Optional<Date> sinceDate = results.get("since");
             Optional<Date> untilDate = results.get("until");
-            List<String> formats = results.get("formats");
             List<String> locations = results.get("repos");
+            List<Format> formats = Format.convertStringsToFormats(results.get("formats"));
 
             verifyDatesRangeIsCorrect(sinceDate, untilDate);
 

--- a/src/main/java/reposense/parser/AuthorConfigCsvParser.java
+++ b/src/main/java/reposense/parser/AuthorConfigCsvParser.java
@@ -7,6 +7,7 @@ import java.util.List;
 
 import reposense.model.Author;
 import reposense.model.RepoConfiguration;
+import reposense.model.RepoLocation;
 
 public class AuthorConfigCsvParser extends CsvParser<RepoConfiguration> {
     public static final String AUTHOR_CONFIG_FILENAME = "author-config.csv";
@@ -76,7 +77,7 @@ public class AuthorConfigCsvParser extends CsvParser<RepoConfiguration> {
      */
     private static RepoConfiguration getRepoConfiguration(
             List<RepoConfiguration> results, String location, String branch) throws InvalidLocationException {
-        RepoConfiguration config = new RepoConfiguration(location, branch);
+        RepoConfiguration config = new RepoConfiguration(new RepoLocation(location), branch);
         int index = results.indexOf(config);
 
         if (index != -1) {

--- a/src/main/java/reposense/parser/CsvParser.java
+++ b/src/main/java/reposense/parser/CsvParser.java
@@ -64,6 +64,8 @@ public abstract class CsvParser<T> {
             throw new IOException(MESSAGE_UNABLE_TO_READ_CSV_FILE, ioe);
         } catch (ParseException pe) {
             logger.log(Level.WARNING, pe.getMessage(), pe);
+        } catch (IllegalArgumentException iae) {
+            logger.log(Level.WARNING, iae.getMessage(), iae);
         }
 
         return results;

--- a/src/main/java/reposense/parser/RepoConfigCsvParser.java
+++ b/src/main/java/reposense/parser/RepoConfigCsvParser.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.util.List;
 
+import reposense.model.Format;
 import reposense.model.RepoConfiguration;
 import reposense.model.RepoLocation;
 
@@ -44,7 +45,7 @@ public class RepoConfigCsvParser extends CsvParser<RepoConfiguration> {
     protected void processLine(List<RepoConfiguration> results, String[] elements) throws InvalidLocationException {
         RepoLocation location = new RepoLocation(getValueInElement(elements, LOCATION_POSITION));
         String branch = getValueInElement(elements, BRANCH_POSITION, RepoConfiguration.DEFAULT_BRANCH);
-        List<String> formats = getManyValueInElement(elements, FILE_FORMATS_POSITION);
+        List<Format> formats = Format.convertStringsToFormats(getManyValueInElement(elements, FILE_FORMATS_POSITION));
         List<String> ignoreGlobList = getManyValueInElement(elements, IGNORE_GLOB_LIST_POSITION);
         String ignoreStandaloneConfig = getValueInElement(elements, IGNORE_STANDALONE_CONFIG_POSITION);
         List<String> ignoreCommitList = getManyValueInElement(elements, IGNORE_COMMIT_LIST_CONFIG_POSITION);

--- a/src/main/java/reposense/parser/RepoConfigCsvParser.java
+++ b/src/main/java/reposense/parser/RepoConfigCsvParser.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.util.List;
 
+import reposense.model.CommitHash;
 import reposense.model.Format;
 import reposense.model.RepoConfiguration;
 import reposense.model.RepoLocation;
@@ -48,7 +49,8 @@ public class RepoConfigCsvParser extends CsvParser<RepoConfiguration> {
         List<Format> formats = Format.convertStringsToFormats(getManyValueInElement(elements, FILE_FORMATS_POSITION));
         List<String> ignoreGlobList = getManyValueInElement(elements, IGNORE_GLOB_LIST_POSITION);
         String ignoreStandaloneConfig = getValueInElement(elements, IGNORE_STANDALONE_CONFIG_POSITION);
-        List<String> ignoreCommitList = getManyValueInElement(elements, IGNORE_COMMIT_LIST_CONFIG_POSITION);
+        List<CommitHash> ignoreCommitList = CommitHash.convertStringsToCommits(
+                getManyValueInElement(elements, IGNORE_COMMIT_LIST_CONFIG_POSITION));
 
         boolean isStandaloneConfigIgnored = ignoreStandaloneConfig.equalsIgnoreCase(IGNORE_STANDALONE_CONFIG_KEYWORD);
 

--- a/src/main/java/reposense/parser/RepoConfigCsvParser.java
+++ b/src/main/java/reposense/parser/RepoConfigCsvParser.java
@@ -5,6 +5,7 @@ import java.nio.file.Path;
 import java.util.List;
 
 import reposense.model.RepoConfiguration;
+import reposense.model.RepoLocation;
 
 public class RepoConfigCsvParser extends CsvParser<RepoConfiguration> {
     public static final String REPO_CONFIG_FILENAME = "repo-config.csv";
@@ -41,7 +42,7 @@ public class RepoConfigCsvParser extends CsvParser<RepoConfiguration> {
      */
     @Override
     protected void processLine(List<RepoConfiguration> results, String[] elements) throws InvalidLocationException {
-        String location = getValueInElement(elements, LOCATION_POSITION);
+        RepoLocation location = new RepoLocation(getValueInElement(elements, LOCATION_POSITION));
         String branch = getValueInElement(elements, BRANCH_POSITION, RepoConfiguration.DEFAULT_BRANCH);
         List<String> formats = getManyValueInElement(elements, FILE_FORMATS_POSITION);
         List<String> ignoreGlobList = getManyValueInElement(elements, IGNORE_GLOB_LIST_POSITION);

--- a/src/systemtest/resources/dateRange/expected/summary.json
+++ b/src/systemtest/resources/dateRange/expected/summary.json
@@ -2,45 +2,55 @@
   "dashboardGeneratedTime": "Tue Jul 24 17:45:15 SGT 2018",
   "repos": [
     {
-      "location": "https://github.com/reposense/testrepo-Alpha.git",
-      "organization": "reposense",
-      "repoName": "testrepo-Alpha",
+      "location": {
+        "location": "https://github.com/reposense/testrepo-Alpha.git",
+        "repoName": "testrepo-Alpha",
+        "organization": "reposense"
+      },
       "branch": "master",
       "displayName": "reposense_testrepo-Alpha_master",
       "sinceDate": "2017-09-01",
       "untilDate": "2017-10-30"
     },
     {
-      "location": "https://github.com/reposense/testrepo-Beta.git",
-      "organization": "reposense",
-      "repoName": "testrepo-Beta",
+      "location": {
+        "location": "https://github.com/reposense/testrepo-Beta.git",
+        "repoName": "testrepo-Beta",
+        "organization": "reposense"
+      },
       "branch": "master",
       "displayName": "reposense_testrepo-Beta_master",
       "sinceDate": "2017-09-01",
       "untilDate": "2017-10-30"
     },
     {
-      "location": "https://github.com/reposense/testrepo-Charlie.git",
-      "organization": "reposense",
-      "repoName": "testrepo-Charlie",
+      "location": {
+        "location": "https://github.com/reposense/testrepo-Charlie.git",
+        "repoName": "testrepo-Charlie",
+        "organization": "reposense"
+      },
       "branch": "master",
       "displayName": "reposense_testrepo-Charlie_master",
       "sinceDate": "2017-09-01",
       "untilDate": "2017-10-30"
     },
     {
-      "location": "https://github.com/reposense/testrepo-Delta.git",
-      "organization": "reposense",
-      "repoName": "testrepo-Delta",
+      "location": {
+        "location": "https://github.com/reposense/testrepo-Delta.git",
+        "repoName": "testrepo-Delta",
+        "organization": "reposense"
+      },
       "branch": "master",
       "displayName": "reposense_testrepo-Delta_master",
       "sinceDate": "2017-09-01",
       "untilDate": "2017-10-30"
     },
     {
-      "location": "https://github.com/reposense/testrepo-Delta.git",
-      "organization": "reposense",
-      "repoName": "testrepo-Delta",
+      "location": {
+        "location": "https://github.com/reposense/testrepo-Delta.git",
+        "repoName": "testrepo-Delta",
+        "organization": "reposense"
+      },
       "branch": "nonExistentBranch",
       "displayName": "reposense_testrepo-Delta_nonExistentBranch",
       "sinceDate": "2017-09-01",

--- a/src/systemtest/resources/noDateRange/expected/summary.json
+++ b/src/systemtest/resources/noDateRange/expected/summary.json
@@ -2,37 +2,47 @@
   "dashboardGeneratedTime": "Tue Jul 24 17:45:15 SGT 2018",
   "repos": [
     {
-      "location": "https://github.com/reposense/testrepo-Alpha.git",
-      "organization": "reposense",
-      "repoName": "testrepo-Alpha",
+      "location": {
+        "location": "https://github.com/reposense/testrepo-Alpha.git",
+        "repoName": "testrepo-Alpha",
+        "organization": "reposense"
+      },
       "branch": "master",
       "displayName": "reposense_testrepo-Alpha_master"
     },
     {
-      "location": "https://github.com/reposense/testrepo-Beta.git",
-      "organization": "reposense",
-      "repoName": "testrepo-Beta",
+      "location": {
+        "location": "https://github.com/reposense/testrepo-Beta.git",
+        "repoName": "testrepo-Beta",
+        "organization": "reposense"
+      },
       "branch": "master",
       "displayName": "reposense_testrepo-Beta_master"
     },
     {
-      "location": "https://github.com/reposense/testrepo-Charlie.git",
-      "organization": "reposense",
-      "repoName": "testrepo-Charlie",
+      "location": {
+        "location": "https://github.com/reposense/testrepo-Charlie.git",
+        "repoName": "testrepo-Charlie",
+        "organization": "reposense"
+      },
       "branch": "master",
       "displayName": "reposense_testrepo-Charlie_master"
     },
     {
-      "location": "https://github.com/reposense/testrepo-Delta.git",
-      "organization": "reposense",
-      "repoName": "testrepo-Delta",
+      "location": {
+        "location": "https://github.com/reposense/testrepo-Delta.git",
+        "repoName": "testrepo-Delta",
+        "organization": "reposense"
+      },
       "branch": "master",
       "displayName": "reposense_testrepo-Delta_master"
     },
     {
-      "location": "https://github.com/reposense/testrepo-Delta.git",
-      "organization": "reposense",
-      "repoName": "testrepo-Delta",
+      "location": {
+        "location": "https://github.com/reposense/testrepo-Delta.git",
+        "repoName": "testrepo-Delta",
+        "organization": "reposense"
+      },
       "branch": "nonExistentBranch",
       "displayName": "reposense_testrepo-Delta_nonExistentBranch"
     }

--- a/src/test/java/reposense/authorship/FileAnalyzerTest.java
+++ b/src/test/java/reposense/authorship/FileAnalyzerTest.java
@@ -13,6 +13,7 @@ import reposense.authorship.model.FileResult;
 import reposense.git.CommitNotFoundException;
 import reposense.git.GitCheckout;
 import reposense.model.Author;
+import reposense.model.CommitHash;
 import reposense.template.GitTestTemplate;
 import reposense.util.TestUtil;
 
@@ -66,7 +67,8 @@ public class FileAnalyzerTest extends GitTestTemplate {
 
         FileInfo fileInfoShort = generateTestFileInfo("blameTest.java");
         config.setIgnoreCommitList(
-                Collections.singletonList(FAKE_AUTHOR_BLAME_TEST_FILE_COMMIT_08022018.substring(0, 8)));
+                Collections.singletonList(
+                        new CommitHash(FAKE_AUTHOR_BLAME_TEST_FILE_COMMIT_08022018_STRING.substring(0, 8))));
         FileInfoAnalyzer.analyzeFile(config, fileInfoShort);
 
         Assert.assertEquals(fileInfoFull, fileInfoShort);
@@ -87,8 +89,9 @@ public class FileAnalyzerTest extends GitTestTemplate {
         FileInfoAnalyzer.analyzeFile(config, fileInfoFull);
 
         FileInfo fileInfoShort = generateTestFileInfo("blameTest.java");
-        config.setIgnoreCommitList(Arrays.asList(FAKE_AUTHOR_BLAME_TEST_FILE_COMMIT_08022018.substring(0, 8),
-                MAIN_AUTHOR_BLAME_TEST_FILE_COMMIT_06022018.substring(0, 8)));
+        config.setIgnoreCommitList(CommitHash.convertStringsToCommits(
+                Arrays.asList(FAKE_AUTHOR_BLAME_TEST_FILE_COMMIT_08022018_STRING.substring(0, 8),
+                        MAIN_AUTHOR_BLAME_TEST_FILE_COMMIT_06022018_STRING.substring(0, 8))));
         FileInfoAnalyzer.analyzeFile(config, fileInfoShort);
 
         Assert.assertEquals(fileInfoFull, fileInfoShort);

--- a/src/test/java/reposense/commits/CommitInfoAnalyzerTest.java
+++ b/src/test/java/reposense/commits/CommitInfoAnalyzerTest.java
@@ -10,6 +10,7 @@ import org.junit.Test;
 import reposense.commits.model.CommitInfo;
 import reposense.commits.model.CommitResult;
 import reposense.model.Author;
+import reposense.model.CommitHash;
 import reposense.template.GitTestTemplate;
 
 public class CommitInfoAnalyzerTest extends GitTestTemplate {
@@ -58,7 +59,8 @@ public class CommitInfoAnalyzerTest extends GitTestTemplate {
         config.setIgnoreCommitList(Collections.singletonList(FAKE_AUTHOR_BLAME_TEST_FILE_COMMIT_08022018));
         List<CommitResult> commitResultsFull = CommitInfoAnalyzer.analyzeCommits(commitInfos, config);
         config.setIgnoreCommitList(
-                Collections.singletonList(FAKE_AUTHOR_BLAME_TEST_FILE_COMMIT_08022018.substring(0, 8)));
+                Collections.singletonList(
+                        new CommitHash(FAKE_AUTHOR_BLAME_TEST_FILE_COMMIT_08022018_STRING.substring(0, 8))));
         List<CommitResult> commitResultsShort = CommitInfoAnalyzer.analyzeCommits(commitInfos, config);
 
         Assert.assertEquals(commitResultsShort, commitResultsFull);
@@ -74,8 +76,9 @@ public class CommitInfoAnalyzerTest extends GitTestTemplate {
         config.setIgnoreCommitList(
                 Arrays.asList(FAKE_AUTHOR_BLAME_TEST_FILE_COMMIT_08022018, EUGENE_AUTHOR_README_FILE_COMMIT_07052018));
         List<CommitResult> commitResultsFull = CommitInfoAnalyzer.analyzeCommits(commitInfos, config);
-        config.setIgnoreCommitList(Arrays.asList(FAKE_AUTHOR_BLAME_TEST_FILE_COMMIT_08022018.substring(0, 8),
-                EUGENE_AUTHOR_README_FILE_COMMIT_07052018.substring(0, 8)));
+        config.setIgnoreCommitList(CommitHash.convertStringsToCommits(Arrays.asList(
+                FAKE_AUTHOR_BLAME_TEST_FILE_COMMIT_08022018_STRING.substring(0, 8),
+                EUGENE_AUTHOR_README_FILE_COMMIT_07052018_STRING.substring(0, 8))));
         List<CommitResult> commitResultsShort = CommitInfoAnalyzer.analyzeCommits(commitInfos, config);
 
         Assert.assertEquals(commitResultsShort, commitResultsFull);

--- a/src/test/java/reposense/git/GitBranchTest.java
+++ b/src/test/java/reposense/git/GitBranchTest.java
@@ -4,6 +4,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import reposense.model.RepoConfiguration;
+import reposense.model.RepoLocation;
 import reposense.parser.ArgsParser;
 import reposense.parser.InvalidLocationException;
 import reposense.template.GitTestTemplate;
@@ -21,10 +22,9 @@ public class GitBranchTest extends GitTestTemplate {
     }
 
     @Test
-    public void getCurrentBranch_uncommonDefaultBranch_success() throws GitCloneException,
-            InvalidLocationException {
-        RepoConfiguration uncommonDefaultConfig = new RepoConfiguration(TEST_REPO_UNCOMMON_DEFAULT_GIT_LOCATION,
-                RepoConfiguration.DEFAULT_BRANCH);
+    public void getCurrentBranch_uncommonDefaultBranch_success() throws GitCloneException, InvalidLocationException {
+        RepoConfiguration uncommonDefaultConfig = new RepoConfiguration(
+                new RepoLocation(TEST_REPO_UNCOMMON_DEFAULT_GIT_LOCATION), RepoConfiguration.DEFAULT_BRANCH);
         uncommonDefaultConfig.setFormats(ArgsParser.DEFAULT_FORMATS);
 
         GitClone.clone(uncommonDefaultConfig);

--- a/src/test/java/reposense/git/GitBranchTest.java
+++ b/src/test/java/reposense/git/GitBranchTest.java
@@ -3,9 +3,9 @@ package reposense.git;
 import org.junit.Assert;
 import org.junit.Test;
 
+import reposense.model.Format;
 import reposense.model.RepoConfiguration;
 import reposense.model.RepoLocation;
-import reposense.parser.ArgsParser;
 import reposense.parser.InvalidLocationException;
 import reposense.template.GitTestTemplate;
 
@@ -25,7 +25,7 @@ public class GitBranchTest extends GitTestTemplate {
     public void getCurrentBranch_uncommonDefaultBranch_success() throws GitCloneException, InvalidLocationException {
         RepoConfiguration uncommonDefaultConfig = new RepoConfiguration(
                 new RepoLocation(TEST_REPO_UNCOMMON_DEFAULT_GIT_LOCATION), RepoConfiguration.DEFAULT_BRANCH);
-        uncommonDefaultConfig.setFormats(ArgsParser.DEFAULT_FORMATS);
+        uncommonDefaultConfig.setFormats(Format.DEFAULT_FORMATS);
 
         GitClone.clone(uncommonDefaultConfig);
         String currentBranch = GitBranch.getCurrentBranch(uncommonDefaultConfig.getRepoRoot());

--- a/src/test/java/reposense/git/GitDiffTest.java
+++ b/src/test/java/reposense/git/GitDiffTest.java
@@ -10,7 +10,8 @@ public class GitDiffTest extends GitTestTemplate {
 
     @Test
     public void diffCommit_validCommitHash_success() {
-        String diffResult = GitDiff.diffCommit(config.getRepoRoot(), FAKE_AUTHOR_BLAME_TEST_FILE_COMMIT_08022018);
+        String diffResult = GitDiff.diffCommit(config.getRepoRoot(),
+                FAKE_AUTHOR_BLAME_TEST_FILE_COMMIT_08022018.toString());
         Assert.assertFalse(diffResult.isEmpty());
     }
 

--- a/src/test/java/reposense/git/GitLogTest.java
+++ b/src/test/java/reposense/git/GitLogTest.java
@@ -8,6 +8,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import reposense.model.Author;
+import reposense.model.Format;
 import reposense.template.GitTestTemplate;
 import reposense.util.TestUtil;
 
@@ -21,14 +22,14 @@ public class GitLogTest extends GitTestTemplate {
 
     @Test
     public void gitLog_nonExistingFormats_noContent() {
-        config.setFormats(Collections.singletonList("py"));
+        config.setFormats(Collections.singletonList(new Format("py")));
         String content = GitLog.get(config, getAlphaAllAliasAuthor());
         Assert.assertTrue(content.isEmpty());
     }
 
     @Test
     public void gitLog_includeAllJavaFiles_success() {
-        config.setFormats(Collections.singletonList("java"));
+        config.setFormats(Collections.singletonList(new Format("java")));
         String content = GitLog.get(config, getAlphaAllAliasAuthor());
         Assert.assertTrue(TestUtil.compareNumberExpectedCommitsToGitLogLines(8, content));
     }
@@ -59,7 +60,7 @@ public class GitLogTest extends GitTestTemplate {
 
     @Test
     public void gitLog_includeAllJavaFilesAuthorIgnoreMovedFile_success() {
-        config.setFormats(Collections.singletonList("java"));
+        config.setFormats(Collections.singletonList(new Format("java")));
         Author ignoreMovedFileAuthor = getAlphaAllAliasAuthor();
         ignoreMovedFileAuthor.setIgnoreGlobList(Collections.singletonList("**movedFile.java"));
 

--- a/src/test/java/reposense/model/CommitHashTest.java
+++ b/src/test/java/reposense/model/CommitHashTest.java
@@ -1,0 +1,23 @@
+package reposense.model;
+
+import java.util.Arrays;
+
+import org.junit.Test;
+
+public class CommitHashTest {
+    @Test
+    public void validateCommits_validHash_success() {
+        CommitHash.validateCommits(Arrays.asList("8d0ac2ee20f04dce8df0591caed460bffacb65a4",
+                "136c6713fc00cfe79a1598e8ce83c6ef3b878660"));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void validateCommits_invalidAlphabet_throwIllegalArgumentException() {
+        CommitHash.validateCommits(Arrays.asList("8d0ac2ee20f04dce8df0591caed460gffacb65a4"));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void validateCommits_nonAlphanumeric_throwIllegalArgumentException() {
+        CommitHash.validateCommits(Arrays.asList("!d0ac2ee20f04dce8df0591caed460gffacb65a4"));
+    }
+}

--- a/src/test/java/reposense/model/FormatTest.java
+++ b/src/test/java/reposense/model/FormatTest.java
@@ -1,0 +1,17 @@
+package reposense.model;
+
+import java.util.Arrays;
+
+import org.junit.Test;
+
+public class FormatTest {
+    @Test
+    public void validateFormats_alphaNumeric_success() {
+        Format.validateFormats(Arrays.asList("java", "7z"));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void validateFormats_nonAlphaNumeric_throwIllegalArgumentException() {
+        Format.validateFormats(Arrays.asList(".java"));
+    }
+}

--- a/src/test/java/reposense/parser/ArgsParserTest.java
+++ b/src/test/java/reposense/parser/ArgsParserTest.java
@@ -19,6 +19,7 @@ import org.junit.Test;
 import reposense.RepoSense;
 import reposense.model.CliArguments;
 import reposense.model.ConfigCliArguments;
+import reposense.model.Format;
 import reposense.model.LocationsCliArguments;
 import reposense.model.RepoConfiguration;
 import reposense.model.ViewCliArguments;
@@ -63,7 +64,8 @@ public class ArgsParserTest {
         Assert.assertEquals(expectedSinceDate, cliArguments.getSinceDate().get());
         Assert.assertEquals(expectedUntilDate, cliArguments.getUntilDate().get());
 
-        List<String> expectedFormats = Arrays.asList("java", "adoc", "html", "css", "js");
+        List<Format> expectedFormats = Format.convertStringsToFormats(
+                Arrays.asList("java", "adoc", "html", "css", "js"));
         Assert.assertEquals(expectedFormats, cliArguments.getFormats());
     }
 
@@ -85,7 +87,8 @@ public class ArgsParserTest {
         Assert.assertEquals(expectedSinceDate, cliArguments.getSinceDate().get());
         Assert.assertEquals(expectedUntilDate, cliArguments.getUntilDate().get());
 
-        List<String> expectedFormats = Arrays.asList("java", "adoc", "html", "css", "js");
+        List<Format> expectedFormats = Format.convertStringsToFormats(Arrays.asList(
+                "java", "adoc", "html", "css", "js"));
         Assert.assertEquals(expectedFormats, cliArguments.getFormats());
     }
 
@@ -102,7 +105,7 @@ public class ArgsParserTest {
         Assert.assertEquals(Optional.empty(), cliArguments.getSinceDate());
         Assert.assertEquals(Optional.empty(), cliArguments.getUntilDate());
         Assert.assertEquals(ArgsParser.DEFAULT_REPORT_NAME, cliArguments.getOutputFilePath().getFileName().toString());
-        Assert.assertEquals(ArgsParser.DEFAULT_FORMATS, cliArguments.getFormats());
+        Assert.assertEquals(Format.DEFAULT_FORMATS, cliArguments.getFormats());
 
         input = String.format("-config %s", CONFIG_FOLDER_RELATIVE);
         cliArguments = ArgsParser.parse(translateCommandline(input));
@@ -115,7 +118,7 @@ public class ArgsParserTest {
         Assert.assertEquals(Optional.empty(), cliArguments.getSinceDate());
         Assert.assertEquals(Optional.empty(), cliArguments.getUntilDate());
         Assert.assertEquals(ArgsParser.DEFAULT_REPORT_NAME, cliArguments.getOutputFilePath().getFileName().toString());
-        Assert.assertEquals(ArgsParser.DEFAULT_FORMATS, cliArguments.getFormats());
+        Assert.assertEquals(Format.DEFAULT_FORMATS, cliArguments.getFormats());
     }
 
     @Test
@@ -177,7 +180,7 @@ public class ArgsParserTest {
         String input = DEFAULT_MANDATORY_ARGS + String.format("-formats %s", formats);
         CliArguments cliArguments = ArgsParser.parse(translateCommandline(input));
         Assert.assertTrue(cliArguments instanceof ConfigCliArguments);
-        List<String> expectedFormats = Arrays.asList("java", "js", "css", "7z");
+        List<Format> expectedFormats = Format.convertStringsToFormats(Arrays.asList("java", "js", "css", "7z"));
         Assert.assertEquals(expectedFormats, cliArguments.getFormats());
     }
 

--- a/src/test/java/reposense/parser/CsvParserTest.java
+++ b/src/test/java/reposense/parser/CsvParserTest.java
@@ -14,6 +14,7 @@ import org.junit.Test;
 
 import reposense.model.Author;
 import reposense.model.CliArguments;
+import reposense.model.CommitHash;
 import reposense.model.ConfigCliArguments;
 import reposense.model.RepoConfiguration;
 import reposense.model.RepoLocation;
@@ -67,7 +68,8 @@ public class CsvParserTest {
 
         Assert.assertTrue(config.isStandaloneConfigIgnored());
 
-        Assert.assertEquals(config.getIgnoreCommitList(), TEST_REPO_BETA_CONFIG_IGNORED_COMMITS);
+        Assert.assertEquals(config.getIgnoreCommitList(),
+                CommitHash.convertStringsToCommits(TEST_REPO_BETA_CONFIG_IGNORED_COMMITS));
     }
 
     @Test

--- a/src/test/java/reposense/parser/CsvParserTest.java
+++ b/src/test/java/reposense/parser/CsvParserTest.java
@@ -16,6 +16,7 @@ import reposense.model.Author;
 import reposense.model.CliArguments;
 import reposense.model.ConfigCliArguments;
 import reposense.model.RepoConfiguration;
+import reposense.model.RepoLocation;
 
 public class CsvParserTest {
     private static final Path TEST_CONFIG_FOLDER = new File(CsvParserTest.class.getClassLoader()
@@ -51,7 +52,7 @@ public class CsvParserTest {
     private static final List<String> FIRST_AUTHOR_GLOB_LIST = Arrays.asList("collated**", "**.java");
 
     @Test
-    public void repoConfig_noSpecialCharacter_success() throws IOException {
+    public void repoConfig_noSpecialCharacter_success() throws IOException, InvalidLocationException {
         RepoConfigCsvParser repoConfigCsvParser = new RepoConfigCsvParser(REPO_CONFIG_NO_SPECIAL_CHARACTER_FILE);
         List<RepoConfiguration> configs = repoConfigCsvParser.parse();
 
@@ -59,7 +60,7 @@ public class CsvParserTest {
 
         RepoConfiguration config = configs.get(0);
 
-        Assert.assertEquals(TEST_REPO_BETA_LOCATION, config.getLocation());
+        Assert.assertEquals(new RepoLocation(TEST_REPO_BETA_LOCATION), config.getLocation());
         Assert.assertEquals(TEST_REPO_BETA_BRANCH, config.getBranch());
 
         Assert.assertEquals(TEST_REPO_BETA_CONFIG_FORMATS, TEST_REPO_BETA_CONFIG_FORMATS);
@@ -70,7 +71,7 @@ public class CsvParserTest {
     }
 
     @Test
-    public void authorConfig_noSpecialCharacter_success() throws IOException {
+    public void authorConfig_noSpecialCharacter_success() throws IOException, InvalidLocationException {
         AuthorConfigCsvParser authorConfigCsvParser =
                 new AuthorConfigCsvParser(AUTHOR_CONFIG_NO_SPECIAL_CHARACTER_FILE);
         List<RepoConfiguration> configs = authorConfigCsvParser.parse();
@@ -79,14 +80,14 @@ public class CsvParserTest {
 
         RepoConfiguration config = configs.get(0);
 
-        Assert.assertEquals(TEST_REPO_BETA_LOCATION, config.getLocation());
+        Assert.assertEquals(new RepoLocation(TEST_REPO_BETA_LOCATION), config.getLocation());
         Assert.assertEquals(TEST_REPO_BETA_BRANCH, config.getBranch());
 
         Assert.assertEquals(AUTHOR_CONFIG_NO_SPECIAL_CHARACTER_AUTHORS, config.getAuthorList());
     }
 
     @Test
-    public void authorConfig_specialCharacter_success() throws IOException {
+    public void authorConfig_specialCharacter_success() throws IOException, InvalidLocationException {
         AuthorConfigCsvParser authorConfigCsvParser = new AuthorConfigCsvParser(AUTHOR_CONFIG_SPECIAL_CHARACTER_FILE);
         List<RepoConfiguration> configs = authorConfigCsvParser.parse();
 
@@ -94,7 +95,7 @@ public class CsvParserTest {
 
         RepoConfiguration config = configs.get(0);
 
-        Assert.assertEquals(TEST_REPO_BETA_LOCATION, config.getLocation());
+        Assert.assertEquals(new RepoLocation(TEST_REPO_BETA_LOCATION), config.getLocation());
         Assert.assertEquals(TEST_REPO_BETA_BRANCH, config.getBranch());
 
         Assert.assertEquals(AUTHOR_CONFIG_SPECIAL_CHARACTER_AUTHORS, config.getAuthorList());
@@ -109,7 +110,8 @@ public class CsvParserTest {
         expectedAuthors.add(FIRST_AUTHOR);
         expectedAuthors.add(SECOND_AUTHOR);
 
-        RepoConfiguration expectedConfig = new RepoConfiguration(TEST_REPO_BETA_LOCATION, TEST_REPO_BETA_BRANCH);
+        RepoConfiguration expectedConfig = new RepoConfiguration(new RepoLocation(TEST_REPO_BETA_LOCATION),
+                TEST_REPO_BETA_BRANCH);
         expectedConfig.setAuthorList(expectedAuthors);
         expectedConfig.setAuthorDisplayName(FIRST_AUTHOR, "Nbr");
         expectedConfig.setAuthorDisplayName(SECOND_AUTHOR, "Zac");
@@ -137,7 +139,7 @@ public class CsvParserTest {
 
     @Test
     public void repoConfig_defaultBranch_success() throws ParseException, IOException {
-        RepoConfiguration expectedConfig = new RepoConfiguration(TEST_REPO_BETA_LOCATION,
+        RepoConfiguration expectedConfig = new RepoConfiguration(new RepoLocation(TEST_REPO_BETA_LOCATION),
                 RepoConfiguration.DEFAULT_BRANCH);
 
         String input = String.format("-config %s", TEST_EMPTY_BRANCH_CONFIG_FOLDER);

--- a/src/test/java/reposense/parser/RepoConfigurationTest.java
+++ b/src/test/java/reposense/parser/RepoConfigurationTest.java
@@ -22,6 +22,7 @@ import reposense.model.Author;
 import reposense.model.CliArguments;
 import reposense.model.ConfigCliArguments;
 import reposense.model.RepoConfiguration;
+import reposense.model.RepoLocation;
 import reposense.report.ReportGenerator;
 import reposense.util.FileUtil;
 import reposense.util.TestUtil;
@@ -78,7 +79,7 @@ public class RepoConfigurationTest {
         expectedAuthors.add(THIRD_AUTHOR);
         expectedAuthors.add(FOURTH_AUTHOR);
 
-        REPO_DELTA_STANDALONE_CONFIG = new RepoConfiguration(TEST_REPO_DELTA, "master");
+        REPO_DELTA_STANDALONE_CONFIG = new RepoConfiguration(new RepoLocation(TEST_REPO_DELTA), "master");
         REPO_DELTA_STANDALONE_CONFIG.setAuthorList(expectedAuthors);
         REPO_DELTA_STANDALONE_CONFIG.addAuthorAliases(FIRST_AUTHOR, FIRST_AUTHOR_ALIASES);
         REPO_DELTA_STANDALONE_CONFIG.addAuthorAliases(SECOND_AUTHOR, SECOND_AUTHOR_ALIASES);
@@ -118,8 +119,8 @@ public class RepoConfigurationTest {
     }
 
     @Test
-    public void repoConfig_usesStandaloneConfig_success() throws InvalidLocationException, GitCloneException {
-        RepoConfiguration actualConfig = new RepoConfiguration(TEST_REPO_DELTA, "master");
+    public void repoConfig_usesStandaloneConfig_success() throws GitCloneException, InvalidLocationException {
+        RepoConfiguration actualConfig = new RepoConfiguration(new RepoLocation(TEST_REPO_DELTA), "master");
         GitClone.clone(actualConfig);
         ReportGenerator.updateRepoConfig(actualConfig);
 
@@ -134,7 +135,7 @@ public class RepoConfigurationTest {
         author.setIgnoreGlobList(REPO_LEVEL_GLOB_LIST);
         expectedAuthors.add(author);
 
-        RepoConfiguration expectedConfig = new RepoConfiguration(TEST_REPO_DELTA, "master");
+        RepoConfiguration expectedConfig = new RepoConfiguration(new RepoLocation(TEST_REPO_DELTA), "master");
         expectedConfig.setAuthorList(expectedAuthors);
         expectedConfig.addAuthorAliases(author, FIRST_AUTHOR_ALIASES);
         expectedConfig.setAuthorDisplayName(author, "Ahm");

--- a/src/test/java/reposense/parser/RepoConfigurationTest.java
+++ b/src/test/java/reposense/parser/RepoConfigurationTest.java
@@ -4,8 +4,6 @@ import static org.apache.tools.ant.types.Commandline.translateCommandline;
 
 import java.io.File;
 import java.io.IOException;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -21,6 +19,7 @@ import reposense.git.GitCloneException;
 import reposense.model.Author;
 import reposense.model.CliArguments;
 import reposense.model.ConfigCliArguments;
+import reposense.model.Format;
 import reposense.model.RepoConfiguration;
 import reposense.model.RepoLocation;
 import reposense.report.ReportGenerator;
@@ -56,7 +55,8 @@ public class RepoConfigurationTest {
     private static final List<String> SECOND_AUTHOR_GLOB_LIST = Arrays.asList("**[!(.md)]", "collated**");
     private static final List<String> THIRD_AUTHOR_GLOB_LIST = Arrays.asList("", "collated**");
 
-    private static final List<String> CONFIG_FORMATS = Arrays.asList("java", "adoc", "md");
+    private static final List<Format> CONFIG_FORMATS = Format.convertStringsToFormats(Arrays.asList(
+            "java", "adoc", "md"));
     private static final List<String> CLI_FORMATS = Arrays.asList("css", "html");
 
     private static RepoConfiguration REPO_DELTA_STANDALONE_CONFIG;
@@ -97,25 +97,6 @@ public class RepoConfigurationTest {
     @Before
     public void cleanRepoDirectory() throws IOException {
         FileUtil.deleteDirectory(FileUtil.REPOS_ADDRESS);
-    }
-
-    @Test
-    public void validateFormats_alphaNumeric_success()
-            throws InvalidLocationException, NoSuchMethodException, InvocationTargetException, IllegalAccessException {
-        Method m = RepoConfiguration.class.getDeclaredMethod("validateFormats", List.class);
-        m.setAccessible(true);
-        m.invoke(null, Arrays.asList("java", "7z"));
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void validateFormats_nonAlphaNumeric_throwIllegalArgumentException() throws Throwable {
-        try {
-            Method m = RepoConfiguration.class.getDeclaredMethod("validateFormats", List.class);
-            m.setAccessible(true);
-            m.invoke(null, Arrays.asList(".java"));
-        } catch (InvocationTargetException ite) {
-            throw ite.getCause();
-        }
     }
 
     @Test
@@ -202,7 +183,7 @@ public class RepoConfigurationTest {
         RepoConfiguration.setFormatsToRepoConfigs(actualConfigs, cliArguments.getFormats());
 
         Assert.assertEquals(1, actualConfigs.size());
-        Assert.assertEquals(CLI_FORMATS, actualConfigs.get(0).getFormats());
+        Assert.assertEquals(Format.convertStringsToFormats(CLI_FORMATS), actualConfigs.get(0).getFormats());
     }
 
     @Test
@@ -215,6 +196,6 @@ public class RepoConfigurationTest {
         RepoConfiguration.setFormatsToRepoConfigs(actualConfigs, cliArguments.getFormats());
 
         Assert.assertEquals(1, actualConfigs.size());
-        Assert.assertEquals(ArgsParser.DEFAULT_FORMATS, actualConfigs.get(0).getFormats());
+        Assert.assertEquals(Format.DEFAULT_FORMATS, actualConfigs.get(0).getFormats());
     }
 }

--- a/src/test/java/reposense/parser/StandaloneConfigJsonParserTest.java
+++ b/src/test/java/reposense/parser/StandaloneConfigJsonParserTest.java
@@ -11,6 +11,7 @@ import org.junit.Test;
 import com.google.gson.JsonSyntaxException;
 
 import reposense.model.Author;
+import reposense.model.Format;
 import reposense.model.RepoConfiguration;
 import reposense.model.RepoLocation;
 import reposense.model.StandaloneConfig;
@@ -54,11 +55,12 @@ public class StandaloneConfigJsonParserTest {
         author.setIgnoreGlobList(Arrays.asList("**.css", "**.html", "**.jade", "**.js"));
 
         EXPECTED_GITHUBID_ONLY_REPOCONFIG = new RepoConfiguration(new RepoLocation(TEST_DUMMY_LOCATION));
-        EXPECTED_GITHUBID_ONLY_REPOCONFIG.setFormats(ArgsParser.DEFAULT_FORMATS);
+        EXPECTED_GITHUBID_ONLY_REPOCONFIG.setFormats(Format.DEFAULT_FORMATS);
         EXPECTED_GITHUBID_ONLY_REPOCONFIG.setAuthorList(Arrays.asList(new Author("yong24s")));
 
         EXPECTED_FULL_REPOCONFIG = new RepoConfiguration(new RepoLocation(TEST_DUMMY_LOCATION));
-        EXPECTED_FULL_REPOCONFIG.setFormats(Arrays.asList("gradle", "jade", "java", "js", "md", "scss", "yml"));
+        EXPECTED_FULL_REPOCONFIG.setFormats(Format.convertStringsToFormats(
+                Arrays.asList("gradle", "jade", "java", "js", "md", "scss", "yml")));
         EXPECTED_FULL_REPOCONFIG.setIgnoreCommitList(Arrays.asList("7b96c563eb2d3612aa5275364333664a18f01491"));
         EXPECTED_FULL_REPOCONFIG.setIgnoreGlobList(Arrays.asList("**.adoc", "collate**"));
         EXPECTED_FULL_REPOCONFIG.setAuthorList(Arrays.asList(author));

--- a/src/test/java/reposense/parser/StandaloneConfigJsonParserTest.java
+++ b/src/test/java/reposense/parser/StandaloneConfigJsonParserTest.java
@@ -11,6 +11,7 @@ import org.junit.Test;
 import com.google.gson.JsonSyntaxException;
 
 import reposense.model.Author;
+import reposense.model.CommitHash;
 import reposense.model.Format;
 import reposense.model.RepoConfiguration;
 import reposense.model.RepoLocation;
@@ -61,7 +62,8 @@ public class StandaloneConfigJsonParserTest {
         EXPECTED_FULL_REPOCONFIG = new RepoConfiguration(new RepoLocation(TEST_DUMMY_LOCATION));
         EXPECTED_FULL_REPOCONFIG.setFormats(Format.convertStringsToFormats(
                 Arrays.asList("gradle", "jade", "java", "js", "md", "scss", "yml")));
-        EXPECTED_FULL_REPOCONFIG.setIgnoreCommitList(Arrays.asList("7b96c563eb2d3612aa5275364333664a18f01491"));
+        EXPECTED_FULL_REPOCONFIG.setIgnoreCommitList(Arrays.asList(new CommitHash(
+                "7b96c563eb2d3612aa5275364333664a18f01491")));
         EXPECTED_FULL_REPOCONFIG.setIgnoreGlobList(Arrays.asList("**.adoc", "collate**"));
         EXPECTED_FULL_REPOCONFIG.setAuthorList(Arrays.asList(author));
         EXPECTED_FULL_REPOCONFIG.setAuthorDisplayName(author, "Yong Hao");

--- a/src/test/java/reposense/parser/StandaloneConfigJsonParserTest.java
+++ b/src/test/java/reposense/parser/StandaloneConfigJsonParserTest.java
@@ -12,6 +12,7 @@ import com.google.gson.JsonSyntaxException;
 
 import reposense.model.Author;
 import reposense.model.RepoConfiguration;
+import reposense.model.RepoLocation;
 import reposense.model.StandaloneConfig;
 import reposense.util.TestUtil;
 
@@ -52,11 +53,11 @@ public class StandaloneConfigJsonParserTest {
         author.setAuthorAliases(Arrays.asList("Yong Hao TENG"));
         author.setIgnoreGlobList(Arrays.asList("**.css", "**.html", "**.jade", "**.js"));
 
-        EXPECTED_GITHUBID_ONLY_REPOCONFIG = new RepoConfiguration(TEST_DUMMY_LOCATION);
+        EXPECTED_GITHUBID_ONLY_REPOCONFIG = new RepoConfiguration(new RepoLocation(TEST_DUMMY_LOCATION));
         EXPECTED_GITHUBID_ONLY_REPOCONFIG.setFormats(ArgsParser.DEFAULT_FORMATS);
         EXPECTED_GITHUBID_ONLY_REPOCONFIG.setAuthorList(Arrays.asList(new Author("yong24s")));
 
-        EXPECTED_FULL_REPOCONFIG = new RepoConfiguration(TEST_DUMMY_LOCATION);
+        EXPECTED_FULL_REPOCONFIG = new RepoConfiguration(new RepoLocation(TEST_DUMMY_LOCATION));
         EXPECTED_FULL_REPOCONFIG.setFormats(Arrays.asList("gradle", "jade", "java", "js", "md", "scss", "yml"));
         EXPECTED_FULL_REPOCONFIG.setIgnoreCommitList(Arrays.asList("7b96c563eb2d3612aa5275364333664a18f01491"));
         EXPECTED_FULL_REPOCONFIG.setIgnoreGlobList(Arrays.asList("**.adoc", "collate**"));
@@ -100,7 +101,7 @@ public class StandaloneConfigJsonParserTest {
 
     private void assertSameConfig(RepoConfiguration expectedRepoConfig, StandaloneConfig actualStandaloneConfig)
             throws InvalidLocationException {
-        RepoConfiguration actualRepoConfig = new RepoConfiguration(TEST_DUMMY_LOCATION);
+        RepoConfiguration actualRepoConfig = new RepoConfiguration(new RepoLocation(TEST_DUMMY_LOCATION));
         actualRepoConfig.update(actualStandaloneConfig);
         TestUtil.compareRepoConfig(expectedRepoConfig, actualRepoConfig);
     }

--- a/src/test/java/reposense/template/GitTestTemplate.java
+++ b/src/test/java/reposense/template/GitTestTemplate.java
@@ -19,9 +19,9 @@ import reposense.git.GitCheckout;
 import reposense.git.GitClone;
 import reposense.git.GitCloneException;
 import reposense.model.Author;
+import reposense.model.Format;
 import reposense.model.RepoConfiguration;
 import reposense.model.RepoLocation;
-import reposense.parser.ArgsParser;
 import reposense.parser.InvalidLocationException;
 import reposense.util.FileUtil;
 
@@ -49,14 +49,14 @@ public class GitTestTemplate {
     public void before() throws InvalidLocationException {
         config = new RepoConfiguration(new RepoLocation(TEST_REPO_GIT_LOCATION), "master");
         config.setAuthorList(Collections.singletonList(getAlphaAllAliasAuthor()));
-        config.setFormats(ArgsParser.DEFAULT_FORMATS);
+        config.setFormats(Format.DEFAULT_FORMATS);
     }
 
     @BeforeClass
     public static void beforeClass() throws GitCloneException, IOException, InvalidLocationException {
         deleteRepos();
         config = new RepoConfiguration(new RepoLocation(TEST_REPO_GIT_LOCATION), "master");
-        config.setFormats(ArgsParser.DEFAULT_FORMATS);
+        config.setFormats(Format.DEFAULT_FORMATS);
         GitClone.clone(config);
     }
 

--- a/src/test/java/reposense/template/GitTestTemplate.java
+++ b/src/test/java/reposense/template/GitTestTemplate.java
@@ -19,6 +19,7 @@ import reposense.git.GitCheckout;
 import reposense.git.GitClone;
 import reposense.git.GitCloneException;
 import reposense.model.Author;
+import reposense.model.CommitHash;
 import reposense.model.Format;
 import reposense.model.RepoConfiguration;
 import reposense.model.RepoLocation;
@@ -34,12 +35,18 @@ public class GitTestTemplate {
     protected static final String FAKE_AUTHOR_NAME = "fakeAuthor";
     protected static final String EUGENE_AUTHOR_NAME = "eugenepeh";
     protected static final String LATEST_COMMIT_HASH = "136c6713fc00cfe79a1598e8ce83c6ef3b878660";
-    protected static final String EUGENE_AUTHOR_README_FILE_COMMIT_07052018 =
+    protected static final String EUGENE_AUTHOR_README_FILE_COMMIT_07052018_STRING =
             "2d87a431fcbb8f73a731b6df0fcbee962c85c250";
-    protected static final String FAKE_AUTHOR_BLAME_TEST_FILE_COMMIT_08022018 =
+    protected static final CommitHash EUGENE_AUTHOR_README_FILE_COMMIT_07052018 =
+            new CommitHash(EUGENE_AUTHOR_README_FILE_COMMIT_07052018_STRING);
+    protected static final String FAKE_AUTHOR_BLAME_TEST_FILE_COMMIT_08022018_STRING =
             "768015345e70f06add2a8b7d1f901dc07bf70582";
-    protected static final String MAIN_AUTHOR_BLAME_TEST_FILE_COMMIT_06022018 =
+    protected static final CommitHash FAKE_AUTHOR_BLAME_TEST_FILE_COMMIT_08022018 =
+            new CommitHash(FAKE_AUTHOR_BLAME_TEST_FILE_COMMIT_08022018_STRING);
+    protected static final String MAIN_AUTHOR_BLAME_TEST_FILE_COMMIT_06022018_STRING =
             "8d0ac2ee20f04dce8df0591caed460bffacb65a4";
+    protected static final CommitHash MAIN_AUTHOR_BLAME_TEST_FILE_COMMIT_06022018 =
+            new CommitHash(MAIN_AUTHOR_BLAME_TEST_FILE_COMMIT_06022018_STRING);
     protected static final String NONEXISTENT_COMMIT_HASH = "nonExistentCommitHash";
 
 

--- a/src/test/java/reposense/template/GitTestTemplate.java
+++ b/src/test/java/reposense/template/GitTestTemplate.java
@@ -20,6 +20,7 @@ import reposense.git.GitClone;
 import reposense.git.GitCloneException;
 import reposense.model.Author;
 import reposense.model.RepoConfiguration;
+import reposense.model.RepoLocation;
 import reposense.parser.ArgsParser;
 import reposense.parser.InvalidLocationException;
 import reposense.util.FileUtil;
@@ -46,7 +47,7 @@ public class GitTestTemplate {
 
     @Before
     public void before() throws InvalidLocationException {
-        config = new RepoConfiguration(TEST_REPO_GIT_LOCATION, "master");
+        config = new RepoConfiguration(new RepoLocation(TEST_REPO_GIT_LOCATION), "master");
         config.setAuthorList(Collections.singletonList(getAlphaAllAliasAuthor()));
         config.setFormats(ArgsParser.DEFAULT_FORMATS);
     }
@@ -54,7 +55,7 @@ public class GitTestTemplate {
     @BeforeClass
     public static void beforeClass() throws GitCloneException, IOException, InvalidLocationException {
         deleteRepos();
-        config = new RepoConfiguration(TEST_REPO_GIT_LOCATION, "master");
+        config = new RepoConfiguration(new RepoLocation(TEST_REPO_GIT_LOCATION), "master");
         config.setFormats(ArgsParser.DEFAULT_FORMATS);
         GitClone.clone(config);
     }


### PR DESCRIPTION
Fixes #316

`RepoConfiguration` has many analysis parameters and as more are added,
it becomes larger and harder to maintain.

Let's delegate some of the parameters to their own classes, this includes
`Location`, `Format` and `Commit`.

These parameters were delegated as currently only formats, ignored
commits and location are being validated.