### PR TITLE
[#1111] Specify HTML doctype for report

### DIFF
--- a/frontend/src/index.pug
+++ b/frontend/src/index.pug
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 html
   head
     title RepoSense Report


### PR DESCRIPTION
Fixes #1111.

```
The report does not specify a HTML doctype, which may cause the
webpage to go into quirks mode, depending on the browser.

Let's specify a HTML doctype to prevent it from happening.
```