### PR TITLE
[#1124] Authorship: file name starting with period not displayed

### DIFF
--- a/frontend/src/static/js/v_authorship.js
+++ b/frontend/src/static/js/v_authorship.js
@@ -276,7 +276,7 @@ window.vAuthorship = {
 
     selectedFiles() {
       return this.files.filter((file) => this.selectedFileTypes.includes(file.fileType)
-          && minimatch(file.path, this.filterSearch, { matchBase: true }))
+          && minimatch(file.path, this.filterSearch, { matchBase: true, dot: true }))
           .sort(this.sortingFunction);
     },
 


### PR DESCRIPTION
Fix #1124

```
File with name starting with period will not have its detail displayed
on authorship panel.

This is due to the minimatch library used which by default will not
match name `a/**/b` with `a/.d/b`, unless dot is set. So the file is
filtered out from selected files.

Let's set the dot property to true to allow the file details to be
displayed properly.
```