### PR TITLE
Fix mismatch of file content #473

### DIFF
--- a/frontend/src/index.jade
+++ b/frontend/src/index.jade
@@ -147,7 +147,7 @@ html
 
         .files(v-if="isLoaded")
           .empty(v-if="files.length===0") nothing to see here :(
-          .file.active(v-for="file in selectedFiles")
+          .file.active(v-for="file in selectedFiles", v-bind:key="file.path")
             .title(onclick="toggleNext(this)")
               span {{ file.path }}&nbsp;
               span.loc ({{ file.lineCount }} lines)


### PR DESCRIPTION
Fixes #473 
```
When a file extension is unselected, the file content is not always updated 
despite a change in filename.

This is due to vuejs reusing the DOM for each file as a performance optimization. 

Let's add a key attribute to each file, so that vuejs can track every file correctly 
with proper reusing of the DOM. 
```