### PR TITLE
Update Gradle Version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,8 +12,6 @@ plugins {
 
 mainClassName = 'reposense.RepoSense'
 
-node.nodeVersion = '10.16.0'
-
 sourceCompatibility = JavaVersion.VERSION_1_8
 targetCompatibility = JavaVersion.VERSION_1_8
 

--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ dependencies {
     implementation  group: 'org.apache.commons', name: 'commons-csv', version: '1.6'
     implementation  group: 'org.fusesource.jansi', name: 'jansi', version: '1.18'
 
-    testImplementation group: 'junit', name: 'junit', version: '5.1.0'
+    testImplementation group: 'junit', name: 'junit', version: '4.12'
 }
 
 sourceSets {

--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ dependencies {
     implementation  group: 'org.apache.commons', name: 'commons-csv', version: '1.6'
     implementation  group: 'org.fusesource.jansi', name: 'jansi', version: '1.18'
 
-    testImplementation group: 'junit', name: 'junit', version: '4.12'
+    testImplementation group: 'junit', name: 'junit', version: '5.1.0'
 }
 
 sourceSets {

--- a/build.gradle
+++ b/build.gradle
@@ -81,13 +81,6 @@ jacocoTestReport {
 }
 
 test {
-    jacoco {
-//        append = true
-//        destinationFile = new File("${buildDir}/jacoco/test.exec")
-//        jacocoTestReport.executionData(systemtest)
-//        jacocoTestReport.executionData(frontendTest)
-    }
-
     testLogging {
         events 'passed', 'skipped', 'failed'
         showStandardStreams = true
@@ -117,11 +110,6 @@ tasks.run.dependsOn('compileJava');
 task systemtest(dependsOn: 'zipReport', type: Test) {
     testClassesDirs = sourceSets.systemtest.output.classesDirs
     classpath = sourceSets.systemtest.runtimeClasspath
-
-    jacoco {
-       //append = true
-       //destinationFile = new File("${buildDir}/jacoco/test.exec")
-    }
 
     testLogging {
         events 'passed', 'skipped', 'failed'

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
     id 'jacoco'
     id 'java'
     id 'com.github.johnrengelman.shadow' version '2.0.4'
-    id 'com.liferay.node' version '4.4.0'
+    id 'com.liferay.node' version '7.1.0'
     id 'com.github.psxpaul.execfork' version '0.1.8'
     id 'com.palantir.git-version' version '0.11.0'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -107,6 +107,7 @@ task zipReport(dependsOn: 'npmRunBrowserify', type: Zip) {
     destinationDir = file('src/main/resources')
 }
 
+tasks.npmRunBrowserify.dependsOn('npmRunSpuild');
 tasks.shadowJar.dependsOn('zipReport');
 tasks.compileJava.dependsOn('zipReport');
 tasks.run.dependsOn('compileJava');

--- a/build.gradle
+++ b/build.gradle
@@ -5,12 +5,14 @@ plugins {
     id 'jacoco'
     id 'java'
     id 'com.github.johnrengelman.shadow' version '2.0.4'
-    id 'com.github.node-gradle.node' version '2.2.4'
+    id 'com.liferay.node' version '7.1.0'
     id 'com.github.psxpaul.execfork' version '0.1.8'
     id 'com.palantir.git-version' version '0.11.0'
 }
 
 mainClassName = 'reposense.RepoSense'
+
+node.nodeVersion = '10.16.0'
 
 sourceCompatibility = JavaVersion.VERSION_1_8
 targetCompatibility = JavaVersion.VERSION_1_8

--- a/build.gradle
+++ b/build.gradle
@@ -4,8 +4,8 @@ plugins {
     id 'idea'
     id 'jacoco'
     id 'java'
-    id 'com.github.johnrengelman.shadow' version '2.0.4'
-    id 'com.liferay.node' version '7.1.0'
+    id 'com.github.johnrengelman.shadow' version '5.2.0'
+    id 'com.liferay.node' version '4.4.0'
     id 'com.github.psxpaul.execfork' version '0.1.8'
     id 'com.palantir.git-version' version '0.11.0'
 }
@@ -47,7 +47,7 @@ sourceSets {
 }
 
 wrapper {
-    gradleVersion = '4.9'
+    gradleVersion = '6.5'
 }
 
 run {

--- a/build.gradle
+++ b/build.gradle
@@ -164,12 +164,12 @@ tasks.withType(Copy) {
 }
 
 task coverage(type: JacocoReport) {
-    sourceDirectories = files(sourceSets.main.allSource.srcDirs)
-    classDirectories = files(sourceSets.main.output)
-    executionData = files(jacocoTestReport.executionData)
+    sourceDirectories.from files(sourceSets.main.allSource.srcDirs)
+    classDirectories.from files(sourceSets.main.output)
+    executionData.from files(jacocoTestReport.executionData)
 
     afterEvaluate {
-        classDirectories = files(classDirectories.files.collect {
+        classDirectories.from files(classDirectories.files.collect {
             fileTree(dir: it, exclude: ['**/*.jar'])
         })
     }

--- a/build.gradle
+++ b/build.gradle
@@ -119,8 +119,8 @@ task systemtest(dependsOn: 'zipReport', type: Test) {
     classpath = sourceSets.systemtest.runtimeClasspath
 
     jacoco {
-        append = true
-        destinationFile = new File("${buildDir}/jacoco/test.exec")
+       //append = true
+       //destinationFile = new File("${buildDir}/jacoco/test.exec")
     }
 
     testLogging {

--- a/build.gradle
+++ b/build.gradle
@@ -47,7 +47,7 @@ sourceSets {
 }
 
 wrapper {
-    gradleVersion = '6.5'
+    gradleVersion = '5.2.1'
 }
 
 run {

--- a/build.gradle
+++ b/build.gradle
@@ -82,8 +82,10 @@ jacocoTestReport {
 
 test {
     jacoco {
-        append = true
-        destinationFile = new File("${buildDir}/jacoco/test.exec")
+//        append = true
+//        destinationFile = new File("${buildDir}/jacoco/test.exec")
+//        jacocoTestReport.executionData(systemtest)
+//        jacocoTestReport.executionData(frontendTest)
     }
 
     testLogging {
@@ -187,5 +189,8 @@ String getRepoSenseVersion() {
     }
     return repoSenseVersion
 }
+
+jacocoTestReport.executionData(systemtest)
+jacocoTestReport.executionData(frontendTest)
 
 defaultTasks 'clean', 'build', 'systemtest', 'frontendTest', 'coverage'

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
     id 'jacoco'
     id 'java'
     id 'com.github.johnrengelman.shadow' version '2.0.4'
-    id 'com.liferay.node' version '6.0.0'
+    id 'com.github.node-gradle.node' version '2.2.4'
     id 'com.github.psxpaul.execfork' version '0.1.8'
     id 'com.palantir.git-version' version '0.11.0'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
     id 'jacoco'
     id 'java'
     id 'com.github.johnrengelman.shadow' version '2.0.4'
-    id 'com.liferay.node' version '7.1.0'
+    id 'com.liferay.node' version '6.0.0'
     id 'com.github.psxpaul.execfork' version '0.1.8'
     id 'com.palantir.git-version' version '0.11.0'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -105,7 +105,6 @@ task zipReport(dependsOn: 'npmRunBrowserify', type: Zip) {
     destinationDir = file('src/main/resources')
 }
 
-tasks.npmRunBrowserify.dependsOn('npmRunSpuild');
 tasks.shadowJar.dependsOn('zipReport');
 tasks.compileJava.dependsOn('zipReport');
 tasks.run.dependsOn('compileJava');

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.9-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.2.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/package.json
+++ b/package.json
@@ -30,10 +30,10 @@
     "stylelint-config-standard": "^18.3.0"
   },
   "devDependencies": {
-    "browserify": "^16.2.3",
+    "browserify": "^16.5.1",
     "eslint": "^4.19.1",
     "eslint-config-airbnb-base": "^13.0.0",
-    "eslint-plugin-import": "^2.13.0",
+    "eslint-plugin-import": "^2.22.0",
     "stylelint": "^10.1.0",
     "stylelint-order": "^3.0.1",
     "vueify": "^9.4.1"

--- a/package.json
+++ b/package.json
@@ -30,10 +30,10 @@
     "stylelint-config-standard": "^18.3.0"
   },
   "devDependencies": {
-    "browserify": "^16.5.1",
+    "browserify": "^16.2.3",
     "eslint": "^4.19.1",
     "eslint-config-airbnb-base": "^13.0.0",
-    "eslint-plugin-import": "^2.22.0",
+    "eslint-plugin-import": "^2.13.0",
     "stylelint": "^10.1.0",
     "stylelint-order": "^3.0.1",
     "vueify": "^9.4.1"


### PR DESCRIPTION
Fixes #1302 

```
The downloadNode Gradle extension is outdated, as a result of which
AppVeyor integration is failing. 

Let's update the Gradle version to keep up to date with its development.

From Gradle 5.0 onwards, the tasks running with code coverage are configured to 
delete the execution data just before they start executing another task. As a result of 
this, our code coverage dropped significantly since we use the same file to store the
execution data of the different tests. 

Let's use different files to store the execution data of the different tests to fix 
this problem. 
```
