### PR TITLE
[#1107] Hide zero line file types from summary view legend

### DIFF
--- a/frontend/src/static/js/v_summary.js
+++ b/frontend/src/static/js/v_summary.js
@@ -243,7 +243,7 @@ window.vSummary = {
       const fileTypes = [];
       repo.forEach((user) => {
         Object.keys(user.fileTypeContribution).forEach((fileType) => {
-          if (!fileTypes.includes(fileType)) {
+          if (!fileTypes.includes(fileType) && user.fileTypeContribution[fileType] > 0) {
             fileTypes.push(fileType);
           }
         });


### PR DESCRIPTION
Fixes #1107 

```
Hide zero line file types from summary view legend

The file type legend in the summary view displays file types with zero
lines amongst all the authors in the repo.

Let’s hide the legend for such file types.
```