### PR TITLE
[#202, #1081] Authorship: improve file collapsing mechanism

### DIFF
--- a/frontend/src/static/css/v_authorship.scss
+++ b/frontend/src/static/css/v_authorship.scss
@@ -10,6 +10,14 @@
     border-width: 0 1px 1px 1px;
   }
 
+  .toolbar {
+    > a {
+      display: block;
+      margin: 1px 0;
+      text-align: end;
+    }
+  }
+
   .title {
     .contribution {
       color: mui-color('red');
@@ -90,23 +98,17 @@
 
     .file {
       pre {
-        display: none;
+        display: grid;
         // GitHub's font family and font size
         font-family: SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
         font-size: 12px;
-      }
+        margin-top: 0;
 
-      &.active {
-        pre {
-          display: grid;
-          margin-top: 0;
-
-          .hljs {
-            // overwrite hljs library
-            display: inherit;
-            padding: 0;
-            white-space: pre-wrap;
-          }
+        .hljs {
+          // overwrite hljs library
+          display: inherit;
+          padding: 0;
+          white-space: pre-wrap;
         }
       }
     }

--- a/frontend/src/static/js/v_authorship.js
+++ b/frontend/src/static/js/v_authorship.js
@@ -40,16 +40,11 @@ window.vAuthorship = {
       totalBlankLineCount: '',
       filesSortType: 'lineOfCode',
       toReverseSortFiles: true,
-      hasActiveFile: true,
       filterSearch: '*',
     };
   },
 
   watch: {
-    selectedFiles() {
-      setTimeout(this.updateCount, 0);
-    },
-
     filterType() {
       if (this.filterType === 'checkboxes') {
         const searchBar = document.getElementById('search');
@@ -103,19 +98,22 @@ window.vAuthorship = {
       encodeHash();
     },
 
-    expandAll(hasActiveFile) {
-      const renameValue = hasActiveFile ? 'file active' : 'file';
-
-      const files = document.getElementsByClassName('file');
-      Array.from(files).forEach((file) => {
-        file.className = renameValue;
+    expandAll() {
+      this.selectedFiles.forEach((file) => {
+        file.active = true;
+        file.wasCodeLoaded = true;
       });
-
-      this.hasActiveFile = hasActiveFile;
     },
 
-    updateCount() {
-      this.hasActiveFile = document.getElementsByClassName('file active').length > 0;
+    collapseAll() {
+      this.selectedFiles.forEach((file) => {
+        file.active = false;
+      });
+    },
+
+    toggleFileActiveProperty(file) {
+      file.active = !file.active;
+      file.wasCodeLoaded = file.wasCodeLoaded || file.active;
     },
 
     hasCommits(info) {
@@ -163,6 +161,7 @@ window.vAuthorship = {
     },
 
     processFiles(files) {
+      const COLLAPSED_VIEW_LINE_COUNT_THRESHOLD = 2000;
       const res = [];
       const fileTypeBlanksInfoObj = {};
       let totalLineCount = 0;
@@ -175,6 +174,8 @@ window.vAuthorship = {
           const out = {};
           out.path = file.path;
           out.lineCount = lineCnt;
+          out.active = lineCnt <= COLLAPSED_VIEW_LINE_COUNT_THRESHOLD;
+          out.wasCodeLoaded = lineCnt <= COLLAPSED_VIEW_LINE_COUNT_THRESHOLD;
           out.fileType = file.fileType;
 
           const segmentInfo = this.splitSegments(file.lines);
@@ -280,6 +281,10 @@ window.vAuthorship = {
           .sort(this.sortingFunction);
     },
 
+    activeFilesCount() {
+      return this.selectedFiles.filter((file) => file.active).length;
+    },
+
     getFileTypeExistingLinesObj() {
       const numLinesModified = {};
       Object.entries(this.filesLinesObj)
@@ -295,6 +300,7 @@ window.vAuthorship = {
     this.initiate();
     this.setInfoHash();
   },
+
   components: {
     vSegment: window.vSegment,
   },

--- a/frontend/src/tabs/authorship.pug
+++ b/frontend/src/tabs/authorship.pug
@@ -1,8 +1,8 @@
 #authorship
   span.large-font Code Panel
   .toolbar(v-if="hasCommits(info)")
-    a(v-if="hasActiveFile", v-on:click="expandAll(false)") hide all file details
-    a(v-else, v-on:click="expandAll(true)") show all file details
+    a(v-if="activeFilesCount < this.selectedFiles.length", v-on:click="expandAll()") show all file details
+    a(v-if="activeFilesCount > 0", v-on:click="collapseAll()") hide all file details
   .panel-heading
     a.group-name(
       v-bind:href="info.location", target="_blank",
@@ -55,9 +55,9 @@
   .files(v-if="isLoaded")
     .empty(v-if="files.length === 0") nothing to see here :(
     template(v-for="file in selectedFiles")
-      .file.active(v-bind:key="file.path")
+      .file(v-bind:key="file.path")
         .title
-          span.path(onclick="toggleNext(this.parentNode)", v-on:click="updateCount") {{ file.path }}&nbsp;
+          span.path(v-on:click="toggleFileActiveProperty(file)") {{ file.path }}&nbsp;
           span.loc ({{ file.lineCount }} lines)
           a(
             v-bind:href="getFileLink(file, 'commits')", target="_blank",
@@ -69,7 +69,7 @@
             title="click to view the blame view of file"
           )
             i.button.fas.fa-user-edit
-        pre.hljs.file-content
+        pre.hljs.file-content(v-if="file.wasCodeLoaded", v-show="file.active")
           template(v-for="segment in file.segments")
             v-segment(v-bind:segment="segment", v-bind:path="file.path")
 


### PR DESCRIPTION
Fixes #1081
Alleviates #202

```
Improve file collapsing in authorship view

The authorship tab relies on several dom querying methods to toggle
whether a file is collapsed from view.
This hurts the performance of file collapsing, and detracts from the
use of vue as RepoSense’s front-end framework, decreasing code
readability.

Let's refactor this to use a new variable in the file object instead,
allowing vue reactivity to take over this behaviour.
This also fixes a bug with files not staying collapsed after changing
the file filter [#1081].

With this change, we are able to conveniently display both the expand
and collapse all buttons at the same time. Let's do so as well.

Occasionally, a small number of files have a large number of line
contributions. This slows the initial loading time at best, and causes
the application to crash at worst.
Let's use the new variable to collapse files with more than
2000 lines of code by default, alleviating this.

```