### PR TITLE
[#699] Ensure author name consistency

### DIFF
--- a/frontend/src/index.jade
+++ b/frontend/src/index.jade
@@ -147,7 +147,7 @@ html
                 .summary-chart__title--index {{ i+1 }}
                 .summary-chart__title--repo(v-if="filterGroupSelection === 'groupByNone'") {{ user.repoPath }}
                 .summary-chart__title--author-repo(v-if="filterGroupSelection === 'groupByAuthors'") {{ user.repoPath }}
-                .summary-chart__title--name(v-if="filterGroupSelection !== 'groupByAuthors'") {{ user.displayName }}
+                .summary-chart__title--name(v-if="filterGroupSelection !== 'groupByAuthors'") {{ user.displayName }} ({{ user.name }})
                 a(
                   title="click to view author's code",
                   v-on:click="$emit('view-authorship', \


### PR DESCRIPTION
Fixes #699 

```
When summary charts are grouped by none or repo/branch, author name shows 
only the display name. Whereas when grouped by author, author name shows the 
display name as well as GitHub username.

This causes inconsistency in the author names. Furthermore, user won't be able to 
refer to the author's GitHub username when the summary charts are grouped by 
none or repo/branch.

Let's ensure the consistency of author names by making the format of author 
name as [display name] ([github username]).
```