### PR TITLE
[#1032] Author: fix error in copy constructor

### DIFF
--- a/src/main/java/reposense/model/Author.java
+++ b/src/main/java/reposense/model/Author.java
@@ -62,7 +62,7 @@ public class Author {
         this.emails = another.emails;
         this.displayName = another.gitId;
         this.authorAliases = another.authorAliases;
-        this.ignoreGlobList = another.authorAliases;
+        this.ignoreGlobList = another.ignoreGlobList;
         this.ignoreGlobMatcher = another.ignoreGlobMatcher;
     }
 


### PR DESCRIPTION
Fixes #1032

```
Author: Fix error in copy constructor

The Author class has a constructor which accepts an existing Author
object and creates a copy. However, the constructor assigns the
list of author aliases of the copied instance to the `ignoreGlobList`
attribute of the new instance.

Let's fix this error so users of this copy constructor will not
face erroneous behaviour.
```