### PR TITLE
[#695] Report: allow reset of date controls

### DIFF
--- a/frontend/src/static/js/v_summary.js
+++ b/frontend/src/static/js/v_summary.js
@@ -145,12 +145,11 @@ window.vSummary = {
     tmpFilterSinceDate() {
       if (this.tmpFilterSinceDate && this.tmpFilterSinceDate >= this.minDate) {
         this.filterSinceDate = this.tmpFilterSinceDate;
-        this.getFiltered();
       } else if (!this.tmpFilterSinceDate) { // If user clears the since date field
         this.filterSinceDate = this.minDate;
         this.tmpFilterSinceDate = this.filterSinceDate;
-        this.getFiltered();
       }
+      this.getFiltered();
     },
     tmpFilterUntilDate() {
       if (this.tmpFilterUntilDate && this.tmpFilterUntilDate <= this.maxDate) {

--- a/frontend/src/static/js/v_summary.js
+++ b/frontend/src/static/js/v_summary.js
@@ -89,9 +89,7 @@ window.vSummary = {
       if (this.tmpFilterSinceDate && this.tmpFilterSinceDate >= this.minDate) {
         this.filterSinceDate = this.tmpFilterSinceDate;
         this.getFiltered();
-      }
-      // If user clears the since date field
-      else if (!this.tmpFilterSinceDate) {
+      } else if (!this.tmpFilterSinceDate) { // If user clears the since date field
         this.filterSinceDate = this.minDate;
         this.tmpFilterSinceDate = this.filterSinceDate;
         this.getFiltered();
@@ -101,9 +99,7 @@ window.vSummary = {
       if (this.tmpFilterUntilDate && this.tmpFilterUntilDate <= this.maxDate) {
         this.filterUntilDate = this.tmpFilterUntilDate;
         this.getFiltered();
-      }
-      // If user clears the until date field
-      else if (!this.tmpFilterUntilDate) {
+      } else if (!this.tmpFilterUntilDate) { // If user clears the until date field
         this.filterUntilDate = this.maxDate;
         this.tmpFilterUntilDate = this.filterUntilDate;
         this.getFiltered();

--- a/frontend/src/static/js/v_summary.js
+++ b/frontend/src/static/js/v_summary.js
@@ -98,12 +98,11 @@ window.vSummary = {
     tmpFilterUntilDate() {
       if (this.tmpFilterUntilDate && this.tmpFilterUntilDate <= this.maxDate) {
         this.filterUntilDate = this.tmpFilterUntilDate;
-        this.getFiltered();
       } else if (!this.tmpFilterUntilDate) { // If user clears the until date field
         this.filterUntilDate = this.maxDate;
         this.tmpFilterUntilDate = this.filterUntilDate;
-        this.getFiltered();
       }
+      this.getFiltered();
     },
   },
   computed: {

--- a/frontend/src/static/js/v_summary.js
+++ b/frontend/src/static/js/v_summary.js
@@ -90,10 +90,22 @@ window.vSummary = {
         this.filterSinceDate = this.tmpFilterSinceDate;
         this.getFiltered();
       }
+      // If user clears the since date field
+      else if (!this.tmpFilterSinceDate) {
+        this.filterSinceDate = this.minDate;
+        this.tmpFilterSinceDate = this.filterSinceDate;
+        this.getFiltered();
+      }
     },
     tmpFilterUntilDate() {
       if (this.tmpFilterUntilDate && this.tmpFilterUntilDate <= this.maxDate) {
         this.filterUntilDate = this.tmpFilterUntilDate;
+        this.getFiltered();
+      }
+      // If user clears the until date field
+      else if (!this.tmpFilterUntilDate) {
+        this.filterUntilDate = this.maxDate;
+        this.tmpFilterUntilDate = this.filterUntilDate;
         this.getFiltered();
       }
     },


### PR DESCRIPTION
```
Pressing the "X" button in the date field only clears the 
date, with no useful functionality.

Users who wish to go back to the default dates will 
need to manually pick the dates from the date picker,
which can be troublesome.

Let's reset the "since date" and "until date" to the earliest and 
latest date respectively, should the user clear the date in the 
respective boxes.
```
Resolves #695 