### PR TITLE
UG/DG: Fix the current item in the siteNav not being marked

### DIFF
--- a/docs/_markbind/navigation/dgSiteNav.md
+++ b/docs/_markbind/navigation/dgSiteNav.md
@@ -15,7 +15,7 @@
 
 <navigation>
 
-{% from "scripts/macros.njk" import show_sitenav_items %}
+{% from "scripts/macros.njk" import show_sitenav_items with context %}
 
 {{ show_sitenav_items(dg_sitenav_items) }}
 

--- a/docs/_markbind/navigation/ugSiteNav.md
+++ b/docs/_markbind/navigation/ugSiteNav.md
@@ -21,7 +21,7 @@
 
 <navigation>
 
-{% from "scripts/macros.njk" import show_sitenav_items %}
+{% from "scripts/macros.njk" import show_sitenav_items with context %}
 
 {{ show_sitenav_items(ug_sitenav_items) }}
 </navigation>


### PR DESCRIPTION
# Before

![image](https://user-images.githubusercontent.com/1673303/85914212-ef107280-b86d-11ea-92c9-ca9f7180b67f.png)

# After
![image](https://user-images.githubusercontent.com/1673303/85914202-e029c000-b86d-11ea-9836-a068d628b0cf.png)


```
UG/DG: Fix the current item in the siteNav not being marked

The site navigation menu of the UG and DG does not highlight the
currently loaded page in blue, as it is supposed to.
The reason is, the {{baseUrl}} variable used in the macro does not
get imported with the macro. The links generated still work because
the baseUrl is empty in this case. But they don't get highlighted due
to some strictness in how MarkBind finds which item to highlight.

Let's fix it by adding `with context` to the nunjucks import statement.
```