### PR TITLE
[#683] Default "since date" and "until date" to 1/1/1970 and today's date respectively

### DIFF
--- a/src/main/java/reposense/commits/CommitResultAggregator.java
+++ b/src/main/java/reposense/commits/CommitResultAggregator.java
@@ -129,9 +129,7 @@ public class CommitResultAggregator {
     }
 
     private static Date getStartDate(List<CommitResult> commitInfos) {
-        Calendar cal = Calendar.getInstance();
-        cal.set(Calendar.YEAR, 2050);
-        Date min = cal.getTime();
+        Date min = new Date(1970);
         if (!commitInfos.isEmpty()) {
             min = commitInfos.get(0).getTime();
         }
@@ -139,9 +137,7 @@ public class CommitResultAggregator {
     }
 
     private static Date getUntilDate(List<CommitResult> commitInfos) {
-        Calendar cal = Calendar.getInstance();
-        cal.set(Calendar.YEAR, 1970);
-        Date max = cal.getTime();
+        Date max = new Date();
         if (!commitInfos.isEmpty()) {
             max = commitInfos.get(commitInfos.size() - 1).getTime();
         }

--- a/src/main/java/reposense/parser/ArgsParser.java
+++ b/src/main/java/reposense/parser/ArgsParser.java
@@ -2,7 +2,6 @@ package reposense.parser;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.time.LocalDate;
 import java.time.ZoneId;
 import java.util.Date;
 import java.util.List;

--- a/src/main/java/reposense/parser/ArgsParser.java
+++ b/src/main/java/reposense/parser/ArgsParser.java
@@ -2,6 +2,7 @@ package reposense.parser;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.time.LocalDate;
 import java.time.ZoneId;
 import java.util.Date;
 import java.util.List;
@@ -51,6 +52,7 @@ public class ArgsParser {
     private static final String MESSAGE_HEADER_MUTEX = "mutual exclusive arguments";
     private static final String MESSAGE_SINCE_DATE_LATER_THAN_UNTIL_DATE =
             "\"Since Date\" cannot be later than \"Until Date\"";
+    private static final String MESSAGE_DATE_OUT_OF_BOUND = "\"%s\" must be no later than today's date.";
     private static final String MESSAGE_USING_DEFAULT_CONFIG_PATH =
             "Config path not provided, using current working directory as default.";
     private static final Path EMPTY_PATH = Paths.get("");
@@ -174,6 +176,8 @@ public class ArgsParser {
             LogsManager.setLogFolderLocation(outputFolderPath);
 
             verifyDatesRangeIsCorrect(sinceDate, untilDate);
+            verifySinceDateIsValid(sinceDate);
+            verifyUntilDateIsValid(untilDate);
 
             if (reportFolderPath != null && !reportFolderPath.equals(EMPTY_PATH) && configFolderPath.equals(EMPTY_PATH)
                 && locations == null) {
@@ -212,6 +216,28 @@ public class ArgsParser {
             throws ParseException {
         if (sinceDate.isPresent() && untilDate.isPresent() && sinceDate.get().getTime() > untilDate.get().getTime()) {
             throw new ParseException(MESSAGE_SINCE_DATE_LATER_THAN_UNTIL_DATE);
+        }
+    }
+
+    /**
+     * Verifies that {@code sinceDate} is no later than today's date.
+     * @throws ParseException if {@code sinceDate} is later than today's date.
+     */
+    private static void verifySinceDateIsValid(Optional<Date> sinceDate) throws ParseException {
+        long todayDate = new Date().getTime();
+        if (sinceDate.isPresent() && sinceDate.get().getTime() > todayDate) {
+            throw new ParseException(String.format(MESSAGE_DATE_OUT_OF_BOUND, "Since date"));
+        }
+    }
+
+    /**
+     * Verifies that {@code untilDate} is no later than today's date.
+     * @throws ParseException if {@code untilDate} is later than today's date.
+     */
+    private static void verifyUntilDateIsValid(Optional<Date> untilDate) throws ParseException {
+        long todayDate = new Date().getTime();
+        if (untilDate.isPresent() && untilDate.get().getTime() > todayDate) {
+            throw new ParseException(String.format(MESSAGE_DATE_OUT_OF_BOUND, "Until date"));
         }
     }
 }


### PR DESCRIPTION
```
Setting "since date" to be after the latest commit date and omitting 
"until date" in CLI input defaults the "until date" to 1970. Also, 
setting "until date" to be before the first commit date and omitting 
"since date" in CLI input defaults the "since date" to 2050.

This results in users being unable to change the "since date" and 
"until date" in the browser to the desired dates.

Let's set the default "since date" and "until date" to be 1/1/1970 and 
today's date respectively should the user specify only one date and 
not the other.
```

Resolves #683 

