### PR TITLE
[#1163] GitLsTreeTest: Improve unix_cloneInvalidWindowsFilePaths_success

### DIFF
--- a/src/test/java/reposense/git/GitLsTreeTest.java
+++ b/src/test/java/reposense/git/GitLsTreeTest.java
@@ -70,11 +70,12 @@ public class GitLsTreeTest extends GitTestTemplate {
     }
 
     @Test
-    public void unix_cloneInvalidWindowsFilePaths_success() {
+    public void unix_cloneInvalidWindowsFilePaths_success() throws Exception {
         // Runs test only on non Windows (Unix) operating systems
         Assume.assumeTrue(!SystemUtil.isWindows());
 
         config.setBranch("391-invalid-filepaths");
+        validateFilePaths(config);
     }
 
     /**


### PR DESCRIPTION
Fixes #1163 

```
When RepoSense is run on Windows OS, it uses the 'validateFilePaths' 
method of the GitLsTree class to verify  if all the file paths in 
the repo are valid file paths on Windows OS.

Within unix_cloneInvalidWindowsFilePaths_success test case, it 
checks whether 'validateFilePaths' method runs correctly on 
non Windows OS. However, this test does not actually call
the `validateFilePaths` method.

Let's call 'validateFilePaths' in the test case, so we can 
confirm that the method works correctly on non Windows OS.

```