### PR TITLE
[#791] CodeView: bugfix for unexpected colors in line numbers

### DIFF
--- a/frontend/src/static/css/style.scss
+++ b/frontend/src/static/css/style.scss
@@ -483,12 +483,9 @@ header{
                 -ms-user-select:none; /* Internet Explorer/Edge */
                 user-select:none; /* Non-prefixed version, currently supported by Chrome and Opera */
 
-                .hljs-number{
-                    color:mui-color('grey');
-                }
-
-                .hljs-comment{
-                    color:mui-color('grey');
+                // overwrite all hljs colours
+                [class^='hljs']{
+                    color: mui-color('grey');
                 }
             }
 

--- a/frontend/src/static/css/style.scss
+++ b/frontend/src/static/css/style.scss
@@ -485,7 +485,7 @@ header{
 
                 // overwrite all hljs colours
                 [class^='hljs']{
-                    color: mui-color('grey');
+                    color:mui-color('grey');
                 }
             }
 


### PR DESCRIPTION
Fixes #791 

```
The css property of line number only overwrites the color property of 
classes 'hljs-number' and 'hljs-comment'. Others classes such as
'hljs-quote', 'hljs-name' and more are not overwritten.

This will cause the color property of certain line numbers to inherit 
from the hljs classes that are not overwritten.

Let's overwrite all hljs classes to ensure the color property of the 
line number to always be grey.
```