### PR TITLE
[#1282] Remove trailing whitespace in issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -17,8 +17,8 @@ labels: "c.Bug"
 
 **Please include the steps to reproduce the bug.**
 
-1. 
-1. 
+1.
+1.
 
 
 **What was expected to happen?**

--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -16,7 +16,7 @@ labels: "a-Docs"
 
 
 **What would you like added or modified in the documentation?**
-<!-- 
+<!--
     Summarize the suggested addition to or
     modification of existing documentation.
 -->


### PR DESCRIPTION
Fixes #1282 

```
There are warnings in travis logs regarding these trailing
whitespaces.
Let's remove them to tidy up the logs.
```
