### PR TITLE
[#382] Authorship: add tagged author that did not commit into list of authors

### DIFF
--- a/src/main/java/reposense/authorship/FileInfoAnalyzer.java
+++ b/src/main/java/reposense/authorship/FileInfoAnalyzer.java
@@ -46,7 +46,7 @@ public class FileInfoAnalyzer {
         aggregateBlameAuthorInfo(config, fileInfo);
 
         if (config.isAnnotationOverwrite()) {
-            AnnotatorAnalyzer.aggregateAnnotationAuthorInfo(fileInfo, config.getAuthorEmailsAndAliasesMap());
+            AnnotatorAnalyzer.aggregateAnnotationAuthorInfo(fileInfo, config);
         }
 
         if (!config.getAuthorList().isEmpty() && fileInfo.isAllAuthorsIgnored(config.getAuthorList())) {

--- a/src/main/java/reposense/report/ReportGenerator.java
+++ b/src/main/java/reposense/report/ReportGenerator.java
@@ -185,8 +185,10 @@ public class ReportGenerator {
         updateRepoConfig(config);
         updateAuthorList(config);
 
-        CommitContributionSummary commitSummary = CommitsReporter.generateCommitSummary(config);
+        //CommitContributionSummary commitSummary = CommitsReporter.generateCommitSummary(config);
         AuthorshipSummary authorshipSummary = AuthorshipReporter.generateAuthorshipSummary(config);
+        CommitContributionSummary commitSummary = CommitsReporter.generateCommitSummary(config);
+
         generateIndividualRepoReport(commitSummary, authorshipSummary, repoReportDirectory);
         logger.info(String.format(MESSAGE_COMPLETE_ANALYSIS, config.getLocation(), config.getBranch()));
     }


### PR DESCRIPTION
Resolves #382.

```
If no configurations are found, RepoSense will use all authors found
in the commit history by default. However, if an author named in the
annotation tag `@@author` is not found in the commit history, that
person's contribution will not show up in the report.

Let's add such an author into the list of authors, and attribute the
lines to said author instead of to `Author.UNKNOWN_AUTHOR`.
```