### PR TITLE
AboutUs: update team members

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,18 +20,7 @@ The features of the report includes:
 ## About Us
 RepoSense is a project based in the [National University of Singapore, School of Computing](http://www.comp.nus.edu.sg/), and is funded by a grant from [NUS Center for Development of Teaching and Learning](http://www.cdtl.nus.edu.sg/).
 
-* [**Aditya Agarwal**](https://github.com/adityaa1998): _Project Member_ since May 2018
-* [**Apoorva Ullas**](https://github.com/apoorva17): _Project Member_ since Aug 2018
-* [**Chelsey Ong Hee**](https://github.com/chelseyong): _Project Member_ since Jan 2019
-* [**Damith C. Rajapakse**](https://github.com/damithc): _Project Mentor_ since Aug 2017
-* [**Gilbert Emerson**](https://github.com/emer7): _Project Member_ since Jan 2019
-* [**Ma Tanghao**](https://github.com/harryggg): _Team Lead_ for May 2017 - May 2018
-* [**Ong Shu Peng**](https://github.com/ongspxm): _Project Member_ since May 2018
-* [**Peh Xian Bin, Eugene**](https://github.com/eugenepeh): _Team Lead_ since May 2018
-* [**Tan Jun An**](https://github.com/yamidark): _Project Member_ since May 2018
-* [**Teng Yong Hao**](https://github.com/yong24s): _Project Member_ since May 2018
-* [**Teo Ming Yi**](https://github.com/myteo): _Project Member_ since Jan 2019
-* [**Wang Chao**](https://github.com/fzdy1914): _Project Member_ since Jan 2019
+Our project team and the list of contributors are [here](docs/Team.md).
 
 ## Contributing
 We welcome pull requests. Please read the [contribution guidelines](docs/Process.md#how-to-contribute-to-the-reposense-repository) before starting work on one.

--- a/docs/Team.md
+++ b/docs/Team.md
@@ -1,0 +1,93 @@
+# RepoSense Project Team
+
+We are a team based in the [School of Computing, National University of Singapore](http://www.comp.nus.edu.sg/).
+
+## Current Team
+
+### [Damith C. Rajapakse](http://www.comp.nus.edu.sg/~damithch)
+![](https://avatars.githubusercontent.com/u/1673303?s=150&v=4)<br/>
+**Role**: Project Advisor
+
+---
+
+### [Peh Xian Bin, Eugene](https://github.com/eugenepeh)
+![](https://avatars.githubusercontent.com/u/19277206?s=150&v=4)<br/>
+**Role**: Project Lead [2018 May - ]<br/>
+
+---
+
+### [Tan Jun An](https://github.com/yamidark)
+![](https://avatars3.githubusercontent.com/u/18352498?s=150&v=4)<br/>
+**Role**: Area Lead for Code Quality [2018 Aug - ]<br/>
+Committer [2018 May - 2018 Aug]<br/>
+
+---
+
+### [Ong Shu Peng](https://github.com/ongspxm)
+![](https://avatars0.githubusercontent.com/u/1430854?s=150&v=4)<br/>
+**Role**: Area Lead for UI [2018 Dec - ]<br/>
+Committer [2018 Aug - 2018 Dec]<br/>
+Contributor [2018 May - 2018 Aug]<br/>
+
+---
+
+### [Teng Yong Hao](https://github.com/yong24s)
+![](https://avatars2.githubusercontent.com/u/2003406?s=150&v=4)<br/>
+**Role**: Mentor [2018 Dec - ]<br/>
+Committer [2018 Aug - 2018 Dec]<br/>
+Contributor [2018 May - 2018 Aug]<br/>
+
+---
+
+### [Wang Chao](https://github.com/fzdy1914)
+![](https://avatars3.githubusercontent.com/u/35621726?s=150&v=4)<br/>
+**Role**: Committer [2019 May - ]<br/>
+Contributor [2018 Dec - 2019 May]<br/>
+
+---
+
+### [James Pang Mun Wai](https://github.com/jamessspanggg)
+![](https://avatars1.githubusercontent.com/u/32864116?s=150&v=4)<br/>
+**Role**: Contributor [2019 May - ]<br/>
+
+---
+
+### [Jin Minjia](https://github.com/bluein-green)
+**Role**: Contributor [2019 May - ]<br/>
+
+---
+
+### [Lee Jin Yao](https://github.com/jylee-git)
+![](https://avatars3.githubusercontent.com/u/35756209?s=150&v=4)<br/>
+**Role**: Contributor [2019 May - ]<br/>
+
+
+## Past Members
+
+### [Ma Tanghao](https://github.com/harryggg)
+Main developer for the initial version [2017 May - 2018 May]
+
+---
+
+### [Aditya Agarwal](https://github.com/adityaa1998)
+Contributor [2018 May - 2018 Aug]
+
+---
+
+### [Apoorva Ullas](https://github.com/apoorva17)
+Contributor [2018 Aug - 2019 May]
+
+---
+
+### [Chelsey Ong Hee](https://github.com/chelseyong)
+Contributor [2018 Dec - 2019 May]
+
+---
+
+### [Gilbert Emerson](https://github.com/emer7)
+Contributor [2018 Dec - 2019 May]
+
+---
+
+### [Teo Ming Yi](https://github.com/myteo)
+Contributor [2018 Dec - 2019 May]


### PR DESCRIPTION
As more members join and leave us, it is about time for us to distinct
the active members so that users can easily seek help from us.

Let's move our team list to a new page to separate our active and past
members into different section. Also, let's include and update the
roles to accredit our senior members who have been helping out with
many of the work, including mentoring the newcomers.