### PR TITLE
[#1204] AuthorConfiguration#resetAuthorInformation can be made more readable

### DIFF
--- a/src/main/java/reposense/model/AuthorConfiguration.java
+++ b/src/main/java/reposense/model/AuthorConfiguration.java
@@ -193,11 +193,17 @@ public class AuthorConfiguration {
     }
 
     /**
-     * Clears author mapping information and resets it with the details of current author list.
+     * Clears author mapping information.
      */
-    public void resetAuthorInformation() {
+    public void clear() {
         authorEmailsAndAliasesMap.clear();
         authorDisplayNameMap.clear();
+    }
+
+    /**
+     * Resets author mapping information with the details of current author list.
+     */
+    public void buildFromAuthorList() {
         authorList.forEach(this::setAuthorDetails);
     }
 

--- a/src/main/java/reposense/model/RepoConfiguration.java
+++ b/src/main/java/reposense/model/RepoConfiguration.java
@@ -386,8 +386,9 @@ public class RepoConfiguration {
      * Clears authors information and sets the {@code authorList} to {@code RepoConfiguration}.
      */
     public void setAuthorList(List<Author> authorList) {
+        authorConfig.clear();
         authorConfig.setAuthorList(authorList);
-        authorConfig.resetAuthorInformation();
+        authorConfig.buildFromAuthorList();
         authorList.forEach(author -> AuthorConfiguration.propagateIgnoreGlobList(author, this.getIgnoreGlobList()));
     }
 


### PR DESCRIPTION
Fixes #1204 

The name of the method can be confusing because it appears like we are
wiping out the author list that was set on the previous line.

Let's,
* Break resetAuthorInformation method into two methods to increase
code readability.