### PR TITLE
[#1207] AuthorConfiguration: Rename authorEmailsAndAliasesMap to authorDetailsToAuthorMap

### DIFF
--- a/src/main/java/reposense/authorship/FileInfoAnalyzer.java
+++ b/src/main/java/reposense/authorship/FileInfoAnalyzer.java
@@ -56,7 +56,7 @@ public class FileInfoAnalyzer {
         aggregateBlameAuthorModifiedAndDateInfo(config, fileInfo);
         fileInfo.setFileType(config.getFileType(fileInfo.getPath()));
 
-        AnnotatorAnalyzer.aggregateAnnotationAuthorInfo(fileInfo, config.getAuthorEmailsAndAliasesMap());
+        AnnotatorAnalyzer.aggregateAnnotationAuthorInfo(fileInfo, config.getAuthorDetailsToAuthorMap());
 
         if (!config.getAuthorList().isEmpty() && fileInfo.isAllAuthorsIgnored(config.getAuthorList())) {
             return null;

--- a/src/main/java/reposense/model/AuthorConfiguration.java
+++ b/src/main/java/reposense/model/AuthorConfiguration.java
@@ -25,7 +25,7 @@ public class AuthorConfiguration {
     private String branch;
 
     private transient List<Author> authorList = new ArrayList<>();
-    private transient Map<String, Author> authorEmailsAndAliasesMap = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+    private transient Map<String, Author> authorDetailsToAuthorMap = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
     private transient Map<Author, String> authorDisplayNameMap = new HashMap<>();
 
     public AuthorConfiguration(RepoLocation location) {
@@ -62,7 +62,7 @@ public class AuthorConfiguration {
         }
 
         setAuthorList(newAuthorList);
-        setAuthorEmailsAndAliasesMap(newAuthorEmailsAndAliasesMap);
+        setAuthorDetailsToAuthorMap(newAuthorEmailsAndAliasesMap);
         setAuthorDisplayNameMap(newAuthorDisplayNameMap);
     }
 
@@ -93,7 +93,7 @@ public class AuthorConfiguration {
         return location.equals(otherAuthorConfig.location)
                 && branch.equals(otherAuthorConfig.branch)
                 && authorList.equals(otherAuthorConfig.authorList)
-                && authorEmailsAndAliasesMap.equals(otherAuthorConfig.authorEmailsAndAliasesMap)
+                && authorDetailsToAuthorMap.equals(otherAuthorConfig.authorDetailsToAuthorMap)
                 && authorDisplayNameMap.equals(otherAuthorConfig.authorDisplayNameMap);
     }
 
@@ -159,7 +159,7 @@ public class AuthorConfiguration {
      */
     public void removeIgnoredAuthors(List<String> ignoredAuthorsList) {
         for (String author : ignoredAuthorsList) {
-            if (authorEmailsAndAliasesMap.containsKey(author)) {
+            if (authorDetailsToAuthorMap.containsKey(author)) {
                 removeAuthorInformation(author);
             }
         }
@@ -171,16 +171,16 @@ public class AuthorConfiguration {
      * @param author Can be an author's git ID, email, or alias
      */
     public void removeAuthorInformation(String author) {
-        Author authorToRemove = authorEmailsAndAliasesMap.get(author);
+        Author authorToRemove = authorDetailsToAuthorMap.get(author);
         authorList.remove(authorToRemove);
         authorDisplayNameMap.remove(authorToRemove);
-        authorEmailsAndAliasesMap.remove(authorToRemove.getGitId());
+        authorDetailsToAuthorMap.remove(authorToRemove.getGitId());
 
         List<String> aliases = authorToRemove.getAuthorAliases();
-        aliases.forEach(alias -> authorEmailsAndAliasesMap.remove(alias));
+        aliases.forEach(alias -> authorDetailsToAuthorMap.remove(alias));
 
         List<String> emails = authorToRemove.getEmails();
-        emails.forEach(email -> authorEmailsAndAliasesMap.remove(email));
+        emails.forEach(email -> authorDetailsToAuthorMap.remove(email));
     }
 
     /**
@@ -211,7 +211,7 @@ public class AuthorConfiguration {
      * Clears author mapping information.
      */
     public void clear() {
-        authorEmailsAndAliasesMap.clear();
+        authorDetailsToAuthorMap.clear();
         authorDisplayNameMap.clear();
     }
 
@@ -222,12 +222,12 @@ public class AuthorConfiguration {
         authorList.forEach(this::setAuthorDetails);
     }
 
-    public Map<String, Author> getAuthorEmailsAndAliasesMap() {
-        return authorEmailsAndAliasesMap;
+    public Map<String, Author> getAuthorDetailsToAuthorMap() {
+        return authorDetailsToAuthorMap;
     }
 
-    public void setAuthorEmailsAndAliasesMap(Map<String, Author> authorEmailsAndAliasesMap) {
-        this.authorEmailsAndAliasesMap = authorEmailsAndAliasesMap;
+    public void setAuthorDetailsToAuthorMap(Map<String, Author> authorDetailsToAuthorMap) {
+        this.authorDetailsToAuthorMap = authorDetailsToAuthorMap;
     }
 
     public void setAuthorDisplayName(Author author, String displayName) {
@@ -241,8 +241,8 @@ public class AuthorConfiguration {
      */
     public void addAuthorEmailsAndAliasesMapEntry(Author author, List<String> values) {
         values.forEach(value -> {
-            checkDuplicateAliases(authorEmailsAndAliasesMap, value, author.getGitId());
-            authorEmailsAndAliasesMap.put(value, author);
+            checkDuplicateAliases(authorDetailsToAuthorMap, value, author.getGitId());
+            authorDetailsToAuthorMap.put(value, author);
         });
     }
 
@@ -255,16 +255,16 @@ public class AuthorConfiguration {
      * If no matching {@code Author} is found, {@code Author#UNKNOWN_AUTHOR} is returned.
      */
     public Author getAuthor(String name, String email) {
-        if (authorEmailsAndAliasesMap.containsKey(name)) {
-            return authorEmailsAndAliasesMap.get(name);
+        if (authorDetailsToAuthorMap.containsKey(name)) {
+            return authorDetailsToAuthorMap.get(name);
         }
-        if (authorEmailsAndAliasesMap.containsKey(email)) {
-            return authorEmailsAndAliasesMap.get(email);
+        if (authorDetailsToAuthorMap.containsKey(email)) {
+            return authorDetailsToAuthorMap.get(email);
         }
         Matcher matcher = EMAIL_PLUS_OPERATOR_PATTERN.matcher(email);
 
         if (matcher.matches()) {
-            return authorEmailsAndAliasesMap.getOrDefault(matcher.group("suffix") + matcher.group("domain"),
+            return authorDetailsToAuthorMap.getOrDefault(matcher.group("suffix") + matcher.group("domain"),
                     Author.UNKNOWN_AUTHOR);
         }
         return Author.UNKNOWN_AUTHOR;

--- a/src/main/java/reposense/model/AuthorConfiguration.java
+++ b/src/main/java/reposense/model/AuthorConfiguration.java
@@ -42,7 +42,7 @@ public class AuthorConfiguration {
      */
     public void update(StandaloneConfig standaloneConfig, List<String> ignoreGlobList) {
         List<Author> newAuthorList = new ArrayList<>();
-        Map<String, Author> newAuthorEmailsAndAliasesMap = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+        Map<String, Author> newAuthorDetailsToAuthorMap = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
         Map<Author, String> newAuthorDisplayNameMap = new HashMap<>();
 
         for (StandaloneAuthor sa : standaloneConfig.getAuthors()) {
@@ -55,24 +55,24 @@ public class AuthorConfiguration {
             List<String> emails = new ArrayList<>(author.getEmails());
             aliases.add(author.getGitId());
             aliases.forEach(alias -> {
-                checkDuplicateAliases(newAuthorEmailsAndAliasesMap, alias, author.getGitId());
-                newAuthorEmailsAndAliasesMap.put(alias, author);
+                checkDuplicateAliases(newAuthorDetailsToAuthorMap, alias, author.getGitId());
+                newAuthorDetailsToAuthorMap.put(alias, author);
             });
-            emails.forEach(email -> newAuthorEmailsAndAliasesMap.put(email, author));
+            emails.forEach(email -> newAuthorDetailsToAuthorMap.put(email, author));
         }
 
         setAuthorList(newAuthorList);
-        setAuthorDetailsToAuthorMap(newAuthorEmailsAndAliasesMap);
+        setAuthorDetailsToAuthorMap(newAuthorDetailsToAuthorMap);
         setAuthorDisplayNameMap(newAuthorDisplayNameMap);
     }
 
     /**
-     * Checks for duplicate aliases in {@code authorEmailsAndAliasesMap} and generates warnings
-     * @param authorEmailsAndAliasesMap
+     * Checks for duplicate aliases in {@code authorDetailsToAuthorMap} and generates warnings
+     * @param authorDetailsToAuthorMap
      * @param alias
      */
-    public void checkDuplicateAliases(Map<String, Author> authorEmailsAndAliasesMap, String alias, String gitId) {
-        if (authorEmailsAndAliasesMap.containsKey(alias)) {
+    public void checkDuplicateAliases(Map<String, Author> authorDetailsToAuthorMap, String alias, String gitId) {
+        if (authorDetailsToAuthorMap.containsKey(alias)) {
             logger.warning(String.format(
                     "Duplicate alias %s found. The alias will belong to the last author - %s", alias, gitId));
         }
@@ -123,10 +123,10 @@ public class AuthorConfiguration {
      */
     private void setAuthorDetails(Author author) {
         // Set GitHub Id and its corresponding email as default
-        addAuthorEmailsAndAliasesMapEntry(author, Arrays.asList(author.getGitId()));
+        addAuthorDetailsToAuthorMapEntry(author, Arrays.asList(author.getGitId()));
 
-        addAuthorEmailsAndAliasesMapEntry(author, author.getAuthorAliases());
-        addAuthorEmailsAndAliasesMapEntry(author, author.getEmails());
+        addAuthorDetailsToAuthorMapEntry(author, author.getAuthorAliases());
+        addAuthorDetailsToAuthorMapEntry(author, author.getEmails());
 
         setAuthorDisplayName(author, author.getDisplayName());
     }
@@ -167,7 +167,7 @@ public class AuthorConfiguration {
 
     /**
      * Removes all information of the {@code author} from the configs
-     * Precondition: {@code author} must be present in {@code authorEmailsAndAliasesMap}
+     * Precondition: {@code author} must be present in {@code authorDetailsToAuthorMap}
      * @param author Can be an author's git ID, email, or alias
      */
     public void removeAuthorInformation(String author) {
@@ -239,7 +239,7 @@ public class AuthorConfiguration {
      * @param author
      * @param values
      */
-    public void addAuthorEmailsAndAliasesMapEntry(Author author, List<String> values) {
+    public void addAuthorDetailsToAuthorMapEntry(Author author, List<String> values) {
         values.forEach(value -> {
             checkDuplicateAliases(authorDetailsToAuthorMap, value, author.getGitId());
             authorDetailsToAuthorMap.put(value, author);

--- a/src/main/java/reposense/model/RepoConfiguration.java
+++ b/src/main/java/reposense/model/RepoConfiguration.java
@@ -481,7 +481,7 @@ public class RepoConfiguration {
     }
 
     public void addAuthorEmailsAndAliasesMapEntry(Author author, List<String> values) {
-        authorConfig.addAuthorEmailsAndAliasesMapEntry(author, values);
+        authorConfig.addAuthorDetailsToAuthorMapEntry(author, values);
     }
 
     public String getDisplayName() {

--- a/src/main/java/reposense/model/RepoConfiguration.java
+++ b/src/main/java/reposense/model/RepoConfiguration.java
@@ -480,7 +480,7 @@ public class RepoConfiguration {
         authorConfig.setAuthorDisplayName(author, displayName);
     }
 
-    public void addAuthorEmailsAndAliasesMapEntry(Author author, List<String> values) {
+    public void addAuthorDetailsToAuthorMapEntry(Author author, List<String> values) {
         authorConfig.addAuthorDetailsToAuthorMapEntry(author, values);
     }
 

--- a/src/main/java/reposense/model/RepoConfiguration.java
+++ b/src/main/java/reposense/model/RepoConfiguration.java
@@ -421,8 +421,8 @@ public class RepoConfiguration {
         return authorConfig.getAuthorDetailsToAuthorMap();
     }
 
-    public void setAuthorEmailsAndAliasesMap(Map<String, Author> authorEmailsAndAliasesMap) {
-        authorConfig.setAuthorDetailsToAuthorMap(authorEmailsAndAliasesMap);
+    public void setAuthorDetailsToAuthorMap(Map<String, Author> authorDetailsToAuthorMap) {
+        authorConfig.setAuthorDetailsToAuthorMap(authorDetailsToAuthorMap);
     }
 
     public void setFormats(List<FileType> formats) {

--- a/src/main/java/reposense/model/RepoConfiguration.java
+++ b/src/main/java/reposense/model/RepoConfiguration.java
@@ -417,7 +417,7 @@ public class RepoConfiguration {
         authorList.forEach(author -> AuthorConfiguration.propagateIgnoreGlobList(author, this.getIgnoreGlobList()));
     }
 
-    public Map<String, Author> getAuthorEmailsAndAliasesMap() {
+    public Map<String, Author> getAuthorDetailsToAuthorMap() {
         return authorConfig.getAuthorDetailsToAuthorMap();
     }
 

--- a/src/main/java/reposense/model/RepoConfiguration.java
+++ b/src/main/java/reposense/model/RepoConfiguration.java
@@ -418,11 +418,11 @@ public class RepoConfiguration {
     }
 
     public Map<String, Author> getAuthorEmailsAndAliasesMap() {
-        return authorConfig.getAuthorEmailsAndAliasesMap();
+        return authorConfig.getAuthorDetailsToAuthorMap();
     }
 
     public void setAuthorEmailsAndAliasesMap(Map<String, Author> authorEmailsAndAliasesMap) {
-        authorConfig.setAuthorEmailsAndAliasesMap(authorEmailsAndAliasesMap);
+        authorConfig.setAuthorDetailsToAuthorMap(authorEmailsAndAliasesMap);
     }
 
     public void setFormats(List<FileType> formats) {

--- a/src/test/java/reposense/authorship/FileInfoExtractorTest.java
+++ b/src/test/java/reposense/authorship/FileInfoExtractorTest.java
@@ -37,8 +37,8 @@ public class FileInfoExtractorTest extends GitTestTemplate {
 
     @Test
     public void extractFileInfosTest() {
-        config.getAuthorEmailsAndAliasesMap().put(MAIN_AUTHOR_NAME, new Author(MAIN_AUTHOR_NAME));
-        config.getAuthorEmailsAndAliasesMap().put(FAKE_AUTHOR_NAME, new Author(FAKE_AUTHOR_NAME));
+        config.getAuthorDetailsToAuthorMap().put(MAIN_AUTHOR_NAME, new Author(MAIN_AUTHOR_NAME));
+        config.getAuthorDetailsToAuthorMap().put(FAKE_AUTHOR_NAME, new Author(FAKE_AUTHOR_NAME));
         GitCheckout.checkout(config.getRepoRoot(), TEST_COMMIT_HASH);
         List<FileInfo> files = FileInfoExtractor.extractFileInfos(config);
         Assert.assertEquals(6, files.size());

--- a/src/test/java/reposense/commits/CommitInfoAnalyzerTest.java
+++ b/src/test/java/reposense/commits/CommitInfoAnalyzerTest.java
@@ -37,14 +37,14 @@ public class CommitInfoAnalyzerTest extends GitTestTemplate {
     @Before
     public void before() throws Exception {
         super.before();
-        config.getAuthorEmailsAndAliasesMap().clear();
+        config.getAuthorDetailsToAuthorMap().clear();
     }
 
     @Test
     public void analyzeCommits_allAuthorNoIgnoredCommitsNoDateRange_success() {
-        config.getAuthorEmailsAndAliasesMap().put(MAIN_AUTHOR_NAME, new Author(MAIN_AUTHOR_NAME));
-        config.getAuthorEmailsAndAliasesMap().put(FAKE_AUTHOR_NAME, new Author(FAKE_AUTHOR_NAME));
-        config.getAuthorEmailsAndAliasesMap().put(EUGENE_AUTHOR_NAME, new Author(EUGENE_AUTHOR_NAME));
+        config.getAuthorDetailsToAuthorMap().put(MAIN_AUTHOR_NAME, new Author(MAIN_AUTHOR_NAME));
+        config.getAuthorDetailsToAuthorMap().put(FAKE_AUTHOR_NAME, new Author(FAKE_AUTHOR_NAME));
+        config.getAuthorDetailsToAuthorMap().put(EUGENE_AUTHOR_NAME, new Author(EUGENE_AUTHOR_NAME));
 
         List<CommitInfo> commitInfos = CommitInfoExtractor.extractCommitInfos(config);
         List<CommitResult> commitResults = CommitInfoAnalyzer.analyzeCommits(commitInfos, config);
@@ -54,8 +54,8 @@ public class CommitInfoAnalyzerTest extends GitTestTemplate {
 
     @Test
     public void analyzeCommits_fakeMainAuthorNoIgnoredCommitsNoDateRange_success() {
-        config.getAuthorEmailsAndAliasesMap().put(MAIN_AUTHOR_NAME, new Author(MAIN_AUTHOR_NAME));
-        config.getAuthorEmailsAndAliasesMap().put(FAKE_AUTHOR_NAME, new Author(FAKE_AUTHOR_NAME));
+        config.getAuthorDetailsToAuthorMap().put(MAIN_AUTHOR_NAME, new Author(MAIN_AUTHOR_NAME));
+        config.getAuthorDetailsToAuthorMap().put(FAKE_AUTHOR_NAME, new Author(FAKE_AUTHOR_NAME));
 
         List<CommitInfo> commitInfos = CommitInfoExtractor.extractCommitInfos(config);
         List<CommitResult> commitResults = CommitInfoAnalyzer.analyzeCommits(commitInfos, config);
@@ -65,7 +65,7 @@ public class CommitInfoAnalyzerTest extends GitTestTemplate {
 
     @Test
     public void analyzeCommits_eugeneAuthorNoIgnoredCommitsNoDateRange_success() {
-        config.getAuthorEmailsAndAliasesMap().put(EUGENE_AUTHOR_NAME, new Author(EUGENE_AUTHOR_NAME));
+        config.getAuthorDetailsToAuthorMap().put(EUGENE_AUTHOR_NAME, new Author(EUGENE_AUTHOR_NAME));
 
         List<CommitInfo> commitInfos = CommitInfoExtractor.extractCommitInfos(config);
         List<CommitResult> commitResults = CommitInfoAnalyzer.analyzeCommits(commitInfos, config);
@@ -75,9 +75,9 @@ public class CommitInfoAnalyzerTest extends GitTestTemplate {
 
     @Test
     public void analyzeCommits_allAuthorSingleCommitIgnoredNoDateRange_success() {
-        config.getAuthorEmailsAndAliasesMap().put(MAIN_AUTHOR_NAME, new Author(MAIN_AUTHOR_NAME));
-        config.getAuthorEmailsAndAliasesMap().put(FAKE_AUTHOR_NAME, new Author(FAKE_AUTHOR_NAME));
-        config.getAuthorEmailsAndAliasesMap().put(EUGENE_AUTHOR_NAME, new Author(EUGENE_AUTHOR_NAME));
+        config.getAuthorDetailsToAuthorMap().put(MAIN_AUTHOR_NAME, new Author(MAIN_AUTHOR_NAME));
+        config.getAuthorDetailsToAuthorMap().put(FAKE_AUTHOR_NAME, new Author(FAKE_AUTHOR_NAME));
+        config.getAuthorDetailsToAuthorMap().put(EUGENE_AUTHOR_NAME, new Author(EUGENE_AUTHOR_NAME));
         List<CommitInfo> commitInfos = CommitInfoExtractor.extractCommitInfos(config);
         config.setIgnoreCommitList(Collections.singletonList(FAKE_AUTHOR_BLAME_TEST_FILE_COMMIT_08022018));
         List<CommitResult> commitResultsFull = CommitInfoAnalyzer.analyzeCommits(commitInfos, config);
@@ -92,9 +92,9 @@ public class CommitInfoAnalyzerTest extends GitTestTemplate {
 
     @Test
     public void analyzeCommits_allAuthorMultipleCommitIgnoredNoDateRange_success() {
-        config.getAuthorEmailsAndAliasesMap().put(MAIN_AUTHOR_NAME, new Author(MAIN_AUTHOR_NAME));
-        config.getAuthorEmailsAndAliasesMap().put(FAKE_AUTHOR_NAME, new Author(FAKE_AUTHOR_NAME));
-        config.getAuthorEmailsAndAliasesMap().put(EUGENE_AUTHOR_NAME, new Author(EUGENE_AUTHOR_NAME));
+        config.getAuthorDetailsToAuthorMap().put(MAIN_AUTHOR_NAME, new Author(MAIN_AUTHOR_NAME));
+        config.getAuthorDetailsToAuthorMap().put(FAKE_AUTHOR_NAME, new Author(FAKE_AUTHOR_NAME));
+        config.getAuthorDetailsToAuthorMap().put(EUGENE_AUTHOR_NAME, new Author(EUGENE_AUTHOR_NAME));
         List<CommitInfo> commitInfos = CommitInfoExtractor.extractCommitInfos(config);
         config.setIgnoreCommitList(
                 Arrays.asList(FAKE_AUTHOR_BLAME_TEST_FILE_COMMIT_08022018, EUGENE_AUTHOR_README_FILE_COMMIT_07052018));
@@ -111,8 +111,8 @@ public class CommitInfoAnalyzerTest extends GitTestTemplate {
     @Test
     public void analyzeCommits_noCommitMessage_success() {
         config.setBranch("empty-commit-message");
-        config.getAuthorEmailsAndAliasesMap().clear();
-        config.getAuthorEmailsAndAliasesMap().put(YONG_AUTHOR_NAME, new Author(YONG_AUTHOR_NAME));
+        config.getAuthorDetailsToAuthorMap().clear();
+        config.getAuthorDetailsToAuthorMap().put(YONG_AUTHOR_NAME, new Author(YONG_AUTHOR_NAME));
 
         List<CommitInfo> commitInfos = CommitInfoExtractor.extractCommitInfos(config);
         List<CommitResult> commitResults = CommitInfoAnalyzer.analyzeCommits(commitInfos, config);

--- a/src/test/java/reposense/model/RepoConfigurationTest.java
+++ b/src/test/java/reposense/model/RepoConfigurationTest.java
@@ -365,7 +365,7 @@ public class RepoConfigurationTest {
         }
         expectedConfig.setAuthorList(expectedAuthorList);
         expectedConfig.setAuthorDisplayNameMap(repoDeltaStandaloneConfig.getAuthorDisplayNameMap());
-        expectedConfig.setAuthorDetailsToAuthorMap(repoDeltaStandaloneConfig.getAuthorEmailsAndAliasesMap());
+        expectedConfig.setAuthorDetailsToAuthorMap(repoDeltaStandaloneConfig.getAuthorDetailsToAuthorMap());
 
         String formats = String.join(" ", CLI_FORMATS);
         String input = new InputBuilder().addConfig(OVERRIDE_STANDALONE_TEST_CONFIG_FILE)

--- a/src/test/java/reposense/model/RepoConfigurationTest.java
+++ b/src/test/java/reposense/model/RepoConfigurationTest.java
@@ -365,7 +365,7 @@ public class RepoConfigurationTest {
         }
         expectedConfig.setAuthorList(expectedAuthorList);
         expectedConfig.setAuthorDisplayNameMap(repoDeltaStandaloneConfig.getAuthorDisplayNameMap());
-        expectedConfig.setAuthorEmailsAndAliasesMap(repoDeltaStandaloneConfig.getAuthorEmailsAndAliasesMap());
+        expectedConfig.setAuthorDetailsToAuthorMap(repoDeltaStandaloneConfig.getAuthorEmailsAndAliasesMap());
 
         String formats = String.join(" ", CLI_FORMATS);
         String input = new InputBuilder().addConfig(OVERRIDE_STANDALONE_TEST_CONFIG_FILE)

--- a/src/test/java/reposense/model/RepoConfigurationTest.java
+++ b/src/test/java/reposense/model/RepoConfigurationTest.java
@@ -99,8 +99,8 @@ public class RepoConfigurationTest {
 
         repoDeltaStandaloneConfig = new RepoConfiguration(new RepoLocation(TEST_REPO_DELTA), "master");
         repoDeltaStandaloneConfig.setAuthorList(expectedAuthors);
-        repoDeltaStandaloneConfig.addAuthorEmailsAndAliasesMapEntry(FIRST_AUTHOR, FIRST_AUTHOR_ALIASES);
-        repoDeltaStandaloneConfig.addAuthorEmailsAndAliasesMapEntry(FOURTH_AUTHOR, FOURTH_AUTHOR_ALIASES);
+        repoDeltaStandaloneConfig.addAuthorDetailsToAuthorMapEntry(FIRST_AUTHOR, FIRST_AUTHOR_ALIASES);
+        repoDeltaStandaloneConfig.addAuthorDetailsToAuthorMapEntry(FOURTH_AUTHOR, FOURTH_AUTHOR_ALIASES);
         repoDeltaStandaloneConfig.setAuthorDisplayName(FIRST_AUTHOR, "Ahm");
         repoDeltaStandaloneConfig.setAuthorDisplayName(SECOND_AUTHOR, "Cod");
         repoDeltaStandaloneConfig.setAuthorDisplayName(THIRD_AUTHOR, "Jor");
@@ -108,7 +108,7 @@ public class RepoConfigurationTest {
 
         SECOND_AUTHOR.setEmails(Arrays.asList("codeeong@gmail.com", "33129797+codeeong@users.noreply.github.com"));
         for (Author author : expectedAuthors) {
-            repoDeltaStandaloneConfig.addAuthorEmailsAndAliasesMapEntry(author, author.getEmails());
+            repoDeltaStandaloneConfig.addAuthorDetailsToAuthorMapEntry(author, author.getEmails());
         }
 
         repoDeltaStandaloneConfig.setIgnoreGlobList(REPO_LEVEL_GLOB_LIST);
@@ -138,7 +138,7 @@ public class RepoConfigurationTest {
 
         RepoConfiguration expectedConfig = new RepoConfiguration(new RepoLocation(TEST_REPO_DELTA), "master");
         expectedConfig.setAuthorList(expectedAuthors);
-        expectedConfig.addAuthorEmailsAndAliasesMapEntry(author, FIRST_AUTHOR_ALIASES);
+        expectedConfig.addAuthorDetailsToAuthorMapEntry(author, FIRST_AUTHOR_ALIASES);
         expectedConfig.setAuthorDisplayName(author, "Ahm");
 
         expectedConfig.setIgnoreGlobList(REPO_LEVEL_GLOB_LIST);
@@ -414,7 +414,7 @@ public class RepoConfigurationTest {
 
         RepoConfiguration expectedConfig = new RepoConfiguration(new RepoLocation(TEST_REPO_DELTA), "master");
         expectedConfig.setAuthorList(expectedAuthors);
-        expectedConfig.addAuthorEmailsAndAliasesMapEntry(author, FIRST_AUTHOR_ALIASES);
+        expectedConfig.addAuthorDetailsToAuthorMapEntry(author, FIRST_AUTHOR_ALIASES);
         expectedConfig.setAuthorDisplayName(author, "Ahm");
 
         expectedConfig.setIgnoreGlobList(REPO_LEVEL_GLOB_LIST);

--- a/src/test/java/reposense/parser/RepoConfigParserTest.java
+++ b/src/test/java/reposense/parser/RepoConfigParserTest.java
@@ -104,14 +104,14 @@ public class RepoConfigParserTest {
         firstRepo.setAuthorList(expectedAuthors);
         firstRepo.setAuthorDisplayName(FIRST_AUTHOR, "Nbr");
         firstRepo.setAuthorDisplayName(SECOND_AUTHOR, "Zac");
-        firstRepo.addAuthorEmailsAndAliasesMapEntry(SECOND_AUTHOR,  Arrays.asList("Zachary Tang"));
+        firstRepo.addAuthorDetailsToAuthorMapEntry(SECOND_AUTHOR,  Arrays.asList("Zachary Tang"));
         firstRepo.setIgnoreGlobList(REPO_LEVEL_GLOB_LIST);
 
         RepoConfiguration secondRepo = new RepoConfiguration(new RepoLocation(TEST_REPO_BETA_LOCATION),
                 TEST_REPO_BETA_ADD_CONFIG_JSON_BRANCH);
         secondRepo.setAuthorList(Arrays.asList(SECOND_AUTHOR));
         secondRepo.setAuthorDisplayName(SECOND_AUTHOR, "Zac");
-        secondRepo.addAuthorEmailsAndAliasesMapEntry(SECOND_AUTHOR,  Arrays.asList("Zachary Tang"));
+        secondRepo.addAuthorDetailsToAuthorMapEntry(SECOND_AUTHOR,  Arrays.asList("Zachary Tang"));
         secondRepo.setIgnoreGlobList(REPO_LEVEL_GLOB_LIST);
 
         String input = new InputBuilder().addConfig(TEST_CONFIG_FOLDER).build();
@@ -146,7 +146,7 @@ public class RepoConfigParserTest {
         expectedBetaConfig.setAuthorList(expectedBetaAuthors);
         expectedBetaConfig.setAuthorDisplayName(FIRST_AUTHOR, "Nbr");
         expectedBetaConfig.setAuthorDisplayName(SECOND_AUTHOR, "Zac");
-        expectedBetaConfig.addAuthorEmailsAndAliasesMapEntry(SECOND_AUTHOR,  Arrays.asList("Zachary Tang"));
+        expectedBetaConfig.addAuthorDetailsToAuthorMapEntry(SECOND_AUTHOR,  Arrays.asList("Zachary Tang"));
         expectedBetaConfig.setIgnoreGlobList(REPO_LEVEL_GLOB_LIST);
 
         RepoConfiguration expectedDeltaConfig =

--- a/src/test/java/reposense/parser/StandaloneConfigJsonParserTest.java
+++ b/src/test/java/reposense/parser/StandaloneConfigJsonParserTest.java
@@ -58,7 +58,7 @@ public class StandaloneConfigJsonParserTest {
         expectedGithubIdOnlyRepoconfig = new RepoConfiguration(new RepoLocation(TEST_DUMMY_LOCATION));
         expectedGithubIdOnlyRepoconfig.setFormats(FileTypeTest.NO_SPECIFIED_FORMATS);
         expectedGithubIdOnlyRepoconfig.setAuthorList(Arrays.asList(new Author("yong24s")));
-        expectedGithubIdOnlyRepoconfig.addAuthorEmailsAndAliasesMapEntry(author, author.getEmails());
+        expectedGithubIdOnlyRepoconfig.addAuthorDetailsToAuthorMapEntry(author, author.getEmails());
 
         expectedFullRepoConfig = new RepoConfiguration(new RepoLocation(TEST_DUMMY_LOCATION));
         expectedFullRepoConfig.setFormats(FileType.convertFormatStringsToFileTypes(
@@ -69,9 +69,9 @@ public class StandaloneConfigJsonParserTest {
         expectedFullRepoConfig.setIgnoredAuthorsList(Arrays.asList("yong24s"));
         expectedFullRepoConfig.setAuthorList(Arrays.asList(author));
         expectedFullRepoConfig.setAuthorDisplayName(author, "Yong Hao");
-        expectedFullRepoConfig.addAuthorEmailsAndAliasesMapEntry(author, Arrays.asList(author.getGitId()));
-        expectedFullRepoConfig.addAuthorEmailsAndAliasesMapEntry(author, author.getAuthorAliases());
-        expectedFullRepoConfig.addAuthorEmailsAndAliasesMapEntry(author, author.getEmails());
+        expectedFullRepoConfig.addAuthorDetailsToAuthorMapEntry(author, Arrays.asList(author.getGitId()));
+        expectedFullRepoConfig.addAuthorDetailsToAuthorMapEntry(author, author.getAuthorAliases());
+        expectedFullRepoConfig.addAuthorDetailsToAuthorMapEntry(author, author.getEmails());
     }
 
     @Test

--- a/src/test/java/reposense/template/GitTestTemplate.java
+++ b/src/test/java/reposense/template/GitTestTemplate.java
@@ -110,8 +110,8 @@ public class GitTestTemplate {
     public FileInfo generateTestFileInfo(String relativePath) {
         FileInfo fileInfo = FileInfoExtractor.generateFileInfo(config.getRepoRoot(), relativePath);
 
-        config.getAuthorEmailsAndAliasesMap().put(MAIN_AUTHOR_NAME, new Author(MAIN_AUTHOR_NAME));
-        config.getAuthorEmailsAndAliasesMap().put(FAKE_AUTHOR_NAME, new Author(FAKE_AUTHOR_NAME));
+        config.getAuthorDetailsToAuthorMap().put(MAIN_AUTHOR_NAME, new Author(MAIN_AUTHOR_NAME));
+        config.getAuthorDetailsToAuthorMap().put(FAKE_AUTHOR_NAME, new Author(FAKE_AUTHOR_NAME));
 
         return fileInfo;
     }


### PR DESCRIPTION
Fixes #1207 

```authorEmailsAndAliasesMap``` is renamed to ```authorDetailsToAuthorMap```. 
This aims to better reflect the following structure within the mapping.
```
git id -> author
email -> author
alias -> author
```