### PR TITLE
[#1019] Handle commit info extraction for empty commits

### DIFF
--- a/src/main/java/reposense/commits/CommitInfoAnalyzer.java
+++ b/src/main/java/reposense/commits/CommitInfoAnalyzer.java
@@ -82,8 +82,10 @@ public class CommitInfoAnalyzer {
         String messageTitle = (elements.length > MESSAGE_TITLE_INDEX) ? elements[MESSAGE_TITLE_INDEX] : "";
         String messageBody = (elements.length > MESSAGE_BODY_INDEX)
                 ? getCommitMessageBody(elements[MESSAGE_BODY_INDEX]) : "";
-
-        String[] refs = elements[REF_NAME_INDEX].split(REF_SPLITTER);
+    
+        String[] refs = (elements.length > REF_NAME_INDEX) 
+                ? elements[REF_NAME_INDEX].split(REF_SPLITTER) 
+                : new String[]{""};
         String[] tags = Arrays.stream(refs).filter(ref -> ref.contains(TAG_PREFIX)).toArray(String[]::new);
         if (tags.length == 0) {
             tags = null; // set to null so it won't be converted to json

--- a/src/main/java/reposense/commits/CommitInfoAnalyzer.java
+++ b/src/main/java/reposense/commits/CommitInfoAnalyzer.java
@@ -82,9 +82,9 @@ public class CommitInfoAnalyzer {
         String messageTitle = (elements.length > MESSAGE_TITLE_INDEX) ? elements[MESSAGE_TITLE_INDEX] : "";
         String messageBody = (elements.length > MESSAGE_BODY_INDEX)
                 ? getCommitMessageBody(elements[MESSAGE_BODY_INDEX]) : "";
-    
-        String[] refs = (elements.length > REF_NAME_INDEX) 
-                ? elements[REF_NAME_INDEX].split(REF_SPLITTER) 
+
+        String[] refs = (elements.length > REF_NAME_INDEX)
+                ? elements[REF_NAME_INDEX].split(REF_SPLITTER)
                 : new String[]{""};
         String[] tags = Arrays.stream(refs).filter(ref -> ref.contains(TAG_PREFIX)).toArray(String[]::new);
         if (tags.length == 0) {

--- a/src/main/java/reposense/commits/CommitInfoExtractor.java
+++ b/src/main/java/reposense/commits/CommitInfoExtractor.java
@@ -59,7 +59,7 @@ public class CommitInfoExtractor {
             Matcher matcher = TRAILING_NEWLINES_PATTERN.matcher(rawCommitInfos[i]);
             String rawCommitInfo = matcher.replaceAll("");
 
-            int statLineSeparatorIndex = rawCommitInfo.lastIndexOf("\n");
+            int statLineSeparatorIndex = rawCommitInfo.lastIndexOf("|");
             String infoLine = rawCommitInfo.substring(0, statLineSeparatorIndex);
             String statLine = rawCommitInfo.substring(statLineSeparatorIndex + 1);
             commitInfos.add(new CommitInfo(infoLine, statLine));

--- a/src/main/java/reposense/git/GitLog.java
+++ b/src/main/java/reposense/git/GitLog.java
@@ -16,7 +16,7 @@ public class GitLog {
     public static final String COMMIT_INFO_DELIMITER = "(?m)^>>>COMMIT INFO<<<\\n";
 
     private static final String PRETTY_FORMAT_STRING =
-            "\">>>COMMIT INFO<<<%n%H|%n|%aN|%n|%aE|%n|%cI|%n|%s|%n|%w(0,4,4)%b%w(0,0,0)|%n|%D\"";
+            "\">>>COMMIT INFO<<<%n%H|%n|%aN|%n|%aE|%n|%cI|%n|%s|%n|%w(0,4,4)%b%w(0,0,0)|%n|%D|\"";
 
     /**
      * Returns the git commit log info of {@code Author}, in the repository specified in {@code config}.

--- a/src/test/java/reposense/commits/CommitInfoAnalyzerTest.java
+++ b/src/test/java/reposense/commits/CommitInfoAnalyzerTest.java
@@ -17,6 +17,7 @@ import reposense.commits.model.CommitInfo;
 import reposense.commits.model.CommitResult;
 import reposense.model.Author;
 import reposense.model.CommitHash;
+import reposense.model.FileTypeTest;
 import reposense.parser.InvalidLocationException;
 import reposense.template.GitTestTemplate;
 
@@ -186,6 +187,27 @@ public class CommitInfoAnalyzerTest extends GitTestTemplate {
         config.setAuthorList(Collections.singletonList(author));
         config.setSinceDate(new GregorianCalendar(2019, Calendar.DECEMBER, 20).getTime());
         config.setUntilDate(new GregorianCalendar(2019, Calendar.DECEMBER, 21).getTime());
+
+        List<CommitInfo> actualCommitInfos = CommitInfoExtractor.extractCommitInfos(config);
+        List<CommitResult> actualCommitResults = CommitInfoAnalyzer.analyzeCommits(actualCommitInfos, config);
+
+        Assert.assertEquals(expectedCommitResults, actualCommitResults);
+    }
+
+    @Test
+    public void analyzeCommits_emptyCommits_success() throws ParseException {
+        Author author = new Author(JAMES_AUTHOR_NAME);
+        List<CommitResult> expectedCommitResults = new ArrayList<>();
+
+        expectedCommitResults.add(new CommitResult(author, "016ab87c4afe89a98225b96c98ff28dd4774410f",
+                parseGitStrictIsoDate("2020-01-27T22:20:51+08:00"), "empty commit",
+                "", null, 0, 0));
+
+        config.setBranch("1019-CommitInfoAnalyzerTest-emptyCommits");
+        config.setAuthorList(Collections.singletonList(author));
+        config.setFormats(FileTypeTest.NO_SPECIFIED_FORMATS);
+        config.setSinceDate(new GregorianCalendar(2020, Calendar.JANUARY, 27).getTime());
+        config.setUntilDate(new GregorianCalendar(2020, Calendar.JANUARY, 28).getTime());
 
         List<CommitInfo> actualCommitInfos = CommitInfoExtractor.extractCommitInfos(config);
         List<CommitResult> actualCommitResults = CommitInfoAnalyzer.analyzeCommits(actualCommitInfos, config);


### PR DESCRIPTION
Fixes #1019 

```
Analyzing repo with empty commits causes CommitInfoAnalyzer 
to throw ArrayIndexOutOfBoundsException. This occurs in 
CommitInfoExtractor#parseGitLogResults, where info lines 
and stat lines are split based on the last index of the newline 
character "\n".

As empty commits have no stat lines, it leads to 
ArrayIndexOutOfBoundsException due to the use of new line 
separator.

Let's:
- use '|' character as the splitting point of 
  info lines and stat lines, instead of the new line '\n' 
  character. This will ensure that the ref name details
  will always be within info lines instead of stat lines.
- add a check for the availability of the ref   
  name before accessing it to prevent the exception. 

Additional Info: No stat lines occurs for commits that are 
empty (done by git commit --allow-empty), since no files are 
changed. The last index of the newline character will situate 
before the ref name details, and info line will contain all 
characters before that index while stat line contains the ref 
name details. Since the ref name is no longer in the info lines, 
accessing the REF_NAME_INDEX within the info lines will
incur an ArrayOutOfBoundsException.
```

Example git log results of non-empty & empty commit:
<img width="296" alt="Screen Shot 2020-01-27 at 10 11 03 PM" src="https://user-images.githubusercontent.com/32864116/73181395-172a6700-4152-11ea-9128-af6127298a6a.png">

<img width="296" alt="Screen Shot 2020-01-27 at 10 11 37 PM" src="https://user-images.githubusercontent.com/32864116/73181346-ff52e300-4151-11ea-9151-c5fc9388cb09.png">
