### PR TITLE
[#1140] Update date hashes when updating date range

### DIFF
--- a/frontend/src/static/js/v_summary.js
+++ b/frontend/src/static/js/v_summary.js
@@ -636,6 +636,8 @@ window.vSummary = {
     },
 
     updateDateRange(since, until) {
+      this.hasModifiedSinceDate = true;
+      this.hasModifiedUntilDate = true;
       this.tmpFilterSinceDate = since;
       this.tmpFilterUntilDate = until;
       deactivateAllOverlays();


### PR DESCRIPTION
Fixes #1140 

```
Clicking on the show ramp chart in this period does not update 
the since and until date hashes, which leads to a different 
summary period after reloading the page.

This is due to the hasModifedSinceDate and hasModifiedUntilDate
not set to true when calling updateDateRange, which prevents
the since and until date hashes to be updated.

Let's set hasModifedSinceDate and hasModifiedUntilDate to be
true when updateDateRange is called.
```