### PR TITLE
FAQ: add another entry to propose email as alternative to GitHub ID #546

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -187,13 +187,17 @@ Date:   Fri Feb 9 19:13:13 2018 +0800
  ...
 ```
 `ActualGitHubId` and `ConfiguredAuthorName` are both `Git Author Name` of the same author.<br>
-To find the author name that you are currently using, run the following command at your analyzed git repository:
+To find the author name that you are currently using for your current git repository, run the following command within your git repository:
 ```
 git config user.name
 ```
-To set the author name to the value you want (e.g., to set it to your GitHub username) for the analyzed git repository, you can use the following command ([more info](https://www.git-tower.com/learn/git/faq/change-author-name-email)):
+To set the author name to the value you want (e.g., to set it to your GitHub username) for the current git repository, you can use the following command ([more info](https://www.git-tower.com/learn/git/faq/change-author-name-email)):
 ```
 git config user.name "YOUR_AUTHOR_NAME”
+```
+To set the author name to the value you want for the future git repository, you can use the following command:
+```
+git config --global user.name "YOUR_AUTHOR_NAME”
 ```
 RepoSense expects the Git Author Name to be the same as author's GitHub username. If an author's `Git Author Name` is different from her `GitHub ID`, the `Git Author Name` needs to be specified in the standalone config file. If the author has more than one `Git Author Name`, multiple values can be entered too.
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -195,7 +195,7 @@ To set the author name to the value you want (e.g., to set it to your GitHub use
 ```
 git config user.name "YOUR_AUTHOR_NAME”
 ```
-To set the author name to use a default value you want for the future git repositories, you can use the following command:
+To set the author name to use a default value you want for future git repositories, you can use the following command:
 ```
 git config --global user.name "YOUR_AUTHOR_NAME”
 ```

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -330,13 +330,13 @@ The formats/file extensions to be analyzed by *RepoSense* can be specified throu
 
 #### Q: How does ignore glob list work?
 **A:** [Glob](https://en.wikipedia.org/wiki/Glob_(programming)) is the pattern to specify a set of filenames with [wildcard characters](https://www.computerhope.com/jargon/w/wildcard.htm). **Ignore glob list** is the list of patterns to specify all the files in the repository which should be ignored from analysis.<br>
-The ignore glob list can be specified through the [author-config file](#author-configcsv), [repo-config file](#repo-configcsv) and [author-config file](#author-configcsv).
+The ignore glob list can be specified through the [standalone config file](#provide-data-using-a-json-config-file), [repo-config file](#repo-configcsv) and [author-config file](#author-configcsv).
 
 #### Q: My commit contributions does not appear in the ramp chart (despite appearing in the contribution bar and code panel)?
 **A:** This is probably a case of giving an incorrect author name alias (or github ID) in your [author-config file](#author-configcsv).<br>
 Please refer to [A Note About Git Author Name](#a-note-about-git-author-name) above on how to find out the correct author name you are using, and how to change it.<br>
 Also ensure that you have added all author name aliases that you may be using (if you are using multiple computers or have previously changed your author name).<br>
-Alternatively, you may choose to configure RepoSense to track using your GitHub email instead in your [author-config file](#author-configcsv), which is more accurate compared to author name aliases. The associated GitHub email you are using can be found in your [GitHub settings](https://github.com/settings/emails).
+Alternatively, you may choose to configure RepoSense to track using your GitHub email instead in your [standalone config file](#provide-data-using-a-json-config-file) or [author-config file](#author-configcsv), which is more accurate compared to author name aliases. The associated GitHub email you are using can be found in your [GitHub settings](https://github.com/settings/emails).
 
 #### Q: My contribution bar and code panel is empty (despite having lots of commit contributions in the ramp chart)?
 **A:** The contribution bar and code panel records the lines you have authored to the **latest** commit of the repository and branch you are analyzing. As such, it is possible that while you have lots of commit contributions, your final authorship contribution is low if you have only deleted lines, someone else have overwritten your code and taken authorship for it (currently, *RepoSense* does not have functionality to track overwritten lines).<br>

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -186,14 +186,14 @@ Date:   Fri Feb 9 19:13:13 2018 +0800
     Initial commit
  ...
 ```
-`ActualGitHubId` and `ConfiguredAuthorName` are both `Git Author Name` of the same author.
-To find the author name that you have set in your local machine, run the following command:
+`ActualGitHubId` and `ConfiguredAuthorName` are both `Git Author Name` of the same author.<br>
+To find the author name that you are currently using, run the following command at your analyzed git repository:
 ```
 git config user.name
 ```
