### PR TITLE
[#661] Tweak chart title format

### DIFF
--- a/src/main/java/reposense/model/RepoConfiguration.java
+++ b/src/main/java/reposense/model/RepoConfiguration.java
@@ -66,7 +66,7 @@ public class RepoConfiguration {
         String repoName = location.getRepoName();
 
         if (organization != null) {
-            displayName = organization + "/" + repoName + "[" + branch + "]";
+            displayName = organization + "_" + repoName + "_" + branch;
             repoFolderName = organization + "_" + repoName;
         } else {
             displayName = repoName + "_" + branch;

--- a/src/main/java/reposense/model/RepoConfiguration.java
+++ b/src/main/java/reposense/model/RepoConfiguration.java
@@ -66,10 +66,10 @@ public class RepoConfiguration {
         String repoName = location.getRepoName();
 
         if (organization != null) {
-            displayName = organization + "_" + repoName + "_" + branch;
-            repoFolderName = organization + "_" + repoName;
+            displayName = organization + "/" + repoName + "/" + branch;
+            repoFolderName = organization + "/" + repoName;
         } else {
-            displayName = repoName + "_" + branch;
+            displayName = repoName + "/" + branch;
             repoFolderName = repoName;
         }
     }

--- a/src/main/java/reposense/model/RepoConfiguration.java
+++ b/src/main/java/reposense/model/RepoConfiguration.java
@@ -66,7 +66,7 @@ public class RepoConfiguration {
         String repoName = location.getRepoName();
 
         if (organization != null) {
-            displayName = organization + "_" + repoName + "_" + branch;
+            displayName = organization + "/" + repoName + "[" + branch + "]";
             repoFolderName = organization + "_" + repoName;
         } else {
             displayName = repoName + "_" + branch;


### PR DESCRIPTION
Fixes #661 
```
We use underscore to contact the org, repo, branch to be the title of
ramp chart.(i.e. org_repo_branch)

The org/repo/branch names might have underscores themselves, which leads
to confusions when trying to distinguish actual org/repo/branch names.

Let's tweak the format to be org/repo[branch] so it is clearer.
```