### PR TITLE
[#1230] Hide show all commit messages link when no messages available

### DIFF
--- a/frontend/src/static/css/panels.scss
+++ b/frontend/src/static/css/panels.scss
@@ -90,6 +90,16 @@
 .toolbar {
   cursor: pointer;
   float: right;
+
+  &--multiline {
+    float: right;
+
+    > a {
+      display: block;
+      margin: 1px 0;
+      text-align: end;
+    }
+  }
 }
 
 .sorting {

--- a/frontend/src/static/css/v_authorship.scss
+++ b/frontend/src/static/css/v_authorship.scss
@@ -10,14 +10,6 @@
     border-width: 0 1px 1px 1px;
   }
 
-  .toolbar {
-    > a {
-      display: block;
-      margin: 1px 0;
-      text-align: end;
-    }
-  }
-
   .title {
     .contribution {
       .radio-button--search {

--- a/frontend/src/static/css/v_zoom.scss
+++ b/frontend/src/static/css/v_zoom.scss
@@ -1,5 +1,13 @@
 @import 'colors';
 
+.toolbar {
+  > a {
+    display: block;
+    margin: 1px 0;
+    text-align: end;
+  }
+}
+
 .zoom {
   &__title {
     &--granularity {

--- a/frontend/src/static/css/v_zoom.scss
+++ b/frontend/src/static/css/v_zoom.scss
@@ -1,13 +1,5 @@
 @import 'colors';
 
-.toolbar {
-  > a {
-    display: block;
-    margin: 1px 0;
-    text-align: end;
-  }
-}
-
 .zoom {
   &__title {
     &--granularity {

--- a/frontend/src/tabs/authorship.pug
+++ b/frontend/src/tabs/authorship.pug
@@ -1,6 +1,6 @@
 #authorship
   span.large-font Code Panel
-  .toolbar(v-if="hasCommits(info)")
+  .toolbar--multiline(v-if="hasCommits(info)")
     a(v-if="activeFilesCount < this.selectedFiles.length", v-on:click="expandAll()") show all file details
     a(v-if="activeFilesCount > 0", v-on:click="collapseAll()") hide all file details
   .panel-heading

--- a/frontend/src/tabs/zoom.pug
+++ b/frontend/src/tabs/zoom.pug
@@ -38,7 +38,6 @@
               v-for="tag in commitResult.tags",
               v-on:click="scrollToCommit(tag, `tag ${commitResult.hash}`)"
             )
-
               font-awesome-icon(icon="tags")
               span &nbsp;{{ tag }}
 

--- a/frontend/src/tabs/zoom.pug
+++ b/frontend/src/tabs/zoom.pug
@@ -1,8 +1,14 @@
 #zoom
   span.large-font Commits Panel
   .toolbar(v-if="filteredUser.commits.length")
-    a(v-if="expandedCommitMessagesCount === 0", v-on:click="toggleAllCommitMessagesBody(true)") show all commit messages
-    a(v-else, v-on:click="toggleAllCommitMessagesBody(false)") hide all commit messages
+    a(
+      v-if="totalCommitMessageBodyCount !== 0 && expandedCommitMessagesCount === 0",
+      v-on:click="toggleAllCommitMessagesBody(true)"
+    ) show all commit messages
+    a(
+      v-if="totalCommitMessageBodyCount !== 0 && expandedCommitMessagesCount !== 0",
+      v-on:click="toggleAllCommitMessagesBody(false)"
+    ) hide all commit messages
   .panel-heading
     .group-name
       span(

--- a/frontend/src/tabs/zoom.pug
+++ b/frontend/src/tabs/zoom.pug
@@ -1,14 +1,15 @@
 #zoom
   span.large-font Commits Panel
   .toolbar(v-if="filteredUser.commits.length")
-    a(
-      v-if="totalCommitMessageBodyCount !== 0 && expandedCommitMessagesCount === 0",
-      v-on:click="toggleAllCommitMessagesBody(true)"
-    ) show all commit messages
-    a(
-      v-if="totalCommitMessageBodyCount !== 0 && expandedCommitMessagesCount !== 0",
-      v-on:click="toggleAllCommitMessagesBody(false)"
-    ) hide all commit messages
+    template(v-if="totalCommitMessageBodyCount !== 0")
+      a(
+        v-if="expandedCommitMessagesCount === 0",
+        v-on:click="toggleAllCommitMessagesBody(true)"
+      ) show all commit messages
+      a(
+        v-else,
+        v-on:click="toggleAllCommitMessagesBody(false)"
+      ) hide all commit messages
   .panel-heading
     .group-name
       span(
@@ -38,6 +39,7 @@
               v-for="tag in commitResult.tags",
               v-on:click="scrollToCommit(tag, `tag ${commitResult.hash}`)"
             )
+
               font-awesome-icon(icon="tags")
               span &nbsp;{{ tag }}
 

--- a/frontend/src/tabs/zoom.pug
+++ b/frontend/src/tabs/zoom.pug
@@ -6,7 +6,7 @@
       v-on:click="toggleAllCommitMessagesBody(true)"
     ) show all commit messages
     a(
-      v-if="expandedCommitMessagesCount !== 0",
+      v-if="expandedCommitMessagesCount > 0",
       v-on:click="toggleAllCommitMessagesBody(false)"
     ) hide all commit messages
   .panel-heading

--- a/frontend/src/tabs/zoom.pug
+++ b/frontend/src/tabs/zoom.pug
@@ -1,15 +1,14 @@
 #zoom
   span.large-font Commits Panel
-  .toolbar(v-if="filteredUser.commits.length")
-    template(v-if="totalCommitMessageBodyCount !== 0")
-      a(
-        v-if="expandedCommitMessagesCount === 0",
-        v-on:click="toggleAllCommitMessagesBody(true)"
-      ) show all commit messages
-      a(
-        v-else,
-        v-on:click="toggleAllCommitMessagesBody(false)"
-      ) hide all commit messages
+  .toolbar(v-if="filteredUser.commits.length && totalCommitMessageBodyCount")
+    a(
+      v-if="expandedCommitMessagesCount < totalCommitMessageBodyCount",
+      v-on:click="toggleAllCommitMessagesBody(true)"
+    ) show all commit messages
+    a(
+      v-if="expandedCommitMessagesCount !== 0",
+      v-on:click="toggleAllCommitMessagesBody(false)"
+    ) hide all commit messages
   .panel-heading
     .group-name
       span(

--- a/frontend/src/tabs/zoom.pug
+++ b/frontend/src/tabs/zoom.pug
@@ -1,6 +1,6 @@
 #zoom
   span.large-font Commits Panel
-  .toolbar(v-if="filteredUser.commits.length && totalCommitMessageBodyCount")
+  .toolbar--multiline(v-if="filteredUser.commits.length && totalCommitMessageBodyCount")
     a(
       v-if="expandedCommitMessagesCount < totalCommitMessageBodyCount",
       v-on:click="toggleAllCommitMessagesBody(true)"


### PR DESCRIPTION
Fixes https://github.com/reposense/RepoSense/issues/1230

```
Currently the `show all commit messages` link on the zoom view displays
even when there is no messages available to show. 

This may cause confusion to the user because clicking on the link gives
no effect.

Let's hide the link when there are no available messages to show.
```