### PR TITLE
.travis.yml: change oraclejdk8 to openjdk8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,10 @@ matrix:
   include:
     - name: Ubuntu 14.04 JDK 8
       os: linux
-      jdk: oraclejdk8
+      jdk: openjdk8
+      before_install:
+        - sudo apt-get update openjdk-8-jdk
+        - sudo apt-get upgrade openjdk-8-jdk
 
     - name: macOS 10.13.6 JDK 8
       os: osx
@@ -14,7 +17,7 @@ matrix:
       before_install:
         - *common_before_install
         - brew install cask
-        - brew cask install caskroom/versions/java8 # Update to the latest version of JDK 8
+        - brew cask install AdoptOpenJDK/openjdk/adoptopenjdk8
         - export JAVA_HOME=`/usr/libexec/java_home -v 1.8`
         - echo "Downgraded JDK to:"; java -version
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ matrix:
       before_install:
         - sudo apt-get update
         - sudo apt-get --only-upgrade install openjdk-8-jdk
+        - echo -e "Actual JDK in use -- "; java -version
 
     - name: macOS 10.13.6 JDK 8
       os: osx
@@ -19,7 +20,7 @@ matrix:
         - brew install cask
         - brew cask install AdoptOpenJDK/openjdk/adoptopenjdk8
         - export JAVA_HOME=`/usr/libexec/java_home -v 1.8`
-        - echo "Downgraded JDK to:"; java -version
+        - echo -e "Actual JDK in use -- "; java -version
 
     - name: "Cypress frontend tests"
       os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,6 @@ matrix:
     - name: Ubuntu 14.04 JDK 8
       os: linux
       jdk: oraclejdk8
-      addons:
-        apt:
-          packages:
-            - oracle-java8-installer # Update to the latest version of JDK 8
 
     - name: macOS 10.13.6 JDK 8
       os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ matrix:
       os: linux
       jdk: openjdk8
       before_install:
-        - sudo apt-get update openjdk-8-jdk
-        - sudo apt-get upgrade openjdk-8-jdk
+        - sudo apt-get update
+        - sudo apt-get --only-upgrade install openjdk-8-jdk
 
     - name: macOS 10.13.6 JDK 8
       os: osx


### PR DESCRIPTION
Fixes #648 

```
The oracle-java8-installer in our .travis.yml refers to
ppa:webupd8team/java repository. According to the repo maintainer [1],
the repository has been discontinued due to "licensing issues".
Similarly, the homebrew java8 [2] has been removed as well.

Let's use openjdk8 instead.

[1]: https://launchpad.net/~webupd8team/+archive/ubuntu/java
[2]: https://www.chuchur.com/article/mac-install-and-uninstall-java-jdk
```
