### PR TITLE
Use nunjucks to generate siteNavs and the site map

### DIFF
--- a/docs/_markbind/navigation/dgSiteNav.md
+++ b/docs/_markbind/navigation/dgSiteNav.md
@@ -1,18 +1,22 @@
-<navigation>
+{% set dg_sitenav_items = [
+  {name: "Contributing", link: "dg/index.html"},
+  {name: "Setting up", link: "dg/settingUp.html"},
+  {name: "Workflow", link: "dg/workflow.html"},
+  {name: "Design and implementation"},
+  {level: 2, name: "Architecture", link: "dg/architecture.html"},
+  {level: 2, name: "HTML report", link: "dg/report.html"},
+  {name: "Project management", link: "dg/projectManagement.html"},
+  {name: "Appendices"},
+  {level: 2, name: "Style guides", link: "dg/styleGuides.html"}
+]
+%}
 
 <span class="lead">****DEVELOPER GUIDE****</span>
 
-* [**Contributing**]({{baseUrl}}/dg/index.html)
-* [**Setting up**]({{baseUrl}}/dg/settingUp.html)
-* [**Workflow**]({{baseUrl}}/dg/workflow.html)
+<navigation>
 
-* **Design and implementation**
-* [&nbsp;&nbsp;Architecture]({{baseUrl}}/dg/architecture.html)
-* [&nbsp;&nbsp;HTML report]({{baseUrl}}/dg/report.html)
+{% from "scripts/macros.njk" import show_sitenav_items %}
 
-* [**Project management**]({{baseUrl}}/dg/projectManagement.html)
-
-* **Appendices**
-* [&nbsp;&nbsp;Style guides]({{baseUrl}}/dg/styleGuides.html)
+{{ show_sitenav_items(dg_sitenav_items) }}
 
 </navigation>

--- a/docs/_markbind/navigation/ugSiteNav.md
+++ b/docs/_markbind/navigation/ugSiteNav.md
@@ -1,22 +1,27 @@
-<navigation>
+{% set ug_sitenav_items = [
+  {name: "Overview", link: "ug/index.html"},
+  {name: "Generating reports", link: "ug/usingReports.html"},
+  {name: "Using reports", link: "ug/generatingReports.html"},
+  {name: "Customizing reports", link: "ug/customizingReports.html"},
+  {name: "Sharing reports", link: "ug/sharingReports.html"},
+  {name: "Appendices"},
+  {level: 2, name: "CLI syntax reference", link: "ug/cli.html"},
+  {level: 2, name: "Config files format", link: "ug/configFiles.html"},
+  {level: 2, name: "Using `@@author` tags", link: "ug/usingAuthorTags.html"},
+  {level: 2, name: "RepoSense with Netlify", link: "ug/withNetlify.html"},
+  {level: 2, name: "RepoSense with GitHub Actions", link: "ug/withGithubActions.html"},
+  {level: 2, name: "RepoSense with Travis", link: "ug/withTravis.html"},
+  {level: 2, name: "`run.sh` format", link: "ug/runSh.html"},
+  {level: 2, name: "FAQ", link: "ug/faq.html"},
+  {level: 2, name: "Troubleshooting", link: "ug/troubleshooting.html"}
+]
+%}
 
 <span class="lead">****USER GUIDE****</span>
 
-* [**Overview**]({{baseUrl}}/ug/index.html)
-* [**Using reports**]({{baseUrl}}/ug/usingReports.html)
-* [**Generating reports**]({{baseUrl}}/ug/generatingReports.html)
-* [**Customizing reports**]({{baseUrl}}/ug/customizingReports.html)
-* [**Sharing reports**]({{baseUrl}}/ug/sharingReports.html)
+<navigation>
 
