### PR TITLE
[#806, #951] ReportGenerator: return paths of generated files

### DIFF
--- a/src/main/java/reposense/report/ReportGenerator.java
+++ b/src/main/java/reposense/report/ReportGenerator.java
@@ -168,6 +168,8 @@ public class ReportGenerator {
     /**
      * Analyzes all repos in {@code configsToAnalyze} and generates their report.
      * Also removes {@code configsToAnalyze} that failed to analyze from {@code configs}.
+     *
+     * @return A list of paths to the JSON report files generated for the repositories in {@code configsToAnalyze}.
      */
     private static List<Path> analyzeRepos(String outputPath, List<RepoConfiguration> configs,
             List<RepoConfiguration> configsToAnalyze, String defaultBranch) {

--- a/src/main/java/reposense/report/ReportGenerator.java
+++ b/src/main/java/reposense/report/ReportGenerator.java
@@ -334,6 +334,8 @@ public class ReportGenerator {
 
     /**
      * Generates a report for a single repository at {@code repoReportDirectory}.
+     *
+     * @return A list of paths to the JSON report files generated for this report.
      */
     private static List<Path> generateIndividualRepoReport(
             String repoReportDirectory, CommitContributionSummary commitSummary, AuthorshipSummary authorshipSummary) {

--- a/src/main/java/reposense/report/ReportGenerator.java
+++ b/src/main/java/reposense/report/ReportGenerator.java
@@ -328,7 +328,7 @@ public class ReportGenerator {
      * Generates a report at the {@code repoReportDirectory}.
      * @return A list of paths to the JSON report files generated for this empty report.
      */
-    public static List<Path> generateEmptyRepoReport(String repoReportDirectory, String displayName) {
+    private static List<Path> generateEmptyRepoReport(String repoReportDirectory, String displayName) {
         CommitReportJson emptyCommitReportJson = new CommitReportJson(displayName);
 
         List<Path> generatedFiles = new ArrayList<>();

--- a/src/main/java/reposense/report/ReportGenerator.java
+++ b/src/main/java/reposense/report/ReportGenerator.java
@@ -13,6 +13,7 @@ import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
@@ -98,11 +99,12 @@ public class ReportGenerator {
         Date reportSinceDate = (cliSinceDate.equals(SinceDateArgumentType.ARBITRARY_FIRST_COMMIT_DATE))
                 ? earliestSinceDate : cliSinceDate;
 
-        FileUtil.writeJsonFile(
+        Optional<Path> summaryPath = FileUtil.writeJsonFile(
                 new SummaryJson(configs, generationDate, reportSinceDate, untilDate, isSinceDateProvided,
                         isUntilDateProvided, RepoSense.getVersion(), ErrorSummary.getInstance().getErrorList()),
-                getSummaryResultPath(outputPath))
-            .ifPresent(reportFoldersAndFiles::add);
+                        getSummaryResultPath(outputPath));
+        summaryPath.ifPresent(reportFoldersAndFiles::add);
+
         logger.info(String.format(MESSAGE_REPORT_GENERATED, outputPath));
 
         return reportFoldersAndFiles;

--- a/src/main/java/reposense/report/ReportGenerator.java
+++ b/src/main/java/reposense/report/ReportGenerator.java
@@ -130,6 +130,8 @@ public class ReportGenerator {
     /**
      * Clone, analyze and generate the report for repositories in {@code repoLocationMap}.
      * Performs analysis and report generation of each repository in parallel with the cloning of the next repository.
+     *
+     * @return A list of paths to the JSON report files generated for each repository.
      */
     private static List<Path> cloneAndAnalyzeRepos(List<RepoConfiguration> configs, String outputPath) {
         Map<RepoLocation, List<RepoConfiguration>> repoLocationMap = groupConfigsByRepoLocation(configs);

--- a/src/main/java/reposense/report/ReportGenerator.java
+++ b/src/main/java/reposense/report/ReportGenerator.java
@@ -157,7 +157,7 @@ public class ReportGenerator {
                 handleCloningFailed(configs, currRepoLocation);
             } else {
                 generatedFiles.addAll(analyzeRepos(outputPath, configs, repoLocationMap.get(clonedRepoLocation),
-                    repoCloner.getCurrentRepoDefaultBranch()));
+                        repoCloner.getCurrentRepoDefaultBranch()));
             }
             currRepoLocation = nextRepoLocation;
         }

--- a/src/main/java/reposense/report/ReportGenerator.java
+++ b/src/main/java/reposense/report/ReportGenerator.java
@@ -11,6 +11,7 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.logging.Level;
@@ -310,17 +311,29 @@ public class ReportGenerator {
     /**
      * Generates a report at the {@code repoReportDirectory}.
      */
-    public static void generateEmptyRepoReport(String repoReportDirectory, String displayName) {
+    public static List<Path> generateEmptyRepoReport(String repoReportDirectory, String displayName) {
         CommitReportJson emptyCommitReportJson = new CommitReportJson(displayName);
-        FileUtil.writeJsonFile(emptyCommitReportJson, getIndividualCommitsPath(repoReportDirectory));
-        FileUtil.writeJsonFile(Collections.emptyList(), getIndividualAuthorshipPath(repoReportDirectory));
+
+        List<Path> generatedFiles = new LinkedList<>();
+
+        FileUtil.writeJsonFile(emptyCommitReportJson, getIndividualCommitsPath(repoReportDirectory))
+                .ifPresent(generatedFiles::add);
+        FileUtil.writeJsonFile(Collections.emptyList(), getIndividualAuthorshipPath(repoReportDirectory))
+                .ifPresent(generatedFiles::add);
+
+        return generatedFiles;
     }
 
-    private static void generateIndividualRepoReport(
+    private static List<Path> generateIndividualRepoReport(
             String repoReportDirectory, CommitContributionSummary commitSummary, AuthorshipSummary authorshipSummary) {
         CommitReportJson commitReportJson = new CommitReportJson(commitSummary, authorshipSummary);
-        FileUtil.writeJsonFile(commitReportJson, getIndividualCommitsPath(repoReportDirectory));
-        FileUtil.writeJsonFile(authorshipSummary.getFileResults(), getIndividualAuthorshipPath(repoReportDirectory));
+
+        List<Path> generatedFiles = new LinkedList<>();
+        FileUtil.writeJsonFile(commitReportJson, getIndividualCommitsPath(repoReportDirectory))
+                .ifPresent(generatedFiles::add);
+        FileUtil.writeJsonFile(authorshipSummary.getFileResults(), getIndividualAuthorshipPath(repoReportDirectory))
+                .ifPresent(generatedFiles::add);
+        return generatedFiles;
     }
 
     private static String getSummaryResultPath(String targetFileLocation) {

--- a/src/main/java/reposense/report/ReportGenerator.java
+++ b/src/main/java/reposense/report/ReportGenerator.java
@@ -215,6 +215,8 @@ public class ReportGenerator {
 
     /**
      * Analyzes repo specified by {@code config} and generates the report.
+     *
+     * @return A list of paths to the JSON report files generated for the repo specified by {@code config}.
      */
     private static List<Path> analyzeRepo(
             RepoConfiguration config, String repoReportDirectory) throws NoAuthorsWithCommitsFoundException {

--- a/src/main/java/reposense/report/ReportGenerator.java
+++ b/src/main/java/reposense/report/ReportGenerator.java
@@ -206,8 +206,8 @@ public class ReportGenerator {
             } catch (NoAuthorsWithCommitsFoundException nafe) {
                 logger.log(Level.WARNING, String.format(MESSAGE_NO_AUTHORS_WITH_COMMITS_FOUND,
                         configToAnalyze.getLocation(), configToAnalyze.getBranch()));
-                generatedFiles.addAll(
-                    generateEmptyRepoReport(repoReportDirectory.toString(), Author.NAME_NO_AUTHOR_WITH_COMMITS_FOUND));
+                generatedFiles.addAll(generateEmptyRepoReport(repoReportDirectory.toString(),
+                        Author.NAME_NO_AUTHOR_WITH_COMMITS_FOUND));
             }
         }
         return generatedFiles;

--- a/src/main/java/reposense/report/ReportGenerator.java
+++ b/src/main/java/reposense/report/ReportGenerator.java
@@ -1,6 +1,5 @@
 package reposense.report;
 
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
@@ -42,7 +41,6 @@ import reposense.report.exception.NoAuthorsWithCommitsFoundException;
 import reposense.system.LogsManager;
 import reposense.util.FileUtil;
 import reposense.util.ProgressTracker;
-import sun.awt.image.ImageWatched;
 
 /**
  * Contains report generation related functionalities.
@@ -206,7 +204,7 @@ public class ReportGenerator {
                 logger.log(Level.WARNING, String.format(MESSAGE_NO_AUTHORS_WITH_COMMITS_FOUND,
                         configToAnalyze.getLocation(), configToAnalyze.getBranch()));
                 generatedFiles.addAll(
-                generateEmptyRepoReport(repoReportDirectory.toString(), Author.NAME_NO_AUTHOR_WITH_COMMITS_FOUND));
+                    generateEmptyRepoReport(repoReportDirectory.toString(), Author.NAME_NO_AUTHOR_WITH_COMMITS_FOUND));
             }
         }
         return generatedFiles;

--- a/src/main/java/reposense/report/ReportGenerator.java
+++ b/src/main/java/reposense/report/ReportGenerator.java
@@ -10,7 +10,6 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Iterator;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -143,7 +142,7 @@ public class ReportGenerator {
         RepoLocation currRepoLocation = repoLocationList.get(0);
         repoCloner.cloneBare(repoLocationMap.get(currRepoLocation).get(0));
 
-        List<Path> generatedFiles = new LinkedList<>();
+        List<Path> generatedFiles = new ArrayList<>();
         for (int index = 1; index <= repoLocationList.size(); index++) {
             RepoLocation nextRepoLocation = (index < repoLocationList.size()) ? repoLocationList.get(index) : null;
             clonedRepoLocation = repoCloner.getClonedRepoLocation();
@@ -174,7 +173,7 @@ public class ReportGenerator {
     private static List<Path> analyzeRepos(String outputPath, List<RepoConfiguration> configs,
             List<RepoConfiguration> configsToAnalyze, String defaultBranch) {
         Iterator<RepoConfiguration> itr = configsToAnalyze.iterator();
-        List<Path> generatedFiles = new LinkedList<>();
+        List<Path> generatedFiles = new ArrayList<>();
         while (itr.hasNext()) {
             progressTracker.incrementProgress();
             RepoConfiguration configToAnalyze = itr.next();
@@ -319,7 +318,7 @@ public class ReportGenerator {
     public static List<Path> generateEmptyRepoReport(String repoReportDirectory, String displayName) {
         CommitReportJson emptyCommitReportJson = new CommitReportJson(displayName);
 
-        List<Path> generatedFiles = new LinkedList<>();
+        List<Path> generatedFiles = new ArrayList<>();
 
         FileUtil.writeJsonFile(emptyCommitReportJson, getIndividualCommitsPath(repoReportDirectory))
                 .ifPresent(generatedFiles::add);
@@ -336,7 +335,7 @@ public class ReportGenerator {
             String repoReportDirectory, CommitContributionSummary commitSummary, AuthorshipSummary authorshipSummary) {
         CommitReportJson commitReportJson = new CommitReportJson(commitSummary, authorshipSummary);
 
-        List<Path> generatedFiles = new LinkedList<>();
+        List<Path> generatedFiles = new ArrayList<>();
         FileUtil.writeJsonFile(commitReportJson, getIndividualCommitsPath(repoReportDirectory))
                 .ifPresent(generatedFiles::add);
         FileUtil.writeJsonFile(authorshipSummary.getFileResults(), getIndividualAuthorshipPath(repoReportDirectory))

--- a/src/main/java/reposense/report/ReportGenerator.java
+++ b/src/main/java/reposense/report/ReportGenerator.java
@@ -212,7 +212,7 @@ public class ReportGenerator {
     /**
      * Analyzes repo specified by {@code config} and generates the report.
      */
-    private static void analyzeRepo(
+    private static List<Path> analyzeRepo(
             RepoConfiguration config, String repoReportDirectory) throws NoAuthorsWithCommitsFoundException {
         // preprocess the config and repo
         updateRepoConfig(config);
@@ -220,8 +220,8 @@ public class ReportGenerator {
 
         CommitContributionSummary commitSummary = CommitsReporter.generateCommitSummary(config);
         AuthorshipSummary authorshipSummary = AuthorshipReporter.generateAuthorshipSummary(config);
-        generateIndividualRepoReport(repoReportDirectory, commitSummary, authorshipSummary);
         logger.info(String.format(MESSAGE_COMPLETE_ANALYSIS, config.getLocation(), config.getBranch()));
+        return generateIndividualRepoReport(repoReportDirectory, commitSummary, authorshipSummary);
     }
 
     /**

--- a/src/main/java/reposense/report/ReportGenerator.java
+++ b/src/main/java/reposense/report/ReportGenerator.java
@@ -225,7 +225,6 @@ public class ReportGenerator {
 
     /**
      * Analyzes repo specified by {@code config} and generates the report.
-     *
      * @return A list of paths to the JSON report files generated for the repo specified by {@code config}.
      */
     private static List<Path> analyzeRepo(
@@ -327,7 +326,6 @@ public class ReportGenerator {
 
     /**
      * Generates a report at the {@code repoReportDirectory}.
-     *
      * @return A list of paths to the JSON report files generated for this empty report.
      */
     public static List<Path> generateEmptyRepoReport(String repoReportDirectory, String displayName) {
@@ -344,7 +342,6 @@ public class ReportGenerator {
 
     /**
      * Generates a report for a single repository at {@code repoReportDirectory}.
-     *
      * @return A list of paths to the JSON report files generated for this report.
      */
     private static List<Path> generateIndividualRepoReport(

--- a/src/main/java/reposense/report/ReportGenerator.java
+++ b/src/main/java/reposense/report/ReportGenerator.java
@@ -140,7 +140,6 @@ public class ReportGenerator {
         repoCloner.cloneBare(repoLocationMap.get(currRepoLocation).get(0));
 
         List<Path> generatedFiles = new LinkedList<>();
-
         for (int index = 1; index <= repoLocationList.size(); index++) {
             RepoLocation nextRepoLocation = (index < repoLocationList.size()) ? repoLocationList.get(index) : null;
             clonedRepoLocation = repoCloner.getClonedRepoLocation();
@@ -169,7 +168,6 @@ public class ReportGenerator {
     private static List<Path> analyzeRepos(String outputPath, List<RepoConfiguration> configs,
             List<RepoConfiguration> configsToAnalyze, String defaultBranch) {
         Iterator<RepoConfiguration> itr = configsToAnalyze.iterator();
-
         List<Path> generatedFiles = new LinkedList<>();
         while (itr.hasNext()) {
             progressTracker.incrementProgress();

--- a/src/main/java/reposense/report/ReportGenerator.java
+++ b/src/main/java/reposense/report/ReportGenerator.java
@@ -169,9 +169,11 @@ public class ReportGenerator {
      * Analyzes all repos in {@code configsToAnalyze} and generates their report.
      * Also removes {@code configsToAnalyze} that failed to analyze from {@code configs}.
      */
-    private static void analyzeRepos(String outputPath, List<RepoConfiguration> configs,
+    private static List<Path> analyzeRepos(String outputPath, List<RepoConfiguration> configs,
             List<RepoConfiguration> configsToAnalyze, String defaultBranch) {
         Iterator<RepoConfiguration> itr = configsToAnalyze.iterator();
+
+        List<Path> generatedFiles = new LinkedList<>();
         while (itr.hasNext()) {
             progressTracker.incrementProgress();
             RepoConfiguration configToAnalyze = itr.next();
@@ -187,7 +189,7 @@ public class ReportGenerator {
                 GitClone.cloneFromBareAndUpdateBranch(Paths.get(FileUtil.REPOS_ADDRESS), configToAnalyze);
 
                 FileUtil.createDirectory(repoReportDirectory);
-                analyzeRepo(configToAnalyze, repoReportDirectory.toString());
+                generatedFiles.addAll(analyzeRepo(configToAnalyze, repoReportDirectory.toString()));
             } catch (IOException ioe) {
                 String logMessage = String.format(MESSAGE_ERROR_CREATING_DIRECTORY,
                         configToAnalyze.getLocation(), configToAnalyze.getBranch());
@@ -204,9 +206,11 @@ public class ReportGenerator {
             } catch (NoAuthorsWithCommitsFoundException nafe) {
                 logger.log(Level.WARNING, String.format(MESSAGE_NO_AUTHORS_WITH_COMMITS_FOUND,
                         configToAnalyze.getLocation(), configToAnalyze.getBranch()));
-                generateEmptyRepoReport(repoReportDirectory.toString(), Author.NAME_NO_AUTHOR_WITH_COMMITS_FOUND);
+                generatedFiles.addAll(
+                generateEmptyRepoReport(repoReportDirectory.toString(), Author.NAME_NO_AUTHOR_WITH_COMMITS_FOUND));
             }
         }
+        return generatedFiles;
     }
 
     /**

--- a/src/main/java/reposense/report/ReportGenerator.java
+++ b/src/main/java/reposense/report/ReportGenerator.java
@@ -325,6 +325,9 @@ public class ReportGenerator {
         return generatedFiles;
     }
 
+    /**
+     * Generates a report for a single repository at {@code repoReportDirectory}.
+     */
     private static List<Path> generateIndividualRepoReport(
             String repoReportDirectory, CommitContributionSummary commitSummary, AuthorshipSummary authorshipSummary) {
         CommitReportJson commitReportJson = new CommitReportJson(commitSummary, authorshipSummary);

--- a/src/main/java/reposense/report/ReportGenerator.java
+++ b/src/main/java/reposense/report/ReportGenerator.java
@@ -104,7 +104,7 @@ public class ReportGenerator {
         Optional<Path> summaryPath = FileUtil.writeJsonFile(
                 new SummaryJson(configs, generationDate, reportSinceDate, untilDate, isSinceDateProvided,
                         isUntilDateProvided, RepoSense.getVersion(), ErrorSummary.getInstance().getErrorList()),
-                        getSummaryResultPath(outputPath));
+                getSummaryResultPath(outputPath));
         summaryPath.ifPresent(reportFoldersAndFiles::add);
 
         logger.info(String.format(MESSAGE_REPORT_GENERATED, outputPath));

--- a/src/main/java/reposense/report/ReportGenerator.java
+++ b/src/main/java/reposense/report/ReportGenerator.java
@@ -324,7 +324,6 @@ public class ReportGenerator {
         CommitReportJson emptyCommitReportJson = new CommitReportJson(displayName);
 
         List<Path> generatedFiles = new ArrayList<>();
-
         FileUtil.writeJsonFile(emptyCommitReportJson, getIndividualCommitsPath(repoReportDirectory))
                 .ifPresent(generatedFiles::add);
         FileUtil.writeJsonFile(Collections.emptyList(), getIndividualAuthorshipPath(repoReportDirectory))

--- a/src/main/java/reposense/report/ReportGenerator.java
+++ b/src/main/java/reposense/report/ReportGenerator.java
@@ -317,6 +317,8 @@ public class ReportGenerator {
 
     /**
      * Generates a report at the {@code repoReportDirectory}.
+     *
+     * @return A list of paths to the JSON report files generated for this empty report.
      */
     public static List<Path> generateEmptyRepoReport(String repoReportDirectory, String displayName) {
         CommitReportJson emptyCommitReportJson = new CommitReportJson(displayName);

--- a/src/main/java/reposense/report/ReportGenerator.java
+++ b/src/main/java/reposense/report/ReportGenerator.java
@@ -226,8 +226,9 @@ public class ReportGenerator {
 
         CommitContributionSummary commitSummary = CommitsReporter.generateCommitSummary(config);
         AuthorshipSummary authorshipSummary = AuthorshipReporter.generateAuthorshipSummary(config);
+        List<Path> generatedFiles = generateIndividualRepoReport(repoReportDirectory, commitSummary, authorshipSummary);
         logger.info(String.format(MESSAGE_COMPLETE_ANALYSIS, config.getLocation(), config.getBranch()));
-        return generateIndividualRepoReport(repoReportDirectory, commitSummary, authorshipSummary);
+        return generatedFiles;
     }
 
     /**

--- a/src/main/java/reposense/report/ReportGenerator.java
+++ b/src/main/java/reposense/report/ReportGenerator.java
@@ -95,7 +95,7 @@ public class ReportGenerator {
         earliestSinceDate = null;
         progressTracker = new ProgressTracker(configs.size());
 
-        cloneAndAnalyzeRepos(configs, outputPath);
+        List<Path> reportFoldersAndFiles = cloneAndAnalyzeRepos(configs, outputPath);
 
         Date reportSinceDate = (cliSinceDate.equals(SinceDateArgumentType.ARBITRARY_FIRST_COMMIT_DATE))
                 ? earliestSinceDate : cliSinceDate;
@@ -103,15 +103,10 @@ public class ReportGenerator {
         FileUtil.writeJsonFile(
                 new SummaryJson(configs, generationDate, reportSinceDate, untilDate, isSinceDateProvided,
                         isUntilDateProvided, RepoSense.getVersion(), ErrorSummary.getInstance().getErrorList()),
-                getSummaryResultPath(outputPath));
+                getSummaryResultPath(outputPath))
+            .ifPresent(reportFoldersAndFiles::add);
         logger.info(String.format(MESSAGE_REPORT_GENERATED, outputPath));
 
-        List<Path> reportFoldersAndFiles = new ArrayList<>();
-        for (RepoConfiguration config : configs) {
-            reportFoldersAndFiles.add(
-                    Paths.get(outputPath + File.separator + config.getOutputFolderName()).toAbsolutePath());
-        }
-        reportFoldersAndFiles.add(Paths.get(outputPath, SummaryJson.SUMMARY_JSON_FILE_NAME));
         return reportFoldersAndFiles;
     }
 

--- a/src/main/java/reposense/util/FileUtil.java
+++ b/src/main/java/reposense/util/FileUtil.java
@@ -85,7 +85,6 @@ public class FileUtil {
 
     /**
      * Writes the JSON file representing the {@code object} at the given {@code path}.
-     *
      * @return An Optional containing the Path to the JSON file, or an empty Optional
      *         if there was an error while writing the JSON file.
      */

--- a/src/main/java/reposense/util/FileUtil.java
+++ b/src/main/java/reposense/util/FileUtil.java
@@ -85,6 +85,9 @@ public class FileUtil {
 
     /**
      * Writes the JSON file representing the {@code object} at the given {@code path}.
+     *
+     * @return An Optional containing the Path to the JSON file, or an empty Optional
+     *         if there was an error while writing the JSON file.
      */
     public static Optional<Path> writeJsonFile(Object object, String path) {
         Gson gson = new GsonBuilder()

--- a/src/main/java/reposense/util/FileUtil.java
+++ b/src/main/java/reposense/util/FileUtil.java
@@ -14,6 +14,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
@@ -85,7 +86,7 @@ public class FileUtil {
     /**
      * Writes the JSON file representing the {@code object} at the given {@code path}.
      */
-    public static void writeJsonFile(Object object, String path) {
+    public static Optional<Path> writeJsonFile(Object object, String path) {
         Gson gson = new GsonBuilder()
                 .setDateFormat(GITHUB_API_DATE_FORMAT)
                 .registerTypeAdapter(FileType.class, new FileType.FileTypeSerializer())
@@ -96,8 +97,10 @@ public class FileUtil {
         try (PrintWriter out = new PrintWriter(path)) {
             out.print(result);
             out.print("\n");
+            return Optional.of(path).map(Paths::get);
         } catch (FileNotFoundException e) {
             logger.log(Level.SEVERE, e.getMessage(), e);
+            return Optional.empty();
         }
     }
 


### PR DESCRIPTION
Fixes #806, fixes #951 

```
ReportGenerator: Ensure the list of paths returned from
`generateReposReport` only contains JSON files that were successfully
generated.

The method `ReportGenerator#generateReposReport` returns a list of
paths to the JSON files that need to be zipped, but assumes
that these files already exist.

Let's return a Optional<Path> from `FileUtil#writeJsonFile` so that
callers of this method can determine whether a JSON file was
successfully generated.

This allows `generateReposReport` to only return paths to JSON files
that were successfully generated.

```