### PR TITLE
[#828] Revert PR #800

### DIFF
--- a/frontend/src/static/js/v_summary.js
+++ b/frontend/src/static/js/v_summary.js
@@ -117,7 +117,6 @@ window.vSummary = {
       minDate: '',
       maxDate: '',
       contributionBarColors: {},
-      canGetFiltered: true, // to prevent redundant getFiltered() calls from initial page load
     };
   },
   watch: {
@@ -353,10 +352,6 @@ window.vSummary = {
       this.$emit('get-dates', [this.minDate, this.maxDate]);
     },
     getFiltered() {
-      // skip filtering of repos if first cycle of watcher updates are not finished
-      if (!this.canGetFiltered) {
-        return;
-      }
       this.setSummaryHash();
       this.getDates();
 
@@ -663,11 +658,7 @@ window.vSummary = {
   created() {
     this.renderFilterHash();
     this.getFiltered();
-    this.canGetFiltered = false; // disable getFiltered() after the first getFiltered() call
     this.processFileFormats();
-  },
-  beforeUpdate() {
-    this.canGetFiltered = true; // enable getFiltered() after first cycle of watcher updates
   },
   components: {
     v_ramp: window.vRamp,


### PR DESCRIPTION
Fixes #828 

```
PR #800 was intended to ensure the getFiltered() method to be executed 
only once when the page is reloaded. The solution used was to set 
boolean canGetFiltered to true in beforeUpdate() lifecycle hook, 
preventing the execution of getFiltered() before the lifecycle hook.
However, the beforeUpdate() lifecycle hook will only be executed when 
there are changes to the DOM. 

Instances where the page is reloaded and there are no changes to the DOM
will not set boolean canGetFiltered to true, preventing getFiltered() to 
be executed until the DOM has changed.

Let's revert PR #800 to allow getFiltered() to be executed even when 
there are no changes to the DOM.
```



