### PR TITLE
[#185] Use realistic person names for test repos

### DIFF
--- a/author-config.csv
+++ b/author-config.csv
@@ -1,9 +1,9 @@
 Repository's Location,Branch,Author's GitHub ID,Author's Email,Author's Display Name,Author's Git Author Name,Ignore Glob List
-https://github.com/reposense/testrepo-Beta.git,master,nbriannl,,Nbr,,
-https://github.com/reposense/testrepo-Beta.git,master,zacharytang,zacharytang.tc@gmail.com,Zac,,src/main**
-https://github.com/reposense/testrepo-Beta.git,master,April0616,,Fan,LAPTOP-7KFM2KSP\User;Fan Yuting,
-https://github.com/reposense/testrepo-Beta.git,master,CindyTsai1,,Cin,YuHsuan,src/test**
-https://github.com/reposense/testrepo-Beta.git,add-config-json,nbriannl,,Nbr,,
-https://github.com/reposense/testrepo-Beta.git,add-config-json,zacharytang,zacharytang.tc@gmail.com,Zac,,src/main**
-https://github.com/reposense/testrepo-Beta.git,add-config-json,April0616,,Fan,LAPTOP-7KFM2KSP\User;Fan Yuting,
-https://github.com/reposense/testrepo-Beta.git,add-config-json,CindyTsai1,,Cin,YuHsuan,src/test**
+https://github.com/reposense/testrepo-Beta.git,master,nbriannl,,"Ashwin Mukadaan Singhania, Rathod",,
+https://github.com/reposense/testrepo-Beta.git,master,zacharytang,zacharytang.tc@gmail.com,Yagami Rukei Polland,,src/main**
+https://github.com/reposense/testrepo-Beta.git,master,April0616,,2805Tagoe,LAPTOP-7KFM2KSP\User;Fan Yuting,
+https://github.com/reposense/testrepo-Beta.git,master,CindyTsai1,,,YuHsuan,src/test**
+https://github.com/reposense/testrepo-Beta.git,add-config-json,nbriannl,,A.M.S.Rathod,,
+https://github.com/reposense/testrepo-Beta.git,add-config-json,zacharytang,zacharytang.tc@gmail.com,Yaga..Polland,,src/main**
+https://github.com/reposense/testrepo-Beta.git,add-config-json,April0616,,  ,LAPTOP-7KFM2KSP\User;Fan Yuting,
+https://github.com/reposense/testrepo-Beta.git,add-config-json,CindyTsai1,,Ravind s/o Ramesh,YuHsuan,src/test**

--- a/src/systemtest/resources/30daysFromUntilDate/expected/reposense_testrepo-Beta_master/commits.json
+++ b/src/systemtest/resources/30daysFromUntilDate/expected/reposense_testrepo-Beta_master/commits.json
@@ -161,9 +161,9 @@
     "nbr": 95.055145
   },
   "authorDisplayNameMap": {
-    "zacharytang": "Zac",
-    "CindyTsai1": "Cin",
-    "April0616": "Fan",
-    "nbr": "Nbr"
+    "zacharytang": "Yagami Rukei Polland",
+    "CindyTsai1": "Ravind s/o Ramesh",
+    "April0616": "2805Tagoe",
+    "nbr": "Ashwin Mukadaan Singhania, Rathod"
   }
 }

--- a/src/systemtest/resources/30daysFromUntilDate/expected/reposense_testrepo-Charlie_master/commits.json
+++ b/src/systemtest/resources/30daysFromUntilDate/expected/reposense_testrepo-Charlie_master/commits.json
@@ -5126,9 +5126,9 @@
     "wangyiming1019": 97767.41
   },
   "authorDisplayNameMap": {
-    "charlesgoh": "Cha",
-    "jeffreygohkw": "Jef",
-    "Esilocke": "Esi",
-    "wangyiming1019": "Wan"
+    "charlesgoh": "Peter Johnson",
+    "jeffreygohkw": "Zhao Xiang Qing",
+    "Esilocke": "Emilia Houston",
+    "wangyiming1019": "Amit Nitin Ravindra Prakash"
   }
 }

--- a/src/systemtest/resources/author-config.csv
+++ b/src/systemtest/resources/author-config.csv
@@ -1,9 +1,9 @@
 Repository's Location,Branch,Author's GitHub ID,Author's Email,Author's Display Name,Author's Git Author Name,Ignore Glob List
