### PR TITLE
[#1446] Restore the name on authorship panel after reloading

### DIFF
--- a/frontend/src/static/js/v_authorship.js
+++ b/frontend/src/static/js/v_authorship.js
@@ -19,6 +19,7 @@ function initialState() {
     filesSortType: 'lineOfCode',
     toReverseSortFiles: true,
     searchBarValue: '',
+    authorDisplayName: '',
   };
 }
 
@@ -155,7 +156,7 @@ window.vAuthorship = {
         } else {
           const author = repo.users.find((user) => user.name === this.info.author);
           if (author) {
-            this.info.name = author.displayName;
+            this.authorDisplayName = author.displayName;
             this.filesLinesObj = author.fileTypeContribution;
           }
         }

--- a/frontend/src/tabs/authorship.pug
+++ b/frontend/src/tabs/authorship.pug
@@ -11,7 +11,7 @@
     ) {{ info.repo }}
     .author(v-if="!info.isMergeGroup")
       span &#8627; &nbsp;
-      span {{ info.name }} ({{ info.author }})
+      span {{ authorDisplayName }} ({{ info.author }})
     .period
       span &#8627; &nbsp;
       span {{ info.minDate }} to {{ info.maxDate }} &nbsp;&nbsp; ({{ selectedFiles.length }} files changed)


### PR DESCRIPTION
Fixes #1446 

Commit message:
```
Restore display name on authorship panel after reloading

Currently, the display name of the author is not shown
after reloading the authorship panel.

Restoring the name will make the interface look more
consistent.

Let's enable the restoring of name after reloading.
```