### PR TITLE
[#600] Integrate Coverage Test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ script:
   - ./config/travis/run-checks.sh
   - npm run lint frontend/src/**/*.js
   - npm run lint frontend/cypress/**.js
-  - time travis_retry ./gradlew clean checkstyleMain checkstyleTest test systemTest
+  - time travis_retry ./gradlew clean checkstyleMain checkstyleTest test systemTest coverage
 
 before_install: &common_before_install
   - npm install --only=dev
@@ -55,3 +55,6 @@ cache:
     - $HOME/.gradle/wrapper/
     - $HOME/Library/Caches/Homebrew
     - $HOME/.cache
+
+after_success:
+  - bash <(curl -s https://codecov.io/bash)

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Build status](https://ci.appveyor.com/api/projects/status/gsbkj5qby3pjd6nw/branch/master?svg=true)](https://ci.appveyor.com/project/eugenepeh/reposense/branch/master)
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/08a3527378464ed4a5ad62e27f590d6a)](https://www.codacy.com/app/reposense/RepoSense?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=reposense/RepoSense&amp;utm_campaign=Badge_Grade)
 [![deploy on_netlify](https://img.shields.io/badge/deploy-on_netlify-blue.svg)](https://reposense.netlify.com/)
+[![codecov.io](https://codecov.io/gh/reposense/RepoSense/branch/master/graphs/badge.svg?branch=master)](http://codecov.io/github/reposense/RepoSense?branch=master)
 
 RepoSense is a contribution analysis tool for Git repositories. It generates a static HTML report including contribution information for each author in the repository.
 The features of the report includes:

--- a/build.gradle
+++ b/build.gradle
@@ -1,12 +1,12 @@
 plugins {
-    id 'java'
+    id 'application'
     id 'checkstyle'
     id 'idea'
-    id 'application'
+    id 'jacoco'
+    id 'java'
     id 'com.github.johnrengelman.shadow' version '2.0.4'
     id 'com.liferay.node' version '4.4.0'
     id 'com.github.psxpaul.execfork' version '0.1.8'
-    id 'jacoco'
 }
 
 mainClassName = 'reposense.RepoSense'
@@ -16,10 +16,6 @@ node.nodeVersion = '10.5.0'
 sourceCompatibility = JavaVersion.VERSION_1_8
 targetCompatibility = JavaVersion.VERSION_1_8
 
-jacoco {
-    toolVersion = "0.8.3"
-}
-
 repositories {
     mavenCentral()
 }
@@ -28,9 +24,24 @@ wrapper {
     gradleVersion = '4.9'
 }
 
+run {
+    //the second arguments indicates the default value associated with the property.
+    args System.getProperty('args', '').split()
+}
+
 checkstyle {
     toolVersion = '8.1'
     configDir = file("$rootProject.projectDir/config/checkstyle")
+}
+
+idea {
+    module {
+        sourceSets.systemtest.allSource.srcDirs.each { srcDir -> module.testSourceDirs += srcDir }
+    }
+}
+
+jacoco {
+    toolVersion = "0.8.3"
 }
 
 test {
@@ -128,17 +139,6 @@ task frontendTest(dependsOn: ['installCypress', 'startServerInBackground'], type
     if (project.hasProperty('ci')) {
         args = ["run-script", "ci"]
     }
-}
-
-idea {
-    module {
-        sourceSets.systemtest.allSource.srcDirs.each { srcDir -> module.testSourceDirs += srcDir }
-    }
-}
-
-run {
-    //the second arguments indicates the default value associated with the property.
-    args System.getProperty('args', '').split()
 }
 
 tasks.withType(Copy) {

--- a/build.gradle
+++ b/build.gradle
@@ -171,4 +171,4 @@ task coverage(type: JacocoReport) {
     }
 }
 
-defaultTasks 'clean', 'build', 'test', 'systemtest', 'frontendTest', 'coverage'
+defaultTasks 'clean', 'build', 'systemtest', 'frontendTest', 'coverage'

--- a/build.gradle
+++ b/build.gradle
@@ -40,18 +40,18 @@ test {
     }
 
     testLogging {
-      events 'passed', 'skipped', 'failed'
-      showStandardStreams = true
+        events 'passed', 'skipped', 'failed'
+        showStandardStreams = true
     }
 }
 
 sourceSets {
-  systemtest {
-    compileClasspath += main.output + test.output
-    runtimeClasspath += main.output + test.output
-    java.srcDir file('src/systemtest/java')
-    resources.srcDir file('src/systemtest/resources')
-  }
+    systemtest {
+        compileClasspath += main.output + test.output
+        runtimeClasspath += main.output + test.output
+        java.srcDir file('src/systemtest/java')
+        resources.srcDir file('src/systemtest/resources')
+    }
 }
 
 configurations {
@@ -126,7 +126,7 @@ task frontendTest(dependsOn: ['installCypress', 'startServerInBackground'], type
 
     // Run tests in CI without slow motion
     if (project.hasProperty('ci')) {
-      args = ["run-script", "ci"]
+        args = ["run-script", "ci"]
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -158,13 +158,13 @@ task coverage(type: JacocoReport) {
     sourceDirectories = files(sourceSets.main.allSource.srcDirs)
     classDirectories = files(sourceSets.main.output)
     executionData = files(jacocoTestReport.executionData)
-    
+
     afterEvaluate {
         classDirectories = files(classDirectories.files.collect {
             fileTree(dir: it, exclude: ['**/*.jar'])
         })
     }
