### PR TITLE
[#833] build.gradle: update node.js to 10.16.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ plugins {
 
 mainClassName = 'reposense.RepoSense'
 
-node.nodeVersion = '10.5.0'
+node.nodeVersion = '10.16.0'
 
 sourceCompatibility = JavaVersion.VERSION_1_8
 targetCompatibility = JavaVersion.VERSION_1_8


### PR DESCRIPTION
```
One of our indirect dependencies, sass@1.22.8, requires
`url.pathToFileURL` which is only available in node.js 10.12.0 or
later.

As our version of node.js is at 10.5.0, this cause our CIs to fail.

Let's update node.js to the latest lts release 10.16.0.
```

Fixes #833 