### PR TITLE
[#980] Date in url adapted without validation

### DIFF
--- a/frontend/src/static/js/v_summary.js
+++ b/frontend/src/static/js/v_summary.js
@@ -346,10 +346,10 @@ window.vSummary = {
       if (hash.mergegroup) {
         this.isMergeGroup = convertBool(hash.mergegroup);
       }
-      if (hash.since) {
+      if (hash.since && dateFormatRegex.test(hash.since)) {
         this.tmpFilterSinceDate = hash.since;
       }
-      if (hash.until) {
+      if (hash.until && dateFormatRegex.test(hash.until)) {
         this.tmpFilterUntilDate = hash.until;
       }
 


### PR DESCRIPTION
Fixes #980
```
Date in authorship can be modified using url, resulting in invalid
date range being input.

This can be fixed by adding a validation function for window hash.

Let's put a validation for the date parameter in url.
```