### PR TITLE
[#910] Save authorship tab controls as hash parameters

### DIFF
--- a/frontend/src/static/css/v_authorship.scss
+++ b/frontend/src/static/css/v_authorship.scss
@@ -44,6 +44,10 @@
         padding: .5rem 1.0rem .25rem 1.0rem;
       }
 
+      .searchbox {
+        margin-bottom: 1em;
+      }
+
       .select {
         font-weight: bold;
       }

--- a/frontend/src/static/js/api.js
+++ b/frontend/src/static/js/api.js
@@ -1,6 +1,7 @@
 // utility functions //
 window.$ = (id) => document.getElementById(id);
 window.enquery = (key, val) => `${key}=${encodeURIComponent(val)}`;
+window.HASH_FILETYPE_DELIMITER = '~';
 const REPORT_DIR = '.';
 
 // data retrieval functions //

--- a/frontend/src/static/js/main.js
+++ b/frontend/src/static/js/main.js
@@ -191,14 +191,7 @@ window.app = new window.Vue({
       window.addHash('tabOpen', this.isTabActive);
       window.removeHash('tabType');
       this.removeZoomHashes();
-      this.removeAuthorshipHashes();
       window.encodeHash();
-    },
-
-    removeAuthorshipHashes() {
-      window.removeHash('tabAuthor');
-      window.removeHash('tabRepo');
-      window.removeHash('authorshipIsMergeGroup');
     },
 
     removeZoomHashes() {
@@ -222,7 +215,6 @@ window.app = new window.Vue({
       this.activateTab('authorship');
     },
     updateTabZoom(obj) {
-      this.removeAuthorshipHashes();
       this.tabInfo.tabZoom = Object.assign({}, obj);
       this.activateTab('zoom');
     },

--- a/frontend/src/static/js/v_authorship.js
+++ b/frontend/src/static/js/v_authorship.js
@@ -41,23 +41,56 @@ window.vAuthorship = {
       totalBlankLineCount: '',
       filesSortType: 'lineOfCode',
       toReverseSortFiles: true,
-      filterSearch: '*',
+      searchBarValue: '',
     };
   },
 
   watch: {
-    filterType() {
-      if (this.filterType === 'checkboxes') {
-        const searchBar = document.getElementById('search');
-        searchBar.value = '';
-        this.filterSearch = '*';
-      } else {
-        this.selectedFileTypes = this.fileTypes.slice();
+    filesSortType() {
+      window.addHash('authorshipSortBy', this.filesSortType);
+      window.encodeHash();
+    },
+
+    toReverseSortFiles() {
+      window.addHash('reverseAuthorshipOrder', this.toReverseSortFiles);
+      window.encodeHash();
+    },
+
+    isLoaded() {
+      if (this.isLoaded) {
+        this.retrieveHashes();
       }
     },
   },
 
   methods: {
+    retrieveHashes() {
+      window.decodeHash();
+      const hash = window.hashParams;
+
+      switch (hash.authorshipSortBy) {
+      case 'path':
+      case 'fileName':
+      case 'fileType':
+        this.filesSortType = hash.authorshipSortBy;
+        break;
+      default:
+        // Invalid value, use the default value of 'lineOfCode'
+      }
+
+      if (hash.reverseAuthorshipOrder === 'false') {
+        this.toReverseSortFiles = false;
+      }
+
+      if ('authorshipFilesGlob' in hash) {
+        this.indicateSearchBar();
+        this.searchBarValue = hash.authorshipFilesGlob;
+      } else if ('authorshipFileTypes' in hash) {
+        const parsedFileTypes = hash.authorshipFileTypes.split('~');
+        this.selectedFileTypes = parsedFileTypes.filter((type) => this.fileTypes.includes(type));
+      }
+    },
+
     initiate() {
       const repo = window.REPOS[this.info.repo];
 
@@ -247,11 +280,22 @@ window.vAuthorship = {
       filesInfoObj[fileType] += lineCount;
     },
 
-    updateFilterSearch(evt) {
-      if (this.filterType === 'checkboxes') {
-        this.indicateSearchBar();
-      }
-      this.filterSearch = (evt.target.value.length !== 0) ? evt.target.value : '*';
+    updateSearchBarValue() {
+      this.searchBarValue = this.$refs.searchBar.value;
+
+      window.addHash('authorshipFilesGlob', this.searchBarValue);
+      window.removeHash('authorshipFileTypes');
+      window.encodeHash();
+    },
+
+    updateFileTypeHash() {
+      const fileTypeHash = this.selectedFileTypes.length > 0
+          ? this.selectedFileTypes.reduce((a, b) => `${a}~${b}`)
+          : '';
+
+      window.addHash('authorshipFileTypes', fileTypeHash);
+      window.removeHash('authorshipFilesGlob');
+      window.encodeHash();
     },
 
     indicateSearchBar() {
@@ -260,12 +304,9 @@ window.vAuthorship = {
     },
 
     indicateCheckBoxes() {
-      if (this.filterType === 'search') {
-        const searchBar = document.getElementById('search');
-        searchBar.value = '';
-        this.filterSearch = '*';
-        this.filterType = 'checkboxes';
-      }
+      this.searchBarValue = '';
+      this.filterType = 'checkboxes';
+      this.updateFileTypeHash();
     },
 
     getFileLink(file, path) {
@@ -298,20 +339,19 @@ window.vAuthorship = {
         return this.selectedFileTypes.length === this.fileTypes.length;
       },
       set(value) {
-        if (this.filterType === 'search') {
-          this.indicateCheckBoxes();
-        }
         if (value) {
           this.selectedFileTypes = this.fileTypes.slice();
         } else {
           this.selectedFileTypes = [];
         }
+
+        this.indicateCheckBoxes();
       },
     },
 
     selectedFiles() {
       return this.files.filter((file) => this.selectedFileTypes.includes(file.fileType)
-          && minimatch(file.path, this.filterSearch, { matchBase: true, dot: true }))
+          && minimatch(file.path, this.searchBarValue || '*', { matchBase: true, dot: true }))
           .sort(this.sortingFunction);
     },
 
@@ -333,6 +373,14 @@ window.vAuthorship = {
   created() {
     this.initiate();
     this.setInfoHash();
+  },
+
+  beforeDestroy() {
+    window.removeHash('authorshipFileTypes');
+    window.removeHash('authorshipFilesGlob');
+    window.removeHash('authorshipSortBy');
+    window.removeHash('reverseAuthorshipOrder');
+    window.encodeHash();
   },
 
   components: {

--- a/frontend/src/static/js/v_authorship.js
+++ b/frontend/src/static/js/v_authorship.js
@@ -59,6 +59,7 @@ window.vAuthorship = {
     isLoaded() {
       if (this.isLoaded) {
         this.retrieveHashes();
+        this.setInfoHash();
       }
     },
   },
@@ -78,17 +79,35 @@ window.vAuthorship = {
         // Invalid value, use the default value of 'lineOfCode'
       }
 
-      if (hash.reverseAuthorshipOrder === 'false') {
-        this.toReverseSortFiles = false;
-      }
+      this.toReverseSortFiles = hash.reverseAuthorshipOrder !== 'false';
 
       if ('authorshipFilesGlob' in hash) {
         this.indicateSearchBar();
         this.searchBarValue = hash.authorshipFilesGlob;
       } else if ('authorshipFileTypes' in hash) {
-        const parsedFileTypes = hash.authorshipFileTypes.split('~');
+        const parsedFileTypes = hash.authorshipFileTypes.split(window.HASH_FILETYPE_DELIMITER);
         this.selectedFileTypes = parsedFileTypes.filter((type) => this.fileTypes.includes(type));
       }
+    },
+
+    setInfoHash() {
+      const { addHash, encodeHash } = window;
+      // We only set these hashes as they are propagated from summary_charts
+      addHash('tabAuthor', this.info.author);
+      addHash('tabRepo', this.info.repo);
+      addHash('authorshipIsMergeGroup', this.info.isMergeGroup);
+      encodeHash();
+    },
+
+    removeAuthorshipHashes() {
+      window.removeHash('authorshipFileTypes');
+      window.removeHash('authorshipFilesGlob');
+      window.removeHash('authorshipSortBy');
+      window.removeHash('reverseAuthorshipOrder');
+      window.removeHash('tabAuthor');
+      window.removeHash('tabRepo');
+      window.removeHash('authorshipIsMergeGroup');
+      window.encodeHash();
     },
 
     initiate() {
@@ -140,14 +159,6 @@ window.vAuthorship = {
           this.filesLinesObj[type] = cnt;
         }
       });
-    },
-
-    setInfoHash() {
-      const { addHash, encodeHash } = window;
-      addHash('tabAuthor', this.info.author);
-      addHash('tabRepo', this.info.repo);
-      addHash('authorshipIsMergeGroup', this.info.isMergeGroup);
-      encodeHash();
     },
 
     expandAll() {
@@ -257,7 +268,6 @@ window.vAuthorship = {
 
       Object.keys(this.filesLinesObj).forEach((file) => {
         if (this.filesLinesObj[file] !== 0) {
-          this.selectedFileTypes.push(file);
           this.fileTypes.push(file);
         }
       });
@@ -372,15 +382,10 @@ window.vAuthorship = {
 
   created() {
     this.initiate();
-    this.setInfoHash();
   },
 
   beforeDestroy() {
-    window.removeHash('authorshipFileTypes');
-    window.removeHash('authorshipFilesGlob');
-    window.removeHash('authorshipSortBy');
-    window.removeHash('reverseAuthorshipOrder');
-    window.encodeHash();
+    this.removeAuthorshipHashes();
   },
 
   components: {

--- a/frontend/src/tabs/authorship.pug
+++ b/frontend/src/tabs/authorship.pug
@@ -30,13 +30,32 @@
             option(v-bind:value='false') Ascending
           label.medium-font order
       .searchbox
-        input.radio-button--search(type="radio", value="search", v-model="filterType")
-        form.file-picker.mui-form--inline(onsubmit="return false")
-          input#search.medium-font(type="search", placeholder="Filter by glob", v-on:change="updateFilterSearch",
-            v-on:click="indicateSearchBar")
-          button#submit-button.medium-font(type="submit", v-on:click="indicateSearchBar") Filter
+        input.radio-button--search(
+          type="radio",
+          value="search",
+          v-model="filterType",
+          v-on:change="indicateSearchBar(); updateSearchBarValue();"
+        )
+        .file-picker.mui-form--inline
+          input#search.medium-font(
+            type="search",
+            placeholder="Filter by glob",
+            ref="searchBar",
+            v-bind:value="searchBarValue",
+            v-on:focus="indicateSearchBar",
+            v-on:keyup.enter="updateSearchBarValue"
+          )
+          button#submit-button.medium-font(
+            type="button",
+            v-on:click="indicateSearchBar(); updateSearchBarValue();"
+          ) Filter
       .fileType
-        input.radio-button--checkbox(type="radio", value="checkboxes", v-model="filterType")
+        input.radio-button--checkbox(
+          type="radio",
+          value="checkboxes",
+          v-model="filterType",
+          v-on:change="indicateCheckBoxes"
+        )
         .checkboxes.mui-form--inline(v-if="files.length > 0")
           label
             input.mui-checkbox--fileType(type="checkbox", v-model="isSelectAllChecked")
@@ -47,7 +66,7 @@
           template(v-for="fileType in Object.keys(getFileTypeExistingLinesObj)")
             label(v-bind:key="fileType")
               input.mui-checkbox--fileType(type="checkbox", v-bind:id="fileType", v-bind:value="fileType",
-                v-on:click="indicateCheckBoxes", v-model="selectedFileTypes")
+                v-on:change="indicateCheckBoxes", v-model="selectedFileTypes")
               span(v-bind:title="getFileTypeBlankLineInfo(fileType)")
                 span {{ fileType }}: {{ getFileTypeExistingLinesObj[fileType] }}&nbsp;
                 span.bloc ({{ fileTypeBlankLinesObj[fileType] }})


### PR DESCRIPTION
Resolves #910 

```
Save authorship tab controls as hash parameters

The filter and sorting options for the authorship tab are not persisted
across page reloads.

This results having to re-select the options whenever the page is
reloaded, leading to a less pleasant user experience.

Let's save the options for these controls as hash parameters, and use
them across page reloads when available.
```