### PR TITLE
[#442] Replace CommandRunner with JGit for GitBranch

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,7 @@ dependencies {
     implementation  group: 'org.apache.commons', name: 'commons-csv', version: '1.6'
     implementation group: 'org.apache.commons', name: 'commons-text', version: '1.9'
     implementation  group: 'org.fusesource.jansi', name: 'jansi', version: '1.18'
+    implementation  group: 'org.eclipse.jgit', name: 'org.eclipse.jgit', version: '5.9.0.202009080501-r'
 
     testImplementation group: 'junit', name: 'junit', version: '4.12'
 }

--- a/src/main/java/reposense/git/GitBranch.java
+++ b/src/main/java/reposense/git/GitBranch.java
@@ -1,30 +1,45 @@
 package reposense.git;
 
-import static reposense.system.CommandRunner.runCommand;
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
-import java.nio.file.Path;
-import java.nio.file.Paths;
+import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.lib.Ref;
 
 import reposense.git.exception.GitBranchException;
-import reposense.util.StringsUtil;
+import reposense.system.LogsManager;
 
 /**
  * Contains git branch related functionalities.
  * Git branch is responsible for list, create, or delete branches.
  */
 public class GitBranch {
+    private static final Logger logger = LogsManager.getLogger(GitBranch.class);
+    private static final String MESSAGE_MISSING_REPOSITORY =
+            "The directory %s does not exist or is not a Git repository.";
 
     /**
      * Returns the current working branch of the repository at {@code root}.
      */
     public static String getCurrentBranch(String root) throws GitBranchException {
-        Path rootPath = Paths.get(root);
-        String gitBranchCommand = "git branch";
+        String branch;
 
         try {
-            return StringsUtil.filterText(runCommand(rootPath, gitBranchCommand), "\\* (.*)").split("\\*")[1].trim();
-        } catch (RuntimeException rte) {
-            throw new GitBranchException(rte);
+            Git git = Git.open(new File(root));
+            List<Ref> gitRefs = git.getRepository().getRefDatabase().getRefs();
+
+            if (gitRefs.size() == 0) {
+                // An empty repository does not have any refs
+                return null;
+            }
+
+            return git.getRepository().getBranch();
+        } catch (IOException ioe) {
+            logger.log(Level.SEVERE, String.format(MESSAGE_MISSING_REPOSITORY, root), ioe);
+            throw new GitBranchException(ioe);
         }
     }
 }

--- a/src/main/java/reposense/report/RepoCloner.java
+++ b/src/main/java/reposense/report/RepoCloner.java
@@ -68,11 +68,18 @@ public class RepoCloner {
             String bareRepoPath = FileUtil.getBareRepoPath(configs[currentIndex]).toString();
             currentRepoDefaultBranch = GitBranch.getCurrentBranch(bareRepoPath);
         } catch (GitBranchException gbe) {
-            // GitBranch will throw this exception when repository is empty
             logger.log(Level.WARNING, String.format(MESSAGE_ERROR_GETTING_BRANCH,
                     configs[currentIndex].getLocation(), configs[currentIndex].getBranch()), gbe);
             return null;
         }
+
+        if (currentRepoDefaultBranch == null) {
+            // Current repository is empty
+            logger.log(Level.WARNING, String.format(MESSAGE_ERROR_GETTING_BRANCH,
+                    configs[currentIndex].getLocation(), configs[currentIndex].getBranch()));
+            return null;
+        }
+
         cleanupPrevRepoFolder();
 
         previousIndex = currentIndex;


### PR DESCRIPTION
Part of #442.

```
CommandRunner should be deprecated and replaced by JGit as it
requires Git to be installed and has poor exception handling.
JGit is able to handle Git operations natively, which makes it
more robust to use.

Let's replace usages of CommandRunner with their equivalents in
JGit, starting with GitBranch.
```

This PR is a proof-of-concept of what JGit can potentially do, instead of relying on CommandRunner.