### PR TITLE
Modify sort by author name to be according to authors' display names

### DIFF
--- a/frontend/src/static/js/v_summary.js
+++ b/frontend/src/static/js/v_summary.js
@@ -738,7 +738,7 @@ window.vSummary = {
       const authorMap = {};
       const filtered = [];
       const sortingWithinOption = this.sortingWithinOption === 'title' ? 'searchPath' : this.sortingWithinOption;
-      const sortingOption = this.sortingOption === 'groupTitle' ? 'name' : this.sortingOption;
+      const sortingOption = this.sortingOption === 'groupTitle' ? 'displayName' : this.sortingOption;
       repos.forEach((users) => {
         users.forEach((user) => {
           if (Object.keys(authorMap).includes(user.name)) {

--- a/frontend/src/static/js/v_summary.js
+++ b/frontend/src/static/js/v_summary.js
@@ -694,7 +694,7 @@ window.vSummary = {
 
     groupByRepos(repos) {
       const sortedRepos = [];
-      const sortingWithinOption = this.sortingWithinOption === 'title' ? 'name' : this.sortingWithinOption;
+      const sortingWithinOption = this.sortingWithinOption === 'title' ? 'displayName' : this.sortingWithinOption;
       const sortingOption = this.sortingOption === 'groupTitle' ? 'searchPath' : this.sortingOption;
       repos.forEach((users) => {
         users.sort(window.comparator((ele) => ele[sortingWithinOption]));


### PR DESCRIPTION
According to @damithc in the slack chat group:
> Yes, it should be display name, which we can control e.g., in this case, we have prefixed it with tutorial ID. The github username is a random string we cannot control. Sorting by it doesn't have much value.

```
The sort by author name implementation is according to the authors' 
GitHub usernames.

Github usernames are strings that users have no control over, 
an unconfigurable field.

Let's modify the sorting of author names to be according to the authors' 
display names.
```