### PR TITLE
[#705] Log: distinct warning and error messages

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,7 @@ dependencies {
     implementation  group: 'org.apache.ant', name: 'ant', version: '1.10.3'
     implementation  group: 'net.sourceforge.argparse4j', name: 'argparse4j', version: '0.8.1'
     implementation  group: 'net.freeutils', name: 'jlhttp', version: '2.4'
+    implementation  group: 'org.fusesource.jansi', name: 'jansi', version: '1.18'
 
     testImplementation group: 'junit', name: 'junit', version: '4.12'
 }

--- a/src/main/java/reposense/system/CustomLogFormatter.java
+++ b/src/main/java/reposense/system/CustomLogFormatter.java
@@ -5,6 +5,8 @@ import static org.fusesource.jansi.Ansi.ansi;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
 import java.util.logging.SimpleFormatter;
@@ -22,6 +24,10 @@ public class CustomLogFormatter extends SimpleFormatter {
             .reset().toString();
     private static final String WARNING_HIGHLIGHT = ansi().bg(Ansi.Color.YELLOW).fg(Ansi.Color.BLACK).a("[WARNING]")
             .reset().toString();
+    private static final Map<Level, String> formatMap = new HashMap<Level, String>() {{
+            put(Level.WARNING, WARNING_HIGHLIGHT);
+            put(Level.SEVERE, ERROR_HIGHLIGHT);
+        }};
 
     public CustomLogFormatter() {
         AnsiConsole.systemInstall();
@@ -32,10 +38,8 @@ public class CustomLogFormatter extends SimpleFormatter {
         StringBuilder builder = new StringBuilder();
         builder.append(dateFormat.format(new Date(record.getMillis()))).append(" - ");
 
-        if (record.getLevel().equals(Level.SEVERE)) {
-            builder.append(ERROR_HIGHLIGHT).append(" ");
-        } else if (record.getLevel().equals(Level.WARNING)) {
-            builder.append(WARNING_HIGHLIGHT).append(" ");
+        if (formatMap.containsKey(record.getLevel())) {
+            builder.append(formatMap.get(record.getLevel())).append(" ");
         }
 
         builder.append(formatMessage(record));

--- a/src/main/java/reposense/system/CustomLogFormatter.java
+++ b/src/main/java/reposense/system/CustomLogFormatter.java
@@ -24,12 +24,11 @@ public class CustomLogFormatter extends SimpleFormatter {
             .reset().toString();
     private static final String WARNING_HIGHLIGHT = ansi().bg(Ansi.Color.YELLOW).fg(Ansi.Color.BLACK).a("[WARNING]")
             .reset().toString();
-    private static final Map<Level, String> formatMap = new HashMap<Level, String>() {{
-            put(Level.WARNING, WARNING_HIGHLIGHT);
-            put(Level.SEVERE, ERROR_HIGHLIGHT);
-        }};
+    private static final Map<Level, String> formatMap = new HashMap<>();
 
     public CustomLogFormatter() {
+        formatMap.put(Level.WARNING, WARNING_HIGHLIGHT);
+        formatMap.put(Level.SEVERE, ERROR_HIGHLIGHT);
         AnsiConsole.systemInstall();
     }
 

--- a/src/main/java/reposense/system/CustomLogFormatter.java
+++ b/src/main/java/reposense/system/CustomLogFormatter.java
@@ -3,6 +3,7 @@ package reposense.system;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.logging.Level;
 import java.util.logging.LogRecord;
 import java.util.logging.SimpleFormatter;
 
@@ -12,11 +13,17 @@ import java.util.logging.SimpleFormatter;
 public class CustomLogFormatter extends SimpleFormatter {
 
     private static final DateFormat dateFormat = new SimpleDateFormat("hh:mm:ss");
+    private static final String ERROR_HIGHLIGHT = "\u001b[37;41m[ERROR]\u001b[0m";
 
     @Override
     public synchronized String format(LogRecord record) {
         StringBuilder builder = new StringBuilder();
         builder.append(dateFormat.format(new Date(record.getMillis()))).append(" - ");
+
+        if (record.getLevel().intValue() >= Level.WARNING.intValue()) {
+            builder.append(ERROR_HIGHLIGHT).append(" ");
+        }
+
         builder.append(formatMessage(record));
         builder.append("\n");
 

--- a/src/main/java/reposense/system/CustomLogFormatter.java
+++ b/src/main/java/reposense/system/CustomLogFormatter.java
@@ -1,5 +1,7 @@
 package reposense.system;
 
+import static org.fusesource.jansi.Ansi.ansi;
+
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Date;
@@ -7,21 +9,33 @@ import java.util.logging.Level;
 import java.util.logging.LogRecord;
 import java.util.logging.SimpleFormatter;
 
+import org.fusesource.jansi.Ansi;
+import org.fusesource.jansi.AnsiConsole;
+
 /**
  * Custom log formatter for different handlers to display only relevant information
  */
 public class CustomLogFormatter extends SimpleFormatter {
 
     private static final DateFormat dateFormat = new SimpleDateFormat("hh:mm:ss");
-    private static final String ERROR_HIGHLIGHT = "\u001b[37;41m[ERROR]\u001b[0m";
+    private static final String ERROR_HIGHLIGHT = ansi().bg(Ansi.Color.RED).fg(Ansi.Color.WHITE).a("[ERROR]")
+            .reset().toString();
+    private static final String WARNING_HIGHLIGHT = ansi().bg(Ansi.Color.YELLOW).fg(Ansi.Color.BLACK).a("[WARNING]")
+            .reset().toString();
+
+    public CustomLogFormatter() {
+        AnsiConsole.systemInstall();
+    }
 
     @Override
     public synchronized String format(LogRecord record) {
         StringBuilder builder = new StringBuilder();
         builder.append(dateFormat.format(new Date(record.getMillis()))).append(" - ");
 
-        if (record.getLevel().intValue() >= Level.WARNING.intValue()) {
+        if (record.getLevel().equals(Level.SEVERE)) {
             builder.append(ERROR_HIGHLIGHT).append(" ");
+        } else if (record.getLevel().equals(Level.WARNING)) {
+            builder.append(WARNING_HIGHLIGHT).append(" ");
         }
 
         builder.append(formatMessage(record));


### PR DESCRIPTION
Part of #705: making error messages more obvious in console output.

```
It is difficult to distinguish `Level.WARNING` and `Level.SEVERE`
log messages from the rest of the log messages in the console.

Users may miss out these important messages.

Let's make these messages more distinct by inserting a highlighted
`[ERROR]` status before the message.
```