### PR TITLE
[#1193] Add helper method to replace direct comparison of git author name with '-'

### DIFF
--- a/frontend/src/static/js/v_authorship.js
+++ b/frontend/src/static/js/v_authorship.js
@@ -170,12 +170,16 @@ window.vAuthorship = {
       file.wasCodeLoaded = file.wasCodeLoaded || file.active;
     },
 
+    isUnknownAuthor(name) {
+      return name === '-';
+    },
+
     hasCommits(info) {
       const { isMergeGroup, author } = info;
       const repo = window.REPOS[info.repo];
       if (repo) {
         return isMergeGroup
-            ? Object.entries(repo.commits.authorFinalContributionMap).some(([name, cnt]) => name !== '-' && cnt > 0)
+            ? Object.entries(repo.commits.authorFinalContributionMap).some(([name, cnt]) => !this.isUnknownAuthor(name) && cnt > 0)
             : repo.commits.authorFinalContributionMap[author] > 0;
       }
       return false;
@@ -190,7 +194,7 @@ window.vAuthorship = {
 
       lines.forEach((line, lineCount) => {
         const isAuthorMatched = this.info.isMergeGroup
-            ? line.author.gitId !== '-'
+            ? !this.isUnknownAuthor(line.author.gitId)
             : line.author.gitId === this.info.author;
         const authored = (line.author && isAuthorMatched);
 
@@ -264,7 +268,7 @@ window.vAuthorship = {
     },
 
     getContributionFromAllAuthors(contributionMap) {
-      return Object.entries(contributionMap).reduce((acc, [author, cnt]) => (author !== '-' ? acc + cnt : acc), 0);
+      return Object.entries(contributionMap).reduce((acc, [author, cnt]) => (!this.isUnknownAuthor(author) ? acc + cnt : acc), 0);
     },
 
     addBlankLineCount(fileType, lineCount, filesInfoObj) {

--- a/frontend/src/static/js/v_authorship.js
+++ b/frontend/src/static/js/v_authorship.js
@@ -179,8 +179,8 @@ window.vAuthorship = {
       const repo = window.REPOS[info.repo];
       if (repo) {
         return isMergeGroup
-            ? Object.entries(repo.commits.authorFinalContributionMap).some(([name, cnt]) => { 
-              !this.isUnknownAuthor(name) && cnt > 0;
+            ? Object.entries(repo.commits.authorFinalContributionMap).some(([name, cnt]) => {
+              return !this.isUnknownAuthor(name) && cnt > 0;
             })
             : repo.commits.authorFinalContributionMap[author] > 0;
       }
@@ -271,7 +271,7 @@ window.vAuthorship = {
 
     getContributionFromAllAuthors(contributionMap) {
       return Object.entries(contributionMap).reduce((acc, [author, cnt]) => {
-        (!this.isUnknownAuthor(author) ? acc + cnt : acc), 0;
+        return (!this.isUnknownAuthor(author) ? acc + cnt : acc), 0;
       });
     },
 

--- a/frontend/src/static/js/v_authorship.js
+++ b/frontend/src/static/js/v_authorship.js
@@ -179,9 +179,9 @@ window.vAuthorship = {
       const repo = window.REPOS[info.repo];
       if (repo) {
         return isMergeGroup
-            ? Object.entries(repo.commits.authorFinalContributionMap).some(([name, cnt]) => {
-              return !this.isUnknownAuthor(name) && cnt > 0;
-            })
+            ? Object.entries(repo.commits.authorFinalContributionMap).some(([name, cnt]) => (
+              !this.isUnknownAuthor(name) && cnt > 0
+            ))
             : repo.commits.authorFinalContributionMap[author] > 0;
       }
       return false;
@@ -270,9 +270,9 @@ window.vAuthorship = {
     },
 
     getContributionFromAllAuthors(contributionMap) {
-      return Object.entries(contributionMap).reduce((acc, [author, cnt]) => {
-        return (!this.isUnknownAuthor(author) ? acc + cnt : acc), 0;
-      });
+      return Object.entries(contributionMap).reduce((acc, [author, cnt]) => (
+        (!this.isUnknownAuthor(author) ? acc + cnt : acc)
+      ), 0);
     },
 
     addBlankLineCount(fileType, lineCount, filesInfoObj) {

--- a/frontend/src/static/js/v_authorship.js
+++ b/frontend/src/static/js/v_authorship.js
@@ -180,7 +180,7 @@ window.vAuthorship = {
       if (repo) {
         return isMergeGroup
             ? Object.entries(repo.commits.authorFinalContributionMap).some(([name, cnt]) => { 
-              !this.isUnknownAuthor(name) && cnt > 0
+              !this.isUnknownAuthor(name) && cnt > 0;
             })
             : repo.commits.authorFinalContributionMap[author] > 0;
       }
@@ -270,7 +270,9 @@ window.vAuthorship = {
     },
 
     getContributionFromAllAuthors(contributionMap) {
-      return Object.entries(contributionMap).reduce((acc, [author, cnt]) => (!this.isUnknownAuthor(author) ? acc + cnt : acc), 0);
+      return Object.entries(contributionMap).reduce((acc, [author, cnt]) => {
+        (!this.isUnknownAuthor(author) ? acc + cnt : acc), 0
+      });
     },
 
     addBlankLineCount(fileType, lineCount, filesInfoObj) {

--- a/frontend/src/static/js/v_authorship.js
+++ b/frontend/src/static/js/v_authorship.js
@@ -271,7 +271,7 @@ window.vAuthorship = {
 
     getContributionFromAllAuthors(contributionMap) {
       return Object.entries(contributionMap).reduce((acc, [author, cnt]) => {
-        (!this.isUnknownAuthor(author) ? acc + cnt : acc), 0
+        (!this.isUnknownAuthor(author) ? acc + cnt : acc), 0;
       });
     },
 

--- a/frontend/src/static/js/v_authorship.js
+++ b/frontend/src/static/js/v_authorship.js
@@ -179,7 +179,9 @@ window.vAuthorship = {
       const repo = window.REPOS[info.repo];
       if (repo) {
         return isMergeGroup
-            ? Object.entries(repo.commits.authorFinalContributionMap).some(([name, cnt]) => !this.isUnknownAuthor(name) && cnt > 0)
+            ? Object.entries(repo.commits.authorFinalContributionMap).some(([name, cnt]) => { 
+              !this.isUnknownAuthor(name) && cnt > 0
+            })
             : repo.commits.authorFinalContributionMap[author] > 0;
       }
       return false;


### PR DESCRIPTION
Fixes #1193 
```
There are a few instances in the frontend code where we are comparing an author
name against the name "-" (which represents an unknown author). 

Let's place this comparison in a method such as isUnknownAuthor 
to improve readability
```