### PR TITLE
[#1328] Fix usage of non-existent delimiter

### DIFF
--- a/frontend/src/static/js/v_authorship.js
+++ b/frontend/src/static/js/v_authorship.js
@@ -68,7 +68,7 @@ window.vAuthorship = {
         : [];
       if (hash.authorshipFileTypes) {
         this.selectedFileTypes = hash.authorshipFileTypes
-            .split(window.HASH_FILETYPE_DELIMITER)
+            .split(window.HASH_DELIMITER)
             .filter((fileType) => this.fileTypes.includes(fileType));
       }
 


### PR DESCRIPTION
```
File type hashes in authorship tab were delimited with a
non-existent delimiter and this causes errors when restoring
selected file types from the hash.

Let's use an appropriate delimiter so that file type hashes 
can be parsed correctly. 
```
Fixes #1328 