### PR TITLE
[#811] Fix position of toggle icons

### DIFF
--- a/frontend/src/static/css/style.scss
+++ b/frontend/src/static/css/style.scss
@@ -503,6 +503,7 @@ header{
                 $grey:mui-color('grey', '400');
                 border-left:0.25rem solid $grey;
                 height:20px; /* height of a single line of code */
+                position:relative;
 
                 &.active{
                     height:100%;


### PR DESCRIPTION
Fixes #811 

```
The 'closer' class designated for icons that toggle code segments
is absolutely positioned. Due its parent class, 'untouched', being 
in default static position, 'closer' is positioned relatively to the 
edges of the root containing block.

When scrolling through horizontally within each code segment, the 
toggle icons remains unchanged in their position in x-axis, hovering 
over the text in code view.

Let's relatively position the 'untouched' class, which turns the class 
into a containing block. This ensures absolutely positioned elements 
contained within will be positioned relative to the edges of 'untouched'
rather than the root containing block. 
```