### PR TITLE
[#1137][#1138] Expand pug-lint glob and remove fix option in lint

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -66,7 +66,7 @@ This project follows [oss-generic coding standards](https://oss-generic.github.i
 Optionally, you can follow the [Using Checkstyle](UsingCheckstyle.md) document to configure *Intellij* to check style-compliance as you write code.
 
 ### Configuring the JavaScript and CSS coding style
-Our project follows the [Airbnb Javascript Style Guide](https://github.com/airbnb/javascript) and [OSS CSS Coding Standard](https://oss-generic.github.io/process/codingStandards/CodingStandard-Css.html), which is governed by the Eslint and Stylelint respectively. We have our own customized style checker for the Pug files, which is governed by pug-lint. Their configuration files can be found at the root of the project. Please run a `npm run lint` from the project root directory and fix all of the lint errors before committing your code for final review.
+Our project follows the [Airbnb Javascript Style Guide](https://github.com/airbnb/javascript) and [OSS CSS Coding Standard](https://oss-generic.github.io/process/codingStandards/CodingStandard-Css.html), which is governed by the Eslint and Stylelint respectively. We have our own customized style checker for the Pug files, which is governed by pug-lint. Their configuration files can be found at the root of the project. Please run a `npm run lint` from the project root directory and fix all of the lint errors before committing your code for final review.  You can also use the `npm run lintfix` script to automatically fix some of the javascript and css lint errors!
 
 Eslint, Stylelint and their accompanying modules can be installed through NPM, so do ensure that you got it [installed](https://www.npmjs.com/get-npm) if you are working on the report.
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "doc": "docs"
   },
   "scripts": {
-    "lint": "eslint -- --fix frontend/src/**/*js frontend/cypress/**.js && stylelint frontend/src/**/*.scss && pug-lint frontend/src/*.pug frontend/src/tabs/*.pug",
+    "lint": "eslint frontend/src/**/*js frontend/cypress/**.js && stylelint frontend/src/**/*.scss && npm run puglint",
+    "puglint": "pug-lint frontend/src/index.pug frontend/src/ramp.pug frontend/src/summary.pug frontend/src/tabs/authorship.pug frontend/src/tabs/segment.pug frontend/src/tabs/zoom.pug",
+    "lintfix": "eslint --fix frontend/src/**/*js frontend/cypress/**.js && stylelint --fix frontend/src/**/*.scss",
     "browserify": "browserify -t vueify -e frontend/src/static/js/v_authorship.js -o frontend/build/static/js/v_authorship.js",
     "spuild": "spuild frontend"
   },


### PR DESCRIPTION
Fixes #1137 
Fixes #1138

```
Expand pug-lint glob and remove fix option in lint

The pug-lint command does not expand globs provided as arguments,
relying instead on bash wildcard expansion. This causes the pug-lint
command to fail on windows.
The main linting script was also written with the --fix option, which
can increase the build time for CI.
This may also cause auto-fixable errors to go undetected, although the
lint script has an extra ‘--' that causes --fix to be recognised as a
file.

Let’s manually expand the globs for the pug-lint command, moving it to
a separate script for brevity.
Let’s also remove the --fix option used by the main linting script,
and move it to a separate lintfix script.
At the same time, let’s introduce --fix for stylelint as well.
```