### PR TITLE
[#1145] SideBar: revamp display logic

### DIFF
--- a/frontend/src/index.pug
+++ b/frontend/src/index.pug
@@ -60,11 +60,9 @@ html
             .tab-panes
               v_authorship#tab-authorship.tab-pane(
                 v-if="tabType === 'authorship'",
-                v-bind:key="generateKey(tabInfo.tabAuthorship)",
                 v-bind:info="tabInfo.tabAuthorship")
               v_zoom#tab-zoom.tab-pane(
                 v-else-if="tabType === 'zoom'",
-                v-bind:key="generateKey(tabInfo.tabZoom)",
                 v-bind:info="tabInfo.tabZoom",
                 v-on:view-summary="updateSummaryDates")
               #tab-empty.tab-pane(v-else)

--- a/frontend/src/static/js/main.js
+++ b/frontend/src/static/js/main.js
@@ -117,10 +117,12 @@ window.app = new window.Vue({
         minDate: '',
         name: '',
         repo: '',
+        totalCommits: '',
       },
       tabZoom: {
         avgCommitSize: 0,
         filterGroupSelection: '',
+        filterTimeFrame: '',
         location: '',
         isMergeGroup: false,
         sinceDate: '',

--- a/frontend/src/static/js/main.js
+++ b/frontend/src/static/js/main.js
@@ -117,7 +117,6 @@ window.app = new window.Vue({
         minDate: '',
         name: '',
         repo: '',
-        totalCommits: '',
       },
       tabZoom: {
         avgCommitSize: 0,

--- a/frontend/src/static/js/main.js
+++ b/frontend/src/static/js/main.js
@@ -106,11 +106,28 @@ window.app = new window.Vue({
     userUpdated: false,
 
     isLoading: false,
-    isCollapsed: false,
     isTabActive: true, // to force tab wrapper to load
 
     tabType: 'empty',
-    tabInfo: {},
+    tabInfo: {
+      tabAuthorship: {
+        author: '',
+        location: '',
+        maxDate: '',
+        minDate: '',
+        name: '',
+        repo: '',
+      },
+      tabZoom: {
+        avgCommitSize: 0,
+        filterGroupSelection: '',
+        location: '',
+        isMergeGroup: false,
+        sinceDate: '',
+        untilDate: '',
+        user: null,
+      },
+    },
     creationDate: '',
 
     errorMessages: {},
@@ -171,14 +188,11 @@ window.app = new window.Vue({
 
     // handle opening of sidebar //
     activateTab(tabName) {
-      // changing isTabActive to trigger redrawing of component
-      this.isTabActive = false;
       if (document.getElementById('tabs-wrapper')) {
         document.getElementById('tabs-wrapper').scrollTop = 0;
       }
 
       this.isTabActive = true;
-      this.isCollapsed = false;
       this.tabType = tabName;
 
       window.addHash('tabOpen', this.isTabActive);
@@ -196,11 +210,11 @@ window.app = new window.Vue({
     },
 
     updateTabAuthorship(obj) {
-      this.tabInfo.tabAuthorship = Object.assign({}, obj);
+      this.tabInfo.tabAuthorship = Object.assign({}, this.tabInfo.tabAuthorship, obj);
       this.activateTab('authorship');
     },
     updateTabZoom(obj) {
-      this.tabInfo.tabZoom = Object.assign({}, obj);
+      this.tabInfo.tabZoom = Object.assign({}, this.tabInfo.tabZoom, obj);
       this.activateTab('zoom');
     },
 
@@ -245,10 +259,6 @@ window.app = new window.Vue({
           // handle zoom tab if needed
         }
       }
-    },
-
-    generateKey(dataObj) {
-      return JSON.stringify(dataObj);
     },
 
     getRepoSenseHomeLink() {

--- a/frontend/src/static/js/v_authorship.js
+++ b/frontend/src/static/js/v_authorship.js
@@ -61,11 +61,6 @@ window.vAuthorship = {
         this.selectedFileTypes = this.fileTypes.slice();
       }
     },
-
-    info() {
-      this.initiate();
-      this.setInfoHash();
-    },
   },
 
   methods: {

--- a/frontend/src/static/js/v_authorship.js
+++ b/frontend/src/static/js/v_authorship.js
@@ -26,7 +26,11 @@ const repoCache = [];
 const minimatch = require('minimatch');
 
 window.vAuthorship = {
-  props: ['info'],
+  props: {
+    info: {
+      type: Object,
+    },
+  },
   template: window.$('v_authorship').innerHTML,
   data() {
     return {
@@ -58,6 +62,11 @@ window.vAuthorship = {
       } else {
         this.selectedFileTypes = this.fileTypes.slice();
       }
+    },
+
+    info() {
+      this.initiate();
+      this.setInfoHash();
     },
   },
 

--- a/frontend/src/static/js/v_authorship.js
+++ b/frontend/src/static/js/v_authorship.js
@@ -61,6 +61,11 @@ window.vAuthorship = {
         this.selectedFileTypes = this.fileTypes.slice();
       }
     },
+
+    info() {
+      this.initiate();
+      this.setInfoHash();
+    },
   },
 
   methods: {

--- a/frontend/src/static/js/v_authorship.js
+++ b/frontend/src/static/js/v_authorship.js
@@ -27,9 +27,7 @@ const minimatch = require('minimatch');
 
 window.vAuthorship = {
   props: {
-    info: {
-      type: Object,
-    },
+    info: Object,
   },
   template: window.$('v_authorship').innerHTML,
   data() {

--- a/frontend/src/static/js/v_summary.js
+++ b/frontend/src/static/js/v_summary.js
@@ -705,12 +705,12 @@ window.vSummary = {
 
     openTabZoom(user, since, until, repo, index) {
       const { avgCommitSize } = this;
-
+      const clonedUser = Object.assign({}, user); // so that changes in summary won't affect zoom
       this.$emit('view-zoom', {
         filterGroupSelection: this.filterGroupSelection,
         filterTimeFrame: this.filterTimeFrame,
         avgCommitSize,
-        user,
+        user: clonedUser,
         location: this.getRepoLink(repo[index]),
         sinceDate: since,
         untilDate: until,

--- a/frontend/src/static/js/v_summary.js
+++ b/frontend/src/static/js/v_summary.js
@@ -708,6 +708,7 @@ window.vSummary = {
 
       this.$emit('view-zoom', {
         filterGroupSelection: this.filterGroupSelection,
+        filterTimeFrame: this.filterTimeFrame,
         avgCommitSize,
         user,
         location: this.getRepoLink(repo[index]),

--- a/frontend/src/static/js/v_summary.js
+++ b/frontend/src/static/js/v_summary.js
@@ -690,7 +690,6 @@ window.vSummary = {
         repo: user.repoName,
         name: user.displayName,
         location: this.getRepoLink(repo[index]),
-        totalCommits: user.totalCommits,
       });
     },
     openTabZoomSubrange(user, repo, index) {

--- a/frontend/src/static/js/v_zoom.js
+++ b/frontend/src/static/js/v_zoom.js
@@ -4,7 +4,11 @@ const commitSortDict = {
 };
 
 window.vZoom = {
-  props: ['info'],
+  props: {
+    info: {
+      type: Object,
+    },
+  },
   template: window.$('v_zoom').innerHTML,
   data() {
     return {
@@ -43,6 +47,11 @@ window.vZoom = {
       });
 
       return nonEmptyCommitMessageCount;
+    },
+  },
+  watch: {
+    info() {
+      this.updateExpandedCommitMessagesCount();
     },
   },
   methods: {

--- a/frontend/src/static/js/v_zoom.js
+++ b/frontend/src/static/js/v_zoom.js
@@ -48,6 +48,11 @@ window.vZoom = {
       return nonEmptyCommitMessageCount;
     },
   },
+  watch: {
+    info() {
+      this.updateExpandedCommitMessagesCount();
+    },
+  },
   methods: {
     openSummary() {
       this.$emit('view-summary', this.info.sinceDate, this.info.untilDate);

--- a/frontend/src/static/js/v_zoom.js
+++ b/frontend/src/static/js/v_zoom.js
@@ -10,7 +10,6 @@ window.vZoom = {
   template: window.$('v_zoom').innerHTML,
   data() {
     return {
-      filterTimeFrame: window.hashParams.timeframe,
       showAllCommitMessageBody: true,
       expandedCommitMessagesCount: this.totalCommitMessageBodyCount,
       commitsSortType: 'time',
@@ -24,12 +23,14 @@ window.vZoom = {
       * window.comparator(commitSortDict[this.commitsSortType])(a, b);
     },
     filteredUser() {
-      const { user } = this.info;
+      const {
+        user, sinceDate, untilDate, filterTimeFrame,
+      } = this.info;
       const filteredUser = Object.assign({}, user);
 
-      const date = this.filterTimeFrame === 'week' ? 'endDate' : 'date';
+      const date = filterTimeFrame === 'week' ? 'endDate' : 'date';
       filteredUser.commits = user.commits.filter(
-          (commit) => commit[date] >= this.info.sinceDate && commit[date] <= this.info.untilDate,
+          (commit) => commit[date] >= sinceDate && commit[date] <= untilDate,
       ).sort(this.sortingFunction);
 
       return filteredUser;

--- a/frontend/src/static/js/v_zoom.js
+++ b/frontend/src/static/js/v_zoom.js
@@ -5,9 +5,7 @@ const commitSortDict = {
 
 window.vZoom = {
   props: {
-    info: {
-      type: Object,
-    },
+    info: Object,
   },
   template: window.$('v_zoom').innerHTML,
   data() {

--- a/frontend/src/static/js/v_zoom.js
+++ b/frontend/src/static/js/v_zoom.js
@@ -47,11 +47,6 @@ window.vZoom = {
       return nonEmptyCommitMessageCount;
     },
   },
-  watch: {
-    info() {
-      this.updateExpandedCommitMessagesCount();
-    },
-  },
   methods: {
     openSummary() {
       this.$emit('view-summary', this.info.sinceDate, this.info.untilDate);

--- a/frontend/src/tabs/zoom.pug
+++ b/frontend/src/tabs/zoom.pug
@@ -22,7 +22,7 @@
       span &#8627; &nbsp;
       span {{ info.sinceDate }} to {{ info.untilDate }} &nbsp;
       a(v-on:click="openSummary") [Show ramp chart for this period]
-    .zoom__title--granularity.mini-font granularity: one ramp per {{ filterTimeFrame }}
+    .zoom__title--granularity.mini-font granularity: one ramp per {{ info.filterTimeFrame }}
     .zoom__title--tags
       template(v-for="commit in filteredUser.commits")
         template(v-for="commitResult in commit.commitResults")
@@ -37,7 +37,7 @@
   v_ramp(
     v-bind:groupby="info.filterGroupSelection",
     v-bind:user="filteredUser",
-    v-bind:tframe="filterTimeFrame",
+    v-bind:tframe="info.filterTimeFrame",
     v-bind:sdate="info.sinceDate",
     v-bind:udate="info.untilDate",
     v-bind:avgsize="info.avgCommitSize",
@@ -56,7 +56,7 @@
       label.medium-font order
 
   .zoom__day(v-for="day in filteredUser.commits", v-bind:key="day.date")
-    h3(v-if="filterTimeFrame === 'week'") Week of {{ day.date }}
+    h3(v-if="info.filterTimeFrame === 'week'") Week of {{ day.date }}
     h3(v-else) {{ day.date }}
     template
       //- use tabindex to enable focus property on div


### PR DESCRIPTION
Fixes #1145 

```
When sidebar needs to be refreshed, such as re-rendering the 
authorship tab and zoom tab, we set `isTabActive` to false first to 
trigger the redrawing process. To ensure that the child component 
gets the updated changes, we bind a unique key to the child 
component to trigger re-rendering.

The previous implementation is done in such a way because the 
child component fails to get the changes in `info` prop due to the 
way we update the `info`[1]. This causes the SideBar component 
to be completely re-rendered, instead of only updating the 
component based on the changes in `info`. If we are able to let the 
SideBar component catch the change of `info`, we can directly 
watch the property and update the data upon the `info` 
change.

Let's declare the `info` prop explicitly and watch the changes in 
`info` prop so Vue is so Vue is able to catch the property change [2] 
to utilize components re-usage. Let's also pass a shallow copied 
`user` to the zoom tab, as we are intending to make zoom tab
and summary tab independent of one another.
```

[1] https://vuejs.org/v2/guide/reactivity.html#Change-Detection-Caveats
[2] https://vuejs.org/v2/guide/reactivity.html#Declaring-Reactive-Properties