### PR TITLE
[#1069] Fix regression due to #943

### DIFF
--- a/frontend/src/tabs/zoom.pug
+++ b/frontend/src/tabs/zoom.pug
@@ -54,8 +54,8 @@
     template(v-if="day.insertions > 0")
       h3(v-if="filterTimeFrame === 'week'") Week of {{ day.date }}
       h3(v-else) {{ day.date }}
-      template
-        .commit-message(
+      ul
+        li.commit-message(
             v-for="slice in day.commitResults"
             v-bind:key="slice.hash"
             v-bind:class="{ 'message-body active': slice.messageBody !== '' }"


### PR DESCRIPTION
Fixed #1069 

```
Due to regression of #943, the commit messages in the
commit panel are not displayed as a list anymore.

Let's make them appear as a list again.
```