### PR TITLE
[#1424] Call `window.decodeHash` only once

### DIFF
--- a/frontend/src/static/js/main.js
+++ b/frontend/src/static/js/main.js
@@ -166,7 +166,6 @@ window.app = new window.Vue({
     },
 
     renderTabHash() {
-      window.decodeHash();
       const hash = window.hashParams;
       if (!hash.tabOpen) {
         return;
@@ -247,6 +246,7 @@ window.app = new window.Vue({
     vAuthorship: window.vAuthorship,
   },
   created() {
+    window.decodeHash();
     this.updateReportDir();
   },
 });

--- a/frontend/src/static/js/v_authorship.js
+++ b/frontend/src/static/js/v_authorship.js
@@ -59,7 +59,6 @@ window.vAuthorship = {
 
   methods: {
     retrieveHashes() {
-      window.decodeHash();
       const hash = window.hashParams;
 
       switch (hash.authorshipSortBy) {

--- a/frontend/src/static/js/v_summary.js
+++ b/frontend/src/static/js/v_summary.js
@@ -231,8 +231,6 @@ window.vSummary = {
     },
 
     renderFilterHash() {
-      window.decodeHash();
-
       const convertBool = (txt) => (txt === 'true');
       const hash = window.hashParams;
 
@@ -268,7 +266,6 @@ window.vSummary = {
         const parsedFileTypes = hash.checkedFileTypes.split(window.HASH_DELIMITER);
         this.checkedFileTypes = parsedFileTypes.filter((type) => this.fileTypes.includes(type));
       }
-      window.decodeHash();
     },
 
     getDates() {

--- a/frontend/src/static/js/v_zoom.js
+++ b/frontend/src/static/js/v_zoom.js
@@ -158,7 +158,6 @@ window.vZoom = {
     },
 
     retrieveSortHash() {
-      window.decodeHash();
       const hash = window.hashParams;
       if (hash.zCST) {
         this.commitsSortType = hash.zCST;
@@ -169,7 +168,6 @@ window.vZoom = {
     },
 
     retrieveSelectedFileTypesHash() {
-      window.decodeHash();
       const hash = window.hashParams;
 
       if (hash.zFT) {


### PR DESCRIPTION

```
window.decodeHash() is called several times throughout the code.
window.decodeHash() reads params from the url.

It does not make sense for window.decodeHash to be called 
any more than once per page reload.

Furthermore, I encountered an issue in projectify frontend
where window.encodeHash() is called 
before window.decodeHash()

Let's call window.decodeHash() only once in the entire code.

Let's call window.decodeHash() before window.encodeHash()
can possibly be called.
```