### PR TITLE
[#635] CodeView: add line number to code

### DIFF
--- a/frontend/src/index.jade
+++ b/frontend/src/index.jade
@@ -287,8 +287,8 @@ html
                         span.tooltiptext.tooltiptext--close Show untouched code
                         span.tooltiptext.tooltiptext--open Hide untouched code
                       .code(v-for="(line, index) in segment.lines")
-                        div.line-number {{ segment.lineNumbers[index] + "\n" }}
-                        div.line-content {{ line + "\n" }}
+                        .line-number {{ segment.lineNumbers[index] + "\n" }}
+                        .line-content {{ line + "\n" }}
         .empty(v-else) loading...
 
     script(src="static/js/api.js")

--- a/frontend/src/index.jade
+++ b/frontend/src/index.jade
@@ -286,7 +286,9 @@ html
                         i.fas.fa-ellipsis-h.icon
                         span.tooltiptext.tooltiptext--close Show untouched code
                         span.tooltiptext.tooltiptext--open Hide untouched code
-                      .code {{ segment.lines.join("\n") }}
+                      .code(v-for="(line, index) in segment.lines")
+                        div.line-number {{ segment.lineNumbers[index] + "\n" }}
+                        div.line-content {{ line + "\n" }}
         .empty(v-else) loading...
 
     script(src="static/js/api.js")

--- a/frontend/src/static/css/style.scss
+++ b/frontend/src/static/css/style.scss
@@ -426,9 +426,9 @@ header{
         }
 
         .line-number{
-            color:mui-color("grey");
-            float: left;
-            width: 2rem;
+            color:mui-color('grey');
+            float:left;
+            width:2rem;
             // Not allowing user to select text
             -webkit-touch-callout:none; /* iOS Safari */
             -webkit-user-select:none; /* Safari */
@@ -438,16 +438,16 @@ header{
             user-select:none; /* Non-prefixed version, currently supported by Chrome and Opera */
 
             .hljs-number{
-                color:mui-color("grey");
+                color:mui-color('grey');
             }
 
             .hljs-comment{
-                color:mui-color("grey");
+                color:mui-color('grey');
             }
         }
 
         .line-content{
-            padding-left: 2rem;
+            padding-left:2rem;
         }
 
         .untouched{

--- a/frontend/src/static/css/style.scss
+++ b/frontend/src/static/css/style.scss
@@ -425,6 +425,27 @@ header{
             background-color:mui-color('green', '50');
         }
 
+        .line-number{
+            color:mui-color("grey");
+            float: left;
+            width: 2rem;
+            // Not allowing user to select text
+            -webkit-touch-callout:none; /* iOS Safari */
+            -webkit-user-select:none; /* Safari */
+            -khtml-user-select:none; /* Konqueror HTML */
+            -moz-user-select:none; /* Firefox */
+            -ms-user-select:none; /* Internet Explorer/Edge */
+            user-select:none; /* Non-prefixed version, currently supported by Chrome and Opera */
+
+            .hljs-number{
+                color:mui-color("grey");
+            }
+
+            .hljs-comment{
+                color:mui-color("grey");
+            }
+        }
+
         .untouched{
             $grey:mui-color('grey', '400');
 

--- a/frontend/src/static/css/style.scss
+++ b/frontend/src/static/css/style.scss
@@ -446,6 +446,10 @@ header{
             }
         }
 
+        .line-content{
+            padding-left: 2rem;
+        }
+
         .untouched{
             $grey:mui-color('grey', '400');
 

--- a/frontend/src/static/js/v_authorship.js
+++ b/frontend/src/static/js/v_authorship.js
@@ -142,7 +142,7 @@ window.vAuthorship = {
           lastState = authored;
         }
 
-        const content = (line.lineNumber + ' ' + line.content) || ' ';
+        const content = (line.lineNumber.toString().padEnd(5) + line.content) || ' ';
         segments[lastId].lines.push(content);
 
         if (line.content === '' && authored) {

--- a/frontend/src/static/js/v_authorship.js
+++ b/frontend/src/static/js/v_authorship.js
@@ -142,7 +142,7 @@ window.vAuthorship = {
           lastState = authored;
         }
 
-        const content = line.content || ' ';
+        const content = (line.lineNumber + ' ' + line.content) || ' ';
         segments[lastId].lines.push(content);
 
         if (line.content === '' && authored) {

--- a/frontend/src/static/js/v_authorship.js
+++ b/frontend/src/static/js/v_authorship.js
@@ -128,9 +128,8 @@ window.vAuthorship = {
       let lastId = -1;
       const segments = [];
       let blankLineCount = 0;
-      let lineCount = 0;
 
-      lines.forEach((line) => {
+      lines.forEach((line, lineCount) => {
         const authored = (line.author && line.author.gitId === this.info.author);
 
         if (authored !== lastState || lastId === -1) {
@@ -147,7 +146,6 @@ window.vAuthorship = {
         const content = line.content || ' ';
         segments[lastId].lines.push(content);
 
-        lineCount += 1;
         segments[lastId].lineNumbers.push(lineCount);
 
         if (line.content === '' && authored) {

--- a/frontend/src/static/js/v_authorship.js
+++ b/frontend/src/static/js/v_authorship.js
@@ -128,6 +128,7 @@ window.vAuthorship = {
       let lastId = -1;
       const segments = [];
       let blankLineCount = 0;
+      let lineCount = 0;
 
       lines.forEach((line) => {
         const authored = (line.author && line.author.gitId === this.info.author);
@@ -136,14 +137,18 @@ window.vAuthorship = {
           segments.push({
             authored,
             lines: [],
+            lineNumbers: [],
           });
 
           lastId += 1;
           lastState = authored;
         }
 
-        const content = (line.lineNumber.toString().padEnd(5) + line.content) || ' ';
+        const content = line.content || ' ';
         segments[lastId].lines.push(content);
+
+        lineCount += 1;
+        segments[lastId].lineNumbers.push(lineCount);
 
         if (line.content === '' && authored) {
           blankLineCount += 1;

--- a/frontend/src/static/js/v_authorship.js
+++ b/frontend/src/static/js/v_authorship.js
@@ -146,7 +146,7 @@ window.vAuthorship = {
         const content = line.content || ' ';
         segments[lastId].lines.push(content);
 
-        segments[lastId].lineNumbers.push(lineCount);
+        segments[lastId].lineNumbers.push(lineCount + 1);
 
         if (line.content === '' && authored) {
           blankLineCount += 1;


### PR DESCRIPTION
Fixes #635 

```
The code view displays only the code without the line number.

It is hard to associate a specific line from the code view with the
actual code without the line number.

Let's update the code view to display the line numbers by adding an
array in each segment to keep track of the line numbers of the code.
```