### PR TITLE
[#1233] Use a more specific regex for URL validation

### DIFF
--- a/src/main/java/reposense/model/RepoLocation.java
+++ b/src/main/java/reposense/model/RepoLocation.java
@@ -1,7 +1,5 @@
 package reposense.model;
 
-import java.net.MalformedURLException;
-import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
@@ -17,7 +15,7 @@ import reposense.parser.InvalidLocationException;
 public class RepoLocation {
     private static final String GIT_LINK_SUFFIX = ".git";
     private static final Pattern GIT_REPOSITORY_LOCATION_PATTERN =
-            Pattern.compile("^.*github.com\\/(?<org>.+?)\\/(?<repoName>.+?)\\.git$");
+            Pattern.compile("^https?:\\/\\/github.com\\/(?<org>.+?)\\/(?<repoName>.+?)\\.git$");
 
     private final String location;
     private final String repoName;
@@ -66,12 +64,8 @@ public class RepoLocation {
             // Ignore exception
         }
 
-        try {
-            new URL(location);
-            isValidGitUrl = location.endsWith(GIT_LINK_SUFFIX);
-        } catch (MalformedURLException mue) {
-            // Ignore exception
-        }
+        Matcher matcher = GIT_REPOSITORY_LOCATION_PATTERN.matcher(location);
+        isValidGitUrl = matcher.matches();
 
         if (!isValidPathLocation && !isValidGitUrl) {
             throw new InvalidLocationException(location + " is an invalid location.");


### PR DESCRIPTION
Resolves #1233.

```
Within RepoLocation, a Git URL is checked using both regex and by
instantiating a java.net.URL object.

With a stronger regex, we can avoid having to instantiate a URL object.

Let's use the stronger regex to replace creating a URL object when
checking a Git URL.
```

Notes:
- The original issue suggests a regex of `^(http|https)://github.com/(?<org>.+?)/(?<repoName>.+?)\\.git$`. There are some minor deviations from this.
    - The forward slashes `/` need to be escaped with `\\`, as done in the old regex.
    - `(http|https)` has been replaced with a more elegant `https?` pattern
    - Thus, the final regex to be used (as shown in the code) is `^https?:\\/\\/github.com\\/(?<org>.+?)\\/(?<repoName>.+?)\\.git$`
- The validation logic within `verifyLocation` ("line 69 - line 74") has been modified to use the regex pattern matching.
    - It cannot be entirely removed as `verifyLocation` must still check that the location is either a valid path or valid URL.
    - We have however eliminated the need to instantiate a `java.net.URL` object, which fits the spirit of the original issue.
- There is a slight duplication of code as a `Matcher` is created once in the `RepoLocation` constructor and once again in `verifyLocation`.
    - It should be possible to eliminate this duplication, but I would appreciate any guidance on how to best do so while maintaining readability (e.g. passing a `Matcher` object to `verifyLocation` might not be very intuitive to the reader).
- The initialization here is now redundant. We could either move the declaration down, or move the logic up to the declaration.
https://github.com/reposense/RepoSense/blob/60de6237039041e7b2dfe9af208d3775fa61fb51/src/main/java/reposense/model/RepoLocation.java#L60