### PR TITLE
[#57] Better Exception Handling

### DIFF
--- a/src/main/java/reposense/authorship/FileInfoExtractor.java
+++ b/src/main/java/reposense/authorship/FileInfoExtractor.java
@@ -21,6 +21,7 @@ import reposense.authorship.model.FileInfo;
 import reposense.authorship.model.LineInfo;
 import reposense.git.CommitNotFoundException;
 import reposense.git.GitChecker;
+import reposense.git.GitCheckerException;
 import reposense.model.RepoConfiguration;
 import reposense.system.CommandRunner;
 import reposense.system.LogsManager;
@@ -59,6 +60,8 @@ public class FileInfoExtractor {
         try {
             GitChecker.checkoutToDate(config.getRepoRoot(), config.getBranch(), config.getUntilDate());
         } catch (CommitNotFoundException cnfe) {
+            return fileInfos;
+        } catch (GitCheckerException e) {
             return fileInfos;
         }
         String lastCommitHash = CommandRunner.getCommitHashBeforeDate(

--- a/src/main/java/reposense/commits/CommitInfoExtractor.java
+++ b/src/main/java/reposense/commits/CommitInfoExtractor.java
@@ -7,6 +7,7 @@ import java.util.logging.Logger;
 
 import reposense.commits.model.CommitInfo;
 import reposense.git.GitChecker;
+import reposense.git.GitCheckerException;
 import reposense.model.Author;
 import reposense.model.RepoConfiguration;
 import reposense.system.CommandRunner;
@@ -24,9 +25,14 @@ public class CommitInfoExtractor {
     public static List<CommitInfo> extractCommitInfos(RepoConfiguration config) {
         logger.info("Extracting commits info for " + config.getLocation() + "...");
 
-        GitChecker.checkoutBranch(config.getRepoRoot(), config.getBranch());
-
         List<CommitInfo> repoCommitInfos = new ArrayList<>();
+
+        try {
+            GitChecker.checkoutBranch(config.getRepoRoot(), config.getBranch());
+        } catch (GitCheckerException gce) {
+
+            return repoCommitInfos;
+        }
 
         for (Author author : config.getAuthorList()) {
             String gitLogResult = CommandRunner.gitLog(config, author);

--- a/src/main/java/reposense/git/GitChecker.java
+++ b/src/main/java/reposense/git/GitChecker.java
@@ -1,6 +1,7 @@
 package reposense.git;
 
 import java.util.Date;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import reposense.commits.model.CommitResult;
@@ -11,30 +12,42 @@ public class GitChecker {
 
     private static final Logger logger = LogsManager.getLogger(GitChecker.class);
 
-    public static void checkOutToRecentBranch(String root) {
+    public static void checkOutToRecentBranch(String root) throws GitCheckerException {
         checkout(root, "-");
     }
 
-    public static void checkoutBranch(String root, String branch) {
+    public static void checkoutBranch(String root, String branch) throws GitCheckerException {
         checkout(root, branch);
     }
 
-    public static void checkOutToCommit(String root, CommitResult commit) {
+    public static void checkOutToCommit(String root, CommitResult commit) throws GitCheckerException {
         logger.info("Checking out " + commit.getHash() + "time:" + commit.getTime());
         checkout(root, commit.getHash());
     }
 
-    public static void checkout(String root, String commitHash) {
-        CommandRunner.checkout(root, commitHash);
+    public static void checkout(String root, String commitHash) throws GitCheckerException {
+        try {
+            CommandRunner.checkout(root, commitHash);
+        } catch (RuntimeException rte) {
+            logger.log(Level.SEVERE, "Error encountered in Git Checkout.", rte);
+            throw new GitCheckerException(rte);
+        }
     }
 
     /**
      * Checks out to the latest commit before {@code untilDate} in {@code branchName} branch
      * if {@code untilDate} is not null.
      * @throws CommitNotFoundException if commits before {@code untilDate} cannot be found.
+     * @throws GitCheckerException if git checkout command failed to run.
      */
-    public static void checkoutToDate(String root, String branchName, Date untilDate) throws CommitNotFoundException {
-        CommandRunner.checkoutToDate(root, branchName, untilDate);
+    public static void checkoutToDate(String root, String branchName, Date untilDate)
+            throws CommitNotFoundException, GitCheckerException {
+        try {
+            CommandRunner.checkoutToDate(root, branchName, untilDate);
+        } catch (RuntimeException rte) {
+            logger.log(Level.SEVERE, "Error encountered in Git Checkout.", rte);
+            throw new GitCheckerException(rte);
+        }
     }
 }
 

--- a/src/main/java/reposense/git/GitCheckerException.java
+++ b/src/main/java/reposense/git/GitCheckerException.java
@@ -1,0 +1,7 @@
+package reposense.git;
+
+public class GitCheckerException extends Exception{
+    public GitCheckerException(Exception e) {
+        super(e.getMessage());
+    }
+}

--- a/src/main/java/reposense/git/GitDownloader.java
+++ b/src/main/java/reposense/git/GitDownloader.java
@@ -41,6 +41,9 @@ public class GitDownloader {
         } catch (RuntimeException e) {
             logger.log(Level.SEVERE, "Branch does not exist! Analyze terminated.", e);
             throw new GitDownloaderException(e);
+        } catch (GitCheckerException e) {
+            logger.log(Level.SEVERE, "Failed to checkout to current branch.", e);
+            throw new GitDownloaderException(e);
         }
 
     }

--- a/src/test/java/reposense/authorship/FileAnalyzerTest.java
+++ b/src/test/java/reposense/authorship/FileAnalyzerTest.java
@@ -12,6 +12,7 @@ import reposense.authorship.model.FileInfo;
 import reposense.authorship.model.FileResult;
 import reposense.git.CommitNotFoundException;
 import reposense.git.GitChecker;
+import reposense.git.GitCheckerException;
 import reposense.model.Author;
 import reposense.template.GitTestTemplate;
 import reposense.util.TestUtil;
@@ -33,7 +34,7 @@ public class FileAnalyzerTest extends GitTestTemplate {
     }
 
     @Test
-    public void blameTestDateRange() throws CommitNotFoundException {
+    public void blameTestDateRange() throws CommitNotFoundException, GitCheckerException {
         Date sinceDate = TestUtil.getDate(2018, Calendar.FEBRUARY, 6);
         Date untilDate = TestUtil.getDate(2018, Calendar.FEBRUARY, 8);
 
@@ -46,7 +47,7 @@ public class FileAnalyzerTest extends GitTestTemplate {
     }
 
     @Test
-    public void movedFileBlameTestDateRange() throws CommitNotFoundException {
+    public void movedFileBlameTestDateRange() throws CommitNotFoundException, GitCheckerException {
         Date sinceDate = TestUtil.getDate(2018, Calendar.FEBRUARY, 7);
         Date untilDate = TestUtil.getDate(2018, Calendar.FEBRUARY, 9);
 

--- a/src/test/java/reposense/authorship/FileInfoExtractorTest.java
+++ b/src/test/java/reposense/authorship/FileInfoExtractorTest.java
@@ -11,6 +11,7 @@ import org.junit.Test;
 
 import reposense.authorship.model.FileInfo;
 import reposense.git.GitChecker;
+import reposense.git.GitCheckerException;
 import reposense.model.Author;
 import reposense.template.GitTestTemplate;
 import reposense.util.TestUtil;
@@ -28,7 +29,7 @@ public class FileInfoExtractorTest extends GitTestTemplate {
     private static final String OCTOBER_SEVENTH_COMMIT_HASH = "b28dfac5bd449825c1a372e58485833b35fdbd50";
 
     @Test
-    public void extractFileInfosTest() {
+    public void extractFileInfosTest() throws GitCheckerException {
         config.getAuthorAliasMap().put(MAIN_AUTHOR_NAME, new Author(MAIN_AUTHOR_NAME));
         config.getAuthorAliasMap().put(FAKE_AUTHOR_NAME, new Author(FAKE_AUTHOR_NAME));
         GitChecker.checkout(config.getRepoRoot(), TEST_COMMIT_HASH);
@@ -62,7 +63,7 @@ public class FileInfoExtractorTest extends GitTestTemplate {
     }
 
     @Test
-    public void extractFileInfos_windowsIllegalFileNameBranch_success() {
+    public void extractFileInfos_windowsIllegalFileNameBranch_success() throws GitCheckerException {
         GitChecker.checkout(config.getRepoRoot(), WINDOWS_ILLEGAL_FILE_NAME_BRANCH);
         List<FileInfo> files = FileInfoExtractor.extractFileInfos(config);
 
@@ -93,7 +94,7 @@ public class FileInfoExtractorTest extends GitTestTemplate {
     }
 
     @Test
-    public void getEditedFileInfos_editFileInfoBranchSinceFebrauryEight_success() {
+    public void getEditedFileInfos_editFileInfoBranchSinceFebrauryEight_success() throws GitCheckerException {
         GitChecker.checkout(config.getRepoRoot(), EDITED_FILE_INFO_BRANCH);
         List<FileInfo> files = FileInfoExtractor.getEditedFileInfos(config, FEBRUARY_EIGHT_COMMIT_HASH);
 
@@ -107,7 +108,7 @@ public class FileInfoExtractorTest extends GitTestTemplate {
     }
 
     @Test
-    public void getEditedFileInfos_editFileInfoBranchSinceFirstCommit_success() {
+    public void getEditedFileInfos_editFileInfoBranchSinceFirstCommit_success() throws GitCheckerException {
         GitChecker.checkout(config.getRepoRoot(), EDITED_FILE_INFO_BRANCH);
         List<FileInfo> files = FileInfoExtractor.getEditedFileInfos(config, FIRST_COMMIT_HASH);
 
@@ -118,7 +119,7 @@ public class FileInfoExtractorTest extends GitTestTemplate {
     }
 
     @Test
-    public void getEditedFileInfos_windowsIllegalFileNameBranchSinceOctoberFifteen_success() {
+    public void getEditedFileInfos_windowsIllegalFileNameBranchSinceOctoberFifteen_success() throws GitCheckerException {
         GitChecker.checkout(config.getRepoRoot(), WINDOWS_ILLEGAL_FILE_NAME_BRANCH);
         List<FileInfo> files = FileInfoExtractor.getEditedFileInfos(config, OCTOBER_SEVENTH_COMMIT_HASH);
 

--- a/src/test/java/reposense/git/GitCheckerTest.java
+++ b/src/test/java/reposense/git/GitCheckerTest.java
@@ -15,7 +15,7 @@ import reposense.util.TestUtil;
 
 public class GitCheckerTest extends GitTestTemplate {
     @Test
-    public void checkoutBranchTest() {
+    public void checkoutBranchTest() throws GitCheckerException {
         Path branchFile = Paths.get(config.getRepoRoot(), "inTestBranch.java");
         Assert.assertFalse(Files.exists(branchFile));
 
@@ -24,7 +24,7 @@ public class GitCheckerTest extends GitTestTemplate {
     }
 
     @Test
-    public void checkoutHashTest() {
+    public void checkoutHashTest() throws GitCheckerException {
         Path newFile = Paths.get(config.getRepoRoot(), "newFile.java");
         Assert.assertTrue(Files.exists(newFile));
 
@@ -33,7 +33,7 @@ public class GitCheckerTest extends GitTestTemplate {
     }
 
     @Test
-    public void checkoutToDate_validDate_success() throws CommitNotFoundException {
+    public void checkoutToDate_validDate_success() throws CommitNotFoundException, GitCheckerException {
         Path newFile = Paths.get(config.getRepoRoot(), "newFile.java");
         Assert.assertTrue(Files.exists(newFile));
 
@@ -43,7 +43,7 @@ public class GitCheckerTest extends GitTestTemplate {
     }
 
     @Test(expected = CommitNotFoundException.class)
-    public void checkoutToDate_invalidDate_throwsEmptyCommitException() throws CommitNotFoundException {
+    public void checkoutToDate_invalidDate_throwsEmptyCommitException() throws CommitNotFoundException, GitCheckerException {
         Date untilDate = TestUtil.getDate(2015, Calendar.FEBRUARY, 6);
         GitChecker.checkoutToDate(config.getRepoRoot(), config.getBranch(), untilDate);
     }


### PR DESCRIPTION
Part of #57 

Add GitCheckerException for better debuggability. Currently when any of the git command fails, it simply throws RuntimeException without telling which specific command failed.

As mentioned in #442, this part of the code will be deprecated to better alternatives, but I still think each git operation deserves exception of its own for better clarity.

There is still a concern whether checked exception is necessary for git failure. If it is unnecessary, then maybe continue using RuntimeException is fine.