### PR TITLE
[#1251] Change file type label font weight

### DIFF
--- a/frontend/src/static/css/v_authorship.scss
+++ b/frontend/src/static/css/v_authorship.scss
@@ -109,7 +109,7 @@
         @include medium-font;
         border-radius: 5px;
         display: inline-block;
-        font-weight: bold;
+        font-weight: normal;
         padding: 0 5px;
       }
     }


### PR DESCRIPTION
```
The file type label is bold and this is inconsistent with other labels.

To standardize, let's set the font weight type of file type label to
normal.
```
Fixes #1251 