### PR TITLE
[#1109] Config.json: include active author and pug file format

### DIFF
--- a/_reposense/config.json
+++ b/_reposense/config.json
@@ -1,6 +1,6 @@
 {
 	"ignoreGlobList": ["**.adoc", "collate**"],
-	"formats": ["gradle", "jade", "pug", "java", "js", "md", "scss", "yml"],
+	"formats": ["gradle", "pug", "java", "js", "md", "scss", "yml"],
 	"ignoreCommitList": ["7b96c563eb2d3612aa5275364333664a18f01491",
 		"90018e49f129ce7e0abdc8b18e91c9813588c601",
 		"b8dbc3cf3c7c334665a828cf4236dcb442228c94",

--- a/_reposense/config.json
+++ b/_reposense/config.json
@@ -1,6 +1,6 @@
 {
 	"ignoreGlobList": ["**.adoc", "collate**"],
-	"formats": ["gradle", "jade", "java", "js", "md", "scss", "yml"],
+	"formats": ["gradle", "jade", "pug", "java", "js", "md", "scss", "yml"],
 	"ignoreCommitList": ["7b96c563eb2d3612aa5275364333664a18f01491",
 		"90018e49f129ce7e0abdc8b18e91c9813588c601",
 		"b8dbc3cf3c7c334665a828cf4236dcb442228c94",

--- a/_reposense/config.json
+++ b/_reposense/config.json
@@ -10,11 +10,6 @@
 	"authors":
 	[
 		{
-			"githubId": "AdityaA1998",
-			"displayName": "Aditya",
-			"authorNames": ["AdityaA1998"]
-		},
-		{
 			"githubId": "eugenepeh",
 			"displayName": "Eugene",
 			"authorNames": ["Eugene Peh"]

--- a/_reposense/config.json
+++ b/_reposense/config.json
@@ -20,6 +20,11 @@
 			"authorNames": ["Eugene Peh"]
 		},
 		{
+			"githubId": "jamessspanggg",
+			"displayName": "James",
+			"authorNames": ["James Pang"]
+		},
+		{
 			"githubId": "ongspxm",
 			"displayName": "Metta",
 			"authorNames": ["Metta Ong"]


### PR DESCRIPTION
Fixes #1109 

```
The default configuration consists of authors that are no longer
active in committing code to RepoSense. The jade file format is
no longer used in RepoSense as it is replaced by pug file format.

Let's add a recent active author, as it may reveal potential bugs.
Let's replace jade to pug file format as well.
```