### PR TITLE
[#850] Ignore git submodules when analyzing repos

### DIFF
--- a/src/main/java/reposense/git/GitDiff.java
+++ b/src/main/java/reposense/git/GitDiff.java
@@ -20,7 +20,7 @@ public class GitDiff {
      */
     public static String diffCommit(String root, String lastCommitHash) {
         Path rootPath = Paths.get(root);
-        return runCommand(rootPath, "git diff -U0 " + lastCommitHash);
+        return runCommand(rootPath, "git diff -U0 --ignore-submodules=all " + lastCommitHash);
     }
 
     /**

--- a/src/main/java/reposense/git/GitDiff.java
+++ b/src/main/java/reposense/git/GitDiff.java
@@ -28,7 +28,8 @@ public class GitDiff {
      * {@code repoRoot}.
      */
     public static List<String> getModifiedFilesList(Path repoRoot) {
-        String diffCommand = String.format("git diff --numstat %s %s", EMPTY_TREE_HASH, CHECKED_OUT_COMMIT_REFERENCE);
+        String diffCommand = String.format("git diff --ignore-submodules=all --numstat %s %s",
+                EMPTY_TREE_HASH, CHECKED_OUT_COMMIT_REFERENCE);
         String diffResult = runCommand(repoRoot.toAbsolutePath(), diffCommand);
         return Arrays.asList(diffResult.split("\n"));
     }

--- a/src/test/java/reposense/git/GitDiffTest.java
+++ b/src/test/java/reposense/git/GitDiffTest.java
@@ -31,4 +31,11 @@ public class GitDiffTest extends GitTestTemplate {
     public void diffCommit_nonexistentCommitHash_throwsRunTimeException() {
         GitDiff.diffCommit(config.getRepoRoot(), NONEXISTENT_COMMIT_HASH);
     }
+
+    @Test
+    public void diffCommit_commitContainingSubmodule_ignoresSubmodule() {
+        GitCheckout.checkout(config.getRepoRoot(), "850-GitDiffTest-commitWithSubmodule_success");
+        String diffResult = GitDiff.diffCommit(config.getRepoRoot(), LATEST_COMMIT_HASH);
+        Assert.assertFalse(diffResult.contains("Subproject commit e41deb84c36c2430caf742abdbd96cc2dc4a09ca"));
+    }
 }

--- a/src/test/java/reposense/git/GitDiffTest.java
+++ b/src/test/java/reposense/git/GitDiffTest.java
@@ -34,8 +34,9 @@ public class GitDiffTest extends GitTestTemplate {
 
     @Test
     public void diffCommit_commitContainingSubmodule_ignoresSubmodule() {
-        GitCheckout.checkout(config.getRepoRoot(), "850-GitDiffTest-commitWithSubmodule_success");
-        String diffResult = GitDiff.diffCommit(config.getRepoRoot(), LATEST_COMMIT_HASH);
-        Assert.assertFalse(diffResult.contains("Subproject commit e41deb84c36c2430caf742abdbd96cc2dc4a09ca"));
+        GitCheckout.checkout(config.getRepoRoot(),
+                "850-GitDiffTest-diffCommit_commitContainingSubmodule_ignoresSubmodule");
+        String diffResult = GitDiff.diffCommit(config.getRepoRoot(), EMPTY_TREE_HASH);
+        Assert.assertFalse(diffResult.contains("Subproject commit"));
     }
 }

--- a/src/test/java/reposense/template/GitTestTemplate.java
+++ b/src/test/java/reposense/template/GitTestTemplate.java
@@ -41,6 +41,7 @@ public class GitTestTemplate {
     protected static final String JAMES_AUTHOR_NAME = "jamessspanggg";
     protected static final String JINYAO_AUTHOR_NAME = "jylee-git";
     protected static final String LATEST_COMMIT_HASH = "136c6713fc00cfe79a1598e8ce83c6ef3b878660";
+    protected static final String EMPTY_TREE_HASH = "4b825dc642cb6eb9a060e54bf8d69288fbee4904";
     protected static final String EUGENE_AUTHOR_README_FILE_COMMIT_07052018_STRING =
             "2d87a431fcbb8f73a731b6df0fcbee962c85c250";
     protected static final CommitHash EUGENE_AUTHOR_README_FILE_COMMIT_07052018 =


### PR DESCRIPTION
Fixes #850 

```
Repos that contains git submodules are not handled properly and cannot
be analyzed.

This is due to the diff result including the submodule information.

Let set --ignore-submodules=all in the git diff command to ignore all
submodule information.
```