### PR TITLE
[#1244] Add handling of filenames wrapped in double quotes

### DIFF
--- a/src/main/java/reposense/commits/CommitInfoAnalyzer.java
+++ b/src/main/java/reposense/commits/CommitInfoAnalyzer.java
@@ -1,5 +1,7 @@
 package reposense.commits;
 
+import static reposense.util.StringsUtil.removeQuote;
+
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
@@ -151,14 +153,19 @@ public class CommitInfoAnalyzer {
      * Extracts the correct file path from the unprocessed git log {@code filePath}
      */
     private static String extractFilePath(String filePath) {
-        if (!filePath.contains(MOVED_FILE_INDICATION)) {
-            return filePath;
+        String filteredFilePath = filePath;
+        if (filteredFilePath.contains(MOVED_FILE_INDICATION)) {
+            // moved file has the format: fileA => newPosition/fileA
+            filteredFilePath = filteredFilePath.substring(filePath.indexOf(MOVED_FILE_INDICATION)
+                    + MOVED_FILE_INDICATION.length());
+
+            // Removes the trailing '}' character from the file name, as renamed file names have ending '}' character.
+            filteredFilePath = filteredFilePath.replaceAll("}$", "");
         }
-        // moved file has the format: fileA => newPosition/fileA
-        String filteredFilePath =
-                filePath.substring(filePath.indexOf(MOVED_FILE_INDICATION) + MOVED_FILE_INDICATION.length());
-        // Removes the trailing '}' character from the file name, as renamed file names have ending '}' character.
-        filteredFilePath = filteredFilePath.replaceAll("}$", "");
+
+        // Removes the trailing double quotes from the file name, as filenames that have special characters
+        // will be escaped and surrounded by double quotes automatically. e.g. READ\ME.md -> "READ\\ME.md"
+        filteredFilePath = removeQuote(filteredFilePath);
         return filteredFilePath;
     }
 

--- a/src/main/java/reposense/commits/CommitInfoAnalyzer.java
+++ b/src/main/java/reposense/commits/CommitInfoAnalyzer.java
@@ -158,7 +158,6 @@ public class CommitInfoAnalyzer {
             // moved file has the format: fileA => newPosition/fileA
             filteredFilePath = filteredFilePath.substring(filePath.indexOf(MOVED_FILE_INDICATION)
                     + MOVED_FILE_INDICATION.length());
-
             // Removes the trailing '}' character from the file name, as renamed file names have ending '}' character.
             filteredFilePath = filteredFilePath.replaceAll("}$", "");
         }

--- a/src/main/java/reposense/commits/CommitInfoExtractor.java
+++ b/src/main/java/reposense/commits/CommitInfoExtractor.java
@@ -31,6 +31,7 @@ public class CommitInfoExtractor {
         logger.info(String.format(MESSAGE_START_EXTRACTING_COMMIT_INFO, config.getLocation(), config.getBranch()));
 
         GitCheckout.checkoutBranch(config.getRepoRoot(), config.getBranch());
+
         List<CommitInfo> repoCommitInfos = new ArrayList<>();
 
         for (Author author : config.getAuthorList()) {

--- a/src/main/java/reposense/commits/CommitInfoExtractor.java
+++ b/src/main/java/reposense/commits/CommitInfoExtractor.java
@@ -31,10 +31,11 @@ public class CommitInfoExtractor {
         logger.info(String.format(MESSAGE_START_EXTRACTING_COMMIT_INFO, config.getLocation(), config.getBranch()));
 
         GitCheckout.checkoutBranch(config.getRepoRoot(), config.getBranch());
-
+        System.out.println("after checkout");
         List<CommitInfo> repoCommitInfos = new ArrayList<>();
 
         for (Author author : config.getAuthorList()) {
+            System.out.println("before git log of author " + author.getDisplayName());
             String gitLogResult = GitLog.getWithFiles(config, author);
             List<CommitInfo> authorCommitInfos = parseGitLogResults(gitLogResult);
             repoCommitInfos.addAll(authorCommitInfos);

--- a/src/main/java/reposense/commits/CommitInfoExtractor.java
+++ b/src/main/java/reposense/commits/CommitInfoExtractor.java
@@ -30,13 +30,10 @@ public class CommitInfoExtractor {
     public static List<CommitInfo> extractCommitInfos(RepoConfiguration config) {
         logger.info(String.format(MESSAGE_START_EXTRACTING_COMMIT_INFO, config.getLocation(), config.getBranch()));
 
-        System.out.println("before checkout");
         GitCheckout.checkoutBranch(config.getRepoRoot(), config.getBranch());
-        System.out.println("after checkout");
         List<CommitInfo> repoCommitInfos = new ArrayList<>();
 
         for (Author author : config.getAuthorList()) {
-            System.out.println("before git log of author " + author.getDisplayName());
             String gitLogResult = GitLog.getWithFiles(config, author);
             List<CommitInfo> authorCommitInfos = parseGitLogResults(gitLogResult);
             repoCommitInfos.addAll(authorCommitInfos);

--- a/src/main/java/reposense/commits/CommitInfoExtractor.java
+++ b/src/main/java/reposense/commits/CommitInfoExtractor.java
@@ -30,6 +30,7 @@ public class CommitInfoExtractor {
     public static List<CommitInfo> extractCommitInfos(RepoConfiguration config) {
         logger.info(String.format(MESSAGE_START_EXTRACTING_COMMIT_INFO, config.getLocation(), config.getBranch()));
 
+        System.out.println("before checkout");
         GitCheckout.checkoutBranch(config.getRepoRoot(), config.getBranch());
         System.out.println("after checkout");
         List<CommitInfo> repoCommitInfos = new ArrayList<>();

--- a/src/test/java/reposense/commits/CommitInfoAnalyzerTest.java
+++ b/src/test/java/reposense/commits/CommitInfoAnalyzerTest.java
@@ -30,6 +30,7 @@ public class CommitInfoAnalyzerTest extends GitTestTemplate {
     private static final FileType FILETYPE_JAVA = new FileType("java", Collections.singletonList("**java"));
     private static final FileType FILETYPE_MD = new FileType("md", Collections.singletonList("**md"));
     private static final FileType FILETYPE_JSON = new FileType("json", Collections.singletonList("**json"));
+    private static final FileType FILETYPE_TXT = new FileType("txt", Collections.singletonList("**txt"));
 
     @Before
     public void before() throws Exception {
@@ -282,6 +283,35 @@ public class CommitInfoAnalyzerTest extends GitTestTemplate {
         List<CommitInfo> actualCommitInfos = CommitInfoExtractor.extractCommitInfos(config);
         List<CommitResult> actualCommitResults = CommitInfoAnalyzer.analyzeCommits(actualCommitInfos, config);
 
+        Assert.assertEquals(expectedCommitResults, actualCommitResults);
+    }
+
+    @Test
+    public void analyzeCommits_fileNameWithSpecialChars_success() throws Exception {
+        Author author = new Author(JAMES_ALTERNATIVE_AUTHOR_NAME);
+        List<CommitResult> expectedCommitResults = new ArrayList<>();
+        Map<FileType, ContributionPair> firstFileTypeAndContributionMap = new HashMap<>();
+        firstFileTypeAndContributionMap.put(FILETYPE_TXT, new ContributionPair(1, 0));
+        expectedCommitResults.add(new CommitResult(author, "cfb3c8dc477cb0af19fce8bead4d278f35afa396",
+                parseGitStrictIsoDate("2020-04-20T12:09:39+08:00"),
+                "Create file name without special chars",
+                "", null, firstFileTypeAndContributionMap));
+        Map<FileType, ContributionPair> secondFileTypeAndContributionMap = new HashMap<>();
+        secondFileTypeAndContributionMap.put(FILETYPE_TXT, new ContributionPair(0, 0));
+        expectedCommitResults.add(new CommitResult(author, "17bde492e9a80d8699ad193cf87e677341f936cc",
+                parseGitStrictIsoDate("2020-04-20T12:17:40+08:00"),
+                "Rename to file name with special chars",
+                "", null, secondFileTypeAndContributionMap));
+
+        config.setBranch("1244-CommitInfoAnalyzerTest-analyzeCommits_fileNameWithSpecialChars_success");
+        config.setAuthorList(Collections.singletonList(author));
+        config.setSinceDate(new GregorianCalendar(2020, Calendar.APRIL, 20).getTime());
+        config.setUntilDate(new GregorianCalendar(2020, Calendar.APRIL, 21).getTime());
+
+        List<CommitInfo> actualCommitInfos = CommitInfoExtractor.extractCommitInfos(config);
+        List<CommitResult> actualCommitResults = CommitInfoAnalyzer.analyzeCommits(actualCommitInfos, config);
+
+        Assert.assertEquals(2, actualCommitInfos.size());
         Assert.assertEquals(expectedCommitResults, actualCommitResults);
     }
 

--- a/src/test/java/reposense/commits/CommitInfoAnalyzerTest.java
+++ b/src/test/java/reposense/commits/CommitInfoAnalyzerTest.java
@@ -11,6 +11,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -22,6 +23,7 @@ import reposense.model.CommitHash;
 import reposense.model.FileType;
 import reposense.model.FileTypeTest;
 import reposense.template.GitTestTemplate;
+import reposense.util.SystemUtil;
 
 public class CommitInfoAnalyzerTest extends GitTestTemplate {
     private static final int NUMBER_EUGENE_COMMIT = 1;
@@ -288,6 +290,9 @@ public class CommitInfoAnalyzerTest extends GitTestTemplate {
 
     @Test
     public void analyzeCommits_fileNameWithSpecialChars_success() throws Exception {
+        // Runs test only on non Windows (Unix) operating systems as the file names are invalid in windows
+        Assume.assumeTrue(!SystemUtil.isWindows());
+
         Author author = new Author(JAMES_ALTERNATIVE_AUTHOR_NAME);
         List<CommitResult> expectedCommitResults = new ArrayList<>();
         Map<FileType, ContributionPair> firstFileTypeAndContributionMap = new HashMap<>();

--- a/src/test/java/reposense/template/GitTestTemplate.java
+++ b/src/test/java/reposense/template/GitTestTemplate.java
@@ -38,6 +38,7 @@ public class GitTestTemplate {
     protected static final String YONG_AUTHOR_NAME = "Yong Hao TENG";
     protected static final String MINGYI_AUTHOR_NAME = "myteo";
     protected static final String JAMES_AUTHOR_NAME = "jamessspanggg";
+    protected static final String JAMES_ALTERNATIVE_AUTHOR_NAME = "James Pang";
     protected static final String JINYAO_AUTHOR_NAME = "jylee-git";
     protected static final String LATEST_COMMIT_HASH = "136c6713fc00cfe79a1598e8ce83c6ef3b878660";
     protected static final String EMPTY_TREE_HASH = "4b825dc642cb6eb9a060e54bf8d69288fbee4904";


### PR DESCRIPTION
Fixes #1244 

```
When a filename contains special characters such as double quotes
or the backslash character \, git log will escape those characters and
surround the entire file name with double quotes.

CommitInfoAnalyzer is not handling these cases, which will lead to an
assertion error that fails the entire analysis.

Let's add the handling of such cases, removing the surrounded quotes
from the filenames, if available.
```

An example to show how Git Log displays files with special characters:
actual: `"READ\ME"` 
how git log displays:`"\"READ\\ME\""`

<img width="1145" alt="Screen Shot 2020-04-19 at 7 27 58 PM" src="https://user-images.githubusercontent.com/32864116/79714538-bf8c3980-8303-11ea-8184-c7d6e42da5c8.png">

Reference to the failed analysis in [CS2103's travis build](https://travis-ci.org/github/nus-cs2103-AY1920S2/ip-dashboard/builds)