### PR TITLE
Add auto scrolling when a segment is collapsed

### DIFF
--- a/frontend/src/static/js/v_segment.js
+++ b/frontend/src/static/js/v_segment.js
@@ -14,5 +14,13 @@ window.vSegment = {
         window.toggleNext(this.$el.childNodes[0]);
       });
     },
+    collapseCode() {
+      const segmentTop = this.$refs.topButton.getBoundingClientRect().top;
+      if (segmentTop < 0) {
+        this.$refs.topButton.scrollIntoView();
+      }
+
+      window.toggleNext(this.$el.childNodes[0]);
+    },
   },
 };

--- a/frontend/src/tabs/segment.pug
+++ b/frontend/src/tabs/segment.pug
@@ -1,10 +1,10 @@
 .segment(v-bind:class="{ untouched: !segment.authored, active: segment.lines.length < 5 }")
-  .closer(v-if="!segment.authored && segment.lines.length > 4", v-on:click="loadCode()")
+  .closer(v-if="!segment.authored && segment.lines.length > 4", v-on:click="loadCode()", ref="topButton")
     i.fas.fa-plus-circle.icon.open(v-bind:title="'Click to open code'")
     i.fas.fa-chevron-circle-down.icon.hide(v-bind:title="'Click to hide code'")
   div(v-if="loaded", v-hljs="path")
     .code(v-for="(line, index) in segment.lines")
       .line-number {{ segment.lineNumbers[index] + "\n" }}
       .line-content {{ line + "\n" }}
-  .closer.bottom(v-if="!segment.authored && segment.lines.length > 4", v-on:click="loadCode()")
+  .closer.bottom(v-if="!segment.authored && segment.lines.length > 4", v-on:click="collapseCode")
     i.fas.fa-chevron-circle-up.icon.hide(v-bind:title="'Click to hide code'")


### PR DESCRIPTION
```
Add auto scrolling when a segment is collapsed

When a segment is collapsed, the scroll position of the authorship view
remains at the same position.
This can cause the user to feel lost after collapsing the segment.

Let's implement auto scrolling for the segment collapse button.
If the top button is out of the user’s view, the authorship view will be
scrolled to the segment’s top.
```