### PR TITLE
[#1129] Reposense class: Throw exception earlier

### DIFF
--- a/src/main/java/reposense/RepoSense.java
+++ b/src/main/java/reposense/RepoSense.java
@@ -125,6 +125,7 @@ public class RepoSense {
 
     /**
      * Constructs a list of {@code RepoConfiguration} if {@code cliArguments} is a {@code LocationsCliArguments}.
+     * If no {@code RepoConfiguration} can be constructed, the method throws a {@code IllegalStateException}.
      */
     public static List<RepoConfiguration> getRepoConfigurations(LocationsCliArguments cliArguments) {
         List<RepoConfiguration> configs = new ArrayList<>();
@@ -134,6 +135,10 @@ public class RepoSense {
             } catch (InvalidLocationException ile) {
                 logger.log(Level.WARNING, ile.getMessage(), ile);
             }
+        }
+
+        if (configs.isEmpty()) {
+            throw new IllegalStateException("Must include at least 1 valid location.");
         }
 
         return configs;

--- a/src/test/java/reposense/parser/ArgsParserTest.java
+++ b/src/test/java/reposense/parser/ArgsParserTest.java
@@ -462,14 +462,13 @@ public class ArgsParserTest {
         Assert.assertEquals(repoAliasCliArguments, reposAliasCliArguments);
     }
 
-    @Test
+    @Test(expected = IllegalStateException.class)
     public void parse_invalidRepoLocation_emptyRepoConfigurationList()
             throws ParseException, HelpScreenException {
         String input = new InputBuilder().addRepos("https://githubaaaa.com/asdasdasdasd/RepoSense").build();
         CliArguments cliArguments = ArgsParser.parse(translateCommandline(input));
         Assert.assertTrue(cliArguments instanceof LocationsCliArguments);
-        List<RepoConfiguration> repoConfigs = RepoSense.getRepoConfigurations((LocationsCliArguments) cliArguments);
-        Assert.assertTrue(repoConfigs.isEmpty());
+        RepoSense.getRepoConfigurations((LocationsCliArguments) cliArguments);
     }
 
     @Test(expected = ParseException.class)


### PR DESCRIPTION
Fixes #1129 

Reposense class: throw exception earlier in `getRepoConfigurations`
Currently, `Reposense` continues with report generation even though there are no valid repo locations in the `--repo` arguments. 

This results in a late crash during the execution of the `cloneAndAnalyzeRepos` method quite some time after Reposense runs. 

Let’s add a state-test at the end of the `getRepoConfigurations` method, to check if any repo location(s) are valid. If there are none, then throw an `IllegalStateException`.

`getRepoConfigurations` is the method that constructs a list of `RepoLocation` objects from the inputs. It is the earliest way to check if there are valid locations, making it easier to identify the cause of the command failure. `IllegalStateException` is thrown as it is not possible for the application to recover and generate reports, because the precondition that is at least 1 valid argument is not met. 
