### PR TITLE
Remove redundant commands in Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,28 +2,23 @@ language: java
 
 matrix:
   include:
-    - os: linux
+    - name: Linux Ubuntu 14.04 JDK 9
+      os: linux
       jdk: oraclejdk9
-    - os: osx
+    - name: MacOS 10.13 JDK 9
+      os: osx
 
 script:
   - ./config/travis/run-checks.sh
   - npm run lint frontend/src/**/*.js
   - time travis_retry ./gradlew clean checkstyleMain checkstyleTest test systemTest
 
-addons:
-  apt:
-    packages:
-      - oracle-java9-installer
-
-before_install:
-  - cd ./frontend; npm install --only=dev; cd ..
-
 before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
   - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
 
 cache:
+  npm: true,
   directories:
     - $HOME/.gradle/caches/
     - $HOME/.gradle/wrapper/

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,20 +9,19 @@ matrix:
     - name: macOS 10.13 JDK 10
       os: osx
 
-install:
-  - npm install --only=dev
-
 script:
   - ./config/travis/run-checks.sh
   - npm run lint frontend/src/**/*.js
   - time travis_retry ./gradlew clean checkstyleMain checkstyleTest test systemTest
+
+before_install:
+  - npm install --only=dev
 
 before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
   - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
 
 cache:
-  npm: true,
   directories:
     - $HOME/.gradle/caches/
     - $HOME/.gradle/wrapper/

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,11 @@ language: java
 
 matrix:
   include:
-    - name: Linux Ubuntu 14.04 JDK 9
+    - name: Ubuntu 14.04 JDK 9
       os: linux
       jdk: oraclejdk9
-    - name: MacOS 10.13 JDK 9
+
+    - name: macOS 10.13 JDK 10
       os: osx
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,9 @@ matrix:
     - name: macOS 10.13 JDK 10
       os: osx
 
+install:
+  - npm install --only=dev
+
 script:
   - ./config/travis/run-checks.sh
   - npm run lint frontend/src/**/*.js


### PR DESCRIPTION
```
In the Travis config file, we specify our Linux environment to use
JDK9 with `jdk: oraclejdk9` and `addons.apt.packages key`, but the
latter is redundant. Similarly, the command used to install frontend npm
dependencies can be simpified. The cd command does not change the
install location of the npm dependencies as frontend folder does not
contain a package.json file.

Let's remove the redundant commands for clarity and maintainability.
```