### PR TITLE
Make -view a flag to launch the report automatically after processing #315

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -69,7 +69,7 @@ Eslint and its accompaning modules can be installed through NPM, so do ensure th
 ### Building and running RepoSense from code
 
 1. Execute the following command on the OS terminal inside the project directory. <br/>
-Usage: `gradlew run -Dargs="([-config CONFIG_FOLDER] | -repos REPO_PATH_OR_URL... | -view REPORT_FOLDER) [-output OUTPUT_DIRECTORY] [-since DD/MM/YYYY] [-until DD/MM/YYYY] [-formats FORMAT...]"` <br/>
+Usage: `gradlew run -Dargs="([-config CONFIG_FOLDER] | -repos REPO_PATH_OR_URL... | -view REPORT_FOLDER) [-output OUTPUT_DIRECTORY] [-since DD/MM/YYYY] [-until DD/MM/YYYY] [-formats FORMAT...][-launch]"` <br/>
 
 Sample usage to generate the report with no specify arguments: (find and use config files in current working directory)
 ```

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -223,9 +223,10 @@ In addition, there are some _optional_ extra parameters you can use to customize
   Example:`-since 01/10/2017`
 * **`-formats LIST_OF_FORMATS`**: A space-separated list of file extensions that should be included in the analysis. Default: `adoc cs css fxml gradle html java js json jsp md py tag xml`<br>
   Example:`-formats css fxml gradle`
+* **`-launch`**: A flag to launch the report automatically after processing.<br>
 
 Here's an example of a command using all parameters:<br>
-`java -jar RepoSense.jar -repo https://github.com/reposense/RepoSense.git -output ./report_folder -since 01/10/2017 -until 01/11/2017 -formats java adoc js`
+`java -jar RepoSense.jar -repo https://github.com/reposense/RepoSense.git -output ./report_folder -since 01/10/2017 -until 01/11/2017 -formats java adoc js -launch`
 
 ### Customize Using csv Config Files
 

--- a/src/main/java/reposense/RepoSense.java
+++ b/src/main/java/reposense/RepoSense.java
@@ -52,6 +52,10 @@ public class RepoSense {
                     formatter.format(ZonedDateTime.now(ZoneId.of("UTC+8"))));
 
             FileUtil.zip(cliArguments.getOutputFilePath().toAbsolutePath(), ".json");
