### PR TITLE
[#1178] Make github profile and repo hyperlinks more consistent

### DIFF
--- a/frontend/src/index.pug
+++ b/frontend/src/index.pug
@@ -15,6 +15,7 @@ html
     link(rel="stylesheet", href="static/css/v_zoom.css")
 
     script(src="https://use.fontawesome.com/releases/v5.0.13/js/all.js", defer=True)
+    script(src="https://cdn.jsdelivr.net/npm/@fortawesome/vue-fontawesome@0.1.9/index.min.js")
     script(src="https://cdn.jsdelivr.net/npm/vue@2.5/dist/vue.js")
     script(src="https://cdn.jsdelivr.net/npm/jszip@3.1/dist/jszip.min.js")
 

--- a/frontend/src/index.pug
+++ b/frontend/src/index.pug
@@ -59,7 +59,7 @@ html
         #tabs-wrapper(v-if="isTabActive")
           #tab-resize(onmousedown="registerMouseMove()")
           .tab-close(v-on:click="deactivateTab")
-            i.fas.fa-caret-right
+            font-awesome-icon(icon="caret-right")
           .tab-content.panel-padding
             .tab-panes
               v-authorship#tab-authorship.tab-pane(
@@ -74,11 +74,11 @@ html
               #tab-empty.tab-pane(v-else)
                 .title
                   span To view the code attributed to a specific author, click the &nbsp;
-                  i.fas.fa-code
+                  font-awesome-icon(icon="code")
                   span &nbsp; icon next to that author's name.
                   br
                   span To hide the code view, click the &nbsp;
-                  i.fas.fa-caret-right
+                  font-awesome-icon(icon="caret-right")
                   span &nbsp; icon on the left.
 
       template(v-else)

--- a/frontend/src/static/js/main.js
+++ b/frontend/src/static/js/main.js
@@ -96,6 +96,8 @@ Vue.directive('hljs', {
   },
 });
 
