### PR TITLE
[#1213] Pass sorting props to v_summary_charts

### DIFF
--- a/frontend/src/static/js/v_summary_charts.js
+++ b/frontend/src/static/js/v_summary_charts.js
@@ -92,7 +92,7 @@ window.viewClick = function viewClick(evt) {
 window.vSummaryCharts = {
   props: ['checkedFileTypes', 'filtered', 'fileTypeColors', 'avgContributionSize', 'filterBreakdown',
       'filterGroupSelection', 'filterTimeFrame', 'filterSinceDate', 'filterUntilDate', 'isMergeGroup',
-      'minDate', 'maxDate'],
+      'minDate', 'maxDate', 'sortingOption', 'sortingWithinOption', 'isSortingDsc', 'isSortingWithinDsc'],
   template: window.$('v_summary_charts').innerHTML,
   computed: {
     avgCommitSize() {

--- a/frontend/src/summary.pug
+++ b/frontend/src/summary.pug
@@ -120,5 +120,9 @@
     v-bind:filter-until-date="filterUntilDate",
     v-bind:is-merge-group="isMergeGroup",
     v-bind:min-date="minDate",
-    v-bind:max-date="maxDate"
+    v-bind:max-date="maxDate",
+    v-bind:sorting-option="sortingOption",
+    v-bind:sorting-within-option="sortingWithinOption",
+    v-bind:is-sorting-dsc="isSortingDsc",
+    v-bind:is-sorting-within-dsc="isSortingWithinDsc"
   )


### PR DESCRIPTION
Fixes #1213 

```
With the recent merged PR #1059, the data related to sorting were not
passed from v_summary to v_summary_charts, even though v_summary_charts
uses those data within openTabZoom method.

This results in zoom tab to not be restorable at some situations, as it 
is unable to utilise the sorting options.

Let's pass all data related to sorting from v_summary to 
v_summary_charts as props.
```