### PR TITLE
[#1029] Add float left property to contribution bar

### DIFF
--- a/frontend/src/static/css/v_summary.scss
+++ b/frontend/src/static/css/v_summary.scss
@@ -170,6 +170,7 @@
 
     &--bar {
       background-color: mui-color('red');
+      float: left;
       height: .3rem;
       margin-top: .1rem;
     }


### PR DESCRIPTION
Fixes #1029 

```
Due to the regression of #1003, the css property 
'float: left' was left out in the contribution bar. When 
break down by file type is checked, the contribution 
bar for each file type occupies separate lines instead 
of continuous lines.

Let's add the css property 'float: left' back to the 
contribution bar.
```