### PR TITLE
[#1009] Appveyor Failing

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,10 @@
 # AppVeyor configuration file
 # For more details see https://www.appveyor.com/docs/build-configuration/
 
+image:
+  - Visual Studio 2015
+  - Previous Visual Studio 2015
+
 # Call on gradle to build and run tests
 # --no-daemon: Prevent the daemon from launching to prevent file-in-use errors
 #     when we cache the ~/.gradle directory


### PR DESCRIPTION
Appveyor is failing due to its update for Visual Studio 2015 image.

Let's include the previous Windows image in the configuration file as a temporary indicator before the issue is truly solved.