### PR TITLE
Defend empty commit message and Add test case.

### DIFF
--- a/src/main/java/reposense/commits/CommitInfoAnalyzer.java
+++ b/src/main/java/reposense/commits/CommitInfoAnalyzer.java
@@ -67,7 +67,13 @@ public class CommitInfoAnalyzer {
             logger.log(Level.WARNING, "Unable to parse the date from git log result for commit.", pe);
         }
 
-        String message = elements[MESSAGE_INDEX];
+        String message = "";
+        try {
+            message = elements[MESSAGE_INDEX];
+        } catch (ArrayIndexOutOfBoundsException ex) {
+            logger.log(Level.WARNING, "Encounter empty commit message.", ex);
+        }
+        
         int insertion = getInsertion(statLine);
         int deletion = getDeletion(statLine);
         return new CommitResult(author, hash, date, message, insertion, deletion);


### PR DESCRIPTION
As I was testing RepoSense on one of my module project repo at this link https://github.com/dlworldpeace/SleaseWeb/commits/master
it encounters ArrayIndexOutOfBoundException when empty commit message is used. 
Thus, this PR aims to fix it and add an empty commit message test case.
