### PR TITLE
[#1201] Fix regressions of PR #779

### DIFF
--- a/frontend/src/static/js/v_zoom.js
+++ b/frontend/src/static/js/v_zoom.js
@@ -58,7 +58,7 @@ window.vZoom = {
     },
 
     getSliceLink(slice) {
-      if (this.info.isMergeGroup) {
+      if (this.info.zIsMerge) {
         return `${window.getBaseLink(slice.repoId)}/commit/${slice.hash}`;
       }
       return `${window.getBaseLink(this.info.zUser.repoId)}/commit/${slice.hash}`;

--- a/frontend/src/tabs/zoom.pug
+++ b/frontend/src/tabs/zoom.pug
@@ -6,7 +6,7 @@
   .zoom__title
     .zoom_title--group.large-font
       span(
-        v-if="info.filterGroupSelection === 'groupByAuthors'"
+        v-if="info.zFilterGroup === 'groupByAuthors'"
       ) {{ filteredUser.displayName }} ({{ filteredUser.name }})
       a(
         v-else,


### PR DESCRIPTION
Fixes #1201 

```
There are regressions caused by PR #779, where the zIsMerge and 
zFilterGroup properties are not used properly within zoom tab.
They are using isMergeGroup and filterGroupSelection instead.

Let's modify them to use zIsMerge and zFilterGroup instead, in this 
way the zoom tab will be using the correct property values.
```