### PR TITLE
[#185] Author: Use practical display names

### DIFF
--- a/author-config.csv
+++ b/author-config.csv
@@ -1,9 +1,9 @@
 Repository's Location,Branch,Author's GitHub ID,Author's Email,Author's Display Name,Author's Git Author Name,Ignore Glob List
-https://github.com/reposense/testrepo-Beta.git,master,nbriannl,,Nbr,,
-https://github.com/reposense/testrepo-Beta.git,master,zacharytang,zacharytang.tc@gmail.com,Zac,,src/main**
-https://github.com/reposense/testrepo-Beta.git,master,April0616,,Fan,LAPTOP-7KFM2KSP\User;Fan Yuting,
-https://github.com/reposense/testrepo-Beta.git,master,CindyTsai1,,Cin,YuHsuan,src/test**
-https://github.com/reposense/testrepo-Beta.git,add-config-json,nbriannl,,Nbr,,
-https://github.com/reposense/testrepo-Beta.git,add-config-json,zacharytang,zacharytang.tc@gmail.com,Zac,,src/main**
-https://github.com/reposense/testrepo-Beta.git,add-config-json,April0616,,Fan,LAPTOP-7KFM2KSP\User;Fan Yuting,
-https://github.com/reposense/testrepo-Beta.git,add-config-json,CindyTsai1,,Cin,YuHsuan,src/test**
+https://github.com/reposense/testrepo-Beta.git,master,nbriannl,,Labayna Neil Brian Narido,,
+https://github.com/reposense/testrepo-Beta.git,master,zacharytang,zacharytang.tc@gmail.com,"Tang Tjun Chii, Zachary",,src/main**
+https://github.com/reposense/testrepo-Beta.git,master,April0616,,Fan Yuting,LAPTOP-7KFM2KSP\User;Fan Yuting,
+https://github.com/reposense/testrepo-Beta.git,master,CindyTsai1,,Tsai Yu Hsuan,YuHsuan,src/test**
+https://github.com/reposense/testrepo-Beta.git,add-config-json,nbriannl,,"Labayna Neil, Brian Narido",,
+https://github.com/reposense/testrepo-Beta.git,add-config-json,zacharytang,zacharytang.tc@gmail.com,Tang Tjun Chii Zachary,,src/main**
+https://github.com/reposense/testrepo-Beta.git,add-config-json,April0616,,Fan Yuting,LAPTOP-7KFM2KSP\User;Fan Yuting,
+https://github.com/reposense/testrepo-Beta.git,add-config-json,CindyTsai1,,Tsai Yu Hsuan,YuHsuan,src/test**

--- a/author-config.csv
+++ b/author-config.csv
@@ -1,9 +1,9 @@
 Repository's Location,Branch,Author's GitHub ID,Author's Email,Author's Display Name,Author's Git Author Name,Ignore Glob List
 https://github.com/reposense/testrepo-Beta.git,master,nbriannl,,Labayna Neil Brian Narido,,
-https://github.com/reposense/testrepo-Beta.git,master,zacharytang,zacharytang.tc@gmail.com,"Tang Tjun Chii, Zachary",,src/main**
+https://github.com/reposense/testrepo-Beta.git,master,zacharytang,zacharytang.tc@gmail.com,Tang Tjun Chii, Zachary,,src/main**
 https://github.com/reposense/testrepo-Beta.git,master,April0616,,Fan Yuting,LAPTOP-7KFM2KSP\User;Fan Yuting,
 https://github.com/reposense/testrepo-Beta.git,master,CindyTsai1,,Tsai Yu Hsuan,YuHsuan,src/test**
-https://github.com/reposense/testrepo-Beta.git,add-config-json,nbriannl,,"Labayna Neil, Brian Narido",,
+https://github.com/reposense/testrepo-Beta.git,add-config-json,nbriannl,,Labayna Neil, Brian Narido,,
 https://github.com/reposense/testrepo-Beta.git,add-config-json,zacharytang,zacharytang.tc@gmail.com,Tang Tjun Chii Zachary,,src/main**
 https://github.com/reposense/testrepo-Beta.git,add-config-json,April0616,,Fan Yuting,LAPTOP-7KFM2KSP\User;Fan Yuting,
 https://github.com/reposense/testrepo-Beta.git,add-config-json,CindyTsai1,,Tsai Yu Hsuan,YuHsuan,src/test**

--- a/author-config.csv
+++ b/author-config.csv
@@ -1,9 +1,9 @@
 Repository's Location,Branch,Author's GitHub ID,Author's Email,Author's Display Name,Author's Git Author Name,Ignore Glob List
 https://github.com/reposense/testrepo-Beta.git,master,nbriannl,,Labayna Neil Brian Narido,,
-https://github.com/reposense/testrepo-Beta.git,master,zacharytang,zacharytang.tc@gmail.com,Tang Tjun Chii, Zachary,,src/main**
+https://github.com/reposense/testrepo-Beta.git,master,zacharytang,zacharytang.tc@gmail.com,"Tang Tjun Chii, Zachary",,src/main**
 https://github.com/reposense/testrepo-Beta.git,master,April0616,,Fan Yuting,LAPTOP-7KFM2KSP\User;Fan Yuting,
 https://github.com/reposense/testrepo-Beta.git,master,CindyTsai1,,Tsai Yu Hsuan,YuHsuan,src/test**
-https://github.com/reposense/testrepo-Beta.git,add-config-json,nbriannl,,Labayna Neil, Brian Narido,,
-https://github.com/reposense/testrepo-Beta.git,add-config-json,zacharytang,zacharytang.tc@gmail.com,Tang Tjun Chii Zachary,,src/main**
+https://github.com/reposense/testrepo-Beta.git,add-config-json,nbriannl,,Labayna Neil Brian Narido,,
+https://github.com/reposense/testrepo-Beta.git,add-config-json,zacharytang,zacharytang.tc@gmail.com,"Tang Tjun Chii, Zachary",,src/main**
 https://github.com/reposense/testrepo-Beta.git,add-config-json,April0616,,Fan Yuting,LAPTOP-7KFM2KSP\User;Fan Yuting,
 https://github.com/reposense/testrepo-Beta.git,add-config-json,CindyTsai1,,Tsai Yu Hsuan,YuHsuan,src/test**

--- a/src/systemtest/resources/author-config.csv
+++ b/src/systemtest/resources/author-config.csv
@@ -1,9 +1,9 @@
 Repository's Location,Branch,Author's GitHub ID,Author's Email,Author's Display Name,Author's Git Author Name,Ignore Glob List
 https://github.com/reposense/testrepo-Beta.git,,nbr,neilbrian.nl@gmail.com,Labayna Neil Brian Narido,,
-https://github.com/reposense/testrepo-Beta.git,,zacharytang,,Tang Tjun Chii, Zachary,Zachary Tang,src/main**
+https://github.com/reposense/testrepo-Beta.git,,zacharytang,,"Tang Tjun Chii, Zachary",Zachary Tang,src/main**
 https://github.com/reposense/testrepo-Beta.git,,April0616,,Fan Yuting,LAPTOP-7KFM2KSP\User;Fan Yuting,
 https://github.com/reposense/testrepo-Beta.git,,CindyTsai1,,Tsai Yu Hsuan,YuHsuan,src/test**
 https://github.com/reposense/testrepo-Charlie.git,,charlesgoh,,Charles Goh,Charles Goh,
 https://github.com/reposense/testrepo-Charlie.git,,Esilocke,,Kelvin Lin,,
 https://github.com/reposense/testrepo-Charlie.git,,jeffreygohkw,,Jeffrey Goh Kian Wei,Jeffrey Goh,
-https://github.com/reposense/testrepo-Charlie.git,,wangyiming1019,,Wang Yi Ming, Kyle,ACER\kyle;Wang Yiming,**.adoc
+https://github.com/reposense/testrepo-Charlie.git,,wangyiming1019,,"Wang Yi Ming, Kyle",ACER\kyle;Wang Yiming,**.adoc

--- a/src/systemtest/resources/author-config.csv
+++ b/src/systemtest/resources/author-config.csv
@@ -1,9 +1,9 @@
 Repository's Location,Branch,Author's GitHub ID,Author's Email,Author's Display Name,Author's Git Author Name,Ignore Glob List
-https://github.com/reposense/testrepo-Beta.git,,nbr,neilbrian.nl@gmail.com,Nbr,,
-https://github.com/reposense/testrepo-Beta.git,,zacharytang,,Zac,Zachary Tang,src/main**
-https://github.com/reposense/testrepo-Beta.git,,April0616,,Fan,LAPTOP-7KFM2KSP\User;Fan Yuting,
-https://github.com/reposense/testrepo-Beta.git,,CindyTsai1,,Cin,YuHsuan,src/test**
-https://github.com/reposense/testrepo-Charlie.git,,charlesgoh,,Cha,Charles Goh,
-https://github.com/reposense/testrepo-Charlie.git,,Esilocke,,Esi,,
-https://github.com/reposense/testrepo-Charlie.git,,jeffreygohkw,,Jef,Jeffrey Goh,
-https://github.com/reposense/testrepo-Charlie.git,,wangyiming1019,,Wan,ACER\kyle;Wang Yiming,**.adoc
+https://github.com/reposense/testrepo-Beta.git,,nbr,neilbrian.nl@gmail.com,"Labayna Neil, Brian Narido",,
+https://github.com/reposense/testrepo-Beta.git,,zacharytang,,"Tang Tjun Chii, Zachary",Zachary Tang,src/main**
+https://github.com/reposense/testrepo-Beta.git,,April0616,,Fan Yuting,LAPTOP-7KFM2KSP\User;Fan Yuting,
+https://github.com/reposense/testrepo-Beta.git,,CindyTsai1,,Tsai Yu Hsuan,YuHsuan,src/test**
+https://github.com/reposense/testrepo-Charlie.git,,charlesgoh,,Charles Goh,Charles Goh,
+https://github.com/reposense/testrepo-Charlie.git,,Esilocke,,Kelvin Lin,,
+https://github.com/reposense/testrepo-Charlie.git,,jeffreygohkw,,Jeffrey Goh Kian Wei,Jeffrey Goh,
+https://github.com/reposense/testrepo-Charlie.git,,wangyiming1019,,"Wang Yi Ming, Kyle",ACER\kyle;Wang Yiming,**.adoc

--- a/src/systemtest/resources/author-config.csv
+++ b/src/systemtest/resources/author-config.csv
@@ -1,9 +1,9 @@
 Repository's Location,Branch,Author's GitHub ID,Author's Email,Author's Display Name,Author's Git Author Name,Ignore Glob List
-https://github.com/reposense/testrepo-Beta.git,,nbr,neilbrian.nl@gmail.com,"Labayna Neil, Brian Narido",,
-https://github.com/reposense/testrepo-Beta.git,,zacharytang,,"Tang Tjun Chii, Zachary",Zachary Tang,src/main**
+https://github.com/reposense/testrepo-Beta.git,,nbr,neilbrian.nl@gmail.com,Labayna Neil Brian Narido,,
+https://github.com/reposense/testrepo-Beta.git,,zacharytang,,Tang Tjun Chii, Zachary,Zachary Tang,src/main**
 https://github.com/reposense/testrepo-Beta.git,,April0616,,Fan Yuting,LAPTOP-7KFM2KSP\User;Fan Yuting,
 https://github.com/reposense/testrepo-Beta.git,,CindyTsai1,,Tsai Yu Hsuan,YuHsuan,src/test**
 https://github.com/reposense/testrepo-Charlie.git,,charlesgoh,,Charles Goh,Charles Goh,
 https://github.com/reposense/testrepo-Charlie.git,,Esilocke,,Kelvin Lin,,
 https://github.com/reposense/testrepo-Charlie.git,,jeffreygohkw,,Jeffrey Goh Kian Wei,Jeffrey Goh,
-https://github.com/reposense/testrepo-Charlie.git,,wangyiming1019,,"Wang Yi Ming, Kyle",ACER\kyle;Wang Yiming,**.adoc
+https://github.com/reposense/testrepo-Charlie.git,,wangyiming1019,,Wang Yi Ming, Kyle,ACER\kyle;Wang Yiming,**.adoc

--- a/src/systemtest/resources/dateRange/expected/reposense_testrepo-Beta_master/commits.json
+++ b/src/systemtest/resources/dateRange/expected/reposense_testrepo-Beta_master/commits.json
@@ -115,6 +115,6 @@
     "zacharytang": "Tang Tjun Chii, Zachary",
     "CindyTsai1": "Tsai Yu Hsuan",
     "April0616": "Fan Yuting",
-    "nbr": "Labayna Neil, Brian Narido"
+    "nbr": "Labayna Neil Brian Narido"
   }
 }

