### PR TITLE
[#1128] Remove setting of file format in BeforeClass method of GitTestTemplate

### DIFF
--- a/src/test/java/reposense/template/GitTestTemplate.java
+++ b/src/test/java/reposense/template/GitTestTemplate.java
@@ -70,7 +70,6 @@ public class GitTestTemplate {
     public static void beforeClass() throws Exception {
         deleteRepos();
         config = new RepoConfiguration(new RepoLocation(TEST_REPO_GIT_LOCATION), "master");
-        config.setFormats(FileTypeTest.DEFAULT_TEST_FORMATS);
         GitClone.clone(config);
     }
 


### PR DESCRIPTION
Fixes #1128 
```
The setting of file format in the BeforeClass method of GitTestTemplate 
is not required for the cloning of the test repository.

Let's remove it to make it clear that this setting is not required for the tests.
```
