### PR TITLE
Cypress: front-end test failing due to timeouts

### DIFF
--- a/frontend/cypress/cypress.json
+++ b/frontend/cypress/cypress.json
@@ -5,5 +5,5 @@
   "fixturesFolder": false,
   "pluginsFile": false,
   "video": false,
-  "defaultCommandTimeout": 60000
+  "defaultCommandTimeout": 30000
 }

--- a/frontend/cypress/cypress.json
+++ b/frontend/cypress/cypress.json
@@ -4,5 +4,6 @@
   "supportFile": "support.js",
   "fixturesFolder": false,
   "pluginsFile": false,
-  "video": false
+  "video": false,
+  "defaultCommandTimeout": 60000
 }


### PR DESCRIPTION
Fixes #584 

```
By default, Cypress use 4000ms as the timeout value for DOM-based
commands.

However, using the default timeout value may result in frontend test
failing, when the CI is experiencing heavier load.

Let's increase the timeout value to 30000ms.
```