### PR TITLE
[#1118] Change the regular expression of the author name tag

### DIFF
--- a/src/main/java/reposense/authorship/analyzer/AnnotatorAnalyzer.java
+++ b/src/main/java/reposense/authorship/analyzer/AnnotatorAnalyzer.java
@@ -16,7 +16,7 @@ import reposense.model.Author;
  */
 public class AnnotatorAnalyzer {
     private static final String AUTHOR_TAG = "@@author";
-    private static final String REGEX_AUTHOR_NAME_FORMAT = "([a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])";
+    private static final String REGEX_AUTHOR_NAME_FORMAT = "([a-zA-Z0-9-]*)";
     private static final Pattern PATTERN_AUTHOR_NAME_FORMAT = Pattern.compile(REGEX_AUTHOR_NAME_FORMAT);
     private static final int MATCHER_GROUP_AUTHOR_NAME = 1;
 


### PR DESCRIPTION
#1118 
```
Adopt a less restrictive regular expression for the author tag.

The regular expression used currently requires the author name to
contain at least 2 alphanumeric characters.

However, there can be greater flexibility for the author name 
format, as long as the author name is not empty.

Let's change the regular expression of the author name tag.
```