### PR TITLE
[#534] Fixes untouched code button failure

### DIFF
--- a/frontend/src/index.jade
+++ b/frontend/src/index.jade
@@ -166,7 +166,7 @@ html
           .empty(v-if="files.length===0") nothing to see here :(
           .file.active(v-for="file in selectedFiles", v-bind:key="file.path")
             .title
-              span.path(onclick="toggleNext(this)") {{ file.path }}&nbsp;
+              span.path(onclick="toggleNext(this.parentNode)") {{ file.path }}&nbsp;
               span.loc ({{ file.lineCount }} lines)
               a(
                 v-bind:href="getFileLink(file, 'commits')", target="_blank",

--- a/frontend/src/static/js/v_authorship.js
+++ b/frontend/src/static/js/v_authorship.js
@@ -2,7 +2,7 @@ window.toggleNext = function toggleNext(ele) {
   // function for toggling unopened code
   const targetClass = 'active';
 
-  const parent = ele.parentNode.parentNode;
+  const parent = ele.parentNode;
   const classes = parent.className.split(' ');
   const idx = classes.indexOf(targetClass);
 


### PR DESCRIPTION
Fixes #534 

In #490, the `toggleNext()` are edited to limit the toggle option to the path of the title.

However, the untouched code button also uses this function. So this button does not work after #390 is merged.

Let's return the `toggleNext()` to its original state, but edit the way to call this function.