### PR TITLE
Open dashboard with code-view shown

### DIFF
--- a/frontend/src/index.jade
+++ b/frontend/src/index.jade
@@ -38,6 +38,15 @@ html
                 v_authorship(
                   v-bind:key="generateKey(tabInfo.tabAuthorship)",
                   v-bind:info="tabInfo.tabAuthorship")
+              #tab-empty.tab-pane(v-else)
+                .title
+                  span To view the code attributed to a specific author, click the &nbsp;
+                  i.fas.fa-code
+                  span &nbsp; icon next to that author's name.
+                  br
+                  span To hide the code view, click the &nbsp;
+                  i.fas.fa-caret-right
+                  span &nbsp; icon on the left.
 
       template(v-else)
         .empty please enter a report directory or upload a report zip

--- a/frontend/src/static/js/main.js
+++ b/frontend/src/static/js/main.js
@@ -24,7 +24,7 @@ window.app = new window.Vue({
     userUpdated: false,
 
     isCollapsed: false,
-    isTabActive: false,
+    isTabActive: true,
     isTabAuthorship: false,
     tabInfo: {},
     tabAuthorship: {},


### PR DESCRIPTION
Fixes #464 
```
Code view is hidden upon initial loading of report.

Let's open the code view for the author at the top of the ramp chart
upon loading to provide a more representative view of the report,
especially for a user seeing a RepoSense report for the first time.
```