### PR TITLE
[#886] Fix test causing Appveyor to fail

### DIFF
--- a/src/main/java/reposense/model/RepoConfiguration.java
+++ b/src/main/java/reposense/model/RepoConfiguration.java
@@ -231,7 +231,7 @@ public class RepoConfiguration {
     }
 
     /**
-     * Gets the path to the root folder of the repository
+     * Gets the path to the root folder of the repository.
      */
     public String getRepoRoot() {
         String path = FileUtil.REPOS_ADDRESS + File.separator + getRepoFolderName() + File.separator;
@@ -244,7 +244,7 @@ public class RepoConfiguration {
     }
 
     /**
-     * Gets the name of the folder containing the cloned repository; the parent directory of the repo's root folder
+     * Gets the name of the folder containing the cloned repository; the parent directory of the repo's root folder.
      */
     public String getRepoFolderName() {
         return repoFolderName;

--- a/src/main/java/reposense/model/RepoConfiguration.java
+++ b/src/main/java/reposense/model/RepoConfiguration.java
@@ -230,6 +230,9 @@ public class RepoConfiguration {
         }
     }
 
+    /**
+     * Gets the path to the root folder of the repository
+     */
     public String getRepoRoot() {
         String path = FileUtil.REPOS_ADDRESS + File.separator + getRepoFolderName() + File.separator;
 
@@ -240,6 +243,9 @@ public class RepoConfiguration {
         return path;
     }
 
+    /**
+     * Gets the name of the folder containing the cloned repository; the parent directory of the repo's root folder
+     */
     public String getRepoFolderName() {
         return repoFolderName;
     }

--- a/src/test/java/reposense/git/GitRevParseTest.java
+++ b/src/test/java/reposense/git/GitRevParseTest.java
@@ -6,7 +6,6 @@ import org.junit.Test;
 
 import reposense.git.exception.GitBranchException;
 import reposense.template.GitTestTemplate;
-import reposense.util.FileUtil;
 
 public class GitRevParseTest extends GitTestTemplate {
 

--- a/src/test/java/reposense/git/GitRevParseTest.java
+++ b/src/test/java/reposense/git/GitRevParseTest.java
@@ -13,12 +13,12 @@ public class GitRevParseTest extends GitTestTemplate {
     @Test
     public void assertBranchExists_withExistingBranch_success() throws GitBranchException {
         config.setBranch("master");
-        GitRevParse.assertBranchExists(config, Paths.get(FileUtil.REPOS_ADDRESS, config.getRepoFolderName()));
+        GitRevParse.assertBranchExists(config, Paths.get(config.getRepoRoot()));
     }
 
     @Test (expected = GitBranchException.class)
     public void assertBranchExists_withNonExistentBranch_throwsGitBranchException() throws GitBranchException {
         config.setBranch("nonExistentBranch");
-        GitRevParse.assertBranchExists(config, Paths.get(FileUtil.REPOS_ADDRESS, config.getRepoFolderName()));
+        GitRevParse.assertBranchExists(config, Paths.get(config.getRepoRoot()));
     }
 }


### PR DESCRIPTION
Fixes #886

```
Appveyor CI is failing due to GitRevParseTest which checks for
existence of master branch.

This is because the git rev-parse command in the failing test method
has been using the wrong directory; the reference should be using the
target repo's root. The test, however, uses the repo folder name (which
is parent of the target repo's root), causing the test to fail.

Lets fix the test to use the correct directory.

When not in the target repo's root, git tends to use the resources of
higher order repositories (if it is found). On AppVeyor, RepoSense has
always been cloned as a repository, which subsequently clones the
target repositories into one of its subfolders for analysis. Hence, the
issue has been kept hidden as the verification has been performed
against the RepoSense's resources and not the target's resources.

This issue came to the light in the release commit when AppVeyor clones
the RepoSense as a release, which does not contain the master branch,
causing the git rev-parse to fail.
```