### PR TITLE
[#938] Fix inaccurate Javadoc comment

### DIFF
--- a/src/main/java/reposense/model/RepoConfiguration.java
+++ b/src/main/java/reposense/model/RepoConfiguration.java
@@ -201,7 +201,8 @@ public class RepoConfiguration {
     }
 
     /**
-     * Clears authors information and use the information provided from {@code standaloneConfig}.
+     * Clears existing information related to this repository and its authors, and replaces it with information from the
+     * {@code standaloneConfig}.
      */
     public void update(StandaloneConfig standaloneConfig) {
         // only assign the new values when all the fields in {@code standaloneConfig} pass the validations.


### PR DESCRIPTION
Fixes #938.

```
The Javadoc comment for the update method within RepoConfiguration 
does not mention that the update function will alter the repository 
level information.

Let's update that Javadoc comment to reflect its functionality.
```