### PR TITLE
[#1429] Make GitHub Actions workflows more specific for artifacts

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -79,7 +79,7 @@ jobs:
         npm install -g markbind-cli
         (cd docs && markbind build)
 
-    - name: Save PR number and HEAD commit
+    - name: Save PR number and HEAD commit (pull request)
       if: ${{ success() && github.event_name == 'pull_request' }}
       run: |
         mkdir -p ./pr

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -79,7 +79,7 @@ jobs:
         npm install -g markbind-cli
         (cd docs && markbind build)
 
-    - name: Save PR number and HEAD commit (pull request)
+    - name: Save PR number and HEAD commit
       if: ${{ success() && github.event_name == 'pull_request' }}
       run: |
         mkdir -p ./pr

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -79,6 +79,13 @@ jobs:
         npm install -g markbind-cli
         (cd docs && markbind build)
 
+    - name: Save PR number and HEAD commit (pull request)
+      if: ${{ success() && github.event_name == 'pull_request' }}
+      run: |
+        mkdir -p ./pr
+        echo ${{ github.event.number }} > ./pr/NUMBER
+        echo ${{ github.event.pull_request.head.sha }} > ./pr/SHA
+
     - name: Upload artifacts (pull request)
       if: ${{ success() && github.event_name == 'pull_request' }}
       uses: actions/upload-artifact@v2

--- a/.github/workflows/pending.yml
+++ b/.github/workflows/pending.yml
@@ -22,14 +22,10 @@ jobs:
       with:
         fetch-depth: 0
 
-    - name: Save PR number and HEAD commit
+    - name: Update PR checklist for surge.sh as pending
       run: |
         mkdir -p ./pr
-        echo ${{ github.event.number }} > ./pr/NUMBER
-        echo ${{ github.event.pull_request.head.sha }} > ./pr/SHA
-
-    - name: Update PR checklist for surge.sh as pending
-      run: ./config/gh-actions/deploy.sh pending
+        ./config/gh-actions/deploy.sh pending
 
     - name: Upload artifacts
       if: ${{ success() }}

--- a/.github/workflows/surge.yml
+++ b/.github/workflows/surge.yml
@@ -39,7 +39,7 @@ jobs:
 
     - name: Extract PR number
       id: pr-number
-      run: echo '::set-output name=ACTIONS_PR_NUMBER::$(cat ./pr/NUMBER)'
+      run: echo '::set-output name=ACTIONS_PR_NUMBER::'$(cat ./pr/NUMBER)
 
     - name: Download deployment status artifacts
       uses: dawidd6/action-download-artifact@v2

--- a/.github/workflows/surge.yml
+++ b/.github/workflows/surge.yml
@@ -33,14 +33,19 @@ jobs:
       uses: dawidd6/action-download-artifact@v2
       with:
         workflow: integration.yml
-        workflow_conclusion: success
+        run_id: ${{ github.event.workflow_run.id }}
         name: reposense-deployment
         path: .
+
+    - name: Extract PR number
+      id: pr-number
+      run: echo '::set-output name=ACTIONS_PR_NUMBER::$(cat ./pr/NUMBER)'
 
     - name: Download deployment status artifacts
       uses: dawidd6/action-download-artifact@v2
       with:
         workflow: pending.yml
+        pr: ${{ steps.pr-number.outputs.ACTIONS_PR_NUMBER }}
         workflow_conclusion: success
         name: reposense-deployment-id
         path: ./pr

--- a/config/gh-actions/deploy.sh
+++ b/config/gh-actions/deploy.sh
@@ -63,7 +63,7 @@ update_deployment() {
   -H "Authorization: token ${GITHUB_TOKEN}" \
   -H "Accept: application/vnd.github.flash-preview+json,application/vnd.github.ant-man-preview+json" \
   -X POST \
-  -d "{\"state\": \"$2\",\"description\": \"$3\", \"log_url\": \"${ACTIONS_WORKFLOW_RUN_URL}\", \"environment\": \"$4\", \"environment_url\": \"$5\"}"
+  -d "{\"state\": \"$2\",\"description\": \"$3\", \"log_url\": \"${ACTIONS_WORKFLOW_RUN_URL}\", \"environment\": \"$4\", \"environment_url\": \"$5\", \"auto_inactive\": false}"
 }
 
 # Split on "/", ref: http://stackoverflow.com/a/5257398/689223

--- a/config/gh-actions/deploy.sh
+++ b/config/gh-actions/deploy.sh
@@ -63,7 +63,7 @@ update_deployment() {
   -H "Authorization: token ${GITHUB_TOKEN}" \
   -H "Accept: application/vnd.github.flash-preview+json,application/vnd.github.ant-man-preview+json" \
   -X POST \
-  -d "{\"state\": \"$2\",\"description\": \"$3\", \"log_url\": \"${ACTIONS_WORKFLOW_RUN_URL}\", \"environment\": \"$4\", \"environment_url\": \"$5\", \"auto_inactive\": false}"
+  -d "{\"state\": \"$2\",\"description\": \"$3\", \"log_url\": \"${ACTIONS_WORKFLOW_RUN_URL}\", \"environment\": \"$4\", \"environment_url\": \"$5\"}"
 }
 
 # Split on "/", ref: http://stackoverflow.com/a/5257398/689223


### PR DESCRIPTION
Fixes #1429.

```
Currently, GitHub Actions can encounter race conditions where
multiple pull requests are deployed at once, causing confusion as
to the exact artifacts to download. This is caused by not
specifying the pull request numbers when downloading artifacts.

Let's make it such that the correct artifacts are downloaded even
when multiple deployments occur concurrently.
```

Testing pull requests:
- https://github.com/dcshzj/RepoSense/pull/4
- https://github.com/dcshzj/RepoSense/pull/5