-https://github.com/reposense/testrepo-Beta.git,,nbr,neilbrian.nl@gmail.com,Nbr,,
-https://github.com/reposense/testrepo-Beta.git,,zacharytang,,Zac,Zachary Tang,src/main**
-https://github.com/reposense/testrepo-Beta.git,,April0616,,Fan,LAPTOP-7KFM2KSP\User;Fan Yuting,
-https://github.com/reposense/testrepo-Beta.git,,CindyTsai1,,Cin,YuHsuan,src/test**
-https://github.com/reposense/testrepo-Charlie.git,,charlesgoh,,Cha,Charles Goh,
-https://github.com/reposense/testrepo-Charlie.git,,Esilocke,,Esi,,
-https://github.com/reposense/testrepo-Charlie.git,,jeffreygohkw,,Jef,Jeffrey Goh,
-https://github.com/reposense/testrepo-Charlie.git,,wangyiming1019,,Wan,ACER\kyle;Wang Yiming,**.adoc
+https://github.com/reposense/testrepo-Beta.git,,nbr,neilbrian.nl@gmail.com,"Ashwin Mukadaan Singhania, Rathod",,
+https://github.com/reposense/testrepo-Beta.git,,zacharytang,,Yagami Rukei Polland,Zachary Tang,src/main**
+https://github.com/reposense/testrepo-Beta.git,,April0616,,2805Tagoe,LAPTOP-7KFM2KSP\User;Fan Yuting,
+https://github.com/reposense/testrepo-Beta.git,,CindyTsai1,,Ravind s/o Ramesh,YuHsuan,src/test**
+https://github.com/reposense/testrepo-Charlie.git,,charlesgoh,,Peter Johnson,Charles Goh,
+https://github.com/reposense/testrepo-Charlie.git,,Esilocke,,Emilia Houston,,
+https://github.com/reposense/testrepo-Charlie.git,,jeffreygohkw,,Zhao Xiang Qing,Jeffrey Goh,
+https://github.com/reposense/testrepo-Charlie.git,,wangyiming1019,,Amit Nitin Ravindra Prakash,ACER\kyle;Wang Yiming,**.adoc

--- a/src/systemtest/resources/dateRange/expected/reposense_testrepo-Beta_master/commits.json
+++ b/src/systemtest/resources/dateRange/expected/reposense_testrepo-Beta_master/commits.json
@@ -119,9 +119,9 @@
     "nbr": 50.165554
   },
   "authorDisplayNameMap": {
-    "zacharytang": "Zac",
-    "CindyTsai1": "Cin",
-    "April0616": "Fan",
-    "nbr": "Nbr"
+    "zacharytang": "Yagami Rukei Polland",
+    "CindyTsai1": "Ravind s/o Ramesh",
+    "April0616": "2805Tagoe",
+    "nbr": "Ashwin Mukadaan Singhania, Rathod"
   }
 }

--- a/src/systemtest/resources/dateRange/expected/reposense_testrepo-Charlie_master/commits.json
+++ b/src/systemtest/resources/dateRange/expected/reposense_testrepo-Charlie_master/commits.json
@@ -4188,9 +4188,9 @@
     "wangyiming1019": 55435.55
   },
   "authorDisplayNameMap": {
-    "charlesgoh": "Cha",
-    "jeffreygohkw": "Jef",
-    "Esilocke": "Esi",
-    "wangyiming1019": "Wan"
+    "charlesgoh": "Peter Johnson",
+    "jeffreygohkw": "Zhao Xiang Qing",
+    "Esilocke": "Emilia Houston",
+    "wangyiming1019": "Amit Nitin Ravindra Prakash"
   }
 }

--- a/src/systemtest/resources/sinceBeginningDateRange/expected/reposense_testrepo-Beta_master/commits.json
+++ b/src/systemtest/resources/sinceBeginningDateRange/expected/reposense_testrepo-Beta_master/commits.json
@@ -407,9 +407,9 @@
     "nbr": 495.91364
   },
   "authorDisplayNameMap": {
-    "zacharytang": "Zac",
-    "CindyTsai1": "Cin",
-    "April0616": "Fan",
-    "nbr": "Nbr"
+    "zacharytang": "Yagami Rukei Polland",
+    "CindyTsai1": "Ravind s/o Ramesh",
+    "April0616": "2805Tagoe",
+    "nbr": "Ashwin Mukadaan Singhania, Rathod"
   }
 }

--- a/src/systemtest/resources/sinceBeginningDateRange/expected/reposense_testrepo-Charlie_master/commits.json
+++ b/src/systemtest/resources/sinceBeginningDateRange/expected/reposense_testrepo-Charlie_master/commits.json
@@ -9354,9 +9354,9 @@
     "wangyiming1019": 63797.973
   },
   "authorDisplayNameMap": {
-    "charlesgoh": "Cha",
-    "jeffreygohkw": "Jef",
-    "Esilocke": "Esi",
-    "wangyiming1019": "Wan"
+    "charlesgoh": "Peter Johnson",
+    "jeffreygohkw": "Zhao Xiang Qing",
+    "Esilocke": "Emilia Houston",
+    "wangyiming1019": "Amit Nitin Ravindra Prakash"
   }
 }


### PR DESCRIPTION
Fixes #185 

```
The names being used for the repositories are short.

Using this kind of too simple test cases can cause bugs to 
go unnoticed and also can cause the actual UI to look 
different from the UI we see in test cases.

Let's change the names to real use case names which 
we are more likely to see. We do this by adding long 
names, names with special characters and numbers, and a 
blank instead of a name.

This has been done this way to cover various equivalence
 partitions of the test input.
```

