### PR TITLE
[#1239] Add filetype tags in commits panel

### DIFF
--- a/frontend/cypress/tests/zoomView/zoomView_reload.js
+++ b/frontend/cypress/tests/zoomView/zoomView_reload.js
@@ -14,6 +14,14 @@ describe('reload page', () => {
     cy.get('#tab-zoom > .sorting > .sort-order > select:visible')
         .select('Descending');
 
+    cy.get('#tab-zoom > .fileTypes input[value="gradle"]')
+        .uncheck()
+        .should('not.be.checked');
+
+    cy.get('#tab-zoom > .fileTypes input[value="scss"]')
+        .uncheck()
+        .should('not.be.checked');
+
     cy.reload();
 
     cy.get('#tab-zoom > .sorting > .sort-by > select:visible')
@@ -21,5 +29,14 @@ describe('reload page', () => {
 
     cy.get('#tab-zoom > .sorting > .sort-order > select:visible')
         .should('have.value', 'true');
+
+    cy.get('#tab-zoom > .fileTypes input[value="all"]')
+        .should('not.be.checked');
+
+    cy.get('#tab-zoom > .fileTypes input[value="gradle"]')
+        .should('not.be.checked');
+
+    cy.get('#tab-zoom > .fileTypes input[value="scss"]')
+        .should('not.be.checked');
   });
 });

--- a/frontend/cypress/tests/zoomView/zoomView_selectFileTypes.js
+++ b/frontend/cypress/tests/zoomView/zoomView_selectFileTypes.js
@@ -26,7 +26,7 @@ describe('check file types ', () => {
       .should('exist');
 
     cy.get('#tab-zoom .fileTypes input[value="all"]')
-      .uncheck()
+      .uncheck();
 
     cy.get('#tab-zoom .zoom__day')
       .should('not.exist');

--- a/frontend/cypress/tests/zoomView/zoomView_selectFileTypes.js
+++ b/frontend/cypress/tests/zoomView/zoomView_selectFileTypes.js
@@ -3,58 +3,58 @@ describe('check file types ', () => {
     Cypress.wait();
 
     cy.get('.icon-button.fa-list-ul')
-      .should('be.visible')
-      .first()
-      .click();
+        .should('be.visible')
+        .first()
+        .click();
 
-    cy.get('#tab-zoom .zoom__day', {timeout: 90000})
-      .should('exist');
+    cy.get('#tab-zoom .zoom__day', { timeout: 90000 })
+        .should('exist');
 
     cy.get('#tab-zoom .fileTypes input[value="all"]')
-      .should('be.checked');
+        .should('be.checked');
   });
 
   it('uncheck all file types should show no files', () => {
     Cypress.wait();
 
     cy.get('.icon-button.fa-list-ul')
-      .should('be.visible')
-      .first()
-      .click();
+        .should('be.visible')
+        .first()
+        .click();
 
     cy.get('#tab-zoom .zoom__day')
-      .should('exist');
+        .should('exist');
 
     cy.get('#tab-zoom .fileTypes input[value="all"]')
-      .uncheck();
+        .uncheck();
 
     cy.get('#tab-zoom .zoom__day')
-      .should('not.exist');
+        .should('not.exist');
   });
 
   it('uncheck file type should uncheck all option and not show legend', () => {
     Cypress.wait();
 
     cy.get('.icon-button.fa-list-ul')
-      .should('be.visible')
-      .first()
-      .click();
+        .should('be.visible')
+        .first()
+        .click();
 
     cy.get('#tab-zoom .fileTypes input[value="java"]')
-      .uncheck()
-      .should('not.be.checked');
+        .uncheck()
+        .should('not.be.checked');
 
     cy.get('#tab-zoom .fileTypes input[value="js"]')
-      .uncheck()
-      .should('not.be.checked');
+        .uncheck()
+        .should('not.be.checked');
 
     cy.get('#tab-zoom .fileTypes input[value="ball"]')
-      .should('not.be.checked');
+        .should('not.be.checked');
 
     cy.get('.zoom__day > .commit-message > .message-title > .fileTypeLabel')
-      .should('not.contain.text', 'java');
+        .should('not.contain.text', 'java');
 
     cy.get('.zoom__day > .commit-message > .message-title > .fileTypeLabel')
-      .should('not.contain.text', 'gradle');
+        .should('not.contain.text', 'gradle');
   });
 });

--- a/frontend/cypress/tests/zoomView/zoomView_selectFileTypes.js
+++ b/frontend/cypress/tests/zoomView/zoomView_selectFileTypes.js
@@ -1,0 +1,60 @@
+describe('check file types ', () => {
+  it('check if all file types are visible by default', () => {
+    Cypress.wait();
+
+    cy.get('.icon-button.fa-list-ul')
+      .should('be.visible')
+      .first()
+      .click();
+
+    cy.get('#tab-zoom .zoom__day', {timeout: 90000})
+      .should('exist');
+
+    cy.get('#tab-zoom .fileTypes input[value="all"]')
+      .should('be.checked');
+  });
+
+  it('uncheck all file types should show no files', () => {
+    Cypress.wait();
+
+    cy.get('.icon-button.fa-list-ul')
+      .should('be.visible')
+      .first()
+      .click();
+
+    cy.get('#tab-zoom .zoom__day')
+      .should('exist');
+
+    cy.get('#tab-zoom .fileTypes input[value="all"]')
+      .uncheck()
+
+    cy.get('#tab-zoom .zoom__day')
+      .should('not.exist');
+  });
+
+  it('uncheck file type should uncheck all option and not show legend', () => {
+    Cypress.wait();
+
+    cy.get('.icon-button.fa-list-ul')
+      .should('be.visible')
+      .first()
+      .click();
+
+    cy.get('#tab-zoom .fileTypes input[value="java"]')
+      .uncheck()
+      .should('not.be.checked');
+
+    cy.get('#tab-zoom .fileTypes input[value="js"]')
+      .uncheck()
+      .should('not.be.checked');
+
+    cy.get('#tab-zoom .fileTypes input[value="ball"]')
+      .should('not.be.checked');
+
+    cy.get('.zoom__day > .commit-message > .message-title > .fileTypeLabel')
+      .should('not.contain.text', 'java');
+
+    cy.get('.zoom__day > .commit-message > .message-title > .fileTypeLabel')
+      .should('not.contain.text', 'gradle');
+  });
+});

--- a/frontend/src/static/css/panels.scss
+++ b/frontend/src/static/css/panels.scss
@@ -96,6 +96,14 @@
   }
 }
 
