### PR TITLE
Edit the typo of `repoConfig_defaultBranch_success()` method

### DIFF
--- a/src/test/java/reposense/parser/CsvParserTest.java
+++ b/src/test/java/reposense/parser/CsvParserTest.java
@@ -154,7 +154,7 @@ public class CsvParserTest {
         RepoConfiguration.merge(actualConfigs, authorConfigs);
 
         Assert.assertEquals(1, actualConfigs.size());
-        Assert.assertEquals(expectedConfig.getBranch(), actualConfigs.get(0).getBranch());
+        Assert.assertEquals(expectedConfig.getLocation(), actualConfigs.get(0).getLocation());
         Assert.assertEquals(expectedConfig.getBranch(), authorConfigs.get(0).getBranch());
     }
 }


### PR DESCRIPTION
The `repoConfig_defaultBranch_success()` method in `CsvParserTest` 
contains duplicated assertion. 

Let's change one of comparing of `Branch` to `Location` to make the 
test more reasonable.

