### PR TITLE
[#1429] Make GitHub Actions workflows more specific for artifacts

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -80,6 +80,7 @@ jobs:
         (cd docs && markbind build)
 
     - name: Save PR number and HEAD commit
+      if: ${{ success() && github.event_name == 'pull_request' }}
       run: |
         mkdir -p ./pr
         echo ${{ github.event.number }} > ./pr/NUMBER

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -79,6 +79,12 @@ jobs:
         npm install -g markbind-cli
         (cd docs && markbind build)
 
+    - name: Save PR number and HEAD commit
+      run: |
+        mkdir -p ./pr
+        echo ${{ github.event.number }} > ./pr/NUMBER
+        echo ${{ github.event.pull_request.head.sha }} > ./pr/SHA
+
     - name: Upload artifacts (pull request)
       if: ${{ success() && github.event_name == 'pull_request' }}
       uses: actions/upload-artifact@v2

--- a/.github/workflows/pending.yml
+++ b/.github/workflows/pending.yml
@@ -22,14 +22,10 @@ jobs:
       with:
         fetch-depth: 0
 
-    - name: Save PR number and HEAD commit
+    - name: Update PR checklist for surge.sh as pending
       run: |
         mkdir -p ./pr
-        echo ${{ github.event.number }} > ./pr/NUMBER
-        echo ${{ github.event.pull_request.head.sha }} > ./pr/SHA
-
-    - name: Update PR checklist for surge.sh as pending
-      run: ./config/gh-actions/deploy.sh pending
+        ./config/gh-actions/deploy.sh pending
 
     - name: Upload artifacts
       if: ${{ success() }}

--- a/.github/workflows/surge.yml
+++ b/.github/workflows/surge.yml
@@ -33,14 +33,19 @@ jobs:
       uses: dawidd6/action-download-artifact@v2
       with:
         workflow: integration.yml
-        workflow_conclusion: success
+        run_id: ${{ github.event.workflow_run.id }}
         name: reposense-deployment
         path: .
+
+    - name: Extract PR number
+      id: pr-number
+      run: echo '::set-output name=ACTIONS_PR_NUMBER::$(cat ./pr/NUMBER)'
 
     - name: Download deployment status artifacts
       uses: dawidd6/action-download-artifact@v2
       with:
         workflow: pending.yml
+        pr: ${{ steps.pr-number.outputs.ACTIONS_PR_NUMBER }}
         workflow_conclusion: success
         name: reposense-deployment-id
         path: ./pr

--- a/docs/about.md
+++ b/docs/about.md
@@ -7,6 +7,8 @@
 
 RepoSense is a project based in the [National University of Singapore, School of Computing](http://www.comp.nus.edu.sg/), and is funded by a _Teaching Enhancement Grant_ from [NUS Center for Development of Teaching and Learning](http://www.cdtl.nus.edu.sg/).
 
+This sentence is extra.
+
 <!-- ==================================================================================================== -->
 
 ## Current team
@@ -105,7 +107,7 @@ Committer [2018 May - 2018 Aug]<br/>
 
 ### [Teng Yong Hao](https://github.com/yong24s)
 ![](https://avatars2.githubusercontent.com/u/2003406?s=150&v=4)<br/>
-**Role**: 
+**Role**:
 Mentor [2018 Dec - 2020 May]<br/>
 Committer [2018 Aug - 2018 Dec]<br/>
 Contributor [2018 May - 2018 Aug]<br/>


### PR DESCRIPTION
Fixes #1429.

```
Currently, GitHub Actions can encounter race conditions where
multiple pull requests are deployed at once, causing confusion as
to the exact artifacts to download. This is caused by not
specifying the pull request numbers when downloading artifacts.

Let's make it such that the correct artifacts are downloaded even
when multiple deployments occur concurrently.
```