### PR TITLE
[#463] Add sorting of ramp chart by repo contribution

### DIFF
--- a/frontend/src/index.jade
+++ b/frontend/src/index.jade
@@ -147,7 +147,7 @@ html
 
         .files(v-if="isLoaded")
           .empty(v-if="files.length===0") nothing to see here :(
-          .file.active(v-for="file in selectedFiles")
+          .file.active(v-for="file in selectedFiles", v-bind:key="file.path")
             .title(onclick="toggleNext(this)")
               span {{ file.path }}&nbsp;
               span.loc ({{ file.lineCount }} lines)

--- a/frontend/src/index.jade
+++ b/frontend/src/index.jade
@@ -55,6 +55,7 @@ html
             .mui-select
               select(v-model="filterSort")
                 option(value="totalCommits") Contribution
+                option(value="repoTotalCommits") Repo Contribution
                 option(value="variance") Variance
                 option(value="displayName") Author Name
                 option(value="searchPath") Repo/Branch Name

--- a/frontend/src/static/js/api.js
+++ b/frontend/src/static/js/api.js
@@ -45,7 +45,6 @@ window.api = {
     return loadJSON(`${REPORT_DIR}/${repoName}/commits.json`).then((commits) => {
       let res = [];
       const repo = window.REPOS[repoName];
-      let temp = [];
       let repoTotalCommits = 0;
 
       Object.keys(commits.authorDisplayNameMap).forEach((author) => {
@@ -70,13 +69,12 @@ window.api = {
           obj.repoName = `${repo.displayName}`;
           obj.location = `${repo.location.location}`;
           repoTotalCommits += obj.totalCommits;
-          temp.push(obj);
+          res.push(obj);
         }
       });
-      temp.forEach((author) => {
+      res.forEach((author) => {
         author.repoTotalCommits = repoTotalCommits;
       });
-      res = temp;
       repo.commits = commits;
       repo.users = res;
 

--- a/frontend/src/static/js/api.js
+++ b/frontend/src/static/js/api.js
@@ -43,8 +43,10 @@ window.api = {
 
   loadCommits(repoName) {
     return loadJSON(`${REPORT_DIR}/${repoName}/commits.json`).then((commits) => {
-      const res = [];
+      let res = [];
       const repo = window.REPOS[repoName];
+      let temp = [];
+      let repoTotalCommits = 0;
 
       Object.keys(commits.authorDisplayNameMap).forEach((author) => {
         if (author) {
@@ -67,11 +69,14 @@ window.api = {
           obj.repoPath = `${repo.displayName}`;
           obj.repoName = `${repo.displayName}`;
           obj.location = `${repo.location.location}`;
-
-          res.push(obj);
+          repoTotalCommits += obj.totalCommits;
+          temp.push(obj);
         }
       });
-
+      temp.forEach((author) => {
+        author.repoTotalCommits = repoTotalCommits;
+      });
+      res = temp;
       repo.commits = commits;
       repo.users = res;
 

--- a/frontend/src/static/js/v_summary.js
+++ b/frontend/src/static/js/v_summary.js
@@ -374,12 +374,6 @@ window.vSummary = {
           users.sort(comparator((ele) => ele['totalCommits']));
           full.push(users);
         });
-        if (this.filterSortReverse) {
-          full.forEach((repo) => {
-            repo.reverse();
-          });
-          full.reverse();
-        }
         if (!this.filterGroupRepos) {
           full.unshift([]);
           full.forEach((users) => {
@@ -404,10 +398,11 @@ window.vSummary = {
 
           });
         }
-        if (this.filterSortReverse) {
-          full.forEach(repo => repo.reverse());
-        }
-       }
+      }
+      if (this.filterSortReverse) {
+        full.forEach(repo => repo.reverse());
+        full.reverse();
+      }
 
       this.filtered = full;
     },

--- a/frontend/src/static/js/v_summary.js
+++ b/frontend/src/static/js/v_summary.js
@@ -369,9 +369,9 @@ window.vSummary = {
     sortFiltered() {
       let full = [];
       if (this.filterSort === 'repoTotalCommits') {
-        this.filtered.sort(comparator(repo => repo[0]['repoTotalCommits']));
+        this.filtered.sort(comparator((repo) => repo[0]['repoTotalCommits']));
         this.filtered.forEach((users) => {
-          users.sort(comparator(ele => ele['totalCommits']));
+          users.sort(comparator((ele) => ele['totalCommits']));
           full.push(users);
         });
         if (this.filterSortReverse) {

--- a/frontend/src/static/js/v_summary.js
+++ b/frontend/src/static/js/v_summary.js
@@ -367,27 +367,47 @@ window.vSummary = {
       return null;
     },
     sortFiltered() {
-      const full = [];
-      if (!this.filterGroupRepos) {
-        full.push([]);
-      }
-
-      this.filtered.forEach((users) => {
-        if (this.filterGroupRepos) {
-          users.sort(comparator(ele => ele[this.filterSort]));
+      let full = [];
+      if (this.filterSort === 'repoTotalCommits') {
+        this.filtered.sort(comparator(repo => repo[0]['repoTotalCommits']));
+        this.filtered.forEach((users) => {
+          users.sort(comparator(ele => ele['totalCommits']));
           full.push(users);
-        } else {
-          users.forEach(user => full[0].push(user));
+        });
+        if (this.filterSortReverse) {
+          full.forEach((repo) => {
+            repo.reverse();
+          });
+          full.reverse();
         }
-      });
-
-      if (!this.filterGroupRepos) {
-        full[0].sort(comparator(ele => ele[this.filterSort]));
+        if (!this.filterGroupRepos) {
+          full.unshift([]);
+          full.forEach((users) => {
+            users.forEach(user => full[0].push(user));
+          });
+          full.splice(0, 1);
+        }
       }
 
-      if (this.filterSortReverse) {
-        full.forEach(repo => repo.reverse());
-      }
+      else {
+        if (!this.filterGroupRepos) {
+          full.push([]);
+          this.filtered.forEach((users) => {
+            users.forEach(user => full[0].push(user));
+          });
+          full[0].sort(comparator(ele => ele[this.filterSort]));
+
+        } else {
+          this.filtered.forEach((users) => {
+            users.sort(comparator(ele => ele[this.filterSort]));
+            full.push(users);
+
+          });
+        }
+        if (this.filterSortReverse) {
+          full.forEach(repo => repo.reverse());
+        }
+       }
 
       this.filtered = full;
     },


### PR DESCRIPTION
Fixes #463.
```
Ramp charts can only be sorted by individual contribution.

Let's allow users to sort ramp charts by repo contribution so that more active repos 
can be identified.
```