### PR TITLE
[#820] Update sample report used in Cypress tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -131,7 +131,7 @@ task systemtest(dependsOn: 'zipReport', type: Test) {
 task startServerInBackground(dependsOn: 'classes', type: com.github.psxpaul.task.JavaExecFork) {
     main = mainClassName
     classpath = sourceSets.main.runtimeClasspath
-    args = ['--repo', 'https://github.com/reposense/RepoSense.git', '--view']
+    args = ['--repo', 'https://github.com/reposense/RepoSense.git', '--view', '--since', 'd1']
     String versionJvmArgs = '-Dversion=' + getRepoSenseVersion()
     jvmArgs = [ versionJvmArgs ]
     waitForPort = 9000


### PR DESCRIPTION
Fixes #820 

```
The current arguments used to generate the sample report used in Cypress 
tests is '--repo https://github.com/reposense/RepoSense.git --view'. 

Since sinceDate and untilDate is not provided in the arguments, the 
report duration will be from one month before today's date until today's 
date. This causes the current sample report used for Cypress tests 
to contain empty ramp charts, which does not mimic a realistic report.

Let's add a '--since d1' argument to the existing arguments, which 
generates a more realistic sample report that contains the commits
made from start until today's date.
```