### PR TITLE
Split repo csv configurations from RepoConfiguration #548

### DIFF
--- a/src/main/java/reposense/RepoSense.java
+++ b/src/main/java/reposense/RepoSense.java
@@ -14,6 +14,7 @@ import reposense.model.CliArguments;
 import reposense.model.ConfigCliArguments;
 import reposense.model.LocationsCliArguments;
 import reposense.model.RepoConfiguration;
+import reposense.model.RepoCsvConfiguration;
 import reposense.model.RepoLocation;
 import reposense.model.ViewCliArguments;
 import reposense.parser.ArgsParser;
@@ -71,8 +72,11 @@ public class RepoSense {
      * @throws IOException if user-supplied csv file does not exists or is not readable.
      */
     public static List<RepoConfiguration> getRepoConfigurations(ConfigCliArguments cliArguments) throws IOException {
-        List<RepoConfiguration> repoConfigs = new RepoConfigCsvParser(cliArguments.getRepoConfigFilePath()).parse();
+        List<RepoCsvConfiguration> repoCsvConfigs =
+                new RepoConfigCsvParser(cliArguments.getRepoConfigFilePath()).parse();
         List<AuthorConfiguration> authorConfigs = null;
+
+        List<RepoConfiguration> repoConfigs = RepoConfiguration.getRepoConfigurationList(repoCsvConfigs);
 
         try {
             authorConfigs = new AuthorConfigCsvParser(cliArguments.getAuthorConfigFilePath()).parse();

--- a/src/main/java/reposense/model/RepoCsvConfiguration.java
+++ b/src/main/java/reposense/model/RepoCsvConfiguration.java
@@ -1,0 +1,103 @@
+package reposense.model;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Represents repo configuration information from CSV config file for a single repository.
+ */
+public class RepoCsvConfiguration {
+    public static final String DEFAULT_BRANCH = "HEAD";
+
+    private RepoLocation location;
+    private String branch;
+    private transient List<Format> formats;
+    private transient List<CommitHash> ignoreCommitList;
+    private transient List<String> ignoreGlobList = new ArrayList<>();
+    private transient boolean isStandaloneConfigIgnored;
+
+    public RepoCsvConfiguration(RepoLocation location, String branch) {
+        this(location, branch, Collections.emptyList(), Collections.emptyList(), false, Collections.emptyList());
+    }
+
+    public RepoCsvConfiguration(RepoLocation location, String branch, List<Format> formats,
+            List<String> ignoreGlobList, boolean isStandaloneConfigIgnored, List<CommitHash> ignoreCommitList) {
+        this.location = location;
+        this.branch = location.isEmpty() ? DEFAULT_BRANCH : branch;
+        this.formats = formats;
+        this.ignoreCommitList = ignoreCommitList;
+        this.ignoreGlobList = ignoreGlobList;
+        this.isStandaloneConfigIgnored = isStandaloneConfigIgnored;
+    }
+
+    public void update(StandaloneConfig standaloneConfig) {
+        ignoreGlobList = standaloneConfig.getIgnoreGlobList();
+        formats = Format.convertStringsToFormats(standaloneConfig.getFormats());
+        ignoreCommitList = CommitHash.convertStringsToCommits(standaloneConfig.getIgnoreCommitList());
+    }
+
+    @Override
+    public boolean equals(Object other) {
+
+        if (other == this) {
+            return true;
+        }
+
+        if (!(other instanceof RepoCsvConfiguration)) {
+            return false;
+        }
+
+        RepoCsvConfiguration otherRepoConfig = (RepoCsvConfiguration) other;
+
+        return location.equals(otherRepoConfig.location)
+                && branch.equals(otherRepoConfig.branch)
+                && ignoreGlobList.equals(otherRepoConfig.ignoreGlobList)
+                && isStandaloneConfigIgnored == otherRepoConfig.isStandaloneConfigIgnored
+                && formats.equals(otherRepoConfig.formats);
+    }
+
+    public RepoLocation getLocation() {
+        return location;
+    }
+
+    public String getBranch() {
+        return branch;
+    }
+
+    public void setBranch(String branch) {
+        this.branch = branch;
+    }
+
+    public List<String> getIgnoreGlobList() {
+        return ignoreGlobList;
+    }
+
+    public void setIgnoreGlobList(List<String> ignoreGlobList) {
+        this.ignoreGlobList = ignoreGlobList;
+    }
+
+    public List<CommitHash> getIgnoreCommitList() {
+        return ignoreCommitList;
+    }
+
+    public void setIgnoreCommitList(List<CommitHash> ignoreCommitList) {
+        this.ignoreCommitList = ignoreCommitList;
+    }
+
+    public List<Format> getFormats() {
+        return formats;
+    }
+
+    public void setFormats(List<Format> formats) {
+        this.formats = formats;
+    }
+
+    public boolean isStandaloneConfigIgnored() {
+        return isStandaloneConfigIgnored;
+    }
+
+    public void setStandaloneConfigIgnored(boolean isStandaloneConfigIgnored) {
+        this.isStandaloneConfigIgnored = isStandaloneConfigIgnored;
+    }
+}

--- a/src/main/java/reposense/parser/RepoConfigCsvParser.java
+++ b/src/main/java/reposense/parser/RepoConfigCsvParser.java
@@ -6,10 +6,10 @@ import java.util.List;
 
 import reposense.model.CommitHash;
 import reposense.model.Format;
-import reposense.model.RepoConfiguration;
+import reposense.model.RepoCsvConfiguration;
 import reposense.model.RepoLocation;
 
-public class RepoConfigCsvParser extends CsvParser<RepoConfiguration> {
+public class RepoConfigCsvParser extends CsvParser<RepoCsvConfiguration> {
     public static final String REPO_CONFIG_FILENAME = "repo-config.csv";
     private static final String IGNORE_STANDALONE_CONFIG_KEYWORD = "yes";
 
@@ -43,9 +43,9 @@ public class RepoConfigCsvParser extends CsvParser<RepoConfiguration> {
      * {@code branch}.
      */
     @Override
-    protected void processLine(List<RepoConfiguration> results, String[] elements) throws InvalidLocationException {
+    protected void processLine(List<RepoCsvConfiguration> results, String[] elements) throws InvalidLocationException {
         RepoLocation location = new RepoLocation(getValueInElement(elements, LOCATION_POSITION));
-        String branch = getValueInElement(elements, BRANCH_POSITION, RepoConfiguration.DEFAULT_BRANCH);
+        String branch = getValueInElement(elements, BRANCH_POSITION, RepoCsvConfiguration.DEFAULT_BRANCH);
         List<Format> formats = Format.convertStringsToFormats(getManyValueInElement(elements, FILE_FORMATS_POSITION));
         List<String> ignoreGlobList = getManyValueInElement(elements, IGNORE_GLOB_LIST_POSITION);
         String ignoreStandaloneConfig = getValueInElement(elements, IGNORE_STANDALONE_CONFIG_POSITION);
@@ -59,7 +59,7 @@ public class RepoConfigCsvParser extends CsvParser<RepoConfiguration> {
                     "Ignoring unknown value " + ignoreStandaloneConfig + " in ignore standalone config column.");
         }
 
-        RepoConfiguration config = new RepoConfiguration(
+        RepoCsvConfiguration config = new RepoCsvConfiguration(
                 location, branch, formats, ignoreGlobList, isStandaloneConfigIgnored, ignoreCommitList);
 
         if (results.contains(config)) {

--- a/src/systemtest/java/reposense/ConfigSystemTest.java
+++ b/src/systemtest/java/reposense/ConfigSystemTest.java
@@ -20,6 +20,7 @@ import reposense.model.AuthorConfiguration;
 import reposense.model.CliArguments;
 import reposense.model.ConfigCliArguments;
 import reposense.model.RepoConfiguration;
+import reposense.model.RepoCsvConfiguration;
 import reposense.parser.ArgsParser;
 import reposense.parser.AuthorConfigCsvParser;
 import reposense.parser.ParseException;
@@ -73,10 +74,11 @@ public class ConfigSystemTest {
 
         CliArguments cliArguments = ArgsParser.parse(translateCommandline(input));
 
-        List<RepoConfiguration> repoConfigs =
+        List<RepoCsvConfiguration> repoCsvConfigs =
                 new RepoConfigCsvParser(((ConfigCliArguments) cliArguments).getRepoConfigFilePath()).parse();
         List<AuthorConfiguration> authorConfigs =
                 new AuthorConfigCsvParser(((ConfigCliArguments) cliArguments).getAuthorConfigFilePath()).parse();
+        List<RepoConfiguration> repoConfigs = RepoConfiguration.getRepoConfigurationList(repoCsvConfigs);
 
         RepoConfiguration.merge(repoConfigs, authorConfigs);
 

--- a/src/test/java/reposense/parser/CsvParserTest.java
+++ b/src/test/java/reposense/parser/CsvParserTest.java
@@ -19,6 +19,7 @@ import reposense.model.CommitHash;
 import reposense.model.ConfigCliArguments;
 import reposense.model.Format;
 import reposense.model.RepoConfiguration;
+import reposense.model.RepoCsvConfiguration;
 import reposense.model.RepoLocation;
 import reposense.util.InputBuilder;
 import reposense.util.TestUtil;
@@ -73,7 +74,9 @@ public class CsvParserTest {
     @Test
     public void repoConfig_noSpecialCharacter_success() throws IOException, InvalidLocationException {
         RepoConfigCsvParser repoConfigCsvParser = new RepoConfigCsvParser(REPO_CONFIG_NO_SPECIAL_CHARACTER_FILE);
-        List<RepoConfiguration> configs = repoConfigCsvParser.parse();
+        List<RepoCsvConfiguration> repoCsvConfigs = repoConfigCsvParser.parse();
+        List<RepoConfiguration> configs = RepoConfiguration.getRepoConfigurationList(repoCsvConfigs);
+
 
         Assert.assertEquals(1, configs.size());
 
@@ -170,10 +173,11 @@ public class CsvParserTest {
         String input = new InputBuilder().addConfig(TEST_CONFIG_FOLDER).build();
         CliArguments cliArguments = ArgsParser.parse(translateCommandline(input));
 
-        List<RepoConfiguration> actualConfigs =
+        List<RepoCsvConfiguration> repoCsvConfigs =
                 new RepoConfigCsvParser(((ConfigCliArguments) cliArguments).getRepoConfigFilePath()).parse();
         List<AuthorConfiguration> authorConfigs =
                 new AuthorConfigCsvParser(((ConfigCliArguments) cliArguments).getAuthorConfigFilePath()).parse();
+        List<RepoConfiguration> actualConfigs = RepoConfiguration.getRepoConfigurationList(repoCsvConfigs);
         RepoConfiguration.merge(actualConfigs, authorConfigs);
 
         Assert.assertEquals(1, actualConfigs.size());
@@ -215,10 +219,11 @@ public class CsvParserTest {
         String input = new InputBuilder().addConfig(MERGE_EMPTY_LOCATION_FOLDER).build();
         CliArguments cliArguments = ArgsParser.parse(translateCommandline(input));
 
-        List<RepoConfiguration> actualConfigs =
+        List<RepoCsvConfiguration> repoCsvConfigs =
                 new RepoConfigCsvParser(((ConfigCliArguments) cliArguments).getRepoConfigFilePath()).parse();
         List<AuthorConfiguration> authorConfigs =
                 new AuthorConfigCsvParser(((ConfigCliArguments) cliArguments).getAuthorConfigFilePath()).parse();
+        List<RepoConfiguration> actualConfigs = RepoConfiguration.getRepoConfigurationList(repoCsvConfigs);
         RepoConfiguration.merge(actualConfigs, authorConfigs);
 
         Assert.assertEquals(2, actualConfigs.size());
@@ -236,10 +241,11 @@ public class CsvParserTest {
         String input = new InputBuilder().addConfig(TEST_EMPTY_BRANCH_CONFIG_FOLDER).build();
         CliArguments cliArguments = ArgsParser.parse(translateCommandline(input));
 
-        List<RepoConfiguration> actualConfigs =
+        List<RepoCsvConfiguration> repoCsvConfigs =
                 new RepoConfigCsvParser(((ConfigCliArguments) cliArguments).getRepoConfigFilePath()).parse();
         List<AuthorConfiguration> authorConfigs =
                 new AuthorConfigCsvParser(((ConfigCliArguments) cliArguments).getAuthorConfigFilePath()).parse();
+        List<RepoConfiguration> actualConfigs = RepoConfiguration.getRepoConfigurationList(repoCsvConfigs);
         RepoConfiguration.merge(actualConfigs, authorConfigs);
 
         Assert.assertEquals(1, actualConfigs.size());

--- a/src/test/java/reposense/parser/RepoConfigurationTest.java
+++ b/src/test/java/reposense/parser/RepoConfigurationTest.java
@@ -25,6 +25,7 @@ import reposense.model.ConfigCliArguments;
 import reposense.model.Format;
 import reposense.model.LocationsCliArguments;
 import reposense.model.RepoConfiguration;
+import reposense.model.RepoCsvConfiguration;
 import reposense.model.RepoLocation;
 import reposense.report.ReportGenerator;
 import reposense.util.FileUtil;
@@ -140,10 +141,11 @@ public class RepoConfigurationTest {
                 .build();
         CliArguments cliArguments = ArgsParser.parse(translateCommandline(input));
 
-        List<RepoConfiguration> actualConfigs =
+        List<RepoCsvConfiguration> repoCsvConfigs =
                 new RepoConfigCsvParser(((ConfigCliArguments) cliArguments).getRepoConfigFilePath()).parse();
         List<AuthorConfiguration> authorConfigs =
                 new AuthorConfigCsvParser(((ConfigCliArguments) cliArguments).getAuthorConfigFilePath()).parse();
+        List<RepoConfiguration> actualConfigs = RepoConfiguration.getRepoConfigurationList(repoCsvConfigs);
         RepoConfiguration.merge(actualConfigs, authorConfigs);
 
         RepoConfiguration actualConfig = actualConfigs.get(0);
@@ -183,8 +185,9 @@ public class RepoConfigurationTest {
                 .build();
         CliArguments cliArguments = ArgsParser.parse(translateCommandline(input));
 
-        List<RepoConfiguration> actualConfigs =
+        List<RepoCsvConfiguration> repoCsvConfigs =
                 new RepoConfigCsvParser(((ConfigCliArguments) cliArguments).getRepoConfigFilePath()).parse();
+        List<RepoConfiguration> actualConfigs = RepoConfiguration.getRepoConfigurationList(repoCsvConfigs);
 
         RepoConfiguration actualConfig = actualConfigs.get(0);
         GitClone.clone(actualConfig);
@@ -201,8 +204,9 @@ public class RepoConfigurationTest {
                 .build();
         CliArguments cliArguments = ArgsParser.parse(translateCommandline(input));
 
-        List<RepoConfiguration> actualConfigs =
+        List<RepoCsvConfiguration> repoCsvConfigs =
                 new RepoConfigCsvParser(((ConfigCliArguments) cliArguments).getRepoConfigFilePath()).parse();
+        List<RepoConfiguration> actualConfigs = RepoConfiguration.getRepoConfigurationList(repoCsvConfigs);
         RepoConfiguration.setFormatsToRepoConfigs(actualConfigs, cliArguments.getFormats());
 
         Assert.assertEquals(1, actualConfigs.size());
@@ -217,8 +221,9 @@ public class RepoConfigurationTest {
                 .build();
         CliArguments cliArguments = ArgsParser.parse(translateCommandline(input));
 
-        List<RepoConfiguration> actualConfigs =
+        List<RepoCsvConfiguration> repoCsvConfigs =
                 new RepoConfigCsvParser(((ConfigCliArguments) cliArguments).getRepoConfigFilePath()).parse();
+        List<RepoConfiguration> actualConfigs = RepoConfiguration.getRepoConfigurationList(repoCsvConfigs);
         RepoConfiguration.setFormatsToRepoConfigs(actualConfigs, cliArguments.getFormats());
 
         Assert.assertEquals(1, actualConfigs.size());
@@ -230,8 +235,9 @@ public class RepoConfigurationTest {
         String input = new InputBuilder().addConfig(WITHOUT_FORMATS_TEST_CONFIG_FILES).build();
         CliArguments cliArguments = ArgsParser.parse(translateCommandline(input));
 
-        List<RepoConfiguration> actualConfigs =
+        List<RepoCsvConfiguration> repoCsvConfigs =
                 new RepoConfigCsvParser(((ConfigCliArguments) cliArguments).getRepoConfigFilePath()).parse();
+        List<RepoConfiguration> actualConfigs = RepoConfiguration.getRepoConfigurationList(repoCsvConfigs);
         RepoConfiguration.setFormatsToRepoConfigs(actualConfigs, cliArguments.getFormats());
 
         Assert.assertEquals(1, actualConfigs.size());


### PR DESCRIPTION
Fixes #548 

```
RepoConfiguration represents all configuration information for a single
repository, for both the case of command line parameters and CSV config
file. In the case of CSV config file, configuration from 
repo-config.csv is also represented by RepoConfiguration.

This makes it harder to maintain as RepoConfiguration violates the
Single Responsibility Principle.

Let's create a new class RepoCsvConfiguration to represent the
repo config file settings, splitting it from the RepoConfiguration.
```