### PR TITLE
[#846] Fix bug of show ramps for this period button only works once

### DIFF
--- a/frontend/src/static/js/main.js
+++ b/frontend/src/static/js/main.js
@@ -191,8 +191,8 @@ window.app = new window.Vue({
     },
 
     // updating summary view
-    updateSummaryDates() {
-      this.$refs.summary.updateDateRange();
+    updateSummaryDates(zoomSince, zoomUntil) {
+      this.$refs.summary.updateDateRange(zoomSince, zoomUntil);
     },
 
     renderAuthorShipTabHash(minDate, maxDate) {

--- a/frontend/src/static/js/main.js
+++ b/frontend/src/static/js/main.js
@@ -191,8 +191,8 @@ window.app = new window.Vue({
     },
 
     // updating summary view
-    updateSummaryDates(zoomSince, zoomUntil) {
-      this.$refs.summary.updateDateRange(zoomSince, zoomUntil);
+    updateSummaryDates(since, until) {
+      this.$refs.summary.updateDateRange(since, until);
     },
 
     renderAuthorShipTabHash(minDate, maxDate) {

--- a/frontend/src/static/js/v_summary.js
+++ b/frontend/src/static/js/v_summary.js
@@ -525,19 +525,10 @@ window.vSummary = {
       this.tmpFilterUntilDate = this.maxDate;
     },
 
-    updateDateRange() {
-      if (drags.length > 0) {
-        const since = new Date(this.filterSinceDate).getTime();
-        const until = new Date(this.filterUntilDate).getTime();
-        const range = until - since;
-
-        const getStr = (time) => getDateStr(new Date(time));
-        this.tmpFilterSinceDate = getStr(since + range * drags[0] / 100);
-        this.tmpFilterUntilDate = getStr(since + range * drags[1] / 100);
-
-        drags = [];
-        deactivateAllOverlays();
-      }
+    updateDateRange(zoomSince, zoomUntil) {
+      this.tmpFilterSinceDate = zoomSince;
+      this.tmpFilterUntilDate = zoomUntil;
+      deactivateAllOverlays();
     },
 
     // update tmp dates manually after enter key in date field //

--- a/frontend/src/static/js/v_summary.js
+++ b/frontend/src/static/js/v_summary.js
@@ -525,9 +525,9 @@ window.vSummary = {
       this.tmpFilterUntilDate = this.maxDate;
     },
 
-    updateDateRange(zoomSince, zoomUntil) {
-      this.tmpFilterSinceDate = zoomSince;
-      this.tmpFilterUntilDate = zoomUntil;
+    updateDateRange(since, until) {
+      this.tmpFilterSinceDate = since;
+      this.tmpFilterUntilDate = until;
       deactivateAllOverlays();
     },
 

--- a/frontend/src/static/js/v_zoom.js
+++ b/frontend/src/static/js/v_zoom.js
@@ -8,7 +8,7 @@ window.vZoom = {
   },
   methods: {
     openSummary() {
-      this.$emit('view-summary', {});
+      this.$emit('view-summary', this.info.sinceDate, this.info.untilDate);
     },
 
     filterCommits() {


### PR DESCRIPTION
Fixes #846 

```
Clicking on show ramp chart for this period button in the commits
panel calls updateDateRange(), which recomputes the duration of the
ramp chart according to the drags by the user. The method proceeds 
to call deactivateAllOverlays(), which removes the drags by the user.

Since no more drags are left after the first execution of 
updateDateRange(), clicking on the show ramp chart for this period
button will not be able to activate updateDateRange().

Let's use the zoom since date and until date to recompute the duration
of the ramp chart, instead of using the drags. This will ensure that
clicking on the button will always show the ramp chart for the 
designated period.
```