### PR TITLE
[#452] GitLogTest failure 

### DIFF
--- a/src/test/java/reposense/git/GitLogTest.java
+++ b/src/test/java/reposense/git/GitLogTest.java
@@ -96,11 +96,10 @@ public class GitLogTest extends GitTestTemplate {
 
     @Test
     public void gitLog_untilDateBeforeAnyCommit_noContent() {
-        Date date = TestUtil.getDate(1970, Calendar.JANUARY, 1);
+        Date date = TestUtil.getDate(2010, Calendar.JANUARY, 1);
         config.setUntilDate(date);
         config.setSinceDate(null);
         String content = GitLog.get(config, getAlphaAllAliasAuthor());
         Assert.assertTrue(content.isEmpty());
-
     }
 }

--- a/src/test/java/reposense/git/GitLogTest.java
+++ b/src/test/java/reposense/git/GitLogTest.java
@@ -92,11 +92,15 @@ public class GitLogTest extends GitTestTemplate {
         config.setSinceDate(date);
         String content = GitLog.get(config, getAlphaAllAliasAuthor());
         Assert.assertTrue(content.isEmpty());
+    }
 
-        date = TestUtil.getDate(1950, Calendar.JANUARY, 1);
+    @Test
+    public void gitLog_untilDateBeforeAnyCommit_noContent() {
+        Date date = TestUtil.getDate(1970, Calendar.JANUARY, 1);
         config.setUntilDate(date);
         config.setSinceDate(null);
-        content = GitLog.get(config, getAlphaAllAliasAuthor());
+        String content = GitLog.get(config, getAlphaAllAliasAuthor());
         Assert.assertTrue(content.isEmpty());
+
     }
 }


### PR DESCRIPTION
Part of #452

GitLogTest#gitLog_sinceDateInFuture_noContent() test method has a check
which asserts that if the until date given is before any of the
repository's commit date, the git log command should not give any
commmit info.

However, after the new year in year 2019, the test now fails. This may
be due to the Year 2038[1] problem. As the given until date is too
early (year 1950), this causes the time difference to overflow. As
such, a future until date is formed instead, causing git log to give
all the commit info, thus the test fails.

As a hotfix for this issue, let's set an earlier until date
(year 2010) for the test instead.

As this check is also not within the scope of the test method,
gitLog_sinceDateInFuture_noContent(), let's refactor it out to
a different test method, gitLog_untilDateBeforeAnyCommit_noContent.

[1]: Description of the Year 2038 problem:
https://en.wikipedia.org/wiki/Year_2038_problem