### PR TITLE
[#1356] Not use # in URLs 

### DIFF
--- a/frontend/src/static/js/api.js
+++ b/frontend/src/static/js/api.js
@@ -63,10 +63,10 @@ window.encodeHash = function encodeHash() {
 window.decodeHash = function decodeHash() {
   const hashParams = {};
 
-  const hash_index = window.location.href.indexOf(HASH_ANCHOR);
-  const parameter_string = hash_index == -1 ? '' : window.location.href.slice(hash_index + 1);
+  const hashIndex = window.location.href.indexOf(HASH_ANCHOR);
+  const parameterString = hashIndex === -1 ? '' : window.location.href.slice(hashIndex + 1);
 
-  parameter_string.split('&')
+  parameterString.split('&')
       .forEach((param) => {
         const [key, val] = param.split('=');
         if (key) {

--- a/frontend/src/static/js/api.js
+++ b/frontend/src/static/js/api.js
@@ -9,6 +9,7 @@ window.REPOS = {};
 window.hashParams = {};
 window.isMacintosh = navigator.platform.includes('Mac');
 
+const HASH_ANCHOR = '?';
 const REPORT_DIR = '.';
 const REPORT_ZIP = null;
 
@@ -51,15 +52,21 @@ window.removeHash = function removeHash(key) {
 window.encodeHash = function encodeHash() {
   const { hashParams } = window;
 
-  window.location.hash = Object.keys(hashParams)
+  const hash = Object.keys(hashParams)
       .map((key) => `${key}=${encodeURIComponent(hashParams[key])}`)
       .join('&');
+
+  const newUrl = window.location.protocol + "//" + window.location.host + window.location.pathname + HASH_ANCHOR + hash;
+  window.history.replaceState(null, '', newUrl);
 };
 
 window.decodeHash = function decodeHash() {
   const hashParams = {};
 
-  window.location.hash.slice(1).split('&')
+  const hash_index = window.location.href.indexOf(HASH_ANCHOR);
+  const parameter_string = hash_index == -1 ? "" : window.location.href.slice(hash_index + 1);
+
+  parameter_string.split('&')
       .forEach((param) => {
         const [key, val] = param.split('=');
         if (key) {

--- a/frontend/src/static/js/api.js
+++ b/frontend/src/static/js/api.js
@@ -56,7 +56,7 @@ window.encodeHash = function encodeHash() {
       .map((key) => `${key}=${encodeURIComponent(hashParams[key])}`)
       .join('&');
 
-  const newUrl = window.location.protocol + "//" + window.location.host + window.location.pathname + HASH_ANCHOR + hash;
+  const newUrl = `${window.location.protocol}//${window.location.host}${window.location.pathname}${HASH_ANCHOR}${hash}`;
   window.history.replaceState(null, '', newUrl);
 };
 
@@ -64,7 +64,7 @@ window.decodeHash = function decodeHash() {
   const hashParams = {};
 
   const hash_index = window.location.href.indexOf(HASH_ANCHOR);
-  const parameter_string = hash_index == -1 ? "" : window.location.href.slice(hash_index + 1);
+  const parameter_string = hash_index == -1 ? '' : window.location.href.slice(hash_index + 1);
 
   parameter_string.split('&')
       .forEach((param) => {


### PR DESCRIPTION
Fixes #1356 

**Current Situation**

Parameters were stored in `window.location.hash` which automatically adds the `#` symbol to the url. (Undesirable due to issues with copying non-alphabetical characters in some pdf applications).

![image](https://user-images.githubusercontent.com/16630400/102066223-86757c00-3e34-11eb-90b5-e5fa85ea3421.png)


**Outline of Solution**

Use `window.history.replaceState()` to edit the url directly to store parameters.

URL uses `?` to separate the path and parameters, and the symbol used can be easily modified in the future.

![image](https://user-images.githubusercontent.com/16630400/102066601-fb48b600-3e34-11eb-82df-62d4697dc950.png)

**Possible Alternative**

Using `window.history.pushState()` will instead leave the old url in the history (so one can navigate back to the previous url by using the back button on the browser. This does not rerender the page however.)

**Proposed commit message:**

```
Parameters were stored in `window.location.hash` which automatically adds the `#` symbol to the url.

This leads to issues with copying non-alphabetical characters in some pdf applications.

Let's replace # with ? in the URL, and additionally make the symbol easy to change in the future.
```