### PR TITLE
build.gradle: fix files compilation order

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -70,6 +70,8 @@ task zipReport(dependsOn: 'npmRunSpuild', type: Zip) {
 tasks.shadowJar.dependsOn('zipReport');
 tasks.run.dependsOn('zipReport');
 
+tasks.run.shouldRunAfter('zipReport');
+
 task systemtest(dependsOn: 'zipReport', type: Test) {
   testClassesDirs = sourceSets.systemtest.output.classesDirs
   classpath = sourceSets.systemtest.runtimeClasspath

--- a/build.gradle
+++ b/build.gradle
@@ -68,9 +68,8 @@ task zipReport(dependsOn: 'npmRunSpuild', type: Zip) {
     destinationDir = file('src/main/resources')
 }
 tasks.shadowJar.dependsOn('zipReport');
-tasks.run.dependsOn('zipReport');
-
-tasks.run.shouldRunAfter('zipReport');
+tasks.compileJava.dependsOn('zipReport');
+tasks.run.dependsOn('compileJava');
 
 task systemtest(dependsOn: 'zipReport', type: Test) {
   testClassesDirs = sourceSets.systemtest.output.classesDirs

--- a/build.gradle
+++ b/build.gradle
@@ -68,8 +68,8 @@ task zipReport(dependsOn: 'npmRunSpuild', type: Zip) {
     destinationDir = file('src/main/resources')
 }
 tasks.shadowJar.dependsOn('zipReport');
-tasks.compileJava.dependsOn('zipReport');
-tasks.run.dependsOn('compileJava');
+tasks.classes.dependsOn('zipReport');
+tasks.run.dependsOn('classes');
 
 task systemtest(dependsOn: 'zipReport', type: Test) {
   testClassesDirs = sourceSets.systemtest.output.classesDirs


### PR DESCRIPTION
Fixes #537 

```
We use `./gradlew run` in development to conveniently run RepoSense
without the need to build a Jar.

It is expected to do the following tasks sequentially:

[a] npmRunSpuild - build frontend/src to frontend/build
[b] zipReport    - zip `frontend/build` to resource of zip
[c] build   	 - build src to build files
[d] run          - execute the build files

We can use `./gradlew run --dry-run` to list the running order.

Actual order:
:compileJava		[c]
:processResources 	[c]
:classes 	        [c]
:downloadNode 		[a]
:npmInstall 		[a]
:npmRunSpuild 		[a]
:zipReport 	        [b]
:run 			[d]

Expected order:
:downloadNode		[a]
:npmInstall		[a]
:npmRunSpuild		[a]
:zipReport		[b]
:compileJava		[c]
:processResources	[c]
:classes		[c]
:run 			[d]

The incorrect order may result in RepoSense failing due to missing
templateZip or using an outdated templateZip.

Let's fix the issue by correctly chaining the task dependencies.
```
