### PR TITLE
[#673] Modify slice url to commit details page when granularity is `Commit`

### DIFF
--- a/frontend/src/index.jade
+++ b/frontend/src/index.jade
@@ -166,7 +166,7 @@ html
                       a.summary-chart__ramp__slice(
                         v-for="(commit, k) in slice.commitResults",
                         v-if="commit.insertions>0",
-                        v-bind:href="getSliceLinkCommit(user, slice, k)", target="_blank",
+                        v-bind:href="getSliceCommitLink(user, slice, k)", target="_blank",
                         v-bind:title="`[${slice.date}] ${commit.message}: ${commit.insertions} lines`",
                         v-bind:class="'summary-chart__ramp__slice--color' + getSliceColor(slice.date)",
                         v-bind:style="{\

--- a/frontend/src/index.jade
+++ b/frontend/src/index.jade
@@ -166,7 +166,7 @@ html
                       a.summary-chart__ramp__slice(
                         v-for="(commit, k) in slice.commitResults",
                         v-if="commit.insertions>0",
-                        v-bind:href="getSliceLink(user, slice)", target="_blank",
+                        v-bind:href="getSliceLinkCommit(user, slice, k)", target="_blank",
                         v-bind:title="`[${slice.date}] ${commit.message}: ${commit.insertions} lines`",
                         v-bind:class="'summary-chart__ramp__slice--color' + getSliceColor(slice.date)",
                         v-bind:style="{\

--- a/frontend/src/static/js/v_summary.js
+++ b/frontend/src/static/js/v_summary.js
@@ -172,6 +172,14 @@ window.vSummary = {
                 + `since=${slice.date}'T'00:00:00+08:00&`
                 + `until=${untilDate}'T'23:59:59+08:00`;
     },
+    getSliceLinkCommit(user, slice, index) {
+      const { REPOS } = window;
+
+      return `http://github.com/${
+        REPOS[user.repoId].location.organization}/${
+        REPOS[user.repoId].location.repoName}/commit/${
+        slice.commitResults[index].hash}`;
+    },
     getFileFormatContributionBars(fileFormatContribution) {
       let totalWidth = 0;
       const contributionLimit = (this.avgContributionSize * 2);

--- a/frontend/src/static/js/v_summary.js
+++ b/frontend/src/static/js/v_summary.js
@@ -172,7 +172,7 @@ window.vSummary = {
                 + `since=${slice.date}'T'00:00:00+08:00&`
                 + `until=${untilDate}'T'23:59:59+08:00`;
     },
-    getSliceLinkCommit(user, slice, index) {
+    getSliceCommitLink(user, slice, index) {
       const { REPOS } = window;
 
       return `http://github.com/${


### PR DESCRIPTION
Fixes #673 

```
When value of granularity is `Commit`, the slice's url points to the GitHub page 
showing a list of commits even though there is only one commit.

Users will need the extra effort to click on the commit in the Github page and 
navigate to the commit details page.

Let's update the slice's url to point directly to the commit details page to save
an extra click from the user.
```