### PR TITLE
Use variables for page titles and headings to reduce duplication

### DIFF
--- a/docs/about.md
+++ b/docs/about.md
@@ -1,8 +1,9 @@
+<variable name="title">About us</variable>
 <frontmatter>
-  title: "About us"
+  title: "{{ title | safe }}"
 </frontmatter>
 
-<h1 class="display-3">About us</h1>
+<h1 class="display-3"><md>{{ title }}</md></h1>
 
 RepoSense is a project based in the [National University of Singapore, School of Computing](http://www.comp.nus.edu.sg/), and is funded by a _Teaching Enhancement Grant_ from [NUS Center for Development of Teaching and Learning](http://www.cdtl.nus.edu.sg/).
 

--- a/docs/contact.md
+++ b/docs/contact.md
@@ -1,8 +1,9 @@
+<variable name="title">Contact us</variable>
 <frontmatter>
-  title: "Contact us"
+  title: "{{ title | safe }}"
 </frontmatter>
 
-<h1 class="display-3">Contact us</h1>
+<h1 class="display-3"><md>{{ title }}</md></h1>
 
 :fas-comment-alt: You can post your questions, suggestions, and bug reports in our [issue tracker](https://github.com/RepoSense/reposense/issues).
 

--- a/docs/dg/architecture.md
+++ b/docs/dg/architecture.md
@@ -1,9 +1,10 @@
+<variable name="title">Architecture</variable>
 <frontmatter>
-  title: "Architecture"
+  title: "{{ title | safe }}"
   pageNav: 3
 </frontmatter>
 
-<h1 class="display-4">Architecture</h1>
+<h1 class="display-4"><md>{{ title }}</md></h1>
 
  ![architecture](../images/architecture.png)
 *Figure 1. Overall architecture of RepoSense*

--- a/docs/dg/index.md
+++ b/docs/dg/index.md
@@ -1,8 +1,9 @@
+<variable name="title">Developer guide</variable>
 <frontmatter>
-  title: "Developer guide"
+  title: "{{ title | safe }}"
 </frontmatter>
 
-<h1 class="display-3">Developer guide</h1>
+<h1 class="display-3"><md>{{ title }}</md></h1>
 
 ## Contributing
 <div class="lead">

--- a/docs/dg/projectManagement.md
+++ b/docs/dg/projectManagement.md
@@ -1,9 +1,10 @@
+<variable name="title">Project management</variable>
 <frontmatter>
-  title: "Project Management"
+  title: "{{ title | safe }}"
   pageNav: 3
 </frontmatter>
 
-<h1 class="display-4">Project Maintenance</h1>
+<h1 class="display-4"><md>{{ title }}</md></h1>
 
 <div class="lead">
 

--- a/docs/dg/report.md
+++ b/docs/dg/report.md
@@ -1,9 +1,10 @@
+<variable name="title">HTML report</variable>
 <frontmatter>
-  title: "HTML Report"
+  title: "{{ title | safe }}"
   pageNav: 3
 </frontmatter>
 
-<h1 class="display-4">HTML report</h1>
+<h1 class="display-4"><md>{{ title }}</md></h1>
 
 The source files for the report is located in [`frontend/src`](https://github.com/reposense/RepoSense/blob/master/frontend/src) and is built by [spuild](https://github.com/ongspxm/spuild2) before being packaged into the JAR file to be extracted as part of the report.
 

--- a/docs/dg/settingUp.md
+++ b/docs/dg/settingUp.md
@@ -1,11 +1,12 @@
+<variable name="title">Setting up</variable>
 <frontmatter>
-  title: "Setting up"
+  title: "{{ title | safe }}"
   pageNav: 3
 </frontmatter>
 
 {% from 'scripts/macros.njk' import embed with context %}
 
-<h1 class="display-4">Setting up</h1>
+<h1 class="display-4"><md>{{ title }}</md></h1>
 
 **Prerequisites:**
 * **JDK `1.8.0_60`** or later ([download :fas-download:](https://www.oracle.com/technetwork/java/javase/downloads/index.html)).

--- a/docs/dg/styleGuides.md
+++ b/docs/dg/styleGuides.md
@@ -1,8 +1,9 @@
+<variable name="title">Appendix: Style guides</variable>
 <frontmatter>
-  title: "Appendix: Style Guides"
+  title: "{{ title | safe }}"
 </frontmatter>
 
-<h1 class="display-4">Appendix: Style guides</h1>
+<h1 class="display-4"><md>{{ title }}</md></h1>
 
 <div class="lead">
 

--- a/docs/dg/workflow.md
+++ b/docs/dg/workflow.md
@@ -1,11 +1,12 @@
+<variable name="title">Workflow</variable>
 <frontmatter>
-  title: "Workflow"
+  title: "{{ title | safe }}"
   pageNav: 3
 </frontmatter>
 
 {% from 'scripts/macros.njk' import embed with context %}
 
-<h1 class="display-4">Workflow</h1>
+<h1 class="display-4"><md>{{ title }}</md></h1>
 
 <div class="lead">
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,6 @@
+<variable name="title">Home</variable>
 <frontmatter>
-  title: "Home"
+  title: "{{ title | safe }}"
 </frontmatter>
 
 {% from 'scripts/macros.njk' import thumbnail with context %}

--- a/docs/showcase.md
+++ b/docs/showcase.md
@@ -1,8 +1,9 @@
+<variable name="title">Showcase</variable>
 <frontmatter>
-  title: "Showcase of use cases"
+  title: "{{ title | safe }}"
 </frontmatter>
 
-<h1 class="display-3">Showcase of use cases</h1>
+<h1 class="display-3"><md>{{ title }}</md></h1>
 
 
 ### Case 1: Monitoring student programmers (**individual** projects)

--- a/docs/ug/cli.md
+++ b/docs/ug/cli.md
@@ -1,9 +1,10 @@
+<variable name="title">Appendix: CLI syntax reference</variable>
 <frontmatter>
-  title: "Appendix: CLI syntax reference"
+  title: "{{ title | safe }}"
   pageNav: 3
 </frontmatter>
 
-<h1 class="display-4">Appendix: CLI syntax reference</h1>
+<h1 class="display-4"><md>{{ title }}</md></h1>
 
 <div class="lead">
 

--- a/docs/ug/configFiles.md
+++ b/docs/ug/configFiles.md
@@ -1,11 +1,12 @@
+<variable name="title">Appendix: Config files format</variable>
 <frontmatter>
-  title: "Appendix: Config files format"
+  title: "{{ title | safe }}"
   pageNav: 3
 </frontmatter>
 
 <variable name="mandatory"><span class="badge badge-danger">mandatory</span></variable>
 
-<h1 class="display-4">Appendix: Config files format</h1>
+<h1 class="display-4"><md>{{ title }}</md></h1>
 
 <div class="lead">
 

--- a/docs/ug/customizingReports.md
+++ b/docs/ug/customizingReports.md
@@ -1,11 +1,12 @@
+<variable name="title">Customizing reports</variable>
 <frontmatter>
-  title: "Customizing reports"
+  title: "{{ title | safe }}"
   pageNav: 3
 </frontmatter>
 
 {% from 'scripts/macros.njk' import embed, step with context %}
 
-<h1 class="display-4">Customizing reports</h1>
+<h1 class="display-4"><md>{{ title }}</md></h1>
 
 <div class="lead">
 

--- a/docs/ug/faq.md
+++ b/docs/ug/faq.md
@@ -1,9 +1,10 @@
+<variable name="title">Appendix: FAQ</variable>
 <frontmatter>
-  title: "FAQ"
+  title: "{{ title | safe }}"
   pageNav: 3
 </frontmatter>
 
-<h1 class="display-4">Appendix: FAQ</h1>
+<h1 class="display-4"><md>{{ title }}</md></h1>
 
 <!-- ------------------------------------------------------------------------------------------------------ -->
 

--- a/docs/ug/generatingReports.md
+++ b/docs/ug/generatingReports.md
@@ -1,11 +1,12 @@
+<variable name="title">Generating a report</variable>
 <frontmatter>
-  title: "Generating a report"
+  title: "{{ title | safe }}"
   pageNav: 3
 </frontmatter>
 
 {% from 'scripts/macros.njk' import embed with context %}
 
-<h1 class="display-4">Generating reports</h1>
+<h1 class="display-4"><md>{{ title }}</md></h1>
 
 <div class="lead">
 

--- a/docs/ug/index.md
+++ b/docs/ug/index.md
@@ -1,10 +1,11 @@
+<variable name="title">User guide</variable>
 <frontmatter>
-  title: "User guide"
+  title: "{{ title | safe }}"
 </frontmatter>
 
 {% from 'scripts/macros.njk' import embed, step, thumbnail with context %}
 
-<h1 class="display-3">User guide</h1>
+<h1 class="display-3"><md>{{ title }}</md></h1>
 
 <div class="lead">
 

--- a/docs/ug/runSh.md
+++ b/docs/ug/runSh.md
@@ -1,10 +1,11 @@
+<variable name="title">`run.sh` format</variable>
 <frontmatter>
-  title: "run.sh format"
+  title: "`run.sh` format"
 </frontmatter>
 
 {% from 'scripts/macros.njk' import embed, step with context %}
 
-<h1 class="display-4"><md>Appendix: `run.sh` format</md></h1>
+<h1 class="display-4"><md>{{ title }}</md></h1>
 
 <div class="lead">
 

--- a/docs/ug/runSh.md
+++ b/docs/ug/runSh.md
@@ -1,6 +1,6 @@
-<variable name="title">`run.sh` format</variable>
+<variable name="title">Appendix: `run.sh` format</variable>
 <frontmatter>
-  title: "`run.sh` format"
+  title: "Appendix: `run.sh` format"
 </frontmatter>
 
 {% from 'scripts/macros.njk' import embed, step with context %}

--- a/docs/ug/sharingReports.md
+++ b/docs/ug/sharingReports.md
@@ -1,11 +1,12 @@
+<variable name="title">Sharing reports</variable>
 <frontmatter>
-  title: "Sharing reports"
+  title: "{{ title | safe }}"
   pageNav: 3
 </frontmatter>
 
 {% from 'scripts/macros.njk' import embed with context %}
 
-<h1 class="display-4">Sharing reports</h1>
+<h1 class="display-4"><md>{{ title }}</md></h1>
 
 <div class="lead">
 

--- a/docs/ug/troubleshooting.md
+++ b/docs/ug/troubleshooting.md
@@ -1,4 +1,4 @@
-<variable name="title">Troubleshooting</variable>
+<variable name="title">Appendix: Troubleshooting</variable>
 <frontmatter>
   title: "{{ title | safe }}"
   pageNav: 3

--- a/docs/ug/troubleshooting.md
+++ b/docs/ug/troubleshooting.md
@@ -1,9 +1,10 @@
+<variable name="title">Troubleshooting</variable>
 <frontmatter>
-  title: "Troubleshooting"
+  title: "{{ title | safe }}"
   pageNav: 3
 </frontmatter>
 
-<h1 class="display-4">Appendix: Troubleshooting</h1>
+<h1 class="display-4"><md>{{ title }}</md></h1>
 
 <!-- ------------------------------------------------------------------------------------------------------ -->
 

--- a/docs/ug/usingAuthorTags.md
+++ b/docs/ug/usingAuthorTags.md
@@ -1,6 +1,6 @@
-<variable name="title">Using `@@author` tags</variable>
+<variable name="title">Appendix: Using `@@author` tags</variable>
 <frontmatter>
-  title: "Using `@@author` tags"
+  title: "Appendix: Using `@@author` tags"
 </frontmatter>
 
 {% from 'scripts/macros.njk' import embed, step with context %}

--- a/docs/ug/usingAuthorTags.md
+++ b/docs/ug/usingAuthorTags.md
@@ -1,10 +1,11 @@
+<variable name="title">Using `@@author` tags</variable>
 <frontmatter>
   title: "Using `@@author` tags"
 </frontmatter>
 
 {% from 'scripts/macros.njk' import embed, step with context %}
 
-<h1 class="display-4"><md>Appendix: Using `@@author` tags</md></h1>
+<h1 class="display-4"><md>{{ title }}</md></h1>
 
 <div class="lead">
 

--- a/docs/ug/usingReports.md
+++ b/docs/ug/usingReports.md
@@ -1,9 +1,10 @@
+<variable name="title">Using reports</variable>
 <frontmatter>
-  title: "Using reports"
+  title: "{{ title | safe }}"
   pageNav: 3
 </frontmatter>
 
-<h1 class="display-4">Using reports</h1>
+<h1 class="display-4"><md>{{ title }}</md></h1>
 
 <div class="lead">
 

--- a/docs/ug/withGithubActions.md
+++ b/docs/ug/withGithubActions.md
@@ -1,4 +1,4 @@
-<variable name="title">RepoSense with GitHub Actions</variable>
+<variable name="title">Appendix: RepoSense with GitHub Actions</variable>
 <frontmatter>
   title: "{{ title | safe }}"
   pageNav: 3

--- a/docs/ug/withGithubActions.md
+++ b/docs/ug/withGithubActions.md
@@ -1,11 +1,12 @@
+<variable name="title">RepoSense with GitHub Actions</variable>
 <frontmatter>
-  title: "Using RepoSense with GitHub Actions"
+  title: "{{ title | safe }}"
   pageNav: 3
 </frontmatter>
 
 {% from 'scripts/macros.njk' import embed, step with context %}
 
-<h1 class="display-4">Appendix: Using RepoSense with GitHub Actions</h1>
+<h1 class="display-4"><md>{{ title }}</md></h1>
 
 <div id="section-setting-up">
 

--- a/docs/ug/withNetlify.md
+++ b/docs/ug/withNetlify.md
@@ -1,4 +1,4 @@
-<variable name="title">RepoSense with Netlify</variable>
+<variable name="title">Appendix: RepoSense with Netlify</variable>
 <frontmatter>
   title: "{{ title | safe }}"
   pageNav: 3

--- a/docs/ug/withNetlify.md
+++ b/docs/ug/withNetlify.md
@@ -1,11 +1,12 @@
+<variable name="title">RepoSense with Netlify</variable>
 <frontmatter>
-  title: "Publishing the dashboard - with Netlify"
+  title: "{{ title | safe }}"
   pageNav: 3
 </frontmatter>
 
 {% from 'scripts/macros.njk' import embed, step with context %}
 
-<h1 class="display-4">Appendix: Using RepoSense with Netlify</h1>
+<h1 class="display-4"><md>{{ title }}</md></h1>
 
 <div id="section-setting-up">
 

--- a/docs/ug/withTravis.md
+++ b/docs/ug/withTravis.md
@@ -1,11 +1,12 @@
+<variable name="title">RepoSense with Travis</variable>
 <frontmatter>
-  title: "Using RepoSense with Travis"
+  title: "{{ title | safe }}"
   pageNav: 3
 </frontmatter>
 
 {% from 'scripts/macros.njk' import embed, step with context %}
 
-<h1 class="display-4">Appendix: Using RepoSense with Travis</h1>
+<h1 class="display-4"><md>{{ title }}</md></h1>
 
 <div id="section-setting-up">
 

--- a/docs/ug/withTravis.md
+++ b/docs/ug/withTravis.md
@@ -1,4 +1,4 @@
-<variable name="title">RepoSense with Travis</variable>
+<variable name="title">Appendix: RepoSense with Travis</variable>
 <frontmatter>
   title: "{{ title | safe }}"
   pageNav: 3


### PR DESCRIPTION
Fixes #1290 and few other similar inconsistencies



Proposed commit message:
```
The page title and the main heading of a page is exactly the same.
Let's use a MarkBind variable to hold that value so that it can be
specified only once and used in both as title and heading.

At the same time, let's fix some inconsistencies between page titles
and headings that were partially caused by the duplication this
commit addresses.

Warning: Two pages (runSh.md, usingAuthorTags.md) do not use
{{ title }} inside the <frontmatter>. This is due to a flaw in the
current MarkBind processor that affects variable values that
have `.` and `@` in them. This flaw has been fixed in the next
upcoming MarkBind release. Those two pages need to be 
updated after that version of MarkBind has been released.
```