### PR TITLE
[#781] Fix broken program when reserved character is used without escaping

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -259,7 +259,7 @@ In addition, there are some _optional_ extra parameters you can use to customize
   Example:`--since 21/10/2017` or `-s 21/10/2017` <br>
   > Note: -
   > - If the start date is not specified, only commits made one month before the end date (if specified) or the date of generating the report, will be captured and analyzed.
-  > - If `^` is specified as the start date (`--since d1` or `-s d1`), then the earliest commit date of all repositories will be taken as the since date.
+  > - If `d1` is specified as the start date (`--since d1` or `-s d1`), then the earliest commit date of all repositories will be taken as the since date.
 * **`--until, -u END_DATE`**: The end date of analysis (`-u` as alias). The analysis excludes the end date. Format: `DD/MM/YYYY`<br>
   Example:`--until 21/10/2017` or `-u 21/10/2017` <br>
   > Note: If the end date is not specified, the date of generating the report will be taken as the end date.

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -259,7 +259,7 @@ In addition, there are some _optional_ extra parameters you can use to customize
   Example:`--since 21/10/2017` or `-s 21/10/2017` <br>
   > Note: -
   > - If the start date is not specified, only commits made one month before the end date (if specified) or the date of generating the report, will be captured and analyzed.
-  > - If `*` is specified as the start date (`--since *` or `-s *`), then the earliest commit date of all repositories will be taken as the since date.
+  > - If `^` is specified as the start date (`--since ^` or `-s ^`), then the earliest commit date of all repositories will be taken as the since date.
 * **`--until, -u END_DATE`**: The end date of analysis (`-u` as alias). The analysis excludes the end date. Format: `DD/MM/YYYY`<br>
   Example:`--until 21/10/2017` or `-u 21/10/2017` <br>
   > Note: If the end date is not specified, the date of generating the report will be taken as the end date.

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -259,7 +259,7 @@ In addition, there are some _optional_ extra parameters you can use to customize
   Example:`--since 21/10/2017` or `-s 21/10/2017` <br>
   > Note: -
   > - If the start date is not specified, only commits made one month before the end date (if specified) or the date of generating the report, will be captured and analyzed.
-  > - If `^` is specified as the start date (`--since ^` or `-s ^`), then the earliest commit date of all repositories will be taken as the since date.
+  > - If `^` is specified as the start date (`--since d1` or `-s d1`), then the earliest commit date of all repositories will be taken as the since date.
 * **`--until, -u END_DATE`**: The end date of analysis (`-u` as alias). The analysis excludes the end date. Format: `DD/MM/YYYY`<br>
   Example:`--until 21/10/2017` or `-u 21/10/2017` <br>
   > Note: If the end date is not specified, the date of generating the report will be taken as the end date.

--- a/src/main/java/reposense/parser/SinceDateArgumentType.java
+++ b/src/main/java/reposense/parser/SinceDateArgumentType.java
@@ -12,17 +12,17 @@ import net.sourceforge.argparse4j.inf.ArgumentParserException;
  */
 public class SinceDateArgumentType extends DateArgumentType {
     /*
-     * When user specifies *, arbitrary first commit date will be returned.
+     * When user specifies ^, arbitrary first commit date will be returned.
      * Then, ReportGenerator will replace the arbitrary since date with the earliest commit date.
      */
     public static final Date ARBITRARY_FIRST_COMMIT_DATE = new Date(Long.MIN_VALUE);
 
     /**
-     * Returns an arbitrary year {@link SinceDateArgumentType#ARBITRARY_FIRST_COMMIT_DATE} if user specifies * in
+     * Returns an arbitrary year {@link SinceDateArgumentType#ARBITRARY_FIRST_COMMIT_DATE} if user specifies ^ in
      * {@code value}, or attempts to return the desired date otherwise.
      */
     @Override
     public Optional<Date> convert(ArgumentParser parser, Argument arg, String value) throws ArgumentParserException {
-        return ("*".equals(value)) ? Optional.of(ARBITRARY_FIRST_COMMIT_DATE) : super.convert(parser, arg, value);
+        return ("^".equals(value)) ? Optional.of(ARBITRARY_FIRST_COMMIT_DATE) : super.convert(parser, arg, value);
     }
 }

--- a/src/main/java/reposense/parser/SinceDateArgumentType.java
+++ b/src/main/java/reposense/parser/SinceDateArgumentType.java
@@ -12,17 +12,21 @@ import net.sourceforge.argparse4j.inf.ArgumentParserException;
  */
 public class SinceDateArgumentType extends DateArgumentType {
     /*
-     * When user specifies ^, arbitrary first commit date will be returned.
+     * When user specifies "d1", arbitrary first commit date will be returned.
      * Then, ReportGenerator will replace the arbitrary since date with the earliest commit date.
      */
     public static final Date ARBITRARY_FIRST_COMMIT_DATE = new Date(Long.MIN_VALUE);
+    public static final String FIRST_COMMIT_DATE_SHORTHAND = "d1";
 
     /**
-     * Returns an arbitrary year {@link SinceDateArgumentType#ARBITRARY_FIRST_COMMIT_DATE} if user specifies ^ in
-     * {@code value}, or attempts to return the desired date otherwise.
+     * Returns an arbitrary year {@link SinceDateArgumentType#ARBITRARY_FIRST_COMMIT_DATE} if user specifies
+     * {@link SinceDateArgumentType#FIRST_COMMIT_DATE_SHORTHAND} in {@code value}, or attempts to return the
+     * desired date otherwise.
      */
     @Override
     public Optional<Date> convert(ArgumentParser parser, Argument arg, String value) throws ArgumentParserException {
-        return ("^".equals(value)) ? Optional.of(ARBITRARY_FIRST_COMMIT_DATE) : super.convert(parser, arg, value);
+        return (FIRST_COMMIT_DATE_SHORTHAND.equals(value))
+                ? Optional.of(ARBITRARY_FIRST_COMMIT_DATE)
+                : super.convert(parser, arg, value);
     }
 }

--- a/src/systemtest/java/reposense/ConfigSystemTest.java
+++ b/src/systemtest/java/reposense/ConfigSystemTest.java
@@ -42,12 +42,12 @@ public class ConfigSystemTest {
     }
 
     /**
-     * System test with a specified until date and a * since date to capture from the first commit.
+     * System test with a specified until date and a ^ since date to capture from the first commit.
      */
     @Test
     public void testSinceBeginningDateRange() throws IOException, URISyntaxException, ParseException,
             HelpScreenException {
-        generateReport(getInputWithDates("*", "2/3/2019"));
+        generateReport(getInputWithDates("^", "2/3/2019"));
         Path actualFiles = Paths.get(getClass().getClassLoader()
                 .getResource("sinceBeginningDateRange/expected").toURI());
         verifyAllJson(actualFiles, FT_TEMP_DIR);

--- a/src/systemtest/java/reposense/ConfigSystemTest.java
+++ b/src/systemtest/java/reposense/ConfigSystemTest.java
@@ -25,6 +25,7 @@ import reposense.parser.ArgsParser;
 import reposense.parser.AuthorConfigCsvParser;
 import reposense.parser.ParseException;
 import reposense.parser.RepoConfigCsvParser;
+import reposense.parser.SinceDateArgumentType;
 import reposense.report.ReportGenerator;
 import reposense.util.FileUtil;
 import reposense.util.InputBuilder;
@@ -42,12 +43,13 @@ public class ConfigSystemTest {
     }
 
     /**
-     * System test with a specified until date and a ^ since date to capture from the first commit.
+     * System test with a specified until date and a {@link SinceDateArgumentType#FIRST_COMMIT_DATE_SHORTHAND}
+     * since date to capture from the first commit.
      */
     @Test
     public void testSinceBeginningDateRange() throws IOException, URISyntaxException, ParseException,
             HelpScreenException {
-        generateReport(getInputWithDates("^", "2/3/2019"));
+        generateReport(getInputWithDates(SinceDateArgumentType.FIRST_COMMIT_DATE_SHORTHAND, "2/3/2019"));
         Path actualFiles = Paths.get(getClass().getClassLoader()
                 .getResource("sinceBeginningDateRange/expected").toURI());
         verifyAllJson(actualFiles, FT_TEMP_DIR);


### PR DESCRIPTION
```
Following #690, asterisk is used in since date argument as a shorthand
to the date of the first commit.

As asterisk is also a reserved character in shell, using it without
escaping cause the program to be unusable.

Let's change the shorthand to d1 so it can be used directly without the
need to escape.
```

Fixes #781