### PR TITLE
ChartView: modify UI of placeholder for repositories with no author commits

### DIFF
--- a/frontend/src/index.pug
+++ b/frontend/src/index.pug
@@ -150,10 +150,11 @@ html
                   span &nbsp; {{ fileFormat }} &nbsp;
             .summary-chart(v-for="(user, i) in repo")
               .summary-chart__title
-                .summary-chart__title--index {{ i+1 }}
-                .summary-chart__title--repo(v-if="filterGroupSelection === 'groupByNone'") {{ user.repoName }}
-                .summary-chart__title--author-repo(v-if="filterGroupSelection === 'groupByAuthors'") {{ user.repoName }}
-                .summary-chart__title--name(v-if="filterGroupSelection !== 'groupByAuthors'") {{ user.displayName }} ({{ user.name }})
+                .summary-chart__title--info(v-if="user.name === '-'") INFO: {{ user.displayName }}
+                .summary-chart__title--index(v-if="user.name !== '-'") {{ i+1 }}
+                .summary-chart__title--repo(v-if="filterGroupSelection === 'groupByNone' && user.name !== '-'") {{ user.repoName }}
+                .summary-chart__title--author-repo(v-if="filterGroupSelection === 'groupByAuthors' && user.name !== '-'") {{ user.repoName }}
+                .summary-chart__title--name(v-if="filterGroupSelection !== 'groupByAuthors' && user.name !== '-'") {{ user.displayName }} ({{ user.name }})
                 a(
                   title="click to view author's code",
                   v-on:click="openTabAuthorship(user, repo, i)"

--- a/frontend/src/index.pug
+++ b/frontend/src/index.pug
@@ -131,7 +131,10 @@ html
           .summary-charts(v-for="repo of filteredRepos")
             .summary-charts__title(v-if="filterGroupSelection === 'groupByRepos'") {{ repo[0].repoName }}&nbsp;&nbsp;
               .summary-charts__title--contribution(title="Total contribution of group") [{{ getGroupTotalContribution(repo) }} lines]
-            .summary-charts__title(v-if="filterGroupSelection === 'groupByAuthors'") {{ repo[0].displayName }} ({{ repo[0].name }})&nbsp;&nbsp;
+            .summary-charts__title(
+                v-if="filterGroupSelection === 'groupByAuthors'",
+                v-bind:class="{ red: repo[0].name === '-' }"
+            ) {{ repo[0].displayName }} ({{ repo[0].name }})&nbsp;&nbsp;
               .summary-charts__title--contribution(title="Total contribution of group") [{{ getGroupTotalContribution(repo) }} lines]
             .summary-charts__fileformat--breakdown(v-if="filterBreakdown")
               template(v-if="filterGroupSelection === 'groupByRepos'")
@@ -150,11 +153,13 @@ html
                   span &nbsp; {{ fileFormat }} &nbsp;
             .summary-chart(v-for="(user, i) in repo")
               .summary-chart__title
-                .summary-chart__title--info(v-if="user.name === '-'") INFO: {{ user.displayName }}
-                .summary-chart__title--index(v-if="user.name !== '-'") {{ i+1 }}
-                .summary-chart__title--repo(v-if="filterGroupSelection === 'groupByNone' && user.name !== '-'") {{ user.repoName }}
-                .summary-chart__title--author-repo(v-if="filterGroupSelection === 'groupByAuthors' && user.name !== '-'") {{ user.repoName }}
-                .summary-chart__title--name(v-if="filterGroupSelection !== 'groupByAuthors' && user.name !== '-'") {{ user.displayName }} ({{ user.name }})
+                .summary-chart__title--index {{ i+1 }}
+                .summary-chart__title--repo(v-if="filterGroupSelection === 'groupByNone'") {{ user.repoName }}
+                .summary-chart__title--author-repo(v-if="filterGroupSelection === 'groupByAuthors'") {{ user.repoName }}
+                .summary-chart__title--name(
+                    v-if="filterGroupSelection !== 'groupByAuthors'",
+                    v-bind:class="{ red: user.name === '-' }"
+                ) {{ user.displayName }} ({{ user.name }})
                 a(
                   title="click to view author's code",
                   v-on:click="openTabAuthorship(user, repo, i)"

--- a/frontend/src/index.pug
+++ b/frontend/src/index.pug
@@ -133,7 +133,7 @@ html
               .summary-charts__title--contribution(title="Total contribution of group") [{{ getGroupTotalContribution(repo) }} lines]
             .summary-charts__title(
                 v-if="filterGroupSelection === 'groupByAuthors'",
-                v-bind:class="{ red: repo[0].name === '-' }"
+                v-bind:class="{ warn: repo[0].name === '-' }"
             ) {{ repo[0].displayName }} ({{ repo[0].name }})&nbsp;&nbsp;
               .summary-charts__title--contribution(title="Total contribution of group") [{{ getGroupTotalContribution(repo) }} lines]
             .summary-charts__fileformat--breakdown(v-if="filterBreakdown")
@@ -158,7 +158,7 @@ html
                 .summary-chart__title--author-repo(v-if="filterGroupSelection === 'groupByAuthors'") {{ user.repoName }}
                 .summary-chart__title--name(
                     v-if="filterGroupSelection !== 'groupByAuthors'",
-                    v-bind:class="{ red: user.name === '-' }"
+                    v-bind:class="{ warn: user.name === '-' }"
                 ) {{ user.displayName }} ({{ user.name }})
                 a(
                   title="click to view author's code",

--- a/frontend/src/static/css/style.scss
+++ b/frontend/src/static/css/style.scss
@@ -45,7 +45,7 @@ a{
     }
 }
 
-.red{
+.warn{
     color:mui-color('red');
 
     .summary-charts__title--contribution{

--- a/frontend/src/static/css/style.scss
+++ b/frontend/src/static/css/style.scss
@@ -45,6 +45,14 @@ a{
     }
 }
 
+.red{
+    color:mui-color('red');
+
+    .summary-charts__title--contribution{
+        color:mui-color('black');
+    }
+}
+
 /** navigation bar **/
 header{
     z-index:100;
@@ -224,10 +232,6 @@ header{
         & > * {
             display:inline;
             padding-right:0.5rem;
-        }
-
-        &--info{
-            color:mui-color("red", "500");
         }
 
         &--index, &--repo{

--- a/frontend/src/static/css/style.scss
+++ b/frontend/src/static/css/style.scss
@@ -226,6 +226,10 @@ header{
             padding-right:0.5rem;
         }
 
+        &--info{
+            color:mui-color("red", "500");
+        }
+
         &--index, &--repo{
             font-weight:bold;
         }


### PR DESCRIPTION
```
Within ChartView, ramp charts with error messages are blended together 
with the other ramp charts without error messages as they both have 
similar UI.

Let's modify the UI of ramp charts with error messages to use red color 
for their info message font to distinguish itself from other ramp 
charts without error messages.
```

**Updated UI**

group by repo:
<img width="803" alt="Screen Shot 2019-07-05 at 11 34 54 AM" src="https://user-images.githubusercontent.com/32864116/60696872-35ace480-9f1a-11e9-84b4-d5fb2bf8561b.png">

group by author:
<img width="803" alt="Screen Shot 2019-07-05 at 11 35 05 AM" src="https://user-images.githubusercontent.com/32864116/60696874-39406b80-9f1a-11e9-8e62-bedc70b24479.png">

group by none:
<img width="801" alt="Screen Shot 2019-07-05 at 11 35 15 AM" src="https://user-images.githubusercontent.com/32864116/60696878-3e051f80-9f1a-11e9-96ac-600c65362f0d.png">