+
+            if (cliArguments.isAutomaticallyLaunching()) {
+                DashboardServer.startServer(SERVER_PORT_NUMBER, (cliArguments.getOutputFilePath().toAbsolutePath()));
+            }
         } catch (IOException ioe) {
             logger.log(Level.WARNING, ioe.getMessage(), ioe);
         } catch (ParseException pe) {

--- a/src/main/java/reposense/model/CliArguments.java
+++ b/src/main/java/reposense/model/CliArguments.java
@@ -13,6 +13,7 @@ public abstract class CliArguments {
     protected Optional<Date> sinceDate;
     protected Optional<Date> untilDate;
     protected List<String> formats;
+    protected Boolean isAutomaticallyLaunching;
 
     public Path getOutputFilePath() {
         return outputFilePath;
@@ -28,6 +29,10 @@ public abstract class CliArguments {
 
     public List<String> getFormats() {
         return formats;
+    }
+
+    public Boolean isAutomaticallyLaunching() {
+        return isAutomaticallyLaunching;
     }
 
     @Override

--- a/src/main/java/reposense/model/ConfigCliArguments.java
+++ b/src/main/java/reposense/model/ConfigCliArguments.java
@@ -17,7 +17,8 @@ public class ConfigCliArguments extends CliArguments {
     private Path authorConfigFilePath;
 
     public ConfigCliArguments(Path configFolderPath,
-            Path outputFilePath, Optional<Date> sinceDate, Optional<Date> untilDate, List<String> formats) {
+            Path outputFilePath, Optional<Date> sinceDate, Optional<Date> untilDate, List<String> formats,
+                              Boolean isAutomaticallyLaunching) {
         this.configFolderPath = configFolderPath;
         this.repoConfigFilePath = configFolderPath.resolve(RepoConfigCsvParser.REPO_CONFIG_FILENAME);
         this.authorConfigFilePath = configFolderPath.resolve(AuthorConfigCsvParser.AUTHOR_CONFIG_FILENAME);
@@ -25,6 +26,7 @@ public class ConfigCliArguments extends CliArguments {
         this.sinceDate = sinceDate;
         this.untilDate = untilDate;
         this.formats = formats;
+        this.isAutomaticallyLaunching = isAutomaticallyLaunching;
     }
 
     public Path getConfigFolderPath() {

--- a/src/main/java/reposense/model/LocationsCliArguments.java
+++ b/src/main/java/reposense/model/LocationsCliArguments.java
@@ -12,12 +12,14 @@ public class LocationsCliArguments extends CliArguments {
     private List<String> locations;
 
     public LocationsCliArguments(List<String> locations,
-            Path outputFilePath, Optional<Date> sinceDate, Optional<Date> untilDate, List<String> formats) {
+            Path outputFilePath, Optional<Date> sinceDate, Optional<Date> untilDate, List<String> formats,
+                                 Boolean isAutomaticallyLaunching) {
         this.locations = locations;
         this.outputFilePath = outputFilePath;
         this.sinceDate = sinceDate;
         this.untilDate = untilDate;
         this.formats = formats;
+        this.isAutomaticallyLaunching = isAutomaticallyLaunching;
     }
 
     public List<String> getLocations() {

--- a/src/main/java/reposense/parser/ArgsParser.java
+++ b/src/main/java/reposense/parser/ArgsParser.java
@@ -8,6 +8,7 @@ import java.util.List;
 import java.util.Optional;
 
 import net.sourceforge.argparse4j.ArgumentParsers;
+import net.sourceforge.argparse4j.impl.Arguments;
 import net.sourceforge.argparse4j.impl.action.HelpArgumentAction;
 import net.sourceforge.argparse4j.inf.ArgumentParser;
 import net.sourceforge.argparse4j.inf.ArgumentParserException;
@@ -92,6 +93,11 @@ public class ArgsParser {
                         + "If not provided, default file formats will be used.\n"
                         + "Please refer to userguide for more information.");
 
+        parser.addArgument("-launch")
+                .setDefault(false)
+                .action(Arguments.storeTrue())
+                .help("A flag to launch the report automatically after processing.");
+
         return parser;
     }
 
@@ -112,11 +118,13 @@ public class ArgsParser {
             Optional<Date> untilDate = results.get("until");
             List<String> formats = results.get("formats");
             List<String> locations = results.get("repos");
+            Boolean isLaunchingAutomatically = results.get("launch");
 
             verifyDatesRangeIsCorrect(sinceDate, untilDate);
 
             if (locations != null) {
-                return new LocationsCliArguments(locations, outputFolderPath, sinceDate, untilDate, formats);
+                return new LocationsCliArguments(locations, outputFolderPath, sinceDate, untilDate, formats,
+                        isLaunchingAutomatically);
             }
 
             if (reportFolderPath != null) {

--- a/src/main/java/reposense/parser/ArgsParser.java
+++ b/src/main/java/reposense/parser/ArgsParser.java
@@ -131,7 +131,8 @@ public class ArgsParser {
                 return new ViewCliArguments(reportFolderPath);
             }
 
-            return new ConfigCliArguments(configFolderPath, outputFolderPath, sinceDate, untilDate, formats);
+            return new ConfigCliArguments(configFolderPath, outputFolderPath, sinceDate, untilDate, formats,
+                    isLaunchingAutomatically);
         } catch (ArgumentParserException ape) {
             throw new ParseException(getArgumentParser().formatUsage() + ape.getMessage() + "\n");
         }

--- a/src/test/java/reposense/parser/ArgsParserTest.java
+++ b/src/test/java/reposense/parser/ArgsParserTest.java
@@ -47,7 +47,7 @@ public class ArgsParserTest {
     @Test
     public void parse_allCorrectInputs_success() throws ParseException, IOException {
         String input = String.format("-config %s -output %s -since 01/07/2017 -until 30/11/2017 "
-                + "-formats java adoc html css js",
+                + "-formats java adoc html css js -launch",
                 CONFIG_FOLDER_ABSOLUTE, OUTPUT_DIRECTORY_ABSOLUTE);
         CliArguments cliArguments = ArgsParser.parse(translateCommandline(input));
         Assert.assertTrue(cliArguments instanceof ConfigCliArguments);
@@ -65,12 +65,15 @@ public class ArgsParserTest {
 
         List<String> expectedFormats = Arrays.asList("java", "adoc", "html", "css", "js");
         Assert.assertEquals(expectedFormats, cliArguments.getFormats());
+
+        Assert.assertTrue(cliArguments.isAutomaticallyLaunching());
     }
 
     @Test
     public void parse_withExtraWhitespaces_success() throws ParseException, IOException {
         String input = String.format("-config %s      -output   %s   -since 01/07/2017   -until    30/11/2017   "
-                + "-formats     java   adoc     html css js ", CONFIG_FOLDER_ABSOLUTE, OUTPUT_DIRECTORY_ABSOLUTE);
+                + "-formats     java   adoc     html css js    -launch", CONFIG_FOLDER_ABSOLUTE,
+                OUTPUT_DIRECTORY_ABSOLUTE);
         CliArguments cliArguments = ArgsParser.parse(translateCommandline(input));
         Assert.assertTrue(cliArguments instanceof ConfigCliArguments);
         Assert.assertTrue(Files.isSameFile(
@@ -87,6 +90,8 @@ public class ArgsParserTest {
 
         List<String> expectedFormats = Arrays.asList("java", "adoc", "html", "css", "js");
         Assert.assertEquals(expectedFormats, cliArguments.getFormats());
+
+        Assert.assertTrue(cliArguments.isAutomaticallyLaunching());
     }
 
     @Test
@@ -103,6 +108,7 @@ public class ArgsParserTest {
         Assert.assertEquals(Optional.empty(), cliArguments.getUntilDate());
         Assert.assertEquals(ArgsParser.DEFAULT_REPORT_NAME, cliArguments.getOutputFilePath().getFileName().toString());
         Assert.assertEquals(ArgsParser.DEFAULT_FORMATS, cliArguments.getFormats());
+        Assert.assertFalse(cliArguments.isAutomaticallyLaunching());
 
         input = String.format("-config %s", CONFIG_FOLDER_RELATIVE);
         cliArguments = ArgsParser.parse(translateCommandline(input));
@@ -116,6 +122,7 @@ public class ArgsParserTest {
         Assert.assertEquals(Optional.empty(), cliArguments.getUntilDate());
         Assert.assertEquals(ArgsParser.DEFAULT_REPORT_NAME, cliArguments.getOutputFilePath().getFileName().toString());
         Assert.assertEquals(ArgsParser.DEFAULT_FORMATS, cliArguments.getFormats());
+        Assert.assertFalse(cliArguments.isAutomaticallyLaunching());
     }
 
     @Test
@@ -149,6 +156,27 @@ public class ArgsParserTest {
         Assert.assertTrue(Files.isSameFile(
                 AUTHOR_CONFIG_CSV_FILE, ((ConfigCliArguments) cliArguments).getAuthorConfigFilePath()));
         Assert.assertTrue(Files.isSameFile(expectedAbsoluteOutputDirectoryPath, cliArguments.getOutputFilePath()));
+    }
+
+    @Test
+    public void parse_configFolderAndLaunchAutomatically_success() throws ParseException, IOException {
+        String input = String.format("-config %s -launch", CONFIG_FOLDER_ABSOLUTE);
+        CliArguments cliArguments = ArgsParser.parse(translateCommandline(input));
+        Assert.assertTrue(cliArguments instanceof ConfigCliArguments);
+        Assert.assertTrue(Files.isSameFile(
+                REPO_CONFIG_CSV_FILE, ((ConfigCliArguments) cliArguments).getRepoConfigFilePath()));
+        Assert.assertTrue(Files.isSameFile(
+                AUTHOR_CONFIG_CSV_FILE, ((ConfigCliArguments) cliArguments).getAuthorConfigFilePath()));
+        Assert.assertTrue(cliArguments.isAutomaticallyLaunching());
+
+        input = String.format("-config %s -launch", CONFIG_FOLDER_RELATIVE);
+        cliArguments = ArgsParser.parse(translateCommandline(input));
+        Assert.assertTrue(cliArguments instanceof ConfigCliArguments);
+        Assert.assertTrue(Files.isSameFile(
+                REPO_CONFIG_CSV_FILE, ((ConfigCliArguments) cliArguments).getRepoConfigFilePath()));
+        Assert.assertTrue(Files.isSameFile(
+                AUTHOR_CONFIG_CSV_FILE, ((ConfigCliArguments) cliArguments).getAuthorConfigFilePath()));
+        Assert.assertTrue(cliArguments.isAutomaticallyLaunching());
     }
 
     @Test
@@ -188,6 +216,22 @@ public class ArgsParserTest {
         Assert.assertTrue(cliArguments instanceof LocationsCliArguments);
         List<RepoConfiguration> repoConfigs = RepoSense.getRepoConfigurations((LocationsCliArguments) cliArguments);
         Assert.assertEquals(2, repoConfigs.size());
+    }
+
+    @Test
+    public void parse_repoLocationsAndLaunchAutomatically_success() throws ParseException, IOException {
+        String input = String.format("-repos \"%s\" %s -launch", TEST_REPO_REPOSENSE, TEST_REPO_DELTA);
+        CliArguments cliArguments = ArgsParser.parse(translateCommandline(input));
+        Assert.assertTrue(cliArguments instanceof LocationsCliArguments);
+        Assert.assertTrue(cliArguments.isAutomaticallyLaunching());
+    }
+
+    @Test
+    public void parse_repoLocationsAndNoLaunchAutomatically_success() throws ParseException, IOException {
+        String input = String.format("-repos \"%s\" %s", TEST_REPO_REPOSENSE, TEST_REPO_DELTA);
+        CliArguments cliArguments = ArgsParser.parse(translateCommandline(input));
+        Assert.assertTrue(cliArguments instanceof LocationsCliArguments);
+        Assert.assertFalse(cliArguments.isAutomaticallyLaunching());
     }
 
     @Test


### PR DESCRIPTION
Fixes #315 

Add -launch flag for users to view the report automatically after it has been generated

A separate -view command is required to view the report after generating it.

Lets
* Create an optional -launch flag for users to view the report automatically
* Keep the original functionality of -view