-    
+
     reports {
         html.enabled = true
         xml.enabled = true

--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,10 @@ node.nodeVersion = '10.5.0'
 sourceCompatibility = JavaVersion.VERSION_1_8
 targetCompatibility = JavaVersion.VERSION_1_8
 
+jacoco {
+    toolVersion = "0.8.3"
+}
+
 repositories {
     mavenCentral()
 }
@@ -31,6 +35,7 @@ checkstyle {
 
 test {
     jacoco {
+        append = true
         destinationFile = new File("${buildDir}/jacoco/test.exec")
     }
 
@@ -83,11 +88,12 @@ tasks.run.dependsOn('compileJava');
 task systemtest(dependsOn: 'zipReport', type: Test) {
     testClassesDirs = sourceSets.systemtest.output.classesDirs
     classpath = sourceSets.systemtest.runtimeClasspath
-    
+
     jacoco {
+        append = true
         destinationFile = new File("${buildDir}/jacoco/test.exec")
     }
-    
+
     testLogging {
         events 'passed', 'skipped', 'failed'
         showStandardStreams = true
@@ -141,7 +147,8 @@ tasks.withType(Copy) {
 
 jacocoTestReport {
     reports {
-        xml.enabled false
+        html.enabled = true
+        xml.enabled true
         csv.enabled false
         html.destination file("${buildDir}/jacocoHtml")
     }
@@ -164,4 +171,4 @@ task coverage(type: JacocoReport) {
     }
 }
 
-defaultTasks 'clean', 'build', 'systemtest', 'frontendTest', 'coverage'
+defaultTasks 'clean', 'build', 'test', 'systemtest', 'frontendTest', 'coverage'

--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,30 @@ repositories {
     mavenCentral()
 }
 
+configurations {
+    systemtestImplementation.extendsFrom testImplementation
+    systemtestRuntime.extendsFrom testRuntime
+}
+
+dependencies {
+    implementation  group: 'com.github.javaparser', name: 'javaparser-core', version: '3.0.1'
+    implementation  group: 'com.google.code.gson' ,name: 'gson', version:'2.8.5'
+    implementation  group: 'org.apache.ant', name: 'ant', version: '1.10.3'
+    implementation  group: 'net.sourceforge.argparse4j', name: 'argparse4j', version: '0.8.1'
+    implementation  group: 'net.freeutils', name: 'jlhttp', version: '2.4'
+
+    testImplementation group: 'junit', name: 'junit', version: '4.12'
+}
+
+sourceSets {
+    systemtest {
+        compileClasspath += main.output + test.output
+        runtimeClasspath += main.output + test.output
+        java.srcDir file('src/systemtest/java')
+        resources.srcDir file('src/systemtest/resources')
+    }
+}
+
 wrapper {
     gradleVersion = '4.9'
 }
@@ -44,6 +68,15 @@ jacoco {
     toolVersion = "0.8.3"
 }
 
+jacocoTestReport {
+    reports {
+        html.enabled = true
+        xml.enabled true
+        csv.enabled false
+        html.destination file("${buildDir}/jacocoHtml")
+    }
+}
+
 test {
     jacoco {
         append = true
@@ -54,30 +87,6 @@ test {
         events 'passed', 'skipped', 'failed'
         showStandardStreams = true
     }
-}
-
-sourceSets {
-    systemtest {
-        compileClasspath += main.output + test.output
-        runtimeClasspath += main.output + test.output
-        java.srcDir file('src/systemtest/java')
-        resources.srcDir file('src/systemtest/resources')
-    }
-}
-
-configurations {
-    systemtestImplementation.extendsFrom testImplementation
-    systemtestRuntime.extendsFrom testRuntime
-}
-
-dependencies {
-    implementation  group: 'com.github.javaparser', name: 'javaparser-core', version: '3.0.1'
-    implementation  group: 'com.google.code.gson' ,name: 'gson', version:'2.8.5'
-    implementation  group: 'org.apache.ant', name: 'ant', version: '1.10.3'
-    implementation  group: 'net.sourceforge.argparse4j', name: 'argparse4j', version: '0.8.1'
-    implementation  group: 'net.freeutils', name: 'jlhttp', version: '2.4'
-
-    testImplementation group: 'junit', name: 'junit', version: '4.12'
 }
 
 shadowJar {
@@ -143,15 +152,6 @@ task frontendTest(dependsOn: ['installCypress', 'startServerInBackground'], type
 
 tasks.withType(Copy) {
     includeEmptyDirs = true
-}
-
-jacocoTestReport {
-    reports {
-        html.enabled = true
-        xml.enabled true
-        csv.enabled false
-        html.destination file("${buildDir}/jacocoHtml")
-    }
 }
 
 task coverage(type: JacocoReport) {

--- a/build.gradle
+++ b/build.gradle
@@ -6,6 +6,7 @@ plugins {
     id 'com.github.johnrengelman.shadow' version '2.0.4'
     id 'com.liferay.node' version '4.4.0'
     id 'com.github.psxpaul.execfork' version '0.1.8'
+    id 'jacoco'
 }
 
 mainClassName = 'reposense.RepoSense'
@@ -20,7 +21,7 @@ repositories {
 }
 
 wrapper {
-  gradleVersion = '4.9'
+    gradleVersion = '4.9'
 }
 
 checkstyle {
@@ -29,10 +30,14 @@ checkstyle {
 }
 
 test {
-  testLogging {
-    events 'passed', 'skipped', 'failed'
-    showStandardStreams = true
-  }
+    jacoco {
+        destinationFile = new File("${buildDir}/jacoco/test.exec")
+    }
+
+    testLogging {
+      events 'passed', 'skipped', 'failed'
+      showStandardStreams = true
+    }
 }
 
 sourceSets {
@@ -45,8 +50,8 @@ sourceSets {
 }
 
 configurations {
-  systemtestImplementation.extendsFrom testImplementation
-  systemtestRuntime.extendsFrom testRuntime
+    systemtestImplementation.extendsFrom testImplementation
+    systemtestRuntime.extendsFrom testRuntime
 }
 
 dependencies {
@@ -76,42 +81,47 @@ tasks.compileJava.dependsOn('zipReport');
 tasks.run.dependsOn('compileJava');
 
 task systemtest(dependsOn: 'zipReport', type: Test) {
-  testClassesDirs = sourceSets.systemtest.output.classesDirs
-  classpath = sourceSets.systemtest.runtimeClasspath
-  testLogging {
-    events 'passed', 'skipped', 'failed'
-    showStandardStreams = true
-  }
+    testClassesDirs = sourceSets.systemtest.output.classesDirs
+    classpath = sourceSets.systemtest.runtimeClasspath
+    
+    jacoco {
+        destinationFile = new File("${buildDir}/jacoco/test.exec")
+    }
+    
+    testLogging {
+        events 'passed', 'skipped', 'failed'
+        showStandardStreams = true
+    }
 }
 
 task startServerInBackground(dependsOn: 'classes', type: com.github.psxpaul.task.JavaExecFork) {
-  main = mainClassName
-  classpath = sourceSets.main.runtimeClasspath
-  args = ['--repo', 'https://github.com/reposense/RepoSense.git', '--view']
-  waitForPort = 9000
+    main = mainClassName
+    classpath = sourceSets.main.runtimeClasspath
+    args = ['--repo', 'https://github.com/reposense/RepoSense.git', '--view']
+    waitForPort = 9000
 }
 
 task installCypress(type: com.liferay.gradle.plugins.node.tasks.NpmInstallTask) {
-  workingDir = file('frontend/cypress/')
+    workingDir = file('frontend/cypress/')
 }
 
 task cypress(dependsOn: ['installCypress', 'startServerInBackground'], type: com.liferay.gradle.plugins.node.tasks.ExecuteNpmTask) {
-  tasks.startServerInBackground.mustRunAfter('installCypress')
+    tasks.startServerInBackground.mustRunAfter('installCypress')
 
-  workingDir = file('frontend/cypress/')
-  args = ["run-script", "debug"]
+    workingDir = file('frontend/cypress/')
+    args = ["run-script", "debug"]
 }
 
 task frontendTest(dependsOn: ['installCypress', 'startServerInBackground'], type: com.liferay.gradle.plugins.node.tasks.ExecuteNpmTask) {
-  tasks.startServerInBackground.mustRunAfter('installCypress')
+    tasks.startServerInBackground.mustRunAfter('installCypress')
 
-  workingDir = file('frontend/cypress/')
-  args = ["run-script", "tests"]
+    workingDir = file('frontend/cypress/')
+    args = ["run-script", "tests"]
 
-  // Run tests in CI without slow motion
-  if (project.hasProperty('ci')) {
-    args = ["run-script", "ci"]
-  }
+    // Run tests in CI without slow motion
+    if (project.hasProperty('ci')) {
+      args = ["run-script", "ci"]
+    }
 }
 
 idea {
@@ -129,4 +139,29 @@ tasks.withType(Copy) {
     includeEmptyDirs = true
 }
 
-defaultTasks 'clean', 'build', 'systemtest', 'frontendTest'
+jacocoTestReport {
+    reports {
+        xml.enabled false
+        csv.enabled false
+        html.destination file("${buildDir}/jacocoHtml")
+    }
+}
+
+task coverage(type: JacocoReport) {
+    sourceDirectories = files(sourceSets.main.allSource.srcDirs)
+    classDirectories = files(sourceSets.main.output)
+    executionData = files(jacocoTestReport.executionData)
+    
+    afterEvaluate {
+        classDirectories = files(classDirectories.files.collect {
+            fileTree(dir: it, exclude: ['**/*.jar'])
+        })
+    }
+    
+    reports {
+        html.enabled = true
+        xml.enabled = true
+    }
+}
+
+defaultTasks 'clean', 'build', 'systemtest', 'frontendTest', 'coverage'


### PR DESCRIPTION
Fixes #600 

We do not have a Coverage Test because our coverage was low and 
had quite a few architecture changes in the past.

Having a coverage test allows us to improve our testing with higher 
revenue and lower costs.

Let's integrate Coverage Test using Gradle Jacoco plugin and codecov.io.

Meanwhile, build.gradle do not have a consistent line indentation and a 
consistent grouping of tasks and configures. Let's make all the lines to 
have an indentation of 4 and rearrange the tasks so they have a better
grouping.
