### PR TITLE
[#672] Toolbar: set 'commit' as default for granularity

### DIFF
--- a/frontend/src/static/js/v_summary.js
+++ b/frontend/src/static/js/v_summary.js
@@ -49,7 +49,7 @@ window.vSummary = {
       isSortingDsc: '',
       sortingWithinOption: '',
       isSortingWithinDsc: '',
-      filterTimeFrame: 'day',
+      filterTimeFrame: 'commit',
       filterBreakdown: false,
       tmpFilterSinceDate: '',
       tmpFilterUntilDate: '',

--- a/frontend/src/static/js/v_summary.js
+++ b/frontend/src/static/js/v_summary.js
@@ -432,7 +432,7 @@ window.vSummary = {
     },
     updateSortSelection() {
       this.getOptionWithOrder();
-      // Update UI selection to change all illegal options
+      // Update UI selection to change all the illegal options
       if (this.filterGroupSelection === 'groupByAuthors') {
         if (!this.sortWithinGroupSelection || this.sortingWithinOption === 'name') {
           this.sortWithinGroupSelection = 'searchPath';

--- a/frontend/src/static/js/v_summary.js
+++ b/frontend/src/static/js/v_summary.js
@@ -432,7 +432,7 @@ window.vSummary = {
     },
     updateSortSelection() {
       this.getOptionWithOrder();
-      // Update UI selection to change all the illegal options
+      // Update UI selection to change all illegal options
       if (this.filterGroupSelection === 'groupByAuthors') {
         if (!this.sortWithinGroupSelection || this.sortingWithinOption === 'name') {
           this.sortWithinGroupSelection = 'searchPath';


### PR DESCRIPTION
Fixes #672 

```
The default value of granularity is `Day`.

`Commit` as granularity is more closer to reality because users are more likely to 
observe per commits rather than per day/week. Users can choose a more 
summarized view at their discretion.

Let's change the default value for granularity to `Commit`.
```