### PR TITLE
[#667] Report: fix search bar not displaying value provided by url parameter

### DIFF
--- a/frontend/src/index.jade
+++ b/frontend/src/index.jade
@@ -73,7 +73,7 @@ html
         form.summary-picker.mui-form--inline(v-on:submit.prevent="getFiltered();")
           .summary-picker__section
             .mui-textfield
-              input.summary-picker__search(type="text", v-on:change="updateFilterSearch")
+              input.summary-picker__search(type="text", v-on:change="updateFilterSearch", v-model="filterSearch")
               label search
             .mui-select.grouping
               select(v-model="filterGroupSelection")


### PR DESCRIPTION
```
Search bar component is not displaying the value that is provided 
by the URL parameter.

This confuses users into thinking that only the listed authors and 
repos are all that's captured by the system, when there are others 
which are filtered out.

Let's fix this bug by adding a two-way binding that binds the search 
field and the corresponding JavaScript filterSearch variable.
```

Fixes #667 