### PR TITLE
Fix unoriented output messages

### DIFF
--- a/src/main/java/reposense/RepoSense.java
+++ b/src/main/java/reposense/RepoSense.java
@@ -64,7 +64,7 @@ public class RepoSense {
         } catch (ParseException pe) {
             logger.log(Level.WARNING, pe.getMessage(), pe);
         } catch (HelpScreenException e) {
-            // help message was printed by the ArgumentParser and it is safe to exit.
+            // help message was printed by the ArgumentParser; it is safe to exit.
         }
     }
 

--- a/src/main/java/reposense/RepoSense.java
+++ b/src/main/java/reposense/RepoSense.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import net.sourceforge.argparse4j.helper.HelpScreenException;
 import reposense.model.AuthorConfiguration;
 import reposense.model.CliArguments;
 import reposense.model.ConfigCliArguments;
@@ -62,6 +63,8 @@ public class RepoSense {
             logger.log(Level.WARNING, ioe.getMessage(), ioe);
         } catch (ParseException pe) {
             logger.log(Level.WARNING, pe.getMessage(), pe);
+        } catch (HelpScreenException e) {
+            // help message was printed by the ArgumentParser and it is safe to exit.
         }
     }
 

--- a/src/main/java/reposense/parser/ArgsParser.java
+++ b/src/main/java/reposense/parser/ArgsParser.java
@@ -43,6 +43,7 @@ public class ArgsParser {
     private static final String PROGRAM_USAGE = "java -jar RepoSense.jar";
     private static final String PROGRAM_DESCRIPTION =
             "RepoSense is a contribution analysis tool for Git repositories.";
+    private static final String MESSAGE_HEADER_MUTEX = "mutual exclusive arguments";
     private static final String MESSAGE_SINCE_DATE_LATER_THAN_UNTIL_DATE =
             "\"Since Date\" cannot be later than \"Until Date\"";
     private static final String MESSAGE_USING_DEFAULT_CONFIG_PATH =
@@ -57,27 +58,18 @@ public class ArgsParser {
                 .description(PROGRAM_DESCRIPTION);
 
         MutuallyExclusiveGroup mutexParser = parser
-                .addMutuallyExclusiveGroup(PROGRAM_USAGE)
+                .addMutuallyExclusiveGroup(MESSAGE_HEADER_MUTEX)
                 .required(false);
 
+        // Boolean flags
         parser.addArgument(HELP_FLAGS)
                 .dest(HELP_FLAGS[0])
                 .help("Show help message.")
                 .action(new HelpArgumentAction());
-
-        mutexParser.addArgument(CONFIG_FLAGS)
-                .dest(CONFIG_FLAGS[0])
-                .type(new ConfigFolderArgumentType())
-                .metavar("PATH")
-                .setDefault(EMPTY_PATH)
-                .help("The directory containing the config files."
-                        + "If not provided, the config files will be obtained from the current working directory.");
-
-        mutexParser.addArgument(REPO_FLAGS)
-                .nargs("+")
-                .dest(REPO_FLAGS[0])
-                .metavar("LOCATION")
-                .help("The GitHub URL or disk locations to clone repository.");
+        parser.addArgument(IGNORE_FLAGS)
+                .dest(IGNORE_FLAGS[0])
+                .action(Arguments.storeTrue())
+                .help("A flag to ignore the standalone config file in the repo.");
 
         parser.addArgument(VIEW_FLAGS)
                 .dest(VIEW_FLAGS[0])
@@ -121,10 +113,19 @@ public class ArgsParser {
                         + "If not provided, default file formats will be used.\n"
                         + "Please refer to userguide for more information.");
 
-        parser.addArgument(IGNORE_FLAGS)
-                .dest(IGNORE_FLAGS[0])
-                .action(Arguments.storeTrue())
-                .help("A flag to ignore the standalone config file in the repo.");
+        // Mutex flags - these will always be the last parameters in help message.
+        mutexParser.addArgument(CONFIG_FLAGS)
+                .dest(CONFIG_FLAGS[0])
+                .type(new ConfigFolderArgumentType())
+                .metavar("PATH")
+                .setDefault(EMPTY_PATH)
+                .help("The directory containing the config files."
+                        + "If not provided, the config files will be obtained from the current working directory.");
+        mutexParser.addArgument(REPO_FLAGS)
+                .nargs("+")
+                .dest(REPO_FLAGS[0])
+                .metavar("LOCATION")
+                .help("The GitHub URL or disk locations to clone repository.");
 
         return parser;
     }

--- a/src/main/java/reposense/parser/ArgsParser.java
+++ b/src/main/java/reposense/parser/ArgsParser.java
@@ -44,6 +44,8 @@ public class ArgsParser {
             "RepoSense is a contribution analysis tool for Git repositories.";
     private static final String MESSAGE_SINCE_DATE_LATER_THAN_UNTIL_DATE =
             "\"Since Date\" cannot be later than \"Until Date\"";
+    private static final String MESSAGE_USING_DEFAULT_CONFIG_PATH =
+            "Config path not provided, using current working directory as default.";
     private static final Path EMPTY_PATH = Paths.get("");
 
     private static ArgumentParser getArgumentParser() {
@@ -163,6 +165,9 @@ public class ArgsParser {
                         isAutomaticallyLaunching, isStandaloneConfigIgnored);
             }
 
+            if (configFolderPath.equals(EMPTY_PATH)) {
+                logger.info(MESSAGE_USING_DEFAULT_CONFIG_PATH);
+            }
             return new ConfigCliArguments(
                     configFolderPath, outputFolderPath, sinceDate, untilDate, formats, isAutomaticallyLaunching);
         } catch (ArgumentParserException ape) {

--- a/src/main/java/reposense/parser/ArgsParser.java
+++ b/src/main/java/reposense/parser/ArgsParser.java
@@ -150,6 +150,7 @@ public class ArgsParser {
             List<String> locations = results.get(REPO_FLAGS[0]);
             List<Format> formats = Format.convertStringsToFormats(results.get(FORMAT_FLAGS[0]));
             boolean isStandaloneConfigIgnored = results.get(IGNORE_FLAGS[0]);
+
             verifyDatesRangeIsCorrect(sinceDate, untilDate);
 
             if (reportFolderPath != null && !reportFolderPath.equals(EMPTY_PATH) && configFolderPath.equals(EMPTY_PATH)

--- a/src/main/java/reposense/parser/ArgsParser.java
+++ b/src/main/java/reposense/parser/ArgsParser.java
@@ -8,6 +8,7 @@ import java.util.Optional;
 import java.util.logging.Logger;
 
 import net.sourceforge.argparse4j.ArgumentParsers;
+import net.sourceforge.argparse4j.helper.HelpScreenException;
 import net.sourceforge.argparse4j.impl.Arguments;
 import net.sourceforge.argparse4j.impl.action.HelpArgumentAction;
 import net.sourceforge.argparse4j.inf.ArgumentParser;
@@ -131,9 +132,11 @@ public class ArgsParser {
     /**
      * Parses the given string arguments to a {@code CliArguments} object.
      *
+     * @throws HelpScreenException if given args contain the --help flag. Help message will be printed out
+     * by the {@code ArgumentParser} hence this is to signal to the caller that the program is safe to exit.
      * @throws ParseException if the given string arguments fails to parse to a {@code CliArguments} object.
      */
-    public static CliArguments parse(String[] args) throws ParseException {
+    public static CliArguments parse(String[] args) throws HelpScreenException, ParseException {
         try {
             ArgumentParser parser = getArgumentParser();
             Namespace results = parser.parseArgs(args);
@@ -146,7 +149,6 @@ public class ArgsParser {
             List<String> locations = results.get(REPO_FLAGS[0]);
             List<Format> formats = Format.convertStringsToFormats(results.get(FORMAT_FLAGS[0]));
             boolean isStandaloneConfigIgnored = results.get(IGNORE_FLAGS[0]);
-
             verifyDatesRangeIsCorrect(sinceDate, untilDate);
 
             if (reportFolderPath != null && !reportFolderPath.equals(EMPTY_PATH) && configFolderPath.equals(EMPTY_PATH)
@@ -170,7 +172,10 @@ public class ArgsParser {
             }
             return new ConfigCliArguments(
                     configFolderPath, outputFolderPath, sinceDate, untilDate, formats, isAutomaticallyLaunching);
-        } catch (ArgumentParserException ape) {
+        } catch (HelpScreenException hse) {
+            throw hse;
+        }
+        catch (ArgumentParserException ape) {
             throw new ParseException(getArgumentParser().formatUsage() + ape.getMessage() + "\n");
         }
     }

--- a/src/systemtest/java/reposense/ConfigSystemTest.java
+++ b/src/systemtest/java/reposense/ConfigSystemTest.java
@@ -16,6 +16,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import net.sourceforge.argparse4j.helper.HelpScreenException;
 import reposense.model.AuthorConfiguration;
 import reposense.model.CliArguments;
 import reposense.model.ConfigCliArguments;
@@ -41,14 +42,14 @@ public class ConfigSystemTest {
     }
 
     @Test
-    public void testNoDateRange() throws IOException, URISyntaxException, ParseException {
+    public void testNoDateRange() throws IOException, URISyntaxException, ParseException, HelpScreenException {
         generateReport();
         Path actualFiles = Paths.get(getClass().getClassLoader().getResource("noDateRange/expected").toURI());
         verifyAllJson(actualFiles, FT_TEMP_DIR);
     }
 
     @Test
-    public void testDateRange() throws IOException, URISyntaxException, ParseException {
+    public void testDateRange() throws IOException, URISyntaxException, ParseException, HelpScreenException {
         generateReport(getInputWithDates("1/9/2017", "30/10/2017"));
         Path actualFiles = Paths.get(getClass().getClassLoader().getResource("dateRange/expected").toURI());
         verifyAllJson(actualFiles, FT_TEMP_DIR);
@@ -58,11 +59,12 @@ public class ConfigSystemTest {
         return String.format("--since %s --until %s", sinceDate, untilDate);
     }
 
-    private void generateReport() throws IOException, URISyntaxException, ParseException {
+    private void generateReport() throws IOException, URISyntaxException, ParseException, HelpScreenException {
         generateReport("");
     }
 
-    private void generateReport(String inputDates) throws IOException, URISyntaxException, ParseException {
+    private void generateReport(String inputDates)
+            throws IOException, URISyntaxException, ParseException, HelpScreenException {
         Path configFolder = Paths.get(getClass().getClassLoader().getResource("repo-config.csv").toURI()).getParent();
 
         String formats = String.join(" ", TESTING_FILE_FORMATS);

--- a/src/test/java/reposense/parser/ArgsParserTest.java
+++ b/src/test/java/reposense/parser/ArgsParserTest.java
@@ -17,6 +17,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import net.sourceforge.argparse4j.helper.HelpScreenException;
 import reposense.RepoSense;
 import reposense.model.CliArguments;
 import reposense.model.ConfigCliArguments;
@@ -54,7 +55,7 @@ public class ArgsParserTest {
     }
 
     @Test
-    public void parse_allCorrectInputs_success() throws ParseException, IOException {
+    public void parse_allCorrectInputs_success() throws ParseException, IOException, HelpScreenException {
         String input = new InputBuilder().addConfig(CONFIG_FOLDER_ABSOLUTE)
                 .addOutput(OUTPUT_DIRECTORY_ABSOLUTE)
                 .addSinceDate("01/07/2017")
@@ -84,8 +85,14 @@ public class ArgsParserTest {
         Assert.assertTrue(cliArguments.isAutomaticallyLaunching());
     }
 
+    @Test(expected = HelpScreenException.class)
+    public void parse_help_throwsHelpScreenException() throws HelpScreenException, ParseException {
+        String input = "--help";
+        ArgsParser.parse(translateCommandline(input));
+    }
+
     @Test
-    public void parse_allCorrectInputsAlias_success() throws ParseException, IOException {
+    public void parse_allCorrectInputsAlias_success() throws ParseException, IOException, HelpScreenException {
         String input = String.format("-c %s -o %s -s 01/07/2017 -u 30/11/2017 -f java adoc html css js -i -v",
                 CONFIG_FOLDER_ABSOLUTE, OUTPUT_DIRECTORY_ABSOLUTE);
         CliArguments cliArguments = ArgsParser.parse(translateCommandline(input));
@@ -110,7 +117,7 @@ public class ArgsParserTest {
     }
 
     @Test
-    public void parse_withExtraWhitespaces_success() throws ParseException, IOException {
+    public void parse_withExtraWhitespaces_success() throws ParseException, IOException, HelpScreenException {
         String input = new InputBuilder().addConfig(CONFIG_FOLDER_ABSOLUTE).addWhiteSpace(5)
                 .addOutput(OUTPUT_DIRECTORY_ABSOLUTE).addWhiteSpace(4)
                 .addSinceDate("01/07/2017").addWhiteSpace(3)
@@ -141,7 +148,7 @@ public class ArgsParserTest {
     }
 
     @Test
-    public void parse_configFolderOnly_success() throws ParseException, IOException {
+    public void parse_configFolderOnly_success() throws ParseException, IOException, HelpScreenException {
         String input = new InputBuilder().addConfig(CONFIG_FOLDER_ABSOLUTE).build();
         CliArguments cliArguments = ArgsParser.parse(translateCommandline(input));
         Assert.assertTrue(cliArguments instanceof ConfigCliArguments);
@@ -172,7 +179,7 @@ public class ArgsParserTest {
     }
 
     @Test
-    public void parse_viewOnly_success() throws ParseException, IOException {
+    public void parse_viewOnly_success() throws ParseException, IOException, HelpScreenException {
         String input = new InputBuilder().addView(OUTPUT_DIRECTORY_ABSOLUTE).build();
         CliArguments cliArguments = ArgsParser.parse(translateCommandline(input));
         Assert.assertTrue(cliArguments instanceof ViewCliArguments);
@@ -181,7 +188,7 @@ public class ArgsParserTest {
     }
 
     @Test
-    public void parse_withIgnore_success() throws ParseException {
+    public void parse_withIgnore_success() throws ParseException, HelpScreenException {
         String input = new InputBuilder().addRepos(TEST_REPO_REPOSENSE, TEST_REPO_DELTA)
                 .addIgnoreStandaloneConfig()
                 .build();
@@ -202,7 +209,7 @@ public class ArgsParserTest {
     }
 
     @Test
-    public void parse_withoutIgnore_success() throws ParseException {
+    public void parse_withoutIgnore_success() throws ParseException, HelpScreenException {
         String input = new InputBuilder().addRepos(TEST_REPO_REPOSENSE, TEST_REPO_DELTA).build();
         CliArguments cliArguments = ArgsParser.parse(translateCommandline(input));
 
@@ -211,7 +218,7 @@ public class ArgsParserTest {
     }
 
     @Test
-    public void parse_viewOnlyWithoutArgs_returnsConfigCliArguments() throws ParseException {
+    public void parse_viewOnlyWithoutArgs_returnsConfigCliArguments() throws ParseException, HelpScreenException {
         String input = new InputBuilder().addView().build();
         CliArguments cliArguments = ArgsParser.parse(translateCommandline(input));
 
@@ -222,7 +229,7 @@ public class ArgsParserTest {
     }
 
     @Test
-    public void parse_configFolderAndOutputDirectory_success() throws ParseException, IOException {
+    public void parse_configFolderAndOutputDirectory_success() throws ParseException, IOException, HelpScreenException {
         Path expectedRelativeOutputDirectoryPath = OUTPUT_DIRECTORY_RELATIVE.resolve(ArgsParser.DEFAULT_REPORT_NAME);
         Path expectedAbsoluteOutputDirectoryPath = OUTPUT_DIRECTORY_ABSOLUTE.resolve(ArgsParser.DEFAULT_REPORT_NAME);
 
@@ -250,7 +257,7 @@ public class ArgsParserTest {
     }
 
     @Test
-    public void parse_configFolderAndViewWithouthArgs_returnsConfigCliArguments() throws ParseException, IOException {
+    public void parse_configFolderAndViewWithouthArgs_returnsConfigCliArguments() throws ParseException, IOException, HelpScreenException {
         String input = new InputBuilder().addConfig(CONFIG_FOLDER_ABSOLUTE)
                 .addView()
                 .build();
@@ -277,7 +284,7 @@ public class ArgsParserTest {
     }
 
     @Test
-    public void parse_configFolderAndViewWithArgs_returnsConfigCliArguments() throws ParseException, IOException {
+    public void parse_configFolderAndViewWithArgs_returnsConfigCliArguments() throws ParseException, IOException, HelpScreenException {
         String input = new InputBuilder().addConfig(CONFIG_FOLDER_ABSOLUTE)
                 .addView(OUTPUT_DIRECTORY_ABSOLUTE)
                 .build();
@@ -292,7 +299,7 @@ public class ArgsParserTest {
     }
 
     @Test
-    public void sinceDate_correctFormat_success() throws ParseException {
+    public void sinceDate_correctFormat_success() throws ParseException, HelpScreenException {
         String input = DEFAULT_INPUT_BUILDER.addSinceDate("01/07/2017").build();
         CliArguments cliArguments = ArgsParser.parse(translateCommandline(input));
         Assert.assertTrue(cliArguments instanceof ConfigCliArguments);
@@ -301,7 +308,7 @@ public class ArgsParserTest {
     }
 
     @Test
-    public void untilDate_correctFormat_success() throws ParseException {
+    public void untilDate_correctFormat_success() throws ParseException, HelpScreenException {
         String input = DEFAULT_INPUT_BUILDER.addUntilDate("30/11/2017").build();
         CliArguments cliArguments = ArgsParser.parse(translateCommandline(input));
         Assert.assertTrue(cliArguments instanceof ConfigCliArguments);
@@ -310,7 +317,7 @@ public class ArgsParserTest {
     }
 
     @Test
-    public void formats_inAlphanumeric_success() throws ParseException {
+    public void formats_inAlphanumeric_success() throws ParseException, HelpScreenException {
         String input = DEFAULT_INPUT_BUILDER.addFormats("java js css 7z").build();
         CliArguments cliArguments = ArgsParser.parse(translateCommandline(input));
         Assert.assertTrue(cliArguments instanceof ConfigCliArguments);
@@ -319,7 +326,7 @@ public class ArgsParserTest {
     }
 
     @Test
-    public void parse_validGitRepoLocations_repoConfigurationListCorrectSize() throws ParseException, IOException {
+    public void parse_validGitRepoLocations_repoConfigurationListCorrectSize() throws ParseException, IOException, HelpScreenException {
         String input = new InputBuilder().addRepos(TEST_REPO_REPOSENSE, TEST_REPO_DELTA).build();
         CliArguments cliArguments = ArgsParser.parse(translateCommandline(input));
         Assert.assertTrue(cliArguments instanceof LocationsCliArguments);
@@ -328,7 +335,7 @@ public class ArgsParserTest {
     }
 
     @Test
-    public void parse_repoLocationsAndView_returnsLocationCliArguments() throws ParseException {
+    public void parse_repoLocationsAndView_returnsLocationCliArguments() throws ParseException, HelpScreenException {
         String input = new InputBuilder().addRepos(TEST_REPO_REPOSENSE, TEST_REPO_DELTA)
                 .addView()
                 .build();
@@ -341,7 +348,7 @@ public class ArgsParserTest {
     }
 
     @Test
-    public void parse_repoLocationsOnly_success() throws ParseException {
+    public void parse_repoLocationsOnly_success() throws ParseException, HelpScreenException {
         String input = new InputBuilder().addRepos(TEST_REPO_REPOSENSE, TEST_REPO_DELTA).build();
         CliArguments cliArguments = ArgsParser.parse(translateCommandline(input));
 
@@ -352,7 +359,7 @@ public class ArgsParserTest {
     }
 
     @Test
-    public void parse_repoLocationsAndViewWithArgs_returnsLocationsCliArguments() throws ParseException {
+    public void parse_repoLocationsAndViewWithArgs_returnsLocationsCliArguments() throws ParseException, HelpScreenException {
         String input = new InputBuilder().addRepos(TEST_REPO_REPOSENSE, TEST_REPO_DELTA)
                 .addView(OUTPUT_DIRECTORY_ABSOLUTE)
                 .build();
@@ -365,7 +372,7 @@ public class ArgsParserTest {
     }
 
     @Test
-    public void parse_viewWithArgCwd_returnsViewCliArguments() throws ParseException {
+    public void parse_viewWithArgCwd_returnsViewCliArguments() throws ParseException, HelpScreenException {
         String input = new InputBuilder().addView(new File(".").toPath()).build();
         CliArguments cliArguments = ArgsParser.parse(translateCommandline(input));
 
@@ -373,7 +380,7 @@ public class ArgsParserTest {
     }
 
     @Test
-    public void parse_configOrLocationsSimilar_success() throws ParseException, IOException {
+    public void parse_configOrLocationsSimilar_success() throws ParseException, IOException, HelpScreenException {
         String input = new InputBuilder().addConfig(CONFIG_FOLDER_ABSOLUTE).build();
         CliArguments configCliArguments = ArgsParser.parse(translateCommandline(input));
         Assert.assertTrue(configCliArguments instanceof ConfigCliArguments);
@@ -390,7 +397,7 @@ public class ArgsParserTest {
     }
 
     @Test
-    public void emptyArgs_defaultConfigFolderPath() throws ParseException, IOException {
+    public void emptyArgs_defaultConfigFolderPath() throws ParseException, HelpScreenException {
         CliArguments cliArguments = ArgsParser.parse(new String[]{});
         Assert.assertTrue(cliArguments instanceof ConfigCliArguments);
         Assert.assertEquals(PROJECT_DIRECTORY.toString(), (
@@ -398,7 +405,7 @@ public class ArgsParserTest {
     }
 
     @Test
-    public void parse_repoAliases_sameResult() throws ParseException, IOException {
+    public void parse_repoAliases_sameResult() throws ParseException, HelpScreenException {
         String input = new InputBuilder().addRepos(TEST_REPO_BETA).build();
         CliArguments repoAliasCliArguments = ArgsParser.parse(translateCommandline(input));
 
@@ -409,7 +416,7 @@ public class ArgsParserTest {
     }
 
     @Test
-    public void parse_invalidRepoLocation_emptyRepoConfigurationList() throws ParseException, IOException {
+    public void parse_invalidRepoLocation_emptyRepoConfigurationList() throws ParseException, IOException, HelpScreenException {
         String input = new InputBuilder().addRepos("https://githubaaaa.com/asdasdasdasd/RepoSense").build();
         CliArguments cliArguments = ArgsParser.parse(translateCommandline(input));
         Assert.assertTrue(cliArguments instanceof LocationsCliArguments);
@@ -418,40 +425,40 @@ public class ArgsParserTest {
     }
 
     @Test(expected = ParseException.class)
-    public void absoluteConfigFolder_withoutRequiredConfigFiles_throwsParseException() throws ParseException {
+    public void absoluteConfigFolder_withoutRequiredConfigFiles_throwsParseException() throws ParseException, HelpScreenException {
         Path absDirectory = PROJECT_DIRECTORY.getParent().toAbsolutePath();
         String input = new InputBuilder().addConfig(absDirectory).build();
         ArgsParser.parse(translateCommandline(input));
     }
 
     @Test(expected = ParseException.class)
-    public void relativeConfigFolder_withoutRequiredConfigFiles_throwsParseException() throws ParseException {
+    public void relativeConfigFolder_withoutRequiredConfigFiles_throwsParseException() throws ParseException, HelpScreenException {
         Path relDirectory = PROJECT_DIRECTORY.getParent();
         String input = new InputBuilder().addConfig(relDirectory).build();
         ArgsParser.parse(translateCommandline(input));
     }
 
     @Test(expected = ParseException.class)
-    public void parse_notExistsConfigFolder_throwsParseException() throws ParseException {
+    public void parse_notExistsConfigFolder_throwsParseException() throws ParseException, HelpScreenException {
         Path absConfigFolder = PROJECT_DIRECTORY.resolve("non_existing_random_folder");
         String input = new InputBuilder().addConfig(absConfigFolder).build();
         ArgsParser.parse(translateCommandline(input));
     }
 
     @Test(expected = ParseException.class)
-    public void parse_configCsvFileAsConfigFolder_throwsParseException() throws ParseException {
+    public void parse_configCsvFileAsConfigFolder_throwsParseException() throws ParseException, HelpScreenException {
         String input = new InputBuilder().addConfig(REPO_CONFIG_CSV_FILE).build();
         ArgsParser.parse(translateCommandline(input));
     }
 
     @Test(expected = ParseException.class)
-    public void parse_missingConfigValue_throwsParseException() throws ParseException {
+    public void parse_missingConfigValue_throwsParseException() throws ParseException, HelpScreenException {
         String input = new InputBuilder().addConfig(new File("").toPath()).build();
         ArgsParser.parse(translateCommandline(input));
     }
 
     @Test
-    public void outputPath_nonExistentDirectory_success() throws ParseException, IOException {
+    public void outputPath_nonExistentDirectory_success() throws ParseException, IOException, HelpScreenException {
         Path nonExistentDirectory = PROJECT_DIRECTORY.resolve("some_non_existent_dir/");
         Path expectedRelativeOutputDirectoryPath = nonExistentDirectory.resolve(ArgsParser.DEFAULT_REPORT_NAME);
         String input = new InputBuilder().addOutput(nonExistentDirectory).build();
@@ -462,19 +469,19 @@ public class ArgsParserTest {
     }
 
     @Test(expected = ParseException.class)
-    public void sinceDate_unsupportedFormats_throwsParseException() throws ParseException {
+    public void sinceDate_unsupportedFormats_throwsParseException() throws ParseException, HelpScreenException {
         String input = DEFAULT_INPUT_BUILDER.addSinceDate("01 July 17").build();
         ArgsParser.parse(translateCommandline(input));
     }
 
     @Test(expected = ParseException.class)
-    public void untilDate_unsupportedFormats_throwsParseException() throws ParseException {
+    public void untilDate_unsupportedFormats_throwsParseException() throws ParseException, HelpScreenException {
         String input = DEFAULT_INPUT_BUILDER.addUntilDate("11/31/2017").build();
         ArgsParser.parse(translateCommandline(input));
     }
 
     @Test(expected = ParseException.class)
-    public void sinceDate_laterThanUntilDate_throwsParseException() throws ParseException {
+    public void sinceDate_laterThanUntilDate_throwsParseException() throws ParseException, HelpScreenException {
         String input = DEFAULT_INPUT_BUILDER.addSinceDate("01/12/2017")
                 .addUntilDate("30/11/2017")
                 .build();
@@ -482,13 +489,13 @@ public class ArgsParserTest {
     }
 
     @Test(expected = ParseException.class)
-    public void formats_notInAlphanumeric_throwsParseException() throws ParseException {
+    public void formats_notInAlphanumeric_throwsParseException() throws ParseException, HelpScreenException {
         String input = DEFAULT_INPUT_BUILDER.addFormats(".java").build();
         ArgsParser.parse(translateCommandline(input));
     }
 
     @Test(expected = ParseException.class)
-    public void parse_mutuallyExclusiveArgumentsConfigAndReposTogether_throwsParseException() throws ParseException {
+    public void parse_mutuallyExclusiveArgumentsConfigAndReposTogether_throwsParseException() throws ParseException, HelpScreenException {
         String input = new InputBuilder().addConfig(CONFIG_FOLDER_ABSOLUTE)
                 .addRepos(TEST_REPO_REPOSENSE)
                 .build();
@@ -496,7 +503,7 @@ public class ArgsParserTest {
     }
 
     @Test(expected = ParseException.class)
-    public void parse_extraArgumentForIgnore_throwsParseException() throws ParseException {
+    public void parse_extraArgumentForIgnore_throwsParseException() throws ParseException, HelpScreenException {
         String input = DEFAULT_INPUT_BUILDER.addIgnoreStandaloneConfig().add("true").build();
         ArgsParser.parse(translateCommandline(input));
     }

--- a/src/test/java/reposense/parser/ArgsParserTest.java
+++ b/src/test/java/reposense/parser/ArgsParserTest.java
@@ -257,7 +257,8 @@ public class ArgsParserTest {
     }
 
     @Test
-    public void parse_configFolderAndViewWithouthArgs_returnsConfigCliArguments() throws ParseException, IOException, HelpScreenException {
+    public void parse_configFolderAndViewWithouthArgs_returnsConfigCliArguments()
+            throws ParseException, IOException, HelpScreenException {
         String input = new InputBuilder().addConfig(CONFIG_FOLDER_ABSOLUTE)
                 .addView()
                 .build();
@@ -284,7 +285,8 @@ public class ArgsParserTest {
     }
 
     @Test
-    public void parse_configFolderAndViewWithArgs_returnsConfigCliArguments() throws ParseException, IOException, HelpScreenException {
+    public void parse_configFolderAndViewWithArgs_returnsConfigCliArguments()
+            throws ParseException, IOException, HelpScreenException {
         String input = new InputBuilder().addConfig(CONFIG_FOLDER_ABSOLUTE)
                 .addView(OUTPUT_DIRECTORY_ABSOLUTE)
                 .build();
@@ -326,7 +328,8 @@ public class ArgsParserTest {
     }
 
     @Test
-    public void parse_validGitRepoLocations_repoConfigurationListCorrectSize() throws ParseException, IOException, HelpScreenException {
+    public void parse_validGitRepoLocations_repoConfigurationListCorrectSize()
+            throws ParseException, HelpScreenException {
         String input = new InputBuilder().addRepos(TEST_REPO_REPOSENSE, TEST_REPO_DELTA).build();
         CliArguments cliArguments = ArgsParser.parse(translateCommandline(input));
         Assert.assertTrue(cliArguments instanceof LocationsCliArguments);
@@ -359,7 +362,8 @@ public class ArgsParserTest {
     }
 
     @Test
-    public void parse_repoLocationsAndViewWithArgs_returnsLocationsCliArguments() throws ParseException, HelpScreenException {
+    public void parse_repoLocationsAndViewWithArgs_returnsLocationsCliArguments()
+            throws ParseException, HelpScreenException {
         String input = new InputBuilder().addRepos(TEST_REPO_REPOSENSE, TEST_REPO_DELTA)
                 .addView(OUTPUT_DIRECTORY_ABSOLUTE)
                 .build();
@@ -416,7 +420,8 @@ public class ArgsParserTest {
     }
 
     @Test
-    public void parse_invalidRepoLocation_emptyRepoConfigurationList() throws ParseException, IOException, HelpScreenException {
+    public void parse_invalidRepoLocation_emptyRepoConfigurationList()
+            throws ParseException, HelpScreenException {
         String input = new InputBuilder().addRepos("https://githubaaaa.com/asdasdasdasd/RepoSense").build();
         CliArguments cliArguments = ArgsParser.parse(translateCommandline(input));
         Assert.assertTrue(cliArguments instanceof LocationsCliArguments);
@@ -425,14 +430,16 @@ public class ArgsParserTest {
     }
 
     @Test(expected = ParseException.class)
-    public void absoluteConfigFolder_withoutRequiredConfigFiles_throwsParseException() throws ParseException, HelpScreenException {
+    public void absoluteConfigFolder_withoutRequiredConfigFiles_throwsParseException()
+            throws ParseException, HelpScreenException {
         Path absDirectory = PROJECT_DIRECTORY.getParent().toAbsolutePath();
         String input = new InputBuilder().addConfig(absDirectory).build();
         ArgsParser.parse(translateCommandline(input));
     }
 
     @Test(expected = ParseException.class)
-    public void relativeConfigFolder_withoutRequiredConfigFiles_throwsParseException() throws ParseException, HelpScreenException {
+    public void relativeConfigFolder_withoutRequiredConfigFiles_throwsParseException()
+            throws ParseException, HelpScreenException {
         Path relDirectory = PROJECT_DIRECTORY.getParent();
         String input = new InputBuilder().addConfig(relDirectory).build();
         ArgsParser.parse(translateCommandline(input));
@@ -495,7 +502,8 @@ public class ArgsParserTest {
     }
 
     @Test(expected = ParseException.class)
-    public void parse_mutuallyExclusiveArgumentsConfigAndReposTogether_throwsParseException() throws ParseException, HelpScreenException {
+    public void parse_mutuallyExclusiveArgumentsConfigAndReposTogether_throwsParseException()
+            throws ParseException, HelpScreenException {
         String input = new InputBuilder().addConfig(CONFIG_FOLDER_ABSOLUTE)
                 .addRepos(TEST_REPO_REPOSENSE)
                 .build();

--- a/src/test/java/reposense/parser/CsvParserTest.java
+++ b/src/test/java/reposense/parser/CsvParserTest.java
@@ -12,6 +12,7 @@ import java.util.List;
 import org.junit.Assert;
 import org.junit.Test;
 
+import net.sourceforge.argparse4j.helper.HelpScreenException;
 import reposense.model.Author;
 import reposense.model.AuthorConfiguration;
 import reposense.model.CliArguments;
@@ -150,7 +151,7 @@ public class CsvParserTest {
     }
 
     @Test
-    public void merge_twoRepoConfigs_success() throws ParseException, IOException {
+    public void merge_twoRepoConfigs_success() throws ParseException, IOException, HelpScreenException {
         FIRST_AUTHOR.setIgnoreGlobList(FIRST_AUTHOR_GLOB_LIST);
         SECOND_AUTHOR.setIgnoreGlobList(REPO_LEVEL_GLOB_LIST);
         SECOND_AUTHOR.setAuthorAliases(SECOND_AUTHOR_ALIASES);
@@ -181,7 +182,7 @@ public class CsvParserTest {
     }
 
     @Test
-    public void merge_emptyLocation_success() throws ParseException, IOException {
+    public void merge_emptyLocation_success() throws ParseException, IOException, HelpScreenException {
         FIRST_AUTHOR.setIgnoreGlobList(FIRST_AUTHOR_GLOB_LIST);
         SECOND_AUTHOR.setIgnoreGlobList(REPO_LEVEL_GLOB_LIST);
         SECOND_AUTHOR.setAuthorAliases(SECOND_AUTHOR_ALIASES);
@@ -229,7 +230,7 @@ public class CsvParserTest {
     }
 
     @Test
-    public void repoConfig_defaultBranch_success() throws ParseException, IOException {
+    public void repoConfig_defaultBranch_success() throws ParseException, IOException, HelpScreenException {
         RepoConfiguration expectedConfig = new RepoConfiguration(new RepoLocation(TEST_REPO_BETA_LOCATION),
                 RepoConfiguration.DEFAULT_BRANCH);
 

--- a/src/test/java/reposense/parser/RepoConfigurationTest.java
+++ b/src/test/java/reposense/parser/RepoConfigurationTest.java
@@ -155,7 +155,8 @@ public class RepoConfigurationTest {
     }
 
     @Test
-    public void repoConfig_ignoresStandaloneConfigInCli_success() throws ParseException, GitCloneException, HelpScreenException {
+    public void repoConfig_ignoresStandaloneConfigInCli_success()
+            throws ParseException, GitCloneException, HelpScreenException {
         RepoConfiguration expectedConfig = new RepoConfiguration(new RepoLocation(TEST_REPO_DELTA), "master");
         expectedConfig.setFormats(Format.convertStringsToFormats(CLI_FORMATS));
         expectedConfig.setStandaloneConfigIgnored(true);
@@ -227,7 +228,8 @@ public class RepoConfigurationTest {
     }
 
     @Test
-    public void repoConfig_withoutFormatsAndCliFormats_useDefaultFormats() throws ParseException, IOException, HelpScreenException {
+    public void repoConfig_withoutFormatsAndCliFormats_useDefaultFormats()
+            throws ParseException, IOException, HelpScreenException {
         String input = new InputBuilder().addConfig(WITHOUT_FORMATS_TEST_CONFIG_FILES).build();
         CliArguments cliArguments = ArgsParser.parse(translateCommandline(input));
 

--- a/src/test/java/reposense/parser/RepoConfigurationTest.java
+++ b/src/test/java/reposense/parser/RepoConfigurationTest.java
@@ -15,6 +15,7 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import net.sourceforge.argparse4j.helper.HelpScreenException;
 import reposense.RepoSense;
 import reposense.git.GitClone;
 import reposense.git.GitCloneException;
@@ -119,7 +120,7 @@ public class RepoConfigurationTest {
 
     @Test
     public void repoConfig_ignoresStandaloneConfig_success()
-            throws ParseException, GitCloneException, IOException {
+            throws ParseException, GitCloneException, IOException, HelpScreenException {
         List<Author> expectedAuthors = new ArrayList<>();
         Author author = new Author(FIRST_AUTHOR);
         author.setIgnoreGlobList(REPO_LEVEL_GLOB_LIST);
@@ -154,7 +155,7 @@ public class RepoConfigurationTest {
     }
 
     @Test
-    public void repoConfig_ignoresStandaloneConfigInCli_success() throws ParseException, GitCloneException {
+    public void repoConfig_ignoresStandaloneConfigInCli_success() throws ParseException, GitCloneException, HelpScreenException {
         RepoConfiguration expectedConfig = new RepoConfiguration(new RepoLocation(TEST_REPO_DELTA), "master");
         expectedConfig.setFormats(Format.convertStringsToFormats(CLI_FORMATS));
         expectedConfig.setStandaloneConfigIgnored(true);
@@ -176,7 +177,7 @@ public class RepoConfigurationTest {
 
     @Test
     public void repoConfig_wrongKeywordUseStandaloneConfig_success()
-            throws ParseException, GitCloneException, IOException {
+            throws ParseException, GitCloneException, IOException, HelpScreenException {
         String formats = String.join(" ", CLI_FORMATS);
         String input = new InputBuilder().addConfig(IGNORE_STANDALONE_KEYWORD_TEST_CONFIG_FILES)
                 .addFormats(formats)
@@ -194,7 +195,7 @@ public class RepoConfigurationTest {
     }
 
     @Test
-    public void repoConfig_withFormats_ignoreCliFormats() throws ParseException, IOException {
+    public void repoConfig_withFormats_ignoreCliFormats() throws ParseException, IOException, HelpScreenException {
         String formats = String.join(" ", CLI_FORMATS);
         String input = new InputBuilder().addConfig(FORMATS_TEST_CONFIG_FILES)
                 .addFormats(formats)
@@ -210,7 +211,7 @@ public class RepoConfigurationTest {
     }
 
     @Test
-    public void repoConfig_withoutFormats_useCliFormats() throws ParseException, IOException {
+    public void repoConfig_withoutFormats_useCliFormats() throws ParseException, IOException, HelpScreenException {
         String formats = String.join(" ", CLI_FORMATS);
         String input = new InputBuilder().addConfig(WITHOUT_FORMATS_TEST_CONFIG_FILES)
                 .addFormats(formats)
@@ -226,7 +227,7 @@ public class RepoConfigurationTest {
     }
 
     @Test
-    public void repoConfig_withoutFormatsAndCliFormats_useDefaultFormats() throws ParseException, IOException {
+    public void repoConfig_withoutFormatsAndCliFormats_useDefaultFormats() throws ParseException, IOException, HelpScreenException {
         String input = new InputBuilder().addConfig(WITHOUT_FORMATS_TEST_CONFIG_FILES).build();
         CliArguments cliArguments = ArgsParser.parse(translateCommandline(input));
 


### PR DESCRIPTION
Fix #587 

```
Some of the messages used in RepoSense are structurally unoriented.

This include the missing transition message where --config flag is
unused, using default path for analysis and the double printing of
the help message, and the confusing arrangement of usage parameters as
shown in #587.

Let's fix these scenarios to improve the quality of our output messages.
```