-To set the author name to the value you want (e.g., to set it to your GitHub username), you can use the following command ([more info](https://www.git-tower.com/learn/git/faq/change-author-name-email)):
+To set the author name to the value you want (e.g., to set it to your GitHub username) for the analyzed git repository, you can use the following command ([more info](https://www.git-tower.com/learn/git/faq/change-author-name-email)):
 ```
-git config --global user.name "YOUR_AUTHOR_NAME”
+git config user.name "YOUR_AUTHOR_NAME”
 ```
 RepoSense expects the Git Author Name to be the same as author's GitHub username. If an author's `Git Author Name` is different from her `GitHub ID`, the `Git Author Name` needs to be specified in the standalone config file. If the author has more than one `Git Author Name`, multiple values can be entered too.
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -191,11 +191,11 @@ To find the author name that you are currently using for your current git reposi
 ```
 git config user.name
 ```
-To set the author name to the value you want (e.g., to set it to your GitHub username) for the current git repository, you can use the following command ([more info](https://www.git-tower.com/learn/git/faq/change-author-name-email)):
+To set the author name to the value you want (e.g., to set it to your GitHub username) for your current git repository, you can use the following command ([more info](https://www.git-tower.com/learn/git/faq/change-author-name-email)):
 ```
 git config user.name "YOUR_AUTHOR_NAME”
 ```
-To set the author name to the value you want for the future git repository, you can use the following command:
+To set the author name to use a default value you want for the future git repositories, you can use the following command:
 ```
 git config --global user.name "YOUR_AUTHOR_NAME”
 ```

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -330,12 +330,13 @@ The formats/file extensions to be analyzed by *RepoSense* can be specified throu
 
 #### Q: How does ignore glob list work?
 **A:** [Glob](https://en.wikipedia.org/wiki/Glob_(programming)) is the pattern to specify a set of filenames with [wildcard characters](https://www.computerhope.com/jargon/w/wildcard.htm). **Ignore glob list** is the list of patterns to specify all the files in the repository which should be ignored from analysis.<br>
-The ignore glob list can be specified through the [standalone config file](#provide-data-using-a-json-config-file), [repo-config file](#repo-configcsv) and [author-config file](#author-configcsv).
+The ignore glob list can be specified through the [author-config file](#author-configcsv), [repo-config file](#repo-configcsv) and [author-config file](#author-configcsv).
 
 #### Q: My commit contributions does not appear in the ramp chart (despite appearing in the contribution bar and code panel)?
 **A:** This is probably a case of giving an incorrect author name alias (or github ID) in your [author-config file](#author-configcsv).<br>
 Please refer to [A Note About Git Author Name](#a-note-about-git-author-name) above on how to find out the correct author name you are using, and how to change it.<br>
-Also ensure that you have added all author name aliases that you may be using (if you are using multiple computers or have previously changed your author name).
+Also ensure that you have added all author name aliases that you may be using (if you are using multiple computers or have previously changed your author name).<br>
+Alternatively, you may choose to configure RepoSense to track using your GitHub email instead in your [author-config file](#author-configcsv), which is more accurate compared to author name aliases. The associated GitHub email you are using can be found in your [GitHub settings](https://github.com/settings/emails).
 
 #### Q: My contribution bar and code panel is empty (despite having lots of commit contributions in the ramp chart)?
 **A:** The contribution bar and code panel records the lines you have authored to the **latest** commit of the repository and branch you are analyzing. As such, it is possible that while you have lots of commit contributions, your final authorship contribution is low if you have only deleted lines, someone else have overwritten your code and taken authorship for it (currently, *RepoSense* does not have functionality to track overwritten lines).<br>

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -186,7 +186,12 @@ Date:   Fri Feb 9 19:13:13 2018 +0800
     Initial commit
  ...
 ```
-`ActualGitHubId` and `ConfiguredAuthorName` are both `Git Author Name` of the same author. To set the author name to the value you want (e.g., to set it to your GitHub username), you can use the following command ([more info](https://www.git-tower.com/learn/git/faq/change-author-name-email)):
+`ActualGitHubId` and `ConfiguredAuthorName` are both `Git Author Name` of the same author.
+To find the author name that you have set in your local machine, run the following command:
+```
+git config user.name
+```
+To set the author name to the value you want (e.g., to set it to your GitHub username), you can use the following command ([more info](https://www.git-tower.com/learn/git/faq/change-author-name-email)):
 ```
 git config --global user.name "YOUR_AUTHOR_NAME”
 ```


### PR DESCRIPTION
Fixes #546 
```
In the UserGuide FAQ section, we mention that commit contribution
may not appear in the ramp chart if the user did not associate the
correct author name aliases to their GitHub ID, and to double check
their author name aliases.

After #493 though, RepoSense allows user to associate their GitHub
email to their GitHub ID as well, which is more accurate as it is a
fixed value, compared to author name aliases which can have many
different values depending on their local git settings and on different
machines. As such, it is better to ask users to use email instead of
author name aliases if they face such problems of their contribution
not being tracked by RepoSense.

Let's update FAQ to propose email as an alternative to associate to the
user's GitHub ID instead.

The command given in the `A Note About Git Author Name` is not
exactly accurate, as it only changes the git author name settings for
future initiated or cloned git repositories, but not for the current
git repository, which is what most users who are reading the FAQ would
want.

Let's also update the `A Note About Git Author Name` section to
include the correct command for changing the git author name settings
for the current git repository as well.
```