### PR TITLE
[#1312] Conditional run for markbind to gh pages deployment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 matrix:
   include:
     - name: Deploy MarkBind to gh pages
+      if: branch = master
       language: node
       node_js:
         - lts/*


### PR DESCRIPTION
Fixes #1312 

```
The markbind to gh pages deployment task is executed at every
pull request, which runs npm install but do not deploy to the
gh pages since it is not the master branch. This is unnecessary 
and takes up build time.

Let's ensure that the deployment task to not be run at all when it 
is not from the master branch.
```