### PR TITLE
[#1354] Treat empty author tags as new author annotation

### DIFF
--- a/src/systemtest/resources/30daysFromUntilDate/expected/reposense_testrepo-Charlie_master/authorship.json
+++ b/src/systemtest/resources/30daysFromUntilDate/expected/reposense_testrepo-Charlie_master/authorship.json
@@ -104490,91 +104490,91 @@
       {
         "lineNumber": 88,
         "author": {
-          "gitId": "wangyiming1019"
+          "gitId": "-"
         },
         "content": "    @Test"
       },
       {
         "lineNumber": 89,
         "author": {
-          "gitId": "wangyiming1019"
+          "gitId": "-"
         },
         "content": "    public void parseCommandAliasAdd() throws Exception {"
       },
       {
         "lineNumber": 90,
         "author": {
-          "gitId": "wangyiming1019"
+          "gitId": "-"
         },
         "content": "        Person person \u003d new PersonBuilder().build();"
       },
       {
         "lineNumber": 91,
         "author": {
-          "gitId": "wangyiming1019"
+          "gitId": "-"
         },
         "content": "        AddCommand command \u003d (AddCommand) parser.parseCommand(AddCommand.COMMAND_ALIAS + \" \""
       },
       {
         "lineNumber": 92,
         "author": {
-          "gitId": "wangyiming1019"
+          "gitId": "-"
         },
         "content": "                + PersonUtil.getPersonDetails(person));"
       },
       {
         "lineNumber": 93,
         "author": {
-          "gitId": "wangyiming1019"
+          "gitId": "-"
         },
         "content": "        assertEquals(new AddCommand(person), command);"
       },
       {
         "lineNumber": 94,
         "author": {
-          "gitId": "Esilocke"
+          "gitId": "-"
         },
         "content": ""
       },
       {
         "lineNumber": 95,
         "author": {
-          "gitId": "Esilocke"
+          "gitId": "-"
         },
         "content": "        Task task \u003d new TaskBuilder().build();"
       },
       {
         "lineNumber": 96,
         "author": {
-          "gitId": "Esilocke"
+          "gitId": "-"
         },
         "content": "        command \u003d (AddCommand) parser.parseCommand(AddCommand.COMMAND_ALIAS + \" \""
       },
       {
         "lineNumber": 97,
         "author": {
-          "gitId": "Esilocke"
+          "gitId": "-"
         },
         "content": "                + PREFIX_TASK + \" \" + TaskUtil.getTaskDetails(task));"
       },
       {
         "lineNumber": 98,
         "author": {
-          "gitId": "Esilocke"
+          "gitId": "-"
         },
         "content": "        assertEquals(new AddCommand(task), command);"
       },
       {
         "lineNumber": 99,
         "author": {
-          "gitId": "Esilocke"
+          "gitId": "-"
         },
         "content": "    }"
       },
       {
         "lineNumber": 100,
         "author": {
-          "gitId": "Esilocke"
+          "gitId": "-"
         },
         "content": ""
       },
@@ -107179,9 +107179,9 @@
     "authorContributionMap": {
       "charlesgoh": 21,
       "jeffreygohkw": 75,
-      "Esilocke": 154,
-      "wangyiming1019": 86,
-      "-": 135
+      "Esilocke": 147,
+      "wangyiming1019": 80,
+      "-": 148
     }
   },
   {

--- a/src/systemtest/resources/30daysFromUntilDate/expected/reposense_testrepo-Charlie_master/commits.json
+++ b/src/systemtest/resources/30daysFromUntilDate/expected/reposense_testrepo-Charlie_master/commits.json
@@ -7652,12 +7652,12 @@
     },
     "Esilocke": {
       "code": 2656,
-      "test": 1594,
+      "test": 1587,
       "docs": 421
     },
     "wangyiming1019": {
       "code": 1058,
-      "test": 1017,
+      "test": 1011,
       "docs": 0
     }
   },

--- a/src/systemtest/resources/sinceBeginningDateRange/expected/reposense_testrepo-Charlie_master/commits.json
+++ b/src/systemtest/resources/sinceBeginningDateRange/expected/reposense_testrepo-Charlie_master/commits.json
@@ -14252,7 +14252,7 @@
   "authorFileTypeContributionMap": {
     "charlesgoh": {
       "code": 1825,
-      "test": 1433,
+      "test": 1430,
       "docs": 970
     },
     "jeffreygohkw": {
@@ -14262,12 +14262,12 @@
     },
     "Esilocke": {
       "code": 4308,
-      "test": 4058,
+      "test": 4051,
       "docs": 2578
     },
     "wangyiming1019": {
       "code": 1142,
-      "test": 1327,
+      "test": 1324,
       "docs": 0
     }
   },


### PR DESCRIPTION
Fixes #1354 
```
AnnotatorAnalyzer: Treat empty author tags as new author annotation

Currently, empty author tags are assumed to signal the end of an
annotation block. Users who wish to disown a code block can
mark the block with the "@@author random-user" tag (where random-user
is a dummy name, not the git author name of any author
in the repository).

Let's allow users to disown code blocks by marking them
with empty author tags (i.e. "@@author"). This is more
convenient as dummy names need not be used.

```