### PR TITLE
[#709] Report: fix colors assigned only to files touched by first author in list

### DIFF
--- a/frontend/src/static/js/v_summary.js
+++ b/frontend/src/static/js/v_summary.js
@@ -355,12 +355,13 @@ window.vSummary = {
       let i = 0;
 
       this.repos.forEach((repo) => {
-        const user = repo.users[0];
-        Object.keys(user.fileFormatContribution).forEach((fileFormat) => {
-          if (!Object.prototype.hasOwnProperty.call(colors, fileFormat)) {
-            colors[fileFormat] = selectedColors[i];
-            i = (i + 1) % selectedColors.length;
-          }
+        repo.users.forEach((user) => {
+          Object.keys(user.fileFormatContribution).forEach((fileFormat) => {
+            if (!Object.prototype.hasOwnProperty.call(colors, fileFormat)) {
+              colors[fileFormat] = selectedColors[i];
+              i = (i + 1) % selectedColors.length;
+            }
+          });
         });
         this.contributionBarColors = colors;
       });


### PR DESCRIPTION
```
Some file formats are not assigned with a color in the summary
view.

Users will not be able to able to see the colors of the files touched 
in the contribution bar.

Let's capture the formats of files that were touched by all authors 
who contributed to the repo and assign the file formats a color.

The current implementation is that only the format of files that were 
touched by the first user that appears in the list of authors who 
contributed to the repo
```

Resolves #709 