-* **Appendices**
-* [&nbsp;&nbsp;CLI syntax reference]({{baseUrl}}/ug/cli.html)
-* [&nbsp;&nbsp;Config files format]({{baseUrl}}/ug/configFiles.html)
-* [&nbsp;&nbsp;Using `@@author` tags]({{baseUrl}}/ug/usingAuthorTags.html)
-* [&nbsp;&nbsp;RepoSense with Netlify]({{baseUrl}}/ug/withNetlify.html)
-* [&nbsp;&nbsp;RepoSense with GitHub Actions]({{baseUrl}}/ug/withGithubActions.html)
-* [&nbsp;&nbsp;RepoSense with Travis]({{baseUrl}}/ug/withTravis.html)
-* [&nbsp;&nbsp;`run.sh` format]({{baseUrl}}/ug/runSh.html)
-* [&nbsp;&nbsp;FAQ]({{baseUrl}}/ug/faq.html)
-* [&nbsp;&nbsp;Troubleshooting]({{baseUrl}}/ug/troubleshooting.html)
+{% from "scripts/macros.njk" import show_sitenav_items %}
 
+{{ show_sitenav_items(ug_sitenav_items) }}
 </navigation>

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,7 +2,7 @@
   title: "Home"
 </frontmatter>
 
-{% from 'scripts/macros.njk' import thumbnail with context %}
+{% from 'scripts/macros.njk' import show_sitenav_items, thumbnail with context %}
 
 <header>
 <div class="jumbotron jumbotron-fluid text-center" style="padding-top: inherit; padding-bottom: inherit">
@@ -87,13 +87,20 @@ Deploy previews are powered by Netlify and Surge.
   </div>
   <div class="col-sm">
 
-<include src="_markbind\navigation\ugSiteNav.md" />
+****USER GUIDE****
+
+{% from "_markbind/navigation/ugSiteNav.md" import ug_sitenav_items %}
+{{ show_sitenav_items(ug_sitenav_items, is_flat=true) }}
 
 
   </div>
   <div class="col-sm">
 
-<include src="_markbind\navigation\dgSiteNav.md" />
+
+****DEVELOPER GUIDE****
+
+{% from "_markbind/navigation/dgSiteNav.md" import dg_sitenav_items %}
+{{ show_sitenav_items(dg_sitenav_items, is_flat=true) }}
 
 
   </div>

--- a/docs/scripts/macros.njk
+++ b/docs/scripts/macros.njk
@@ -1,3 +1,16 @@
+{% macro show_sitenav_items(items, is_flat=false) %}
+  {% for i in items %}
+    {% if i.level == 2 %}
+  * [{{ i.name }}]({{baseUrl}}/{{ i.link }})
+    {% elseif i.link %}
+* [**{{ i.name }}**]({{baseUrl}}/{{ i.link }})
+    {% else %}
+* **{{ i.name }}**{% if not is_flat%} :expanded:{% endif %}
+    {% endif %}
+  {% endfor %}
+{% endmacro %}
+
+
 {% macro embed(header, src, level="0") %}
 <div class="indented-level{{ level }}">
 
@@ -8,6 +21,7 @@
 </div>
 <p/>
 {% endmacro %}
+
 
 {% macro thumbnail(icon, size=50) %}<thumbnail circle text="{{ icon }}" background="#006600" font-color="white" size="{{ size }}" />{% endmacro %}
 


### PR DESCRIPTION
## Before:
![image](https://user-images.githubusercontent.com/1673303/85196560-8e34e780-b30d-11ea-9625-0ad61fb5dfc3.png)
![image](https://user-images.githubusercontent.com/1673303/85196576-a1e04e00-b30d-11ea-90f9-381024ad98c3.png)

## After:
![image](https://user-images.githubusercontent.com/1673303/85196527-5ded4900-b30d-11ea-8ebe-c4140617444f.png)
![image](https://user-images.githubusercontent.com/1673303/85196544-72c9dc80-b30d-11ea-8862-eef26ee26b90.png)


```
<include>ing the (ug|dg)SiteNave.md in the landing page site-map avoids
duplication but prevents optimal use of siteNav as well as site-map.
For example, we cannot use `:expanded:` in the siteNav to make an item
collapsible because `:expanded:` appears as raw text in the landing page.

Let's use nunjucks to define siteNav items as an array and a macro to
render it optimally for both reuse contexts.

Pros:
* siteNav items are now collapsible
* landing page shows links as a hierarchy rather than a flat list

Cons:
* The code is more complicated than before: But, the complexity is
  within the expertise of RepoSense developers as nunjucks code is
  similar to JavaScript.
```