### PR TITLE
[#7][Enhancement] Generate collate files and allow users to download them

### DIFF
--- a/frontend/src/index.jade
+++ b/frontend/src/index.jade
@@ -37,8 +37,7 @@ html
                     a(v-else, v-on:click="expand(false)") Collapse all
                 v_authorship(
                   v-bind:key="generateKey(tabInfo.tabAuthorship)",
-                  v-bind:info="tabInfo.tabAuthorship",
-                  v-bind:path="getLink()")
+                  v-bind:info="tabInfo.tabAuthorship")
 
       template(v-else)
         .empty please enter a report directory or upload a report zip

--- a/frontend/src/index.jade
+++ b/frontend/src/index.jade
@@ -37,7 +37,8 @@ html
                     a(v-else, v-on:click="expand(false)") Collapse all
                 v_authorship(
                   v-bind:key="generateKey(tabInfo.tabAuthorship)",
-                  v-bind:info="tabInfo.tabAuthorship")
+                  v-bind:info="tabInfo.tabAuthorship",
+                  v-bind:path="getLink()")
 
       template(v-else)
         .empty please enter a report directory or upload a report zip
@@ -123,6 +124,9 @@ html
       #authorship
         .title
           .repoName {{ info.repo }}
+          span
+            a(v-bind:href="link")
+              download Collated-file
           .author {{ info.name }} ({{ info.author }}) contribution from {{ info.minDate }} to {{ info.maxDate }}
           .contribution(v-if="isLoaded")
             span Total LoC contributed:&nbsp;

--- a/frontend/src/index.jade
+++ b/frontend/src/index.jade
@@ -124,9 +124,9 @@ html
       #authorship
         .title
           .repoName {{ info.repo }}
-          span
+          #downloadLink
             a(v-bind:href="link")
-              download Collated-file
+              i.fas.fa-download
           .author {{ info.name }} ({{ info.author }}) contribution from {{ info.minDate }} to {{ info.maxDate }}
           .contribution(v-if="isLoaded")
             span Total LoC contributed:&nbsp;

--- a/frontend/src/static/css/style.scss
+++ b/frontend/src/static/css/style.scss
@@ -248,6 +248,9 @@ header{
                 }
             }
         }
+        #downloadLink {
+            float: right;
+        }
     }
 
     .files{

--- a/frontend/src/static/js/api.js
+++ b/frontend/src/static/js/api.js
@@ -87,4 +87,8 @@ window.api = {
       });
   },
 
+  downloadFile() {
+    return `${REPORT_DIR}/collated/`
+  }
+
 };

--- a/frontend/src/static/js/api.js
+++ b/frontend/src/static/js/api.js
@@ -87,8 +87,8 @@ window.api = {
       });
   },
 
-  downloadFile() {
-    return `${REPORT_DIR}/collated/`
+  downloadFile(repoName) {
+    return `${REPORT_DIR}/${repoName}/collated/`
   }
 
 };

--- a/frontend/src/static/js/main.js
+++ b/frontend/src/static/js/main.js
@@ -64,9 +64,6 @@ window.app = new window.Vue({
         this.userUpdated = true;
       });
     },
