### PR TITLE
[#231] modify local repository URL to the correct remote repository 

### DIFF
--- a/src/main/java/reposense/git/GitRemote.java
+++ b/src/main/java/reposense/git/GitRemote.java
@@ -20,6 +20,10 @@ public class GitRemote {
         Path rootPath = Paths.get(config.getLocation().toString());
         String command = "git remote get-url origin";
 
-        return runCommand(rootPath, command).replace("\n", "");
+        try {
+            return runCommand(rootPath, command).replace("\n", "");
+        } catch (RuntimeException re) {
+            return null;
+        }
     }
 }

--- a/src/main/java/reposense/git/GitRemote.java
+++ b/src/main/java/reposense/git/GitRemote.java
@@ -1,0 +1,25 @@
+package reposense.git;
+
+import static reposense.system.CommandRunner.runCommand;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import reposense.model.RepoConfiguration;
+
+/**
+ * Contains git remote related functionalities.
+ * Git remote is responsible to manage the set of tracked repositories.
+ */
+public class GitRemote {
+
+    /**
+     * Extracts the remote url from the cloned local repository
+     */
+    public static String getRemoteUrl(RepoConfiguration config) {
+        Path rootPath = Paths.get(config.getLocation().toString());
+        String command = "git remote get-url origin";
+
+        return runCommand(rootPath, command).replace("\n", "");
+    }
+}

--- a/src/main/java/reposense/git/GitRemote.java
+++ b/src/main/java/reposense/git/GitRemote.java
@@ -4,14 +4,20 @@ import static reposense.system.CommandRunner.runCommand;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.logging.Logger;
 
 import reposense.model.RepoConfiguration;
+import reposense.system.LogsManager;
 
 /**
  * Contains git remote related functionalities.
  * Git remote is responsible to manage the set of tracked repositories.
  */
 public class GitRemote {
+
+    private static final Logger logger = LogsManager.getLogger(GitRemote.class);
+    private static final String MESSAGE_REMOTE_DOES_NOT_EXIST =
+            "%s does not have a remote url, will not update the location.";
 
     /**
      * Extracts the remote url from the cloned local repository
@@ -23,6 +29,7 @@ public class GitRemote {
         try {
             return runCommand(rootPath, command).replace("\n", "");
         } catch (RuntimeException re) {
+            logger.info(String.format(MESSAGE_REMOTE_DOES_NOT_EXIST, config.getLocation()));
             return null;
         }
     }

--- a/src/main/java/reposense/model/RepoConfiguration.java
+++ b/src/main/java/reposense/model/RepoConfiguration.java
@@ -370,6 +370,10 @@ public class RepoConfiguration {
         return location;
     }
 
+    public void setLocation(RepoLocation location) {
+        this.location = location;
+    }
+
     public String getOrganization() {
         return location.getOrganization();
     }

--- a/src/main/java/reposense/report/ReportGenerator.java
+++ b/src/main/java/reposense/report/ReportGenerator.java
@@ -230,13 +230,17 @@ public class ReportGenerator {
      * Updates {@code config} with the correct remote repository link if analysing from local repositories.
      */
     public static void updateRemoteLink(RepoConfiguration config) {
-        String location = config.getLocation().toString();
-        if (!location.contains("https://github.com") && !location.contains("http://github.com")) {
+        String organization = config.getLocation().getOrganization();
+        if (organization == null) {
             String remote = GitRemote.getRemoteUrl(config);
-            try {
-                config.setLocation(new RepoLocation(remote));
-            } catch (InvalidLocationException ile) {
-                logger.warning(String.format(MESSAGE_INVALID_LOCATION, remote));
+
+            // only set the location if remote location can be found
+            if (remote != null) {
+                try {
+                    config.setLocation(new RepoLocation(remote));
+                } catch (InvalidLocationException ile) {
+                    logger.warning(String.format(MESSAGE_INVALID_LOCATION, remote));
+                }
             }
         }
     }


### PR DESCRIPTION
Fixes #231 

```
When analysing local repositories, clicking on their links from the 
ramp slices, octocat icon and repository title leads users to 
non-existent links.

This will cause users to not be able to locate to the correct remote 
repository that the local repository was cloned from.

Let's update the URL of these links to redirect to the correct remote
repository by updating location to the remote location that is 
obtained from running the git command: git remote get-url origin
```