### PR TITLE
Refactor ramp and zoom globals

### DIFF
--- a/frontend/src/ramp.pug
+++ b/frontend/src/ramp.pug
@@ -3,7 +3,7 @@
     template(v-for="(slice, j) in user.commits")
       a.ramp__slice(
         draggable="false",
-        onclick="rampClick(event);",
+        v-on:click="rampClick",
         v-for="(commit, k) in slice.commitResults",
         v-if="commit.insertions>0",
         v-bind:href="getLink(user, commit)", target="_blank",
@@ -20,7 +20,7 @@
   template(v-else)
     a.ramp__slice(
       draggable="false",
-      onclick="rampClick(event);",
+      v-on:click="rampClick",
       v-for="(slice, j) in user.commits",
       v-if="slice.insertions > 0",
       v-bind:title="`${tframe === 'day' \

--- a/frontend/src/static/js/v_ramp.js
+++ b/frontend/src/static/js/v_ramp.js
@@ -4,12 +4,6 @@ function getBaseLink(repoId) {
     window.REPOS[repoId].location.repoName}`;
 }
 
-window.rampClick = function rampClick(evt) {
-  const isKeyPressed = this.isMacintosh ? evt.metaKey : evt.ctrlKey;
-  if (isKeyPressed) {
-    evt.preventDefault();
-  }
-};
 
 window.vRamp = {
   props: ['groupby', 'user', 'tframe', 'avgsize', 'sdate', 'udate', 'mergegroup'],
@@ -76,6 +70,14 @@ window.vRamp = {
     getSliceColor(date) {
       const timeMs = (new Date(date)).getTime();
       return (timeMs / window.DAY_IN_MS) % 5;
+    },
+
+    // Prevent browser from switching to new tab when clicking ramp
+    rampClick(evt) {
+      const isKeyPressed = window.isMacintosh ? evt.metaKey : evt.ctrlKey;
+      if (isKeyPressed) {
+        evt.preventDefault();
+      }
     },
   },
 };

--- a/frontend/src/static/js/v_zoom.js
+++ b/frontend/src/static/js/v_zoom.js
@@ -1,8 +1,3 @@
-const commitSortDict = {
-  lineOfCode: (commit) => commit.insertions,
-  time: (commit) => commit.date,
-};
-
 window.vZoom = {
   props: ['info'],
   template: window.$('v_zoom').innerHTML,
@@ -17,8 +12,12 @@ window.vZoom = {
 
   computed: {
     sortingFunction() {
+      const commitSortFunction = this.commitsSortType === 'time'
+        ? (commit) => commit.date
+        : (commit) => commit.insertions;
+
       return (a, b) => (this.toReverseSortedCommits ? -1 : 1)
-      * window.comparator(commitSortDict[this.commitsSortType])(a, b);
+        * window.comparator(commitSortFunction)(a, b);
     },
     filteredUser() {
       const {


### PR DESCRIPTION
```
Refactor ramp and zoom globals

The ramp and zoom components have some component specific methods and
variables that can be moved inside the component definition.

Let’s do so, encapsulating component logic within the component itself.
```

ps: Travis is passing but the status isn't being reported back, have tried rebuilding quite a few times