### PR TITLE
UG: Tweak instructions for Netlify, Travis, GitHub Actions

### DIFF
--- a/docs/ug/grantingWriteAccess.mbdf
+++ b/docs/ug/grantingWriteAccess.mbdf
@@ -3,8 +3,8 @@
 We recommend using a [personal access token](https://github.blog/2013-05-16-personal-api-tokens/) if aiming for the ease of setup and [deploy key](https://developer.github.com/v3/guides/managing-deploy-keys/#deploy-keys) if aiming for enhanced security.
 
 ### If you wish to use _personal access token_:
-1. Follow this [guide](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/) and give only `public_repo` permission.
-1. **Copy** the token for later use.
+1. **Create a _personal access token_** by following this [guide](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/) and give only `public_repo` permission.
+1. **Copy the token** for later use.
 
 ### If you wish to use _deploy key_:
 
@@ -13,8 +13,11 @@ We recommend using a [personal access token](https://github.blog/2013-05-16-pers
 [Windows users] `ssh-keygen` and `base64` are accessible using [Git Bash](https://gitforwindows.org/).
 </box>
 
-1. Use `ssh-keygen` to create a public/private key pair without a passphrase. <br/>
-i.e. `ssh-keygen -t ecdsa -b 521 -f id_reposense -q -N ""`
-1. Go to the [deploy key settings](https://github.com/reposense/publish-RepoSense/settings/keys) of your publish-RepoSense fork and create a new deploy key with the contents of `id_reposense.pub`.
-1. **Copy** the base64 encoded content of the private key for later use. <br/>
-i.e. `cat id_reposense | base64 -w 0`
+1. **Create a public-private key pair** (without a passphrase) using the `ssh-keygen`. <br/>
+   i.e., `ssh-keygen -t ecdsa -b 521 -f id_reposense -q -N ""`
+1. **Create a deploy key** as follows:
+   1. Go to the `settings` page of your publish-RepoSense fork
+   1. Click on the `Deploy keys` item in the navigation menu in that page
+   1. Click on the `Add deploy key` button and create a new deploy key with the contents of `id_reposense.pub`.
+1. **Copy the private key** in base64 encoded format for later use. <br/>
+   i.e., `cat id_reposense | base64 -w 0`

--- a/docs/ug/withGithubActions.md
+++ b/docs/ug/withGithubActions.md
@@ -21,14 +21,21 @@ You can use [_GitHub Actions_](https://github.com/features/actions) (together wi
 
 <include src="withTravis.md#section-fork-token" />
 
-{{ step(3)}} Go to the [secrets settings](https://github.com/reposense/publish-RepoSense/settings/secrets) of your _publish-RepoSense_ fork, add a new secret as `ACCESS_TOKEN` or `DEPLOY_KEY` depending on your earlier choice and paste the token/key; then click `Add secret`:<br>
+{{ step(3)}} **Add the token/key as a secret:**
+
+1. Go to the `Settings` page of your fork of the [publish-RepoSense](https://github.com/reposense/publish-RepoSense) repo.
+1. Click on the `Secrets` menu item on the left of that page.
+1. Click on `Add secret`.
+1. Add a new secret with the name `ACCESS_TOKEN` or `DEPLOY_KEY` (depending on your earlier choice) and the value of the token/key you copied earlier.<br>
 ![GitHub Actions Secrets](../images/publishingguide-secrets.png "GitHub Actions Secrets")
 
-{{ step(4)}}
+{{ step(4)}} **Update report configuration:**
 
 <include src="withTravis.md#section-edit-configs" />
 
-{{ step(5)}} To access your site, go to the settings of your fork in GitHub, under **GitHub Pages** section, look for `Your site is published at [LINK]`. It should look something like `https://[YOUR_GITHUB_ID].github.io/publish-RepoSense`.
+{{ step(5)}} **View the generated report:**
+
+To access your regenerated RepoSense report, go to the settings of your fork in GitHub, under **GitHub Pages** section, look for `Your site is published at [LINK]`. It should look something like `https://[YOUR_GITHUB_ID].github.io/publish-RepoSense`.
 ![GitHub Setting](../images/publishingguide-githubsetting.jpg "GitHub Setting")
 </div>
 

--- a/docs/ug/withNetlify.md
+++ b/docs/ug/withNetlify.md
@@ -19,14 +19,17 @@ Note that Netlify has a low limit for free tier users (only 300 _build minutes_ 
 
 ## Setting up
 
-1. **Fork the _publish-RepoSense_ repository** using this [link](https://github.com/RepoSense/publish-RepoSense/fork). Optionally, you can rename the fork to match your RepoSense report e.g., `project-code-dashboard`.
-1. **Set up Netlify for your fork** as described in this [guide](https://www.netlify.com/blog/2016/09/29/a-step-by-step-guide-deploying-on-netlify/).<br>
-   ==You will need to use the following in step 5==:
+{{ step(1) }} **Fork the _publish-RepoSense_ repository** using this [link](https://github.com/RepoSense/publish-RepoSense/fork). Optionally, you can rename the fork to match your RepoSense report e.g., `project-code-dashboard`.
+
+{{ step(2) }} **Set up Netlify for your fork** as described in this [guide](https://www.netlify.com/blog/2016/09/29/a-step-by-step-guide-deploying-on-netlify/).<br>
+   ==You will need to use the following in `Step 5: Configure Your Settings` of that guide==:
    * build command: `pip install requests && ./run.sh`<br>
    * publish directory: `./reposense-report`
 
    After Netlify finishes building the site, you should be able to see a dummy report at the URL of your Netlify site.
-1. **Generate the report you want** by updating the settings in your fork.
+
+{{ step(3)}} **Generate the report you want** by updating the settings in your fork.
+
    1. Go to the `run.sh` file of your fork (on GitHub).
    1. Update the last line (i.e., the command for running RepoSense) to match the report you want to generate:<br>
       `java -jar RepoSense.jar --repos FULL_REPO_URL` (assuming you want to generate a default report for just one repo)<br>

--- a/docs/ug/withTravis.md
+++ b/docs/ug/withTravis.md
@@ -35,19 +35,28 @@ The instructions below assume you are using GitHub pages to host your report.
   {{ embed("Granting write access on GitHub", "grantingWriteAccess.mbdf") }}
 </div>
 
-{{ step(3) }} Sign up and login to [Travis-CI](https://travis-ci.org/).
+{{ step(3) }} **Login to [Travis-CI](https://travis-ci.org/).** You may have to sign up first.
 
-{{ step(4) }} Go to [your account](https://travis-ci.org/account/repositories), click on `Sync account` to fetch all your repositories into Travis-CI.
+{{ step(4) }} **Syncy your Travis account with GitHub:**
 
-{{ step(5) }} Go to your [publish-RepoSense fork in Travis-CI](https://travis-ci.org/search/publish-RepoSense/), under `Current` tab click on `Activate repository`.
+1. Go to [your account](https://travis-ci.org/account/repositories).
+1. Click on `Sync account` to fetch all your repositories into Travis-CI.
 
-{{ step(6) }} In the same page, click on `More options` on the right then access `Settings`:
-![Travis-CI Dashboard](../images/publishingguide-travissetting.jpg "Travis-CI Dashboard")
+{{ step(5) }} **Activate the repository:**
 
-{{ step(7) }} Under `Environment Variables`, name a variable as `GITHUB_TOKEN` or `GITHUB_DEPLOY_KEY` depending on your earlier choice and paste the token/key into its value field; then click `Add`. Ensure that the `Display value in build log` is `switched off` for security reasons:
-![Travis-CI Environment Variable](../images/publishingguide-githubtoken.jpg "Travis-CI Environment Variable")
+1. Go to your [publish-RepoSense fork in Travis-CI](https://travis-ci.org/search/publish-RepoSense/)
+1. Under `Current` tab, click on `Activate repository`.
 
-{{ step(8) }}
+{{ step(6) }} **Set the token/key:**
+
+1. In the same page, click on `More options` on the right.
+1. Then, click on the `Settings` option:<br>
+   ![Travis-CI Dashboard](../images/publishingguide-travissetting.jpg "Travis-CI Dashboard")
+1. Under `Environment Variables`, name a variable as `GITHUB_TOKEN` or `GITHUB_DEPLOY_KEY` depending on your earlier choice and paste the token/key into its value field; then click `Add`.
+1. Ensure that the `Display value in build log` is `switched off` for security reasons:<br>
+   ![Travis-CI Environment Variable](../images/publishingguide-githubtoken.jpg "Travis-CI Environment Variable")
+
+{{ step(7) }} **Update the report configuration:**
 
 <span id="section-edit-configs">
 
@@ -57,7 +66,10 @@ In your fork, edit `run.sh` (and if applicable, `repo-config.csv`, `author-confi
   {{ embed("Appendix: **Config files format**", 'configFiles.md') }}
 </span>
 
-{{ step(9) }} To access your site, go to the settings of your fork in GitHub, under **GitHub Pages** section, look for `Your site is published at [LINK]`. It should look something like `https://[YOUR_GITHUB_ID].github.io/publish-RepoSense`.
+{{ step(8) }} **View the generated report:**
+
+1. Go to the `Settings` page of your fork in GitHub.
+1. Under the `GitHub Pages` section, look for `Your site is published at [LINK]`. It should look something like `https://[YOUR_GITHUB_ID].github.io/publish-RepoSense`.
 ![GitHub Setting](../images/publishingguide-githubsetting.jpg "GitHub Setting")
 
 <box type="info" seamless>


### PR DESCRIPTION
I was initially trying to fix two broken links but ended up refining the rest of the steps as well.

```
UG: Tweak instructions for Netlify, Travis, GitHub Actions

Let's tweak the intsructions for working with Netlify, Travis, and
GitHub Actions in the following ways:
* Use 'Step N' tags for setting up instructions in all three.
* For the above, start each step with a bolded phrase that gives an
  overview of the step.
* Remove links to admin-only pages because the reader does not have
  access to those pages e.g., publish-RepoSense/settings/secrets etc.
* Show multi-part steps as multiple sub-steps.
```

Changes are in these pages:
* UG -> RepoSense with Netlify
* UG -> RepoSense with GitHub Actions
* UG -> RepoSense with Travis