### PR TITLE
[#1139] Fix no-param- reassign warnings

### DIFF
--- a/frontend/src/static/js/api.js
+++ b/frontend/src/static/js/api.js
@@ -108,9 +108,10 @@ window.api = {
   setContributionOfCommitResults(dailyCommits) {
     dailyCommits.forEach((commit) => {
       commit.commitResults.forEach((result) => {
-        result.insertions = Object.values(result.fileTypesAndContributionMap)
+        const copyResult = result;
+        copyResult.insertions = Object.values(result.fileTypesAndContributionMap)
             .reduce((acc, fileType) => acc + fileType.insertions, 0);
-        result.deletions = Object.values(result.fileTypesAndContributionMap)
+        copyResult.deletions = Object.values(result.fileTypesAndContributionMap)
             .reduce((acc, fileType) => acc + fileType.deletions, 0);
       });
     });

--- a/frontend/src/static/js/api.js
+++ b/frontend/src/static/js/api.js
@@ -109,9 +109,9 @@ window.api = {
     dailyCommits.forEach((commit) => {
       commit.commitResults.forEach((result) => {
         const copyResult = result;
-        copyResult.insertions = Object.values(result.fileTypesAndContributionMap)
+        copyResult.insertions = Object.values(copyResult.fileTypesAndContributionMap)
             .reduce((acc, fileType) => acc + fileType.insertions, 0);
-        copyResult.deletions = Object.values(result.fileTypesAndContributionMap)
+        copyResult.deletions = Object.values(copyResult.fileTypesAndContributionMap)
             .reduce((acc, fileType) => acc + fileType.deletions, 0);
       });
     });

--- a/frontend/src/static/js/safari_date.js
+++ b/frontend/src/static/js/safari_date.js
@@ -20,13 +20,14 @@ function validateInputDate(event) {
 }
 
 function deleteDashInputDate(event) {
+  const copyEvent = event;
   const key = event.keyCode;
   const date = event.target.value;
   // remove two chars before the cursor's position if deleting dash character
   if (isBackSpaceOrDeleteKey(key)) {
     const cursorPosition = event.target.selectionStart;
     if (date[cursorPosition - 1] === '-') {
-      event.target.value = date.slice(0, cursorPosition - 1);
+      copyEvent.target.value = date.slice(0, cursorPosition - 1);
     }
   }
 }
@@ -37,11 +38,12 @@ window.formatInputDateOnKeyDown = function (event) {
 };
 
 window.appendDashInputDate = function (event) {
+  const copyEvent = event;
   const date = event.target.value;
   // append dash to date with format yyyy-mm-dd
   if (date.match(/^\d{4}$/) !== null) {
-    event.target.value += '-';
+    copyEvent.target.value += '-';
   } else if (date.match(/^\d{4}-\d{2}$/) !== null) {
-    event.target.value += '-';
+    copyEvent.target.value += '-';
   }
 };

--- a/frontend/src/static/js/safari_date.js
+++ b/frontend/src/static/js/safari_date.js
@@ -21,11 +21,11 @@ function validateInputDate(event) {
 
 function deleteDashInputDate(event) {
   const copyEvent = event;
-  const key = event.keyCode;
-  const date = event.target.value;
+  const key = copyEvent.keyCode;
+  const date = copyEvent.target.value;
   // remove two chars before the cursor's position if deleting dash character
   if (isBackSpaceOrDeleteKey(key)) {
-    const cursorPosition = event.target.selectionStart;
+    const cursorPosition = copyEvent.target.selectionStart;
     if (date[cursorPosition - 1] === '-') {
       copyEvent.target.value = date.slice(0, cursorPosition - 1);
     }
@@ -39,7 +39,7 @@ window.formatInputDateOnKeyDown = function (event) {
 
 window.appendDashInputDate = function (event) {
   const copyEvent = event;
-  const date = event.target.value;
+  const date = copyEvent.target.value;
   // append dash to date with format yyyy-mm-dd
   if (date.match(/^\d{4}$/) !== null) {
     copyEvent.target.value += '-';

--- a/frontend/src/static/js/v_authorship.js
+++ b/frontend/src/static/js/v_authorship.js
@@ -167,20 +167,23 @@ window.vAuthorship = {
 
     expandAll() {
       this.selectedFiles.forEach((file) => {
-        file.active = true;
-        file.wasCodeLoaded = true;
+        const copyFile = file;
+        copyFile.active = true;
+        copyFile.wasCodeLoaded = true;
       });
     },
 
     collapseAll() {
       this.selectedFiles.forEach((file) => {
-        file.active = false;
+        const copyFile = file;
+        copyFile.active = false;
       });
     },
 
     toggleFileActiveProperty(file) {
-      file.active = !file.active;
-      file.wasCodeLoaded = file.wasCodeLoaded || file.active;
+      const copyFile = file;
+      copyFile.active = !file.active;
+      copyFile.wasCodeLoaded = file.wasCodeLoaded || file.active;
     },
 
     hasCommits(info) {
@@ -288,11 +291,12 @@ window.vAuthorship = {
     },
 
     addBlankLineCount(fileType, lineCount, filesInfoObj) {
-      if (!filesInfoObj[fileType]) {
-        filesInfoObj[fileType] = 0;
+      const copyFilesInfoObj = filesInfoObj;
+      if (!copyFilesInfoObj[fileType]) {
+        copyFilesInfoObj[fileType] = 0;
       }
 
-      filesInfoObj[fileType] += lineCount;
+      copyFilesInfoObj[fileType] += lineCount;
     },
 
     updateSearchBarValue() {

--- a/frontend/src/static/js/v_authorship.js
+++ b/frontend/src/static/js/v_authorship.js
@@ -182,8 +182,8 @@ window.vAuthorship = {
 
     toggleFileActiveProperty(file) {
       const copyFile = file;
-      copyFile.active = !file.active;
-      copyFile.wasCodeLoaded = file.wasCodeLoaded || file.active;
+      copyFile.active = !copyFile.active;
+      copyFile.wasCodeLoaded = copyFile.wasCodeLoaded || copyFile.active;
     },
 
     hasCommits(info) {

--- a/frontend/src/static/js/v_summary.js
+++ b/frontend/src/static/js/v_summary.js
@@ -6,7 +6,7 @@ const dateFormatRegex = /([12]\d{3}-(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01]))$/;
 
 window.deactivateAllOverlays = function deactivateAllOverlays() {
   document.querySelectorAll('.summary-chart__ramp .overlay')
-      .forEach((x) => { x.className = 'overlay'; });
+      .forEach((x) => { x.classList.add('overlay'); });
 };
 
 window.getDateStr = function getDateStr(date) {

--- a/frontend/src/static/js/v_summary.js
+++ b/frontend/src/static/js/v_summary.js
@@ -377,8 +377,8 @@ window.vSummary = {
           copyCommitResult.repoId = user.repoId;
         });
 
-        if (Object.prototype.hasOwnProperty.call(dateToIndexMap, date)) {
-          const commitWithSameDate = merged[dateToIndexMap[date]];
+        if (Object.prototype.hasOwnProperty.call(copyDateToIndexMap, date)) {
+          const commitWithSameDate = merged[copyDateToIndexMap[date]];
 
           commitResults.forEach((commitResult) => {
             commitWithSameDate.commitResults.push(commitResult);
@@ -387,7 +387,7 @@ window.vSummary = {
           commitWithSameDate.insertions += insertions;
           commitWithSameDate.deletions += deletions;
         } else {
-          copyDateToIndexMap[date] = Object.keys(dateToIndexMap).length;
+          copyDateToIndexMap[date] = Object.keys(copyDateToIndexMap).length;
           merged.push(commit);
         }
       });
@@ -399,7 +399,7 @@ window.vSummary = {
         const key = fileType[0];
         const value = fileType[1];
 
-        if (!Object.prototype.hasOwnProperty.call(merged, key)) {
+        if (!Object.prototype.hasOwnProperty.call(copyMerged, key)) {
           copyMerged[key] = 0;
         }
         copyMerged[key] += value;
@@ -553,7 +553,7 @@ window.vSummary = {
         const commit = commits.shift();
         copyWeek.insertions += commit.insertions;
         copyWeek.deletions += commit.deletions;
-        commit.commitResults.forEach((commitResult) => week.commitResults.push(commitResult));
+        commit.commitResults.forEach((commitResult) => copyWeek.commitResults.push(commitResult));
       }
     },
 
@@ -569,11 +569,11 @@ window.vSummary = {
         return null;
       }
 
-      if (!sinceDate || sinceDate === 'undefined') {
+      if (!copySinceDate || copySinceDate === 'undefined') {
         copySinceDate = userFirst.date;
       }
 
-      if (!untilDate) {
+      if (!copyUntilDate) {
         copyUntilDate = userLast.date;
       }
 
@@ -595,7 +595,7 @@ window.vSummary = {
 
     filterCommitByCheckedFileTypes(commit) {
       const copyCommit = commit;
-      const filteredCommitResults = commit.commitResults.map((result) => {
+      const filteredCommitResults = copyCommit.commitResults.map((result) => {
         const filteredFileTypes = this.getFilteredFileTypes(result);
         this.updateCommitResultWithFileTypes(result, filteredFileTypes);
         return result;
@@ -614,7 +614,7 @@ window.vSummary = {
           .reduce((obj, fileType) => {
             const copyObj = obj;
             copyObj[fileType] = commitResult.fileTypesAndContributionMap[fileType];
-            return obj;
+            return copyObj;
           }, {});
     },
 
@@ -673,7 +673,7 @@ window.vSummary = {
 
     updateTmpFilterSinceDate(event) {
       const copyEvent = event;
-      const since = event.target.value;
+      const since = copyEvent.target.value;
       this.hasModifiedSinceDate = true;
 
       if (!this.isSafariBrowser) {
@@ -693,7 +693,7 @@ window.vSummary = {
 
     updateTmpFilterUntilDate(event) {
       const copyEvent = event;
-      const until = event.target.value;
+      const until = copyEvent.target.value;
       this.hasModifiedUntilDate = true;
 
       if (!this.isSafariBrowser) {
@@ -714,9 +714,9 @@ window.vSummary = {
     updateCheckedFileTypeContribution(ele) {
       const copyEle = ele;
       let validCommits = 0;
-      Object.keys(ele.fileTypeContribution).forEach((fileType) => {
+      Object.keys(copyEle.fileTypeContribution).forEach((fileType) => {
         if (this.checkedFileTypes.includes(fileType)) {
-          validCommits += ele.fileTypeContribution[fileType];
+          validCommits += copyEle.fileTypeContribution[fileType];
         }
       });
       copyEle.checkedFileTypeContribution = validCommits;
@@ -874,7 +874,7 @@ window.vSummary = {
   beforeMount() {
     this.$root.$on('restoreCommits', (info) => {
       const copyInfo = info;
-      const zoomFilteredUser = this.restoreZoomFiltered(info);
+      const zoomFilteredUser = this.restoreZoomFiltered(copyInfo);
       copyInfo.zUser = zoomFilteredUser;
     });
 

--- a/frontend/src/static/js/v_summary.js
+++ b/frontend/src/static/js/v_summary.js
@@ -6,7 +6,10 @@ const dateFormatRegex = /([12]\d{3}-(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01]))$/;
 
 window.deactivateAllOverlays = function deactivateAllOverlays() {
   document.querySelectorAll('.summary-chart__ramp .overlay')
-      .forEach((x) => { x.classList.add('overlay'); });
+      .forEach((x) => {
+        const copyX = x;
+        copyX.className = 'overlay';
+      });
 };
 
 window.getDateStr = function getDateStr(date) {

--- a/frontend/src/static/js/v_summary_charts.js
+++ b/frontend/src/static/js/v_summary_charts.js
@@ -37,7 +37,8 @@ function getBaseTarget(target) {
 function deactivateAllOverlays() {
   document.querySelectorAll('.summary-chart__ramp .overlay')
       .forEach((x) => {
-        x.classList.add('overlay');
+        const copyX = x;
+        copyX.className = 'overlay';
       });
 }
 

--- a/frontend/src/static/js/v_summary_charts.js
+++ b/frontend/src/static/js/v_summary_charts.js
@@ -37,7 +37,7 @@ function getBaseTarget(target) {
 function deactivateAllOverlays() {
   document.querySelectorAll('.summary-chart__ramp .overlay')
       .forEach((x) => {
-        x.className = 'overlay';
+        x.classList.add('overlay');
       });
 }
 

--- a/frontend/src/static/js/v_zoom.js
+++ b/frontend/src/static/js/v_zoom.js
@@ -100,7 +100,8 @@ window.vZoom = {
 
       const commitMessageClasses = document.getElementsByClassName('commit-message message-body');
       Array.from(commitMessageClasses).forEach((commitMessageClass) => {
-        commitMessageClass.classList.add(toRename);
+        const copyCommitMessageClass = commitMessageClass;
+        copyCommitMessageClass.className = (toRename);
       });
 
       this.expandedCommitMessagesCount = isActive ? this.totalCommitMessageBodyCount : 0;

--- a/frontend/src/static/js/v_zoom.js
+++ b/frontend/src/static/js/v_zoom.js
@@ -100,7 +100,7 @@ window.vZoom = {
 
       const commitMessageClasses = document.getElementsByClassName('commit-message message-body');
       Array.from(commitMessageClasses).forEach((commitMessageClass) => {
-        commitMessageClass.className = toRename;
+        commitMessageClass.classList.add(toRename);
       });
 
       this.expandedCommitMessagesCount = isActive ? this.totalCommitMessageBodyCount : 0;


### PR DESCRIPTION
Fixes #1139 

```
When running npm lint under frontend a large number of
`no-param-reassign` warnings are displayed.

Let's investigate the issue and fix it accordingly so that the
warnings are removed.
```