-    getLink() {
-      return window.api.downloadFile();
-    },
     getUsers() {
       const full = [];
       Object.keys(this.repos).forEach((repo) => {

--- a/frontend/src/static/js/main.js
+++ b/frontend/src/static/js/main.js
@@ -64,6 +64,9 @@ window.app = new window.Vue({
         this.userUpdated = true;
       });
     },
+    getLink() {
+      return window.api.downloadFile();
+    },
     getUsers() {
       const full = [];
       Object.keys(this.repos).forEach((repo) => {

--- a/frontend/src/static/js/v_authorship.js
+++ b/frontend/src/static/js/v_authorship.js
@@ -26,7 +26,7 @@ function expandAll(isActive) {
 
 const repoCache = [];
 window.vAuthorship = {
-  props: ['info', 'path'],
+  props: ['info'],
   template: window.$('v_authorship').innerHTML,
   data() {
     return {
@@ -56,7 +56,7 @@ window.vAuthorship = {
         window.api.loadAuthorship(this.info.repo)
           .then(files => this.processFiles(files));
       }
-      this.link = this.path + this.info.author + ".md";
+      this.link = window.api.downloadFile(this.info.repo) + this.info.author + ".md";
     },
 
     splitSegments(lines) {

--- a/frontend/src/static/js/v_authorship.js
+++ b/frontend/src/static/js/v_authorship.js
@@ -26,7 +26,7 @@ function expandAll(isActive) {
 
 const repoCache = [];
 window.vAuthorship = {
-  props: ['info'],
+  props: ['info', 'path'],
   template: window.$('v_authorship').innerHTML,
   data() {
     return {
@@ -34,6 +34,7 @@ window.vAuthorship = {
       files: [],
       filesLinesObj: {},
       totalLineCount: "",
+      link: "",
     };
   },
 
@@ -55,6 +56,7 @@ window.vAuthorship = {
         window.api.loadAuthorship(this.info.repo)
           .then(files => this.processFiles(files));
       }
+      this.link = this.path + this.info.author + ".md";
     },
 
     splitSegments(lines) {

--- a/src/main/java/reposense/report/Collate.java
+++ b/src/main/java/reposense/report/Collate.java
@@ -1,0 +1,88 @@
+package reposense.report;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
+import reposense.authorship.model.FileResult;
+import reposense.authorship.model.LineInfo;
+import reposense.model.Author;
+import reposense.util.FileUtil;
+
+public class Collate {
+
+    private static final String MARKDOWN_TITLE = "# %s";
+    private static final String MARKDOWN_H6 = "###### %s";
+    private static final String MARKDOWN_CODE = "```";
+
+    private HashMap<Author, HashMap<String, List<String>>> codeFromFileFromAuthor = new HashMap<>();
+    private HashMap<Author, List<String>> codeFromAuthor = new HashMap<>();
+    private List<Author> authors;
+    private List<FileResult> fileResults;
+    private Path saveDirectory;
+
+    public Collate(List<Author> authors, List<FileResult> fileResults, Path saveDirectory) {
+        this.authors = authors;
+        this.fileResults = fileResults;
+        this.saveDirectory = saveDirectory;
+    }
+
+
+    public void generateIndividualCollateFiles() {
+        extractCodeFromFileResult();
+        collateCodeFromFiles();
+        collateCodeFromAuthors();
+    }
+
+    private void extractCodeFromFileResult() {
+        for (FileResult fileResult : fileResults) {
+            String file = fileResult.getPath();
+            for (LineInfo lineInfo : fileResult.getLines()) {
+                Author author = lineInfo.getAuthor();
+                if (authors.contains(author)) {
+                    addToCollation(author, file, lineInfo.getContent());
+                }
+            }
+        }
+    }
+
+    private void addToCollation(Author author, String file, String line) {
+        if (!codeFromFileFromAuthor.containsKey(author)) {
+            codeFromFileFromAuthor.put(author, new HashMap<>());
+        }
+        if (!codeFromFileFromAuthor.get(author).containsKey(file)) {
+            codeFromFileFromAuthor.get(author).put(file, new ArrayList<>());
+        }
+        codeFromFileFromAuthor.get(author).get(file).add(line);
+    }
+
+    private void collateCodeFromFiles() {
+        for (Author author: authors) {
+            codeFromAuthor.put(author, new ArrayList<>());
+            HashMap<String, List<String>> filesWritten = codeFromFileFromAuthor.get(author);
+            List<String> markUpLines = new ArrayList<>();
+            if (filesWritten != null && !filesWritten.isEmpty()) {
+                for (String file: filesWritten.keySet()) {
+                    markUpLines.add(String.format(MARKDOWN_H6, file));
+                    markUpLines.add(MARKDOWN_CODE);
+                    for (String line: filesWritten.get(file)) {
+                        markUpLines.add(line);
+                    }
+                    markUpLines.add(MARKDOWN_CODE);
+                }
+                codeFromAuthor.put(author, markUpLines);
+
+            }
+        }
+    }
+
+    private void collateCodeFromAuthors() {
+        for (Author author: authors){
+            List<String> codeByAuthor = codeFromAuthor.get(author);
+            codeByAuthor.add(0, String.format(MARKDOWN_TITLE, author.getGitId()));
+            FileUtil.writeToCollateFile(author.getGitId(), codeByAuthor, saveDirectory);
+        }
+    }
+
+}

--- a/src/main/java/reposense/report/ReportGenerator.java
+++ b/src/main/java/reposense/report/ReportGenerator.java
@@ -50,16 +50,20 @@ public class ReportGenerator {
         FileUtil.copyTemplate(is, outputPath);
 
         for (RepoConfiguration config : configs) {
-            Path repoReportDirectory;
+            Path repoReportDirectory, saveCollateDirectory;
             try {
                 GitDownloader.downloadRepo(config);
                 repoReportDirectory = Paths.get(outputPath, config.getDisplayName());
+                saveCollateDirectory = Paths.get(outputPath, "collated");
                 FileUtil.createDirectory(repoReportDirectory);
+                FileUtil.createDirectory(saveCollateDirectory);
             } catch (GitDownloaderException gde) {
                 logger.log(Level.WARNING,
                         "Exception met while trying to clone the repo, will skip this repo.", gde);
                 repoReportDirectory = Paths.get(outputPath, config.getDisplayName());
+                saveCollateDirectory = Paths.get(outputPath, "collated");
                 FileUtil.createDirectory(repoReportDirectory);
+                FileUtil.createDirectory(saveCollateDirectory);
                 generateEmptyRepoReport(repoReportDirectory.toString());
                 continue;
             } catch (IOException ioe) {
@@ -78,6 +82,8 @@ public class ReportGenerator {
             CommitContributionSummary commitSummary = CommitsReporter.generateCommitSummary(config);
             AuthorshipSummary authorshipSummary = AuthorshipReporter.generateAuthorshipSummary(config);
             generateIndividualRepoReport(commitSummary, authorshipSummary, repoReportDirectory.toString());
+            Collate collator = new Collate(config.getAuthorList(), authorshipSummary.getFileResults(), saveCollateDirectory);
+            collator.generateIndividualCollateFiles();
 
             try {
                 FileUtil.deleteDirectory(FileUtil.REPOS_ADDRESS);

--- a/src/main/java/reposense/report/ReportGenerator.java
+++ b/src/main/java/reposense/report/ReportGenerator.java
@@ -54,14 +54,14 @@ public class ReportGenerator {
             try {
                 GitDownloader.downloadRepo(config);
                 repoReportDirectory = Paths.get(outputPath, config.getDisplayName());
-                saveCollateDirectory = Paths.get(outputPath, "collated");
+                saveCollateDirectory = Paths.get(repoReportDirectory.toString(), "collated");
                 FileUtil.createDirectory(repoReportDirectory);
                 FileUtil.createDirectory(saveCollateDirectory);
             } catch (GitDownloaderException gde) {
                 logger.log(Level.WARNING,
                         "Exception met while trying to clone the repo, will skip this repo.", gde);
                 repoReportDirectory = Paths.get(outputPath, config.getDisplayName());
-                saveCollateDirectory = Paths.get(outputPath, "collated");
+                saveCollateDirectory = Paths.get(repoReportDirectory.toString(), "collated");
                 FileUtil.createDirectory(repoReportDirectory);
                 FileUtil.createDirectory(saveCollateDirectory);
                 generateEmptyRepoReport(repoReportDirectory.toString());

--- a/src/main/java/reposense/util/FileUtil.java
+++ b/src/main/java/reposense/util/FileUtil.java
@@ -13,6 +13,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Comparator;
+import java.util.List;
 import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -37,6 +38,9 @@ public class FileUtil {
     private static final String GITHUB_API_DATE_FORMAT = "yyyy-MM-dd";
     private static final ByteBuffer buffer = ByteBuffer.allocate(1 << 11); // 2KB
 
+    private static final String COLLATED_FILE_PATH_FORMAT = "%s" + File.separator + "%s.md";
+    private static final String ERROR_FILE_NOT_FOUND = "File was not found: %s";
+
     public static void writeJsonFile(Object object, String path) {
         Gson gson = new GsonBuilder()
                 .setDateFormat(GITHUB_API_DATE_FORMAT)
@@ -50,6 +54,18 @@ public class FileUtil {
         } catch (FileNotFoundException e) {
             logger.log(Level.SEVERE, e.getMessage(), e);
         }
+    }
+
+    public static void writeToCollateFile(String authorName, List<String>code, Path directory) {
+        File file = new File(String.format(COLLATED_FILE_PATH_FORMAT, directory, authorName));
+        try (PrintWriter writer = new PrintWriter(file)) {
+            for (String line : code) {
+                writer.println(line);
+            }
+        } catch (FileNotFoundException e) {
+            System.out.println(String.format(ERROR_FILE_NOT_FOUND, authorName));
+        }
+
     }
 
     public static void deleteDirectory(String root) throws IOException {


### PR DESCRIPTION
Currently, RepoSense does not allow users to download their individual contribution. Graders may also have difficulty marking students' code because the original code is in json format, and additional processing may be needed for scripts which run quality checking.

Now, in addition to the commits and authorship json files, every repository folder contains a `collated` folder, which has all the individual collate-files (`name.md`) after file processing.

If the users themselves want to download a copy of the collate file, they may click on the download icon in the tabs section (below `Collapse All`).
![downloadfile](https://user-images.githubusercontent.com/30564248/50439169-fdee3000-092b-11e9-84ac-212c93ff37ec.jpg)

