### PR TITLE
Non-linear ramp chart cause by invalid date range #585

### DIFF
--- a/frontend/src/static/js/v_summary.js
+++ b/frontend/src/static/js/v_summary.js
@@ -77,13 +77,13 @@ window.vSummary = {
       this.getFiltered();
     },
     tmpFilterSinceDate() {
-      if (this.tmpFilterSinceDate >= this.minDate) {
+      if (this.tmpFilterSinceDate && this.tmpFilterSinceDate >= this.minDate) {
         this.filterSinceDate = this.tmpFilterSinceDate;
         this.getFiltered();
       }
     },
     tmpFilterUntilDate() {
-      if (this.tmpFilterUntilDate <= this.maxDate) {
+      if (this.tmpFilterUntilDate && this.tmpFilterUntilDate <= this.maxDate) {
         this.filterUntilDate = this.tmpFilterUntilDate;
         this.getFiltered();
       }


### PR DESCRIPTION
```
Currently, the ramp chart's filter is updated when the checks have
passed. The checks only accounts for cases where the dates are valid,
checking that they are within range. When dates such as "2019-02-31" is
given, the filter is updated anyways. This causes the ramp charts to be
generated up till the repository's latest commit.

Let's add an additional check to ensure that a valid temporary date is
given before we update the filter fields.
```