### PR TITLE
Fix broken link on ramps #471

### DIFF
--- a/frontend/src/static/js/v_summary.js
+++ b/frontend/src/static/js/v_summary.js
@@ -140,8 +140,8 @@ window.vSummary = {
       const untilDate = this.filterTimeFrame === 'week' ? addDays(slice.sinceDate, 6): slice.sinceDate;
 
       return `http://github.com/${
-        REPOS[user.repoId].organization}/${
-        REPOS[user.repoId].repoName}/commits/${
+        REPOS[user.repoId].location.organization}/${
+        REPOS[user.repoId].location.repoName}/commits/${
         REPOS[user.repoId].branch}?`
                 + `author=${user.name}&`
                 + `since=${slice.sinceDate}'T'00:00:00+08:00&`


### PR DESCRIPTION
Fix #471 

```
The link on ramps are broken; the organization and repository name on
the url links are undefined.

This is due the change in #425 where we encapsulate the names in
another layer of abstraction.

Let's fix the property accessors in v_summary.js to restore the broken
hyperlink.

```