### PR TITLE
[#851] Disable ramp url if merged group and group by authors is selected

### DIFF
--- a/frontend/src/ramp.pug
+++ b/frontend/src/ramp.pug
@@ -1,4 +1,4 @@
-.ramp
+.ramp(v-bind:class="{ 'merged-author' : mergegroup && groupby === 'groupByAuthors' }")
   template(v-if="tframe === 'commit'")
     template(v-for="(slice, j) in user.commits")
       a.ramp__slice(
@@ -31,11 +31,6 @@
             zIndex: user.commits.length - j,\
             borderLeftWidth: getWidth(slice) + 'em',\
             right: (getSlicePos(tframe === 'day' ? slice.date : slice.endDate) * 100) + '%' \
-          },\
-          /* disallow clickable ramp slices when merging groups that are grouped by authors \
-             as unable to form a url that navigates to different repositories of the same author */\
-          mergegroup && groupby === 'groupByAuthors' ?\
-            { cursor: 'auto', pointerEvents: 'none' }  :\
-            { cursor: 'pointer', pointerEvents: 'auto' }\
+          }\
       ]"
     )

--- a/frontend/src/static/css/style.scss
+++ b/frontend/src/static/css/style.scss
@@ -368,6 +368,13 @@ header {
   height: $height;
   position: relative;
 
+  /* disallow clickable ramp slices when merging groups that are grouped by authors
+     as unable to form a url that navigates to different repositories of the same author */
+  &.merged-author {
+    cursor: auto;
+    pointer-events: none;
+  }
+
   &__slice {
     border-left-color: rgba(0, 0, 0, 0);
     border-left-style: solid;


### PR DESCRIPTION
Fixes #851 

```
When the merge group option is checked and charts are grouped by
authors, the url of some ramps may point to the wrong repository.

This is due to our current structure of the merged group, where each
merged group stores only one repository name, which then causes 
all url of ramps to point to the same repository.

Since changing the structure of the merged group that allows each ramp
to store their respective repositories may take quite an effort, let's 
disable the url of the ramps when merge group option is checked and 
charts are grouped by authors.
```