### PR TITLE
Downgrade to JDK8 in CIs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,17 +9,22 @@ matrix:
     - name: macOS 10.13.6 JDK 11.01
       os: osx
       osx_image: xcode10.1
+      before_install:
+        - export HOMEBREW_NO_AUTO_UPDATE=1; # Prevent time-consuming updating
+        - brew install cask;
+      install:
+        - brew cask install caskroom/versions/java8
+        - java -version
 
 script:
   - ./config/travis/run-checks.sh
   - npm run lint frontend/src/**/*.js
   - time travis_retry ./gradlew clean checkstyleMain checkstyleTest test systemTest
 
-# Use latest version of JDK 8
 addons:
   apt:
     packages:
-      - oracle-java8-installer
+      - oracle-java8-installer # Use the latest version of JDK 8
 
 before_install:
   - npm install --only=dev
@@ -32,3 +37,4 @@ cache:
   directories:
     - $HOME/.gradle/caches/
     - $HOME/.gradle/wrapper/
+    - $HOME/Library/Caches/Homebrew

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ matrix:
       os: osx
       osx_image: xcode10.1
       before_install:
-        - <<: *common_before_install
+        - *common_before_install
         - export HOMEBREW_NO_AUTO_UPDATE=1 # Prevent time-consuming updating
         - brew install cask
         - brew cask install caskroom/versions/java8 # Update to the latest version of JDK 8

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,12 @@ script:
   - npm run lint frontend/src/**/*.js
   - time travis_retry ./gradlew clean checkstyleMain checkstyleTest test systemTest
 
+# Use latest version of JDK 8
+addons:
+  apt:
+    packages:
+      - oracle-java8-installer
+
 before_install:
   - npm install --only=dev
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,9 @@ language: java
 
 matrix:
   include:
-    - name: Ubuntu 14.04 JDK 9
+    - name: Ubuntu 14.04 JDK 8
       os: linux
-      jdk: oraclejdk9
+      jdk: oraclejdk8
 
     - name: macOS 10.13.6 JDK 11.01
       os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,13 +13,14 @@ matrix:
     - name: macOS 10.13.6 JDK 8
       os: osx
       osx_image: xcode10.1
+      env:
+        - HOMEBREW_NO_AUTO_UPDATE=1 # Prevent time-consuming brew update
       before_install:
         - *common_before_install
-        - export HOMEBREW_NO_AUTO_UPDATE=1 # Prevent time-consuming updating
         - brew install cask
         - brew cask install caskroom/versions/java8 # Update to the latest version of JDK 8
         - export JAVA_HOME=`/usr/libexec/java_home -v 1.8`
-        - echo "Updated JDK to:"; java -version
+        - echo "Downgraded JDK to:"; java -version
 
 script:
   - ./config/travis/run-checks.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,28 +5,28 @@ matrix:
     - name: Ubuntu 14.04 JDK 8
       os: linux
       jdk: oraclejdk8
+      addons:
+        apt:
+          packages:
+            - oracle-java8-installer # Update to the latest version of JDK 8
 
-    - name: macOS 10.13.6 JDK 11.01
+    - name: macOS 10.13.6 JDK 8
       os: osx
       osx_image: xcode10.1
       before_install:
-        - export HOMEBREW_NO_AUTO_UPDATE=1; # Prevent time-consuming updating
-        - brew install cask;
-      install:
-        - brew cask install caskroom/versions/java8
-        - java -version
+        - <<: *common_before_install
+        - export HOMEBREW_NO_AUTO_UPDATE=1 # Prevent time-consuming updating
+        - brew install cask
+        - brew cask install caskroom/versions/java8 # Update to the latest version of JDK 8
+        - export JAVA_HOME=`/usr/libexec/java_home -v 1.8`
+        - echo "Updated JDK to:"; java -version
 
 script:
   - ./config/travis/run-checks.sh
   - npm run lint frontend/src/**/*.js
   - time travis_retry ./gradlew clean checkstyleMain checkstyleTest test systemTest
 
-addons:
-  apt:
-    packages:
-      - oracle-java8-installer # Use the latest version of JDK 8
-
-before_install:
+before_install: &common_before_install
   - npm install --only=dev
 
 before_cache:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,7 +11,7 @@ test_script:
     - appveyor-retry gradlew.bat --no-daemon test systemTest
 
 environment:
-    JAVA_HOME: C:\Program Files\Java\jdk9  # Use 64-bit Java
+    JAVA_HOME: C:\Program Files\Java\jdk1.8.0  # Use 64-bit Java
 
 # Files/folders to preserve between builds to speed them up
 cache:


### PR DESCRIPTION
```
RepoSense is advertised to run on JDK 1.8.0_60 and later.

However, we use JDK 9 in our CIs.

Let's downgrade to use JDK 8 in CIs to validate this non-functional
requirement.
```