+Vue.component('font-awesome-icon', window['vue-fontawesome'].FontAwesomeIcon);
+
 window.app = new window.Vue({
   el: '#app',
   data: {

--- a/frontend/src/summary.pug
+++ b/frontend/src/summary.pug
@@ -72,7 +72,7 @@
     .error-message-box__close-button(onclick="dismissTab(this)") &times;
     .error-message-box__message The following issues occurred when analyzing the following repositories:
     .error-message-box__failed-repo(v-for="errorBlock in errorMessages")
-      i.fas.fa-exclamation.mini-font
+      font-awesome-icon.mini-font(icon="exclamation")
       span.error-message-box__failed-repo--name {{ errorBlock.repoName }}
       .error-message-box__failed-repo--reason(
         v-if="errorBlock.errorMessage.startsWith('Unexpected error stack trace')"

--- a/frontend/src/summary_charts.pug
+++ b/frontend/src/summary_charts.pug
@@ -11,25 +11,25 @@
       .summary-charts__title--contribution.mini-font(
         title="Total contribution of group"
       ) [{{ getGroupTotalContribution(repo) }} lines]
-      template(v-if="isMergeGroup")
-        a(
-          v-if="filterGroupSelection === 'groupByRepos'",
-          v-bind:href="getRepoLink(repo[0])", target="_blank",
-          title="click to view group's repo"
-        )
-          i.icon-button.fab.fa-github
-        a(
-          v-else-if="filterGroupSelection === 'groupByAuthors'",
-          v-bind:href="getAuthorProfileLink(repo[0].name)", target="_blank",
-          title="click to view author's profile"
-        )
-          i.icon-button.fab.fa-github
-        a(
-          title="click to view breakdown of commits",
-          onclick="deactivateAllOverlays()",
-          v-on:click="openTabZoom(repo[0], filterSinceDate, filterUntilDate, repo, 0)"
-        )
-          i.icon-button.fas.fa-list-ul
+      a(
+        v-if="filterGroupSelection === 'groupByRepos'",
+        v-bind:href="getRepoLink(repo[0])", target="_blank",
+        title="click to view group's repo"
+      )
+        font-awesome-icon.icon-button(:icon="['fab', 'github']")
+      a(
+        v-else-if="filterGroupSelection === 'groupByAuthors'",
+        v-bind:href="getAuthorProfileLink(repo[0].name)", target="_blank",
+        title="click to view author's profile"
+      )
+        font-awesome-icon.icon-button(icon="user")
+      a(
+        v-if="isMergeGroup"
+        title="click to view breakdown of commits",
+        onclick="deactivateAllOverlays()",
+        v-on:click="openTabZoom(repo[0], filterSinceDate, filterUntilDate, repo, 0)"
+      )
+        font-awesome-icon.icon-button(icon="list-ul")
       .summary-charts__title--percentile.mini-font {{ getPercentile(i) }} %
     .summary-charts__fileType--breakdown(v-if="filterBreakdown")
       template(v-if="filterGroupSelection !== 'groupByNone'")
@@ -37,7 +37,8 @@
           v-for="fileType in getFileTypes(repo)",
           v-bind:key="fileType"
         )
-          i.fas.fa-circle(
+          font-awesome-icon(
+            icon="circle",
             v-bind:style="{ 'color' : fileTypeColors[fileType] }"
           )
           span &nbsp; {{ fileType }} &nbsp;
@@ -52,22 +53,29 @@
         ) {{ user.displayName }} ({{ user.name }})
         .summary-chart__title--contribution.mini-font [{{ user.totalCommits }} lines]
         a(
+          v-if="filterGroupSelection !== 'groupByRepos'",
+          v-bind:href="getRepoLink(repo[i])", target="_blank",
+          title="click to view repo"
+        )
+          font-awesome-icon.icon-button(:icon="['fab', 'github']")
+        a(
+          v-if="filterGroupSelection !== 'groupByAuthors'",
+          v-bind:href="getAuthorProfileLink(repo[i].name)", target="_blank",
+          title="click to view author's profile"
+        )
+          font-awesome-icon.icon-button(icon="user")
+        a(
           title="click to view author's code",
           onclick="deactivateAllOverlays()",
           v-on:click="openTabAuthorship(user, repo, i)"
         )
-          i.icon-button.fas.fa-code
-        a(
-          v-bind:href="getRepoLink(repo[i])", target="_blank",
-          title="click to view author's repo"
-        )
-          i.icon-button.fab.fa-github
+          font-awesome-icon.icon-button(icon="code")
         a(
           title="click to view breakdown of commits",
           onclick="deactivateAllOverlays()",
           v-on:click="openTabZoom(user, filterSinceDate, filterUntilDate)"
         )
-          i.icon-button.fas.fa-list-ul
+          font-awesome-icon.icon-button(icon="list-ul")
         .summary-chart__title--percentile.mini-font(
           v-if="filterGroupSelection === 'groupByNone'"
         ) {{ getPercentile(i) }} %

--- a/frontend/src/summary_charts.pug
+++ b/frontend/src/summary_charts.pug
@@ -24,7 +24,7 @@
       )
         font-awesome-icon.icon-button(icon="user")
       a(
-        v-if="isMergeGroup"
+        v-if="isMergeGroup",
         title="click to view breakdown of commits",
         onclick="deactivateAllOverlays()",
         v-on:click="openTabZoom(repo[0], filterSinceDate, filterUntilDate, repo, 0)"

--- a/frontend/src/tabs/authorship.pug
+++ b/frontend/src/tabs/authorship.pug
@@ -63,12 +63,12 @@
             v-bind:href="getFileLink(file, 'commits')", target="_blank",
             title="click to view the history view of file"
           )
-            i.button.fas.fa-history
+            font-awesome-icon.button(icon="history")
           a(
             v-bind:href="getFileLink(file, 'blame')", target="_blank",
             title="click to view the blame view of file"
           )
-            i.button.fas.fa-user-edit
+            font-awesome-icon.button(icon="user-edit")
         pre.hljs.file-content(v-if="file.wasCodeLoaded", v-show="file.active")
           template(v-for="segment in file.segments")
             v-segment(v-bind:segment="segment", v-bind:path="file.path")

--- a/frontend/src/tabs/segment.pug
+++ b/frontend/src/tabs/segment.pug
@@ -1,10 +1,10 @@
 .segment(v-bind:class="{ untouched: !segment.authored, active: segment.lines.length < 5 }")
   .closer(v-if="!segment.authored && segment.lines.length > 4", v-on:click="loadCode()")
-    i.fas.fa-plus-circle.icon.open(v-bind:title="'Click to open code'")
-    i.fas.fa-chevron-circle-down.icon.hide(v-bind:title="'Click to hide code'")
+    font-awesome-icon.icon.open(icon="plus-circle", v-bind:title="'Click to open code'")
+    font-awesome-icon.icon.hide(icon="chevron-circle-down", v-bind:title="'Click to hide code'")
   div(v-if="loaded", v-hljs="path")
     .code(v-for="(line, index) in segment.lines")
       .line-number {{ segment.lineNumbers[index] + "\n" }}
       .line-content {{ line + "\n" }}
   .closer.bottom(v-if="!segment.authored && segment.lines.length > 4", v-on:click="loadCode()")
-    i.fas.fa-chevron-circle-up.icon.hide(v-bind:title="'Click to hide code'")
+    font-awesome-icon.icon.hide(icon="chevron-circle-up", v-bind:title="'Click to hide code'")

--- a/frontend/src/tabs/zoom.pug
+++ b/frontend/src/tabs/zoom.pug
@@ -32,7 +32,7 @@
               v-for="tag in commitResult.tags",
               v-on:click="scrollToCommit(tag, `tag ${commitResult.hash}`)"
             )
-              i.fas.fa-tags
+              font-awesome-icon(icon="tags")
               span &nbsp;{{ tag }}
 
   v-ramp(
@@ -73,7 +73,7 @@
         span &nbsp; ({{ slice.insertions }} lines) &nbsp;
         template(v-if="slice.tags", v-for="tag in slice.tags")
           .tag.mini-font(tabindex="-1", v-bind:class="[`${slice.hash}`, tag]")
-            i.fas.fa-tags
+            font-awesome-icon(icon="tags")
             span &nbsp;{{ tag }}
         a(
           v-if="slice.messageBody !== ''",
@@ -81,7 +81,7 @@
           onclick="toggleNext(this)",
           title="Click to show/hide the commit message body"
         )
-          i.commit-message--button.fas.fa-ellipsis-h
+          font-awesome-icon.commit-message--button(icon="ellipsis-h")
         .body(v-if="slice.messageBody !== ''")
           pre {{ slice.messageBody }}
             .dashed-border


### PR DESCRIPTION
Fixes #1178 and  #1191.
```
When grouped by repo, the same icon to link to the repo is duplicated
multiple times for no reason. Also, the icon to link to the author's
profile is hard to find.

We can make the links more intuitive and consistent by putting links to
the author's profile beside author names, and links to repo beside repo
names.

Let's reorder the icon group such that the hyperlinks are closer to the
respective names, as well as always showing the icons beside their
respective names. As this change heavily relies on the icons being
responsive, let's resolve issue #1191 as well to make use of
vue-fontawesome to make the icons responsive.
```

Note that there are some existing bugs that affect this PR.
1. Affected by #1185, but should work with the previews as the `config.json` is specified. Preferably merge after #1185 is resolved.