### PR TITLE
Report: fix breakdown by file type

### DIFF
--- a/frontend/src/index.pug
+++ b/frontend/src/index.pug
@@ -169,7 +169,7 @@ html
                   span &nbsp; {{ fileType }} &nbsp;
               template(v-else)
                 .summary-charts__fileType--breakdown__legend(
-                    v-for="fileType in Object.keys(contributionBaFileTypeColors)")
+                    v-for="fileType in Object.keys(contributionBarFileTypeColors)")
                   i.fas.fa-circle(
                       v-bind:style="{ 'color' : contributionBarFileTypeColors[fileType] }"
                   )


### PR DESCRIPTION
```
Breakdown by file types functionality is broken when grouping by NONE 
or by AUTHORS.

This is caused by a typo in a variable name that does not exist. As a 
result, the report is unable to populate the list of file types and 
users won't be able to view the breakdown of contribution by file type 
when grouping by NONE or by AUTHORS.

Let's fix the typo in the variable name.
```