--- a/src/systemtest/resources/dateRange/expected/reposense_testrepo-Beta_master/commits.json
+++ b/src/systemtest/resources/dateRange/expected/reposense_testrepo-Beta_master/commits.json
@@ -112,9 +112,9 @@
     "nbr": 50.165554
   },
   "authorDisplayNameMap": {
-    "zacharytang": "Zac",
-    "CindyTsai1": "Cin",
-    "April0616": "Fan",
-    "nbr": "Nbr"
+    "zacharytang": "Tang Tjun Chii, Zachary",
+    "CindyTsai1": "Tsai Yu Hsuan",
+    "April0616": "Fan Yuting",
+    "nbr": "Labayna Neil, Brian Narido"
   }
 }

--- a/src/systemtest/resources/noDateRange/expected/reposense_testrepo-Beta_master/commits.json
+++ b/src/systemtest/resources/noDateRange/expected/reposense_testrepo-Beta_master/commits.json
@@ -372,9 +372,9 @@
     "nbr": 495.91364
   },
   "authorDisplayNameMap": {
-    "zacharytang": "Zac",
-    "CindyTsai1": "Cin",
-    "April0616": "Fan",
-    "nbr": "Nbr"
+    "zacharytang": "Tang Tjun Chii, Zachary",
+    "CindyTsai1": "Tsai Yu Hsuan",
+    "April0616": "Fan Yuting",
+    "nbr": "Labayna Neil, Brian Narido"
   }
 }

--- a/src/systemtest/resources/noDateRange/expected/reposense_testrepo-Beta_master/commits.json
+++ b/src/systemtest/resources/noDateRange/expected/reposense_testrepo-Beta_master/commits.json
@@ -375,6 +375,6 @@
     "zacharytang": "Tang Tjun Chii, Zachary",
     "CindyTsai1": "Tsai Yu Hsuan",
     "April0616": "Fan Yuting",
-    "nbr": "Labayna Neil, Brian Narido"
+    "nbr": "Labayna Neil Brian Narido"
   }
 }


### PR DESCRIPTION
```
Truncated names are set for author display name in author-config.csv 
file.

This may cause some bugs to go unnoticed when different variations of 
names are used, such as long names or names with special characters.

Let's modify "Author's Display Name" column to use practical display 
names instead of using truncated names to fulfill the equivalence 
partition of the test input.
```

Resolves #185 