+.fileTypeLabel {
+  border-radius: 5px;
+  display: inline-block;
+  font-weight: bold;
+  margin: 0 5px 5px 0;
+  padding: 0 5px;
+}
+
 .toolbar {
   cursor: pointer;
   float: right;

--- a/frontend/src/static/css/panels.scss
+++ b/frontend/src/static/css/panels.scss
@@ -79,6 +79,7 @@
 .fileTypes {
   align-items: center;
   display: flex;
+  margin: 5px 0 5px 0;
   text-align: left;
 
   .checkboxes {

--- a/frontend/src/static/css/panels.scss
+++ b/frontend/src/static/css/panels.scss
@@ -99,7 +99,6 @@
 .fileTypeLabel {
   border-radius: 5px;
   display: inline-block;
-  font-weight: bold;
   margin: 0 5px 5px 0;
   padding: 0 5px;
 }

--- a/frontend/src/static/css/v_authorship.scss
+++ b/frontend/src/static/css/v_authorship.scss
@@ -104,14 +104,6 @@
         margin-right: 8px;
         vertical-align: middle;
       }
-
-      .fileTypeLabel {
-        @include medium-font;
-        border-radius: 5px;
-        display: inline-block;
-        font-weight: normal;
-        padding: 0 5px;
-      }
     }
 
     .segment {

--- a/frontend/src/static/css/v_zoom.scss
+++ b/frontend/src/static/css/v_zoom.scss
@@ -23,6 +23,14 @@
 
     &__day,
     &__title {
+      .file-type {
+        border-radius: 5px;
+        display: inline-block;
+        font-weight: bold;
+        margin: .2rem .2rem .2rem 0;
+        padding: 0 5px;
+      }
+
       /* Tags in commits */
       .tag {
         @include mini-font;

--- a/frontend/src/static/css/v_zoom.scss
+++ b/frontend/src/static/css/v_zoom.scss
@@ -23,14 +23,6 @@
 
     &__day,
     &__title {
-      .file-type {
-        border-radius: 5px;
-        display: inline-block;
-        font-weight: bold;
-        margin: .2rem .2rem .2rem 0;
-        padding: 0 5px;
-      }
-
       /* Tags in commits */
       .tag {
         @include mini-font;

--- a/frontend/src/static/js/v_summary.js
+++ b/frontend/src/static/js/v_summary.js
@@ -912,6 +912,7 @@ window.vSummary = {
     this.$root.$on('restoreCommits', (info) => {
       const zoomFilteredUser = this.restoreZoomFiltered(info);
       info.zUser = zoomFilteredUser;
+      info.zFileTypeColors = this.fileTypeColors;
     });
   },
   mounted() {

--- a/frontend/src/static/js/v_summary_charts.js
+++ b/frontend/src/static/js/v_summary_charts.js
@@ -179,6 +179,7 @@ window.vSummaryCharts = {
         zSince: since,
         zUntil: until,
         zIsMerge: isMerge,
+        zFileTypeColors: this.fileTypeColors,
         zFromRamp: false,
         zFilterSearch: filterSearch,
       };

--- a/frontend/src/static/js/v_zoom.js
+++ b/frontend/src/static/js/v_zoom.js
@@ -72,7 +72,7 @@ window.vZoom = {
     },
 
     restoreZoomTab() {
-      // restore selected user's commits from v_summary
+      // restore selected user's commits and file type colors from v_summary
       this.$root.$emit('restoreCommits', this.info);
     },
 

--- a/frontend/src/static/js/v_zoom.js
+++ b/frontend/src/static/js/v_zoom.js
@@ -9,6 +9,7 @@ window.vZoom = {
       expandedCommitMessagesCount: this.totalCommitMessageBodyCount,
       commitsSortType: 'time',
       toReverseSortedCommits: true,
+      isCommitsFinalized: false,
       selectedFileTypes: [],
       fileTypes: [],
     };
@@ -33,7 +34,7 @@ window.vZoom = {
       filteredUser.commits = zUser.commits.filter(
           (commit) => commit[date] >= zSince && commit[date] <= zUntil,
       ).sort(this.sortingFunction);
-      this.updateFileTypes(filteredUser.commits);
+      this.isCommitsFinalized = true;
 
       return filteredUser;
     },
@@ -82,6 +83,15 @@ window.vZoom = {
     ...Vuex.mapState(['fileTypeColors']),
   },
 
+  watch: {
+    isCommitsFinalized() {
+      if (this.isCommitsFinalized) {
+        this.updateFileTypes(this.filteredUser.commits);
+        this.selectedFileTypes = this.fileTypes.slice();
+      }
+    },
+  },
+
   methods: {
     initiate() {
       if (!this.info.zUser) { // restoring zoom tab from reloaded page
@@ -125,7 +135,6 @@ window.vZoom = {
         });
       });
       this.fileTypes.sort();
-      this.selectedFileTypes = this.fileTypes.slice();
     },
 
     setInfoHash() {

--- a/frontend/src/static/js/v_zoom.js
+++ b/frontend/src/static/js/v_zoom.js
@@ -7,6 +7,7 @@ window.vZoom = {
       expandedCommitMessagesCount: this.totalCommitMessageBodyCount,
       commitsSortType: 'time',
       toReverseSortedCommits: true,
+      shouldShowFileTypes: false,
     };
   },
 

--- a/frontend/src/static/js/v_zoom.js
+++ b/frontend/src/static/js/v_zoom.js
@@ -87,7 +87,7 @@ window.vZoom = {
   watch: {
     isCommitsFinalized() {
       if (this.isCommitsFinalized) {
-        this.updateFileTypes(this.filteredUser.commits);
+        this.updateFileTypes();
         this.selectedFileTypes = this.fileTypes.slice();
         this.retrieveSelectedFileTypesHash();
       }
@@ -125,18 +125,19 @@ window.vZoom = {
       this.$root.$emit('restoreCommits', this.info);
     },
 
-    updateFileTypes(commits) {
-      this.fileTypes = [];
-      commits.forEach((day) => {
+    updateFileTypes() {
+      const commitsFileTypes = new Set();
+      this.filteredUser.commits.forEach((day) => {
         day.commitResults.forEach((slice) => {
           Object.keys(slice.fileTypesAndContributionMap).forEach((fileType) => {
-            if (this.fileTypes.indexOf(fileType) === -1) {
-              this.fileTypes.push(fileType);
-            }
+            commitsFileTypes.add(fileType);
           });
         });
       });
-      this.fileTypes.sort();
+      this.fileTypes = Object.keys(this.filteredUser.fileTypeContribution).filter(
+          (fileType) => commitsFileTypes.has(fileType),
+      );
+      this.isFileTypesLoaded = true;
     },
 
     retrieveSelectedFileTypesHash() {

--- a/frontend/src/static/js/v_zoom.js
+++ b/frontend/src/static/js/v_zoom.js
@@ -7,7 +7,7 @@ window.vZoom = {
       expandedCommitMessagesCount: this.totalCommitMessageBodyCount,
       commitsSortType: 'time',
       toReverseSortedCommits: true,
-      shouldShowFileTypes: false,
+      shouldShowFileTypes: true,
       selectedFileTypes: [],
       fileTypes: [],
     };

--- a/frontend/src/static/js/v_zoom.js
+++ b/frontend/src/static/js/v_zoom.js
@@ -78,6 +78,7 @@ window.vZoom = {
         } else {
           this.selectedFileTypes = [];
         }
+        this.updateSelectedFileTypesHash();
       },
     },
     ...Vuex.mapState(['fileTypeColors']),
@@ -88,6 +89,7 @@ window.vZoom = {
       if (this.isCommitsFinalized) {
         this.updateFileTypes(this.filteredUser.commits);
         this.selectedFileTypes = this.fileTypes.slice();
+        this.retrieveSelectedFileTypesHash();
       }
     },
   },
@@ -135,6 +137,26 @@ window.vZoom = {
         });
       });
       this.fileTypes.sort();
+    },
+
+    retrieveSelectedFileTypesHash() {
+      window.decodeHash();
+      const hash = window.hashParams;
+
+      if (hash.zFT) {
+        this.selectedFileTypes = hash.zFT
+            .split(window.HASH_DELIMITER)
+            .filter((fileType) => this.fileTypes.includes(fileType));
+      }
+    },
+
+    updateSelectedFileTypesHash() {
+      const fileTypeHash = this.selectedFileTypes.length > 0
+          ? this.selectedFileTypes.reduce((a, b) => `${a}~${b}`)
+          : '';
+
+      window.addHash('zFT', fileTypeHash);
+      window.encodeHash();
     },
 
     setInfoHash() {
@@ -185,6 +207,7 @@ window.vZoom = {
       window.removeHash('zFGS');
       window.removeHash('zFTF');
       window.removeHash('zMG');
+      window.removeHash('zFT');
       window.encodeHash();
     },
 

--- a/frontend/src/static/js/v_zoom.js
+++ b/frontend/src/static/js/v_zoom.js
@@ -1,3 +1,5 @@
+/* global Vuex */
+
 window.vZoom = {
   props: ['info'],
   template: window.$('v_zoom').innerHTML,
@@ -79,6 +81,7 @@ window.vZoom = {
         }
       },
     },
+    ...Vuex.mapState(['fileTypeColors']),
   },
 
   methods: {

--- a/frontend/src/static/js/v_zoom.js
+++ b/frontend/src/static/js/v_zoom.js
@@ -58,7 +58,7 @@ window.vZoom = {
     },
     totalCommitMessageBodyCount() {
       let nonEmptyCommitMessageCount = 0;
-      this.filteredUser.commits.forEach((commit) => {
+      this.selectedCommits.forEach((commit) => {
         commit.commitResults.forEach((commitResult) => {
           if (commitResult.messageBody !== '') {
             nonEmptyCommitMessageCount += 1;
@@ -91,6 +91,11 @@ window.vZoom = {
         this.selectedFileTypes = this.fileTypes.slice();
         this.retrieveSelectedFileTypesHash();
       }
+    },
+    selectedFileTypes() {
+      this.$nextTick(() => {
+        this.updateExpandedCommitMessagesCount();
+      });
     },
   },
 
@@ -221,7 +226,6 @@ window.vZoom = {
   },
   mounted() {
     this.setInfoHash();
-    this.updateExpandedCommitMessagesCount();
   },
   beforeDestroy() {
     this.removeZoomHashes();

--- a/frontend/src/static/js/v_zoom.js
+++ b/frontend/src/static/js/v_zoom.js
@@ -34,7 +34,6 @@ window.vZoom = {
       filteredUser.commits = zUser.commits.filter(
           (commit) => commit[date] >= zSince && commit[date] <= zUntil,
       ).sort(this.sortingFunction);
-      this.selectedCommits = filteredUser.commits;
       this.updateFileTypes(filteredUser.commits);
 
       return filteredUser;

--- a/frontend/src/static/js/v_zoom.js
+++ b/frontend/src/static/js/v_zoom.js
@@ -9,7 +9,6 @@ window.vZoom = {
       expandedCommitMessagesCount: this.totalCommitMessageBodyCount,
       commitsSortType: 'time',
       toReverseSortedCommits: true,
-      shouldShowFileTypes: true,
       selectedFileTypes: [],
       fileTypes: [],
     };

--- a/frontend/src/static/js/v_zoom.js
+++ b/frontend/src/static/js/v_zoom.js
@@ -40,18 +40,18 @@ window.vZoom = {
     },
     selectedCommits() {
       const commits = [];
-      this.filteredUser.commits.forEach((commitDay) => {
-        const filteredDay = { ...commitDay };
-        filteredDay.commitResults = [];
-        commitDay.commitResults.forEach((slice) => {
+      this.filteredUser.commits.forEach((commit) => {
+        const filteredCommit = { ...commit };
+        filteredCommit.commitResults = [];
+        commit.commitResults.forEach((slice) => {
           if (Object.keys(slice.fileTypesAndContributionMap).some(
               (fileType) => this.selectedFileTypes.indexOf(fileType) !== -1,
           )) {
-            filteredDay.commitResults.push(slice);
+            filteredCommit.commitResults.push(slice);
           }
         });
-        if (filteredDay.commitResults.length > 0) {
-          commits.push(filteredDay);
+        if (filteredCommit.commitResults.length > 0) {
+          commits.push(filteredCommit);
         }
       });
       return commits;
@@ -127,8 +127,8 @@ window.vZoom = {
 
     updateFileTypes() {
       const commitsFileTypes = new Set();
-      this.filteredUser.commits.forEach((day) => {
-        day.commitResults.forEach((slice) => {
+      this.filteredUser.commits.forEach((commit) => {
+        commit.commitResults.forEach((slice) => {
           Object.keys(slice.fileTypesAndContributionMap).forEach((fileType) => {
             commitsFileTypes.add(fileType);
           });

--- a/frontend/src/tabs/zoom.pug
+++ b/frontend/src/tabs/zoom.pug
@@ -67,7 +67,24 @@
       input.medium-font(type="checkbox", v-model="shouldShowFileTypes")
       span.medium-font show file type in commits
 
-  .zoom__day(v-for="day in filteredUser.commits", v-bind:key="day.date")
+  .fileTypes(v-if="shouldShowFileTypes")
+    .checkboxes.mui-form--inline(v-if="fileTypes.length > 0")
+      label(style='background-color: #000000; color: #ffffff')
+        input.mui-checkbox--fileType(type="checkbox", v-model="isSelectAllChecked")
+        span All&nbsp;
+      template(v-for="fileType in fileTypes")
+        label(
+          v-bind:key="fileType",
+          v-bind:style="{\
+                  'background-color': info.zFileTypeColors[fileType],\
+                  'color': this.getFontColor(info.zFileTypeColors[fileType])\
+                  }"
+        )
+          input.mui-checkbox--fileType(type="checkbox", v-bind:id="fileType", v-bind:value="fileType",
+            v-model="selectedFileTypes")
+          span {{ fileType }} &nbsp;
+
+  .zoom__day(v-for="day in selectedCommits", v-bind:key="day.date")
     h3(v-if="info.zTimeFrame === 'week'") Week of {{ day.date }}
     h3(v-else) {{ day.date }}
     template
@@ -83,8 +100,8 @@
           .not-within-border(v-if="slice.messageTitle.length > 50") {{ slice.messageTitle.substr(50) }}
         span &nbsp; ({{ slice.insertions }} lines) &nbsp;
         template(v-if="shouldShowFileTypes")
-          span.fileTypeLabel.medium-font(
-            v-for="fileType in Object.keys(slice.fileTypesAndContributionMap)",
+          span.fileTypeLabel(
+            v-for="fileType in filterSelectedFileTypes(Object.keys(slice.fileTypesAndContributionMap))",
             v-bind:style="{\
               'background-color': info.zFileTypeColors[fileType],\
               'color': this.getFontColor(info.zFileTypeColors[fileType])\

--- a/frontend/src/tabs/zoom.pug
+++ b/frontend/src/tabs/zoom.pug
@@ -79,6 +79,13 @@
           .within-border {{ slice.messageTitle.substr(0, 50) }}
           .not-within-border(v-if="slice.messageTitle.length > 50") {{ slice.messageTitle.substr(50) }}
         span &nbsp; ({{ slice.insertions }} lines) &nbsp;
+        template(v-for="fileType in Object.keys(slice.fileTypesAndContributionMap)")
+          .file-type.medium-font(
+            v-bind:style="{\
+              'background-color': info.zFileTypeColors[fileType],\
+              'color': this.getFontColor(info.zFileTypeColors[fileType])\
+              }"
+          ) {{ fileType }}
         template(v-if="slice.tags", v-for="tag in slice.tags")
           .tag(tabindex="-1", v-bind:class="[`${slice.hash}`, tag]")
             font-awesome-icon(icon="tags")

--- a/frontend/src/tabs/zoom.pug
+++ b/frontend/src/tabs/zoom.pug
@@ -78,7 +78,7 @@
                   }"
         )
           input.mui-checkbox--fileType(type="checkbox", v-bind:value="fileType",
-            v-model="selectedFileTypes")
+            v-on:change="updateSelectedFileTypesHash", v-model="selectedFileTypes")
           span {{ fileType }} &nbsp;
 
   .zoom__day(v-for="day in selectedCommits", v-bind:key="day.date")

--- a/frontend/src/tabs/zoom.pug
+++ b/frontend/src/tabs/zoom.pug
@@ -67,7 +67,7 @@
   .fileTypes
     .checkboxes.mui-form--inline(v-if="fileTypes.length > 0")
       label(style='background-color: #000000; color: #ffffff')
-        input.mui-checkbox--fileType(type="checkbox", v-model="isSelectAllChecked")
+        input.mui-checkbox--fileType(type="checkbox", v-model="isSelectAllChecked", value="all")
         span All&nbsp;
       template(v-for="fileType in fileTypes")
         label(

--- a/frontend/src/tabs/zoom.pug
+++ b/frontend/src/tabs/zoom.pug
@@ -63,11 +63,8 @@
         option(v-bind:value='true') Descending
         option(v-bind:value='false') Ascending
       label order
-    .mui-checkbox
-      input.medium-font(type="checkbox", v-model="shouldShowFileTypes")
-      span.medium-font show file type in commits
 
-  .fileTypes(v-if="shouldShowFileTypes")
+  .fileTypes
     .checkboxes.mui-form--inline(v-if="fileTypes.length > 0")
       label(style='background-color: #000000; color: #ffffff')
         input.mui-checkbox--fileType(type="checkbox", v-model="isSelectAllChecked")
@@ -99,7 +96,7 @@
           .within-border {{ slice.messageTitle.substr(0, 50) }}
           .not-within-border(v-if="slice.messageTitle.length > 50") {{ slice.messageTitle.substr(50) }}
         span &nbsp; ({{ slice.insertions }} lines) &nbsp;
-        template(v-if="shouldShowFileTypes")
+        template
           span.fileTypeLabel(
             v-for="fileType in filterSelectedFileTypes(Object.keys(slice.fileTypesAndContributionMap))",
             v-bind:style="{\

--- a/frontend/src/tabs/zoom.pug
+++ b/frontend/src/tabs/zoom.pug
@@ -76,8 +76,8 @@
         label(
           v-bind:key="fileType",
           v-bind:style="{\
-                  'background-color': info.zFileTypeColors[fileType],\
-                  'color': this.getFontColor(info.zFileTypeColors[fileType])\
+                  'background-color': fileTypeColors[fileType],\
+                  'color': this.getFontColor(fileTypeColors[fileType])\
                   }"
         )
           input.mui-checkbox--fileType(type="checkbox", v-bind:value="fileType",
@@ -103,8 +103,8 @@
           span.fileTypeLabel(
             v-for="fileType in filterSelectedFileTypes(Object.keys(slice.fileTypesAndContributionMap))",
             v-bind:style="{\
-              'background-color': info.zFileTypeColors[fileType],\
-              'color': this.getFontColor(info.zFileTypeColors[fileType])\
+              'background-color': fileTypeColors[fileType],\
+              'color': this.getFontColor(fileTypeColors[fileType])\
               }"
           ) {{ fileType }}
         template(v-if="slice.tags", v-for="tag in slice.tags")

--- a/frontend/src/tabs/zoom.pug
+++ b/frontend/src/tabs/zoom.pug
@@ -80,7 +80,7 @@
                   'color': this.getFontColor(info.zFileTypeColors[fileType])\
                   }"
         )
-          input.mui-checkbox--fileType(type="checkbox", v-bind:id="fileType", v-bind:value="fileType",
+          input.mui-checkbox--fileType(type="checkbox", v-bind:value="fileType",
             v-model="selectedFileTypes")
           span {{ fileType }} &nbsp;
 

--- a/frontend/src/tabs/zoom.pug
+++ b/frontend/src/tabs/zoom.pug
@@ -63,6 +63,9 @@
         option(v-bind:value='true') Descending
         option(v-bind:value='false') Ascending
       label order
+    .mui-checkbox
+      input.medium-font(type="checkbox", v-model="shouldShowFileTypes")
+      span.medium-font show file type in commits
 
   .zoom__day(v-for="day in filteredUser.commits", v-bind:key="day.date")
     h3(v-if="info.zTimeFrame === 'week'") Week of {{ day.date }}
@@ -79,8 +82,9 @@
           .within-border {{ slice.messageTitle.substr(0, 50) }}
           .not-within-border(v-if="slice.messageTitle.length > 50") {{ slice.messageTitle.substr(50) }}
         span &nbsp; ({{ slice.insertions }} lines) &nbsp;
-        template(v-for="fileType in Object.keys(slice.fileTypesAndContributionMap)")
-          .file-type.medium-font(
+        template(v-if="shouldShowFileTypes")
+          span.fileTypeLabel.medium-font(
+            v-for="fileType in Object.keys(slice.fileTypesAndContributionMap)",
             v-bind:style="{\
               'background-color': info.zFileTypeColors[fileType],\
               'color': this.getFontColor(info.zFileTypeColors[fileType])\


### PR DESCRIPTION
Resolves #1239
```
With PR #1192, we have the file type info of each commit, 
but users are still unable to view the type of file changes 
made in each commit as this information is not displayed.

The addition of filetype tags in the commits panel gives 
users an easy view to the type of changes made in 
each commit.

Let's add file type tags to each commit in the 
commits panel along with an additional filtering 
functionality for easy viewing.
```