### PR TITLE
[#842] Fix out of bound ramp slices

### DIFF
--- a/frontend/src/static/js/v_summary.js
+++ b/frontend/src/static/js/v_summary.js
@@ -423,7 +423,7 @@ window.vSummary = {
       if (nextMondayDate <= untilDate) {
         this.pushCommitsWeek(sinceMs, nextMondayMs - 1, res, commits);
         this.pushCommitsWeek(nextMondayMs, untilMs, res, commits);
-      } else { // duration between since date and until date is less than one week
+      } else {
         this.pushCommitsWeek(sinceMs, untilMs, res, commits);
       }
       user.commits = res;

--- a/frontend/src/static/js/v_summary.js
+++ b/frontend/src/static/js/v_summary.js
@@ -417,8 +417,8 @@ window.vSummary = {
       const untilDate = this.filterUntilDate;
 
       const nextMondayMs = (new Date(nextMondayDate)).getTime();
-      const untilMs = (new Date(untilDate)).getTime();
       const sinceMs = new Date(this.filterSinceDate).getTime();
+      const untilMs = (new Date(untilDate)).getTime();
 
       if (nextMondayDate <= untilDate) {
         this.pushCommitsWeek(sinceMs, nextMondayMs - 1, res, commits);

--- a/frontend/src/static/js/v_summary.js
+++ b/frontend/src/static/js/v_summary.js
@@ -413,21 +413,19 @@ window.vSummary = {
 
       const res = [];
 
-      const sinceDate = dateRounding(this.filterSinceDate, 0); // round up for the next monday
+      const nextMondayDate = dateRounding(this.filterSinceDate, 0); // round up for the next monday
       const untilDate = this.filterUntilDate;
 
-      const sinceMs = (new Date(sinceDate)).getTime();
+      const nextMondayMs = (new Date(nextMondayDate)).getTime();
       const untilMs = (new Date(untilDate)).getTime();
+      const sinceMs = new Date(this.filterSinceDate).getTime();
 
-      // add first week commits starting from filterSinceDate to end of the week
-      // if filterSinceDate is not the start of the week
-      if (this.filterSinceDate !== sinceDate) {
-        const firstWeekDateMs = new Date(this.filterSinceDate).getTime();
-        this.pushCommitsWeek(firstWeekDateMs, sinceMs - 1, res, commits);
+      if (nextMondayDate <= untilDate) {
+        this.pushCommitsWeek(sinceMs, nextMondayMs - 1, res, commits);
+        this.pushCommitsWeek(nextMondayMs, untilMs, res, commits);
+      } else { // duration between since date and until date is less than one week
+        this.pushCommitsWeek(sinceMs, untilMs, res, commits);
       }
-
-      this.pushCommitsWeek(sinceMs, untilMs, res, commits);
-
       user.commits = res;
     },
     pushCommitsWeek(sinceMs, untilMs, res, commits) {


### PR DESCRIPTION
Fixes #842 

```
Ramp slices appear outside of the ramp charts in week granularity.

This is due to the implementation of splitCommitsWeek() does not take
into account when the duration between since date and until date is
less than one week. When the duration is less than a week, the
algorithm calculates commits up to the following Monday, even if they
are beyond the until date. Hence, it causes a distortion in the ui.

Let's revamp the logic within splitCommitsWeek to check, and trim any
commits beyond the until date.
```