### PR TITLE
[#1081] Authorship view: bug in `hide all file details` button

### DIFF
--- a/frontend/src/static/js/v_authorship.js
+++ b/frontend/src/static/js/v_authorship.js
@@ -296,6 +296,14 @@ window.vAuthorship = {
       return `Total: Blank: ${this.totalBlankLineCount}, Non-Blank: ${
         this.totalLineCount - this.totalBlankLineCount}`;
     },
+
+    toDisplay(file) {
+      if (this.selectedFiles.includes(file)
+          && minimatch(file.path, this.filterSearch, { matchBase: true })) {
+        return 'block';
+      }
+      return 'none';
+    },
   },
 
   computed: {
@@ -303,6 +311,9 @@ window.vAuthorship = {
       return this.files.filter((file) => this.isSelectedFileTypes(file.fileType)
           && minimatch(file.path, this.filterSearch, { matchBase: true }))
           .sort(this.sortingFunction);
+    },
+    sortedFiles() {
+      return this.files.sort(this.sortingFunction);
     },
     getFileTypeExistingLinesObj() {
       const numLinesModified = {};

--- a/frontend/src/tabs/authorship.pug
+++ b/frontend/src/tabs/authorship.pug
@@ -55,8 +55,10 @@
 
   .files(v-if="isLoaded")
     .empty(v-if="files.length === 0") nothing to see here :(
-    template(v-for="file in selectedFiles")
-      .file.active(v-bind:key="file.path")
+    template(v-for="file in sortedFiles", v-bind:key="file.path")
+      .file.active(
+        v-bind:style="{ display: `${toDisplay(file)}`}"
+      )
         .title
           span.path(onclick="toggleNext(this.parentNode)", v-on:click="updateCount") {{ file.path }}&nbsp;
           span.loc ({{ file.lineCount }} lines)


### PR DESCRIPTION
Fixes #1081
```
When changing file type filter, the state of each file div is not
reserved. Thus, the file detail will always be displayed when
`selectedFiles` is recomputed. 

We can reserve the state of the file div to retain the change in
whether we should display the details for a certain file.

Let's make the vue template loop for all files and decide if we
should display certain file by dynamically binding the style.
```