### PR TITLE
[#1249] Disable view code icon when merge group and group by authors

### DIFF
--- a/frontend/src/summary_charts.pug
+++ b/frontend/src/summary_charts.pug
@@ -25,6 +25,7 @@
         font-awesome-icon.icon-button(icon="user")
       template(v-if="isMergeGroup")
         a(
+          v-if="filterGroupSelection !== 'groupByAuthors'"
           title="click to view group's code",
           onclick="deactivateAllOverlays()",
           v-on:click="openTabAuthorship(repo[0], repo, 0)"


### PR DESCRIPTION
Fixes #1249
```
View code icon shows when group by authors and merge group is
selected.

However, the functionality is not implemented yet. Clicking on the
icon shows garbage results.

Let's remove the icon when group by authors and merge group is selected.
```