### PR TITLE
CSVParser: check column headers when parsing config CSV files

### DIFF
--- a/config/author-config.csv
+++ b/config/author-config.csv
@@ -1,4 +1,4 @@
-Repository's Location,Branch,Author's GitHub ID,Author's Email,Author's Display Name,Author's Git Author Name,Ignore Glob List
+Repository's Location,Branch,Author's GitHub ID,Author's Emails,Author's Display Name,Author's Git Author Name,Ignore Glob List
 https://github.com/reposense/testrepo-Beta.git,master,nbriannl,,"Ashwin Mukadaan Singhania, Rathod",,
 https://github.com/reposense/testrepo-Beta.git,master,zacharytang,zacharytang.tc@gmail.com,Yagami Rukei Polland,,src/main**
 https://github.com/reposense/testrepo-Beta.git,master,April0616,,2805Tagoe,LAPTOP-7KFM2KSP\User;Fan Yuting,

--- a/config/group-config.csv
+++ b/config/group-config.csv
@@ -1,4 +1,4 @@
-Repository's Location,Group Name, Globs
+Repository's Location,Group Name,Globs
 https://github.com/reposense/testrepo-Delta.git,code,**.java
 https://github.com/reposense/testrepo-Delta.git,tests,src/test**
 https://github.com/reposense/testrepo-Delta.git,docs,docs**;**.adoc;**.md

--- a/config/repo-config.csv
+++ b/config/repo-config.csv
@@ -1,4 +1,4 @@
-Repository's Location,Branch,File formats,Ignore Glob List,Ignore standalone config,Ignore Commits List,Ignore Authors List
+Repository's Location,Branch,File formats,Ignore Glob List,Ignore standalone config,Ignore Commit List,Ignore Authors List
 https://github.com/reposense/testrepo-Alpha.git,master,,,,2fb6b9b2dd9fa40bf0f9815da2cb0ae8731436c7;c5a6dc774e22099cd9ddeb0faff1e75f9cf4f151;cd7f610e0becbdf331d5231887d8010a689f87c7;768015345e70f06add2a8b7d1f901dc07bf70582,
 https://github.com/reposense/testrepo-Beta.git,master,fxml,docs**,yes,,
 https://github.com/reposense/testrepo-Beta.git,add-config-json,fxml,docs**,yes,,

--- a/src/main/java/reposense/parser/AuthorConfigCsvParser.java
+++ b/src/main/java/reposense/parser/AuthorConfigCsvParser.java
@@ -20,26 +20,36 @@ public class AuthorConfigCsvParser extends CsvParser<AuthorConfiguration> {
     /**
      * Positions of the elements of a line in author-config.csv config file.
      */
-    private static final int LOCATION_POSITION = 0;
-    private static final int BRANCH_POSITION = 1;
-    private static final int GITHUB_ID_POSITION = 2;
-    private static final int EMAIL_POSITION = 3;
-    private static final int DISPLAY_NAME_POSITION = 4;
-    private static final int ALIAS_POSITION = 5;
-    private static final int IGNORE_GLOB_LIST_POSITION = 6;
-    private static final int HEADER_SIZE = IGNORE_GLOB_LIST_POSITION + 1; // last position + 1
+    private static final String LOCATION_HEADER = "Repository's Location";
+    private static final String BRANCH_HEADER = "Branch";
+    private static final String GITHUB_ID_HEADER = "Author's GitHub ID";
+    private static final String EMAIL_HEADER = "Author's Emails";
+    private static final String DISPLAY_NAME_HEADER = "Author's Display Name";
+    private static final String ALIAS_HEADER = "Author's Git Author Name";
+    private static final String IGNORE_GLOB_LIST_HEADER = "Ignore Glob List";
 
     public AuthorConfigCsvParser(Path csvFilePath) throws IOException {
-        super(csvFilePath, HEADER_SIZE);
+        super(csvFilePath);
     }
 
     /**
-     * Gets the list of positions that are mandatory for verification.
+     * Gets the list of headers that are mandatory for verification.
      */
     @Override
-    protected int[] mandatoryPositions() {
-        return new int[] {
-            GITHUB_ID_POSITION,
+    protected String[] mandatoryHeaders() {
+        return new String[] {
+                GITHUB_ID_HEADER,
+        };
+    }
+
+    /**
+     * Gets the list of optional headers that can be parsed.
+     */
+    @Override
+    protected String[] optionalHeaders() {
+        return new String[] {
+                LOCATION_HEADER, BRANCH_HEADER, EMAIL_HEADER, DISPLAY_NAME_HEADER, ALIAS_HEADER,
+                IGNORE_GLOB_LIST_HEADER,
         };
     }
 
@@ -51,13 +61,13 @@ public class AuthorConfigCsvParser extends CsvParser<AuthorConfiguration> {
     @Override
     protected void processLine(List<AuthorConfiguration> results, CSVRecord record)
             throws ParseException {
-        String location = get(record, LOCATION_POSITION);
-        String branch = getOrDefault(record, BRANCH_POSITION, AuthorConfiguration.DEFAULT_BRANCH);
-        String gitHubId = get(record, GITHUB_ID_POSITION);
-        List<String> emails = getAsList(record, EMAIL_POSITION);
-        String displayName = get(record, DISPLAY_NAME_POSITION);
-        List<String> aliases = getAsList(record, ALIAS_POSITION);
-        List<String> ignoreGlobList = getAsList(record, IGNORE_GLOB_LIST_POSITION);
+        String location = get(record, LOCATION_HEADER);
+        String branch = getOrDefault(record, BRANCH_HEADER, AuthorConfiguration.DEFAULT_BRANCH);
+        String gitHubId = get(record, GITHUB_ID_HEADER);
+        List<String> emails = getAsList(record, EMAIL_HEADER);
+        String displayName = get(record, DISPLAY_NAME_HEADER);
+        List<String> aliases = getAsList(record, ALIAS_HEADER);
+        List<String> ignoreGlobList = getAsList(record, IGNORE_GLOB_LIST_HEADER);
 
         AuthorConfiguration config = findMatchingAuthorConfiguration(results, location, branch);
 

--- a/src/main/java/reposense/parser/CsvParser.java
+++ b/src/main/java/reposense/parser/CsvParser.java
@@ -50,7 +50,6 @@ public abstract class CsvParser<T> {
     private static final String MESSAGE_ZERO_VALID_CONFIGS = "No valid configurations in the %s.";
 
     private Path csvFilePath;
-    private int headerSize;
     private Map<String, Integer> headerMap = new HashMap();
     private int numOfLinesBeforeFirstRecord = 0;
 
@@ -227,7 +226,7 @@ public abstract class CsvParser<T> {
      * @throws InvalidCsvException if {@code possibleHeader} does not contain all the mandatory headers.
      */
     private void validateHeader(String[] possibleHeader) throws InvalidCsvException {
-        headerSize = possibleHeader.length;
+        int headerSize = possibleHeader.length;
         for (int i = 0; i < headerSize; i++) {
             String possible = possibleHeader[i].trim();
             for (String parsedHeader : mandatoryAndOptionalHeaders()) {

--- a/src/main/java/reposense/parser/CsvParser.java
+++ b/src/main/java/reposense/parser/CsvParser.java
@@ -6,12 +6,7 @@ import java.io.FileReader;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.Optional;
-import java.util.StringJoiner;
+import java.util.*;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
@@ -28,6 +23,7 @@ public abstract class CsvParser<T> {
     protected static final String COLUMN_VALUES_SEPARATOR = ";";
     protected static final Logger logger = LogsManager.getLogger(CsvParser.class);
 
+    private static final String EMPTY_STRING = "";
     private static final String OVERRIDE_KEYWORD = "override:";
     private static final String MESSAGE_EMPTY_LINE = "[EMPTY LINE]";
     private static final String MESSAGE_UNABLE_TO_READ_CSV_FILE = "Unable to read the supplied CSV file.";
@@ -37,26 +33,25 @@ public abstract class CsvParser<T> {
             + "Content: %s\n"
             + "Error: %s";
     private static final String MESSAGE_EMPTY_CSV_FORMAT = "The CSV file, %s, is empty.";
-    private static final String MESSAGE_WRONG_HEADER_SIZE = "Wrong number of columns in header of CSV file, %s. \n"
-            + "Number of columns in header: %d\n"
-            + "Expected number of columns: %d";
+    private static final String MESSAGE_MANDATORY_HEADER_MISSING = "Required column header, %s, not found in " +
+            "CSV file, %s";
     private static final String MESSAGE_ZERO_VALID_CONFIGS = "No valid configurations in the %s.";
 
     private Path csvFilePath;
-    private int expectedHeaderSize;
+    private int headerSize;
+    private Map<String,Integer> headerMap = new HashMap();
     private int numOfLinesBeforeFirstRecord = 0;
 
     /**
      * @throws IOException if {@code csvFilePath} is an invalid path.
      */
-    public CsvParser(Path csvFilePath, int expectedHeaderSize) throws IOException {
+    public CsvParser(Path csvFilePath) throws IOException {
         if (csvFilePath == null || !Files.exists(csvFilePath)) {
             throw new FileNotFoundException("Csv file does not exist at the given path.\n"
                     + "Use '-help' to list all the available subcommands and some concept guides.");
         }
 
         this.csvFilePath = csvFilePath;
-        this.expectedHeaderSize = expectedHeaderSize;
     }
 
     /**
@@ -131,8 +126,8 @@ public abstract class CsvParser<T> {
                     csvFilePath.getFileName(), getRowContentAsRawString(record)));
             return true;
         }
-        for (int position : mandatoryPositions()) {
-            if (record.get(position).isEmpty()) {
+        for (String header : mandatoryHeaders()) {
+            if (get(record, header).isEmpty()) {
                 logger.warning(String.format(MESSAGE_MALFORMED_LINE_FORMAT, getLineNumber(record),
                         csvFilePath.getFileName(), getRowContentAsRawString(record)));
                 return true;
@@ -142,41 +137,45 @@ public abstract class CsvParser<T> {
     }
 
     /**
-     * Returns the value of {@code record} at {@code colNum}.
+     * Returns the value of {@code record} at the column with the header {@code header}.
      */
-    protected String get(final CSVRecord record, int colNum) {
-        return record.get(colNum).trim();
+    protected String get(final CSVRecord record, String header) {
+        if (headerMap.containsKey(header)) {
+            return record.get(headerMap.get(header)).trim();
+        } else {
+            return EMPTY_STRING;
+        }
     }
 
     /**
-     * Returns the value of {@code record} at {@code colNum} if present, or
+     * Returns the value of {@code record} at the column with the header {@code header} if present, or
      * returns {@code defaultValue} otherwise.
      */
-    protected String getOrDefault(final CSVRecord record, int colNum, String defaultValue) {
-        return get(record, colNum).isEmpty() ? defaultValue : get(record, colNum);
+    protected String getOrDefault(final CSVRecord record, String header, String defaultValue) {
+        return get(record, header).isEmpty() ? defaultValue : get(record, header);
     }
 
     /**
-     * Returns the value of {@code record} at {@code colNum} as a {@code List},
+     * Returns the value of {@code record} at the column with the header {@code header} as a {@code List},
      * delimited by {@code COLUMN_VALUES_SEPARATOR} if it is in {@code record} and not empty, or
      * returns an empty {@code List} otherwise.
      */
-    protected List<String> getAsList(final CSVRecord record, int colNum) {
-        if (get(record, colNum).isEmpty()) {
+    protected List<String> getAsList(final CSVRecord record, String header) {
+        if (get(record, header).isEmpty()) {
             return Collections.emptyList();
         }
-        return Arrays.stream(get(record, colNum).split(COLUMN_VALUES_SEPARATOR))
+        return Arrays.stream(get(record, header).split(COLUMN_VALUES_SEPARATOR))
                 .map(String::trim)
                 .collect(Collectors.toList());
     }
 
     /**
      * Returns the values in {@code record} as a list with the {@link CsvParser#OVERRIDE_KEYWORD} prefix removed.
-     * Returns an empty list if {@code record} at {@code colNum} is empty.
+     * Returns an empty list if {@code record} at the column with the header {@code header} is empty.
      */
-    protected List<String> getAsListWithoutOverridePrefix(final CSVRecord record, int colNum) {
-        List<String> data = getAsList(record, colNum);
-        if (isElementOverridingStandaloneConfig(record, colNum)) {
+    protected List<String> getAsListWithoutOverridePrefix(final CSVRecord record, String header) {
+        List<String> data = getAsList(record, header);
+        if (isElementOverridingStandaloneConfig(record, header)) {
             data.set(0, data.get(0).replaceFirst(OVERRIDE_KEYWORD, ""));
             data.removeIf(String::isEmpty);
         }
@@ -189,10 +188,11 @@ public abstract class CsvParser<T> {
     }
 
     /**
-     * Returns true if the {@code record} at {@code colNum} is prefixed with the override keyword.
+     * Returns true if the {@code record} at the column with the header {@code header} is prefixed with
+     * the override keyword.
      */
-    protected boolean isElementOverridingStandaloneConfig(final CSVRecord record, int colNum) {
-        return get(record, colNum).startsWith(OVERRIDE_KEYWORD);
+    protected boolean isElementOverridingStandaloneConfig(final CSVRecord record, String header) {
+        return get(record, header).startsWith(OVERRIDE_KEYWORD);
     }
 
     /**
@@ -211,22 +211,43 @@ public abstract class CsvParser<T> {
     }
 
     /**
-     * Checks if {@code possibleHeader} contains the expected number of columns.
-     * @throws InvalidCsvException if {@code possibleHeader} does not have as many columns as expected.
+     * Generates map of column header to position number for input {@code possibleHeader}.
+     * @throws InvalidCsvException if {@code possibleHeader} does not contain all the mandatory headers.
      */
     private void validateHeader(String[] possibleHeader) throws InvalidCsvException {
-        int actualNumberOfColumns = possibleHeader.length;
-        if (actualNumberOfColumns != expectedHeaderSize) {
-            throw new InvalidCsvException(String.format(
-                    MESSAGE_WRONG_HEADER_SIZE, csvFilePath.getFileName(), actualNumberOfColumns,
-                    expectedHeaderSize));
+        headerSize = possibleHeader.length;
+        for (int i = 0; i < headerSize; i++) {
+            String possible = possibleHeader[i].trim();
+            for (String parsedHeader : mandatoryHeaders()) {
+                if (possible.equalsIgnoreCase(parsedHeader)) {
+                    headerMap.put(parsedHeader, i);
+                    break;
+                }
+            }
+            for (String parsedHeader : optionalHeaders()) {
+                if (possible.equalsIgnoreCase(parsedHeader)) {
+                    headerMap.put(parsedHeader, i);
+                    break;
+                }
+            }
+        }
+        for (String mandatory : mandatoryHeaders()) {
+            if (!headerMap.containsKey(mandatory)) {
+                throw new InvalidCsvException(String.format(
+                        MESSAGE_MANDATORY_HEADER_MISSING, mandatory, csvFilePath.getFileName()));
+            }
         }
     }
 
     /**
-     * Gets the list of positions that are mandatory for verification.
+     * Gets the list of headers that are mandatory for verification.
      */
-    protected abstract int[] mandatoryPositions();
+    protected abstract String[] mandatoryHeaders();
+
+    /**
+     * Gets the list of optional headers that can be parsed.
+     */
+    protected abstract String[] optionalHeaders();
 
     /**
      * Processes the csv file line by line.

--- a/src/main/java/reposense/parser/CsvParser.java
+++ b/src/main/java/reposense/parser/CsvParser.java
@@ -42,6 +42,8 @@ public abstract class CsvParser<T> {
     private static final String MESSAGE_EMPTY_CSV_FORMAT = "The CSV file, %s, is empty.";
     private static final String MESSAGE_MANDATORY_HEADER_MISSING = "Required column header, %s, not found in "
             + "CSV file, %s";
+    private static final String MESSAGE_COLUMNS_RECOGNIZED = "Parsed header of CSV file, %s, and recognized columns: "
+            + "%s";
     private static final String MESSAGE_ZERO_VALID_CONFIGS = "No valid configurations in the %s.";
 
     private Path csvFilePath;
@@ -244,6 +246,8 @@ public abstract class CsvParser<T> {
                         MESSAGE_MANDATORY_HEADER_MISSING, mandatory, csvFilePath.getFileName()));
             }
         }
+        logger.info(String.format(MESSAGE_COLUMNS_RECOGNIZED, csvFilePath.getFileName(),
+                String.join(",  ", headerMap.keySet())));
     }
 
     /**

--- a/src/main/java/reposense/parser/CsvParser.java
+++ b/src/main/java/reposense/parser/CsvParser.java
@@ -6,7 +6,14 @@ import java.io.FileReader;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.StringJoiner;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
@@ -33,13 +40,13 @@ public abstract class CsvParser<T> {
             + "Content: %s\n"
             + "Error: %s";
     private static final String MESSAGE_EMPTY_CSV_FORMAT = "The CSV file, %s, is empty.";
-    private static final String MESSAGE_MANDATORY_HEADER_MISSING = "Required column header, %s, not found in " +
-            "CSV file, %s";
+    private static final String MESSAGE_MANDATORY_HEADER_MISSING = "Required column header, %s, not found in "
+            + "CSV file, %s";
     private static final String MESSAGE_ZERO_VALID_CONFIGS = "No valid configurations in the %s.";
 
     private Path csvFilePath;
     private int headerSize;
-    private Map<String,Integer> headerMap = new HashMap();
+    private Map<String, Integer> headerMap = new HashMap();
     private int numOfLinesBeforeFirstRecord = 0;
 
     /**

--- a/src/main/java/reposense/parser/GroupConfigCsvParser.java
+++ b/src/main/java/reposense/parser/GroupConfigCsvParser.java
@@ -19,22 +19,31 @@ public class GroupConfigCsvParser extends CsvParser<GroupConfiguration> {
     /**
      * Positions of the elements of a line in group-config.csv config file
      */
-    private static final int LOCATION_POSITION = 0;
-    private static final int GROUP_NAME_POSITION = 1;
-    private static final int FILES_GLOB_POSITION = 2;
-    private static final int HEADER_SIZE = FILES_GLOB_POSITION + 1; // last position + 1
+    private static final String LOCATION_HEADER = "Repository's Location";
+    private static final String GROUP_NAME_HEADER = "Group Name";
+    private static final String FILES_GLOB_HEADER = "Globs";
 
     public GroupConfigCsvParser(Path csvFilePath) throws IOException {
-        super(csvFilePath, HEADER_SIZE);
+        super(csvFilePath);
     }
 
     /**
-     * Gets the list of positions that are mandatory for verification.
+     * Gets the list of headers that are mandatory for verification.
      */
     @Override
-    protected int[] mandatoryPositions() {
-        return new int[] {
-            GROUP_NAME_POSITION, FILES_GLOB_POSITION,
+    protected String[] mandatoryHeaders() {
+        return new String[] {
+                GROUP_NAME_HEADER, FILES_GLOB_HEADER,
+        };
+    }
+
+    /**
+     * Gets the list of optional headers that can be parsed.
+     */
+    @Override
+    protected String[] optionalHeaders() {
+        return new String[] {
+                LOCATION_HEADER,
         };
     }
 
@@ -43,9 +52,9 @@ public class GroupConfigCsvParser extends CsvParser<GroupConfiguration> {
      */
     @Override
     protected void processLine(List<GroupConfiguration> results, CSVRecord record) throws InvalidLocationException {
-        String location = get(record, LOCATION_POSITION);
-        String groupName = get(record, GROUP_NAME_POSITION);
-        List<String> globList = getAsList(record, FILES_GLOB_POSITION);
+        String location = get(record, LOCATION_HEADER);
+        String groupName = get(record, GROUP_NAME_HEADER);
+        List<String> globList = getAsList(record, FILES_GLOB_HEADER);
 
         GroupConfiguration groupConfig = null;
         groupConfig = findMatchingGroupConfiguration(results, location);

--- a/src/main/java/reposense/parser/RepoConfigCsvParser.java
+++ b/src/main/java/reposense/parser/RepoConfigCsvParser.java
@@ -52,7 +52,7 @@ public class RepoConfigCsvParser extends CsvParser<RepoConfiguration> {
     protected String[] optionalHeaders() {
         return new String[] {
                 BRANCH_HEADER, FILE_FORMATS_HEADER, IGNORE_GLOB_LIST_HEADER, IGNORE_STANDALONE_CONFIG_HEADER,
-                IGNORE_COMMIT_LIST_CONFIG_HEADER, IGNORE_AUTHOR_LIST_CONFIG_HEADER,
+                IGNORE_COMMIT_LIST_CONFIG_HEADER, IGNORE_AUTHOR_LIST_CONFIG_HEADER, SHALLOW_CLONING_CONFIG_HEADER,
         };
     }
 

--- a/src/main/java/reposense/parser/RepoConfigCsvParser.java
+++ b/src/main/java/reposense/parser/RepoConfigCsvParser.java
@@ -21,26 +21,36 @@ public class RepoConfigCsvParser extends CsvParser<RepoConfiguration> {
     /**
      * Positions of the elements of a line in repo-config.csv config file
      */
-    private static final int LOCATION_POSITION = 0;
-    private static final int BRANCH_POSITION = 1;
-    private static final int FILE_FORMATS_POSITION = 2;
-    private static final int IGNORE_GLOB_LIST_POSITION = 3;
-    private static final int IGNORE_STANDALONE_CONFIG_POSITION = 4;
-    private static final int IGNORE_COMMIT_LIST_CONFIG_POSITION = 5;
-    private static final int IGNORE_AUTHOR_LIST_CONFIG_POSITION = 6;
-    private static final int HEADER_SIZE = IGNORE_AUTHOR_LIST_CONFIG_POSITION + 1; // last position + 1
+    private static final String LOCATION_HEADER = "Repository's Location";
+    private static final String BRANCH_HEADER = "Branch";
+    private static final String FILE_FORMATS_HEADER = "File formats";
+    private static final String IGNORE_GLOB_LIST_HEADER = "Ignore Glob List";
+    private static final String IGNORE_STANDALONE_CONFIG_HEADER = "Ignore standalone config";
+    private static final String IGNORE_COMMIT_LIST_CONFIG_HEADER = "Ignore Commit List";
+    private static final String IGNORE_AUTHOR_LIST_CONFIG_HEADER = "Ignore Authors List";
 
     public RepoConfigCsvParser(Path csvFilePath) throws IOException {
-        super(csvFilePath, HEADER_SIZE);
+        super(csvFilePath);
     }
 
     /**
-     * Gets the list of positions that are mandatory for verification.
+     * Gets the list of headers that are mandatory for verification.
      */
     @Override
-    protected int[] mandatoryPositions() {
-        return new int[] {
-            LOCATION_POSITION,
+    protected String[] mandatoryHeaders() {
+        return new String[] {
+                LOCATION_HEADER,
+        };
+    }
+
+    /**
+     * Gets the list of optional headers that can be parsed.
+     */
+    @Override
+    protected String[] optionalHeaders() {
+        return new String[] {
+                BRANCH_HEADER, FILE_FORMATS_HEADER, IGNORE_GLOB_LIST_HEADER, IGNORE_STANDALONE_CONFIG_HEADER,
+                IGNORE_COMMIT_LIST_CONFIG_HEADER, IGNORE_AUTHOR_LIST_CONFIG_HEADER,
         };
     }
 
@@ -51,26 +61,26 @@ public class RepoConfigCsvParser extends CsvParser<RepoConfiguration> {
      */
     @Override
     protected void processLine(List<RepoConfiguration> results, CSVRecord record) throws InvalidLocationException {
-        RepoLocation location = new RepoLocation(get(record, LOCATION_POSITION));
-        String branch = getOrDefault(record, BRANCH_POSITION, RepoConfiguration.DEFAULT_BRANCH);
+        RepoLocation location = new RepoLocation(get(record, LOCATION_HEADER));
+        String branch = getOrDefault(record, BRANCH_HEADER, RepoConfiguration.DEFAULT_BRANCH);
 
-        boolean isFormatsOverriding = isElementOverridingStandaloneConfig(record, FILE_FORMATS_POSITION);
+        boolean isFormatsOverriding = isElementOverridingStandaloneConfig(record, FILE_FORMATS_HEADER);
         List<FileType> formats = FileType.convertFormatStringsToFileTypes(
-                getAsListWithoutOverridePrefix(record, FILE_FORMATS_POSITION));
+                getAsListWithoutOverridePrefix(record, FILE_FORMATS_HEADER));
 
-        boolean isIgnoreGlobListOverriding = isElementOverridingStandaloneConfig(record, IGNORE_GLOB_LIST_POSITION);
-        List<String> ignoreGlobList = getAsListWithoutOverridePrefix(record, IGNORE_GLOB_LIST_POSITION);
+        boolean isIgnoreGlobListOverriding = isElementOverridingStandaloneConfig(record, IGNORE_GLOB_LIST_HEADER);
+        List<String> ignoreGlobList = getAsListWithoutOverridePrefix(record, IGNORE_GLOB_LIST_HEADER);
 
         boolean isIgnoreCommitListOverriding =
-                isElementOverridingStandaloneConfig(record, IGNORE_COMMIT_LIST_CONFIG_POSITION);
+                isElementOverridingStandaloneConfig(record, IGNORE_COMMIT_LIST_CONFIG_HEADER);
         List<CommitHash> ignoreCommitList = CommitHash.convertStringsToCommits(
-                getAsListWithoutOverridePrefix(record, IGNORE_COMMIT_LIST_CONFIG_POSITION));
+                getAsListWithoutOverridePrefix(record, IGNORE_COMMIT_LIST_CONFIG_HEADER));
 
         boolean isIgnoredAuthorsListOverriding =
-                isElementOverridingStandaloneConfig(record, IGNORE_AUTHOR_LIST_CONFIG_POSITION);
-        List<String> ignoredAuthorsList = getAsListWithoutOverridePrefix(record, IGNORE_AUTHOR_LIST_CONFIG_POSITION);
+                isElementOverridingStandaloneConfig(record, IGNORE_AUTHOR_LIST_CONFIG_HEADER);
+        List<String> ignoredAuthorsList = getAsListWithoutOverridePrefix(record, IGNORE_AUTHOR_LIST_CONFIG_HEADER);
 
-        String ignoreStandaloneConfig = get(record, IGNORE_STANDALONE_CONFIG_POSITION);
+        String ignoreStandaloneConfig = get(record, IGNORE_STANDALONE_CONFIG_HEADER);
         boolean isStandaloneConfigIgnored = ignoreStandaloneConfig.equalsIgnoreCase(IGNORE_STANDALONE_CONFIG_KEYWORD);
 
         if (!isStandaloneConfigIgnored && !ignoreStandaloneConfig.isEmpty()) {

--- a/src/systemtest/resources/author-config.csv
+++ b/src/systemtest/resources/author-config.csv
@@ -1,4 +1,4 @@
-Repository's Location,Branch,Author's GitHub ID,Author's Email,Author's Display Name,Author's Git Author Name,Ignore Glob List
+Repository's Location,Branch,Author's GitHub ID,Author's Emails,Author's Display Name,Author's Git Author Name,Ignore Glob List
 https://github.com/reposense/testrepo-Beta.git,,nbrduplicate,neilbrian.nl@gmail.com,,,
 https://github.com/reposense/testrepo-Beta.git,,nbr,neilbrian.nl@gmail.com,"Ashwin Mukadaan Singhania, Rathod",,
 https://github.com/reposense/testrepo-Beta.git,,zacharytang,,Yagami Rukei Polland,Zachary Tang,src/main**

--- a/src/systemtest/resources/group-config.csv
+++ b/src/systemtest/resources/group-config.csv
@@ -1,4 +1,4 @@
-Repository's Location,Group Name, Globs
+Repository's Location,Group Name,Globs
 https://github.com/reposense/testrepo-Alpha.git,code,**.java
 https://github.com/reposense/testrepo-Charlie.git,code,**.java
 https://github.com/reposense/testrepo-Charlie.git,test,src/test**

--- a/src/systemtest/resources/repo-config.csv
+++ b/src/systemtest/resources/repo-config.csv
@@ -1,4 +1,4 @@
-Repository's Location,Branch,File formats,Ignore Glob List,Ignore standalone config,Ignore Commits List,Ignore Authors List
+Repository's Location,Branch,File formats,Ignore Glob List,Ignore standalone config,Ignore Commit List,Ignore Authors List
 https://github.com/reposense/testrepo-Alpha.git,,,,,2fb6b9b2dd9fa40bf0f9815da2cb0ae8731436c7;c5a6dc774e22099cd9ddeb0faff1e75f9cf4f151;cd7f610e0becbdf331d5231887d8010a689f87c7;768015345e70f06add2a8b7d1f901dc07bf70582,
 https://github.com/reposense/testrepo-Beta.git,,fxml,docs**,yes,,
 https://github.com/reposense/testrepo-Charlie.git,,,,,9859b492760ca3a04432fcecc3ad64302a00689f;95aec8300a020c775d272d4f230d4ff5409793ef;b4b671e671ad3d917328322884c0e643b5b4d47d;80b2c05fcd8145df4301d6e57f89374c5e07cd28,

--- a/src/systemtest/resources/repo-config.csv
+++ b/src/systemtest/resources/repo-config.csv
@@ -1,4 +1,4 @@
-Repository's Location,Branch,File formats,Ignore Glob List,Ignore standalone config,Ignore Commits List,Ignore Authors List,Shallow Cloning
+Repository's Location,Branch,File formats,Ignore Glob List,Ignore standalone config,Ignore Commit List,Ignore Authors List,Shallow Cloning
 https://github.com/reposense/testrepo-Alpha.git,,,,,2fb6b9b2dd9fa40bf0f9815da2cb0ae8731436c7;c5a6dc774e22099cd9ddeb0faff1e75f9cf4f151;cd7f610e0becbdf331d5231887d8010a689f87c7;768015345e70f06add2a8b7d1f901dc07bf70582,,
 https://github.com/reposense/testrepo-Beta.git,,fxml,docs**,yes,,,
 https://github.com/reposense/testrepo-Charlie.git,,,,,9859b492760ca3a04432fcecc3ad64302a00689f;95aec8300a020c775d272d4f230d4ff5409793ef;b4b671e671ad3d917328322884c0e643b5b4d47d;80b2c05fcd8145df4301d6e57f89374c5e07cd28,,

--- a/src/test/java/reposense/parser/AuthorConfigParserTest.java
+++ b/src/test/java/reposense/parser/AuthorConfigParserTest.java
@@ -32,8 +32,12 @@ public class AuthorConfigParserTest {
             "AuthorConfigParserTest/authorconfig_multipleEmails_test.csv");
     private static final Path AUTHOR_CONFIG_INVALID_LOCATION = loadResource(AuthorConfigParserTest.class,
             "AuthorConfigParserTest/authorconfig_invalidLocation_test.csv");
-    private static final Path AUTHOR_CONFIG_INVALID_HEADER_SIZE = loadResource(AuthorConfigParserTest.class,
-            "AuthorConfigParserTest/authorconfig_invalidHeaderSize_test.csv");
+    private static final Path AUTHOR_CONFIG_DIFFERENT_COLUMN_ORDER = loadResource(AuthorConfigParserTest.class,
+            "AuthorConfigParserTest/authorconfig_differentColumnOrder_test.csv");
+    private static final Path AUTHOR_CONFIG_MISSING_OPTIONAL_HEADER = loadResource(AuthorConfigParserTest.class,
+            "AuthorConfigParserTest/authorconfig_missingOptionalHeader_test.csv");
+    private static final Path AUTHOR_CONFIG_MISSING_MANDATORY_HEADER = loadResource(AuthorConfigParserTest.class,
+            "AuthorConfigParserTest/authorconfig_missingMandatoryHeader_test.csv");
 
     private static final String TEST_REPO_BETA_LOCATION = "https://github.com/reposense/testrepo-Beta.git";
     private static final String TEST_REPO_BETA_MASTER_BRANCH = "master";
@@ -153,9 +157,37 @@ public class AuthorConfigParserTest {
         Assert.assertEquals(3, config.getAuthorList().size());
     }
 
+    @Test
+    public void authorConfig_differentColumnOrder_success() throws Exception {
+        AuthorConfigCsvParser authorConfigCsvParser =
+                new AuthorConfigCsvParser(AUTHOR_CONFIG_DIFFERENT_COLUMN_ORDER);
+        List<AuthorConfiguration> configs = authorConfigCsvParser.parse();
+
+        Assert.assertEquals(1, configs.size());
+
+        AuthorConfiguration config = configs.get(0);
+
+        Assert.assertEquals(new RepoLocation(TEST_REPO_BETA_LOCATION), config.getLocation());
+        Assert.assertEquals(TEST_REPO_BETA_MASTER_BRANCH, config.getBranch());
+
+        Assert.assertEquals(AUTHOR_CONFIG_NO_SPECIAL_CHARACTER_AUTHORS, config.getAuthorList());
+    }
+
+    @Test
+    public void authorConfig_missingOptionalHeader_success() throws Exception {
+        AuthorConfigCsvParser authorConfigCsvParser = new AuthorConfigCsvParser(AUTHOR_CONFIG_MISSING_OPTIONAL_HEADER);
+        List<AuthorConfiguration> configs = authorConfigCsvParser.parse();
+
+        Assert.assertEquals(1, configs.size());
+
+        AuthorConfiguration config = configs.get(0);
+
+        Assert.assertEquals(4, config.getAuthorList().size());
+    }
+
     @Test (expected = InvalidCsvException.class)
-    public void authorConfig_invalidHeaderSize_throwsInvalidCsvException() throws Exception {
-        AuthorConfigCsvParser authorConfigCsvParser = new AuthorConfigCsvParser(AUTHOR_CONFIG_INVALID_HEADER_SIZE);
+    public void authorConfig_missingMandatoryHeader_throwsInvalidCsvException() throws Exception {
+        AuthorConfigCsvParser authorConfigCsvParser = new AuthorConfigCsvParser(AUTHOR_CONFIG_MISSING_MANDATORY_HEADER);
         authorConfigCsvParser.parse();
     }
 

--- a/src/test/java/reposense/parser/GroupConfigParserTest.java
+++ b/src/test/java/reposense/parser/GroupConfigParserTest.java
@@ -20,8 +20,12 @@ public class GroupConfigParserTest {
             "GroupConfigParserTest/groupconfig_emptyLocation_test.csv");
     private static final Path GROUP_CONFIG_INVALID_LOCATION_FILE = loadResource(GroupConfigParserTest.class,
             "GroupConfigParserTest/groupconfig_invalidLocation_test.csv");
-    private static final Path GROUP_CONFIG_INVALID_HEADER_SIZE_FILE = loadResource(GroupConfigParserTest.class,
-            "GroupConfigParserTest/groupconfig_invalidHeaderSize_test.csv");
+    private static final Path GROUP_CONFIG_DIFFERENT_COLUMN_ORDER_FILE = loadResource(GroupConfigParserTest.class,
+            "GroupConfigParserTest/groupconfig_differentColumnOrder_test.csv");
+    private static final Path GROUP_CONFIG_MISSING_OPTIONAL_HEADER_FILE = loadResource(GroupConfigParserTest.class,
+            "GroupConfigParserTest/groupconfig_missingOptionalHeader_test.csv");
+    private static final Path GROUP_CONFIG_MISSING_MANDATORY_HEADER_FILE = loadResource(GroupConfigParserTest.class,
+            "GroupConfigParserTest/groupconfig_missingMandatoryHeader_test.csv");
 
     private static final String TEST_REPO_BETA_LOCATION = "https://github.com/reposense/testrepo-Beta.git";
     private static final List<FileType> TEST_REPO_BETA_GROUPS = Arrays.asList(
@@ -74,9 +78,35 @@ public class GroupConfigParserTest {
         Assert.assertEquals(TEST_REPO_DELTA_GROUPS, actualDeltaConfig.getGroupsList());
     }
 
+    @Test
+    public void groupConfig_differentColumnOrder_success() throws Exception {
+        GroupConfigCsvParser groupConfigCsvParser = new GroupConfigCsvParser(GROUP_CONFIG_DIFFERENT_COLUMN_ORDER_FILE);
+        List<GroupConfiguration> groupConfigs = groupConfigCsvParser.parse();
+
+        Assert.assertEquals(2, groupConfigs.size());
+
+        GroupConfiguration actualBetaConfig = groupConfigs.get(0);
+        Assert.assertEquals(TEST_REPO_BETA_LOCATION, actualBetaConfig.getLocation().toString());
+        Assert.assertEquals(TEST_REPO_BETA_GROUPS, actualBetaConfig.getGroupsList());
+
+        GroupConfiguration actualDeltaConfig = groupConfigs.get(1);
+        Assert.assertEquals(TEST_REPO_DELTA_LOCATION, actualDeltaConfig.getLocation().toString());
+        Assert.assertEquals(TEST_REPO_DELTA_GROUPS, actualDeltaConfig.getGroupsList());
+    }
+
+    @Test
+    public void groupConfig_missingOptionalHeader_success() throws Exception {
+        GroupConfigCsvParser groupConfigCsvParser = new GroupConfigCsvParser(GROUP_CONFIG_MISSING_OPTIONAL_HEADER_FILE);
+        List<GroupConfiguration> groupConfigs = groupConfigCsvParser.parse();
+
+        Assert.assertEquals(1, groupConfigs.size());
+
+        Assert.assertEquals(3, groupConfigs.get(0).getGroupsList().size());
+    }
+
     @Test (expected = InvalidCsvException.class)
-    public void groupConfig_invalidHeaderSize_throwsInvalidCsvException() throws Exception {
-        GroupConfigCsvParser groupConfigCsvParser = new GroupConfigCsvParser(GROUP_CONFIG_INVALID_HEADER_SIZE_FILE);
+    public void groupConfig_missingMandatoryHeader_throwsInvalidCsvException() throws Exception {
+        GroupConfigCsvParser groupConfigCsvParser = new GroupConfigCsvParser(GROUP_CONFIG_MISSING_MANDATORY_HEADER_FILE);
         groupConfigCsvParser.parse();
     }
 }

--- a/src/test/java/reposense/parser/GroupConfigParserTest.java
+++ b/src/test/java/reposense/parser/GroupConfigParserTest.java
@@ -106,7 +106,8 @@ public class GroupConfigParserTest {
 
     @Test (expected = InvalidCsvException.class)
     public void groupConfig_missingMandatoryHeader_throwsInvalidCsvException() throws Exception {
-        GroupConfigCsvParser groupConfigCsvParser = new GroupConfigCsvParser(GROUP_CONFIG_MISSING_MANDATORY_HEADER_FILE);
+        GroupConfigCsvParser groupConfigCsvParser = new GroupConfigCsvParser(
+                GROUP_CONFIG_MISSING_MANDATORY_HEADER_FILE);
         groupConfigCsvParser.parse();
     }
 }

--- a/src/test/java/reposense/parser/RepoConfigParserTest.java
+++ b/src/test/java/reposense/parser/RepoConfigParserTest.java
@@ -33,6 +33,12 @@ public class RepoConfigParserTest {
             "RepoConfigParserTest/repoconfig_overrideKeyword_test.csv");
     private static final Path REPO_CONFIG_REDUNDANT_LINES_FILE = loadResource(RepoConfigParserTest.class,
             "RepoConfigParserTest/require_trailing_whitespaces/repoconfig_redundantLines_test.csv");
+    private static final Path REPO_CONFIG_DUPLICATE_HEADERS_CASE_SENSITIVE_FILE =
+            loadResource(RepoConfigParserTest.class,
+            "RepoConfigParserTest/repoconfig_duplicateHeadersCaseSensitive_test.csv");
+    private static final Path REPO_CONFIG_DUPLICATE_HEADERS_CASE_INSENSITIVE_FILE =
+            loadResource(RepoConfigParserTest.class,
+            "RepoConfigParserTest/repoconfig_duplicateHeadersCaseInsensitive_test.csv");
     private static final Path REPO_CONFIG_DIFFERENT_COLUMN_ORDER_FILE = loadResource(RepoConfigParserTest.class,
             "RepoConfigParserTest/repoconfig_differentColumnOrder_test.csv");
     private static final Path REPO_CONFIG_OPTIONAL_HEADER_MISSING_FILE = loadResource(RepoConfigParserTest.class,
@@ -291,6 +297,20 @@ public class RepoConfigParserTest {
     @Test (expected = InvalidCsvException.class)
     public void repoConfig_zeroValidRecords_throwsInvalidCsvException() throws Exception {
         RepoConfigCsvParser repoConfigCsvParser = new RepoConfigCsvParser(REPO_CONFIG_ZERO_VALID_RECORDS);
+        repoConfigCsvParser.parse();
+    }
+
+    @Test (expected = InvalidCsvException.class)
+    public void repoConfig_duplicateHeadersCaseSensitive_throwsInvalidCsvException() throws Exception {
+        RepoConfigCsvParser repoConfigCsvParser =
+                new RepoConfigCsvParser(REPO_CONFIG_DUPLICATE_HEADERS_CASE_SENSITIVE_FILE);
+        repoConfigCsvParser.parse();
+    }
+
+    @Test (expected = InvalidCsvException.class)
+    public void repoConfig_duplicateHeadersCaseInsensitive_throwsInvalidCsvException() throws Exception {
+        RepoConfigCsvParser repoConfigCsvParser =
+                new RepoConfigCsvParser(REPO_CONFIG_DUPLICATE_HEADERS_CASE_INSENSITIVE_FILE);
         repoConfigCsvParser.parse();
     }
 }

--- a/src/test/java/reposense/parser/RepoConfigParserTest.java
+++ b/src/test/java/reposense/parser/RepoConfigParserTest.java
@@ -33,8 +33,12 @@ public class RepoConfigParserTest {
             "RepoConfigParserTest/repoconfig_overrideKeyword_test.csv");
     private static final Path REPO_CONFIG_REDUNDANT_LINES_FILE = loadResource(RepoConfigParserTest.class,
             "RepoConfigParserTest/require_trailing_whitespaces/repoconfig_redundantLines_test.csv");
-    private static final Path REPO_CONFIG_INVALID_HEADER_SIZE_FILE = loadResource(RepoConfigParserTest.class,
-            "RepoConfigParserTest/repoconfig_invalidHeaderSize_test.csv");
+    private static final Path REPO_CONFIG_DIFFERENT_COLUMN_ORDER_FILE = loadResource(RepoConfigParserTest.class,
+            "RepoConfigParserTest/repoconfig_differentColumnOrder_test.csv");
+    private static final Path REPO_CONFIG_OPTIONAL_HEADER_MISSING_FILE = loadResource(RepoConfigParserTest.class,
+            "RepoConfigParserTest/repoconfig_missingOptionalHeader_test.csv");
+    private static final Path REPO_CONFIG_MANDATORY_HEADER_MISSING_FILE = loadResource(RepoConfigParserTest.class,
+            "RepoConfigParserTest/repoconfig_missingMandatoryHeader_test.csv");
     private static final Path MERGE_EMPTY_LOCATION_FOLDER = loadResource(RepoConfigParserTest.class,
             "RepoConfigParserTest/repoconfig_merge_empty_location_test");
     private static final Path REPO_CONFIG_ZERO_VALID_RECORDS = loadResource(RepoConfigParserTest.class,
@@ -233,9 +237,54 @@ public class RepoConfigParserTest {
         Assert.assertTrue(deltaConfig.isStandaloneConfigIgnored());
     }
 
+    @Test
+    public void repoConfig_differentColumnOrder_success() throws Exception {
+        RepoConfigCsvParser repoConfigCsvParser = new RepoConfigCsvParser(REPO_CONFIG_DIFFERENT_COLUMN_ORDER_FILE);
+        List<RepoConfiguration> configs = repoConfigCsvParser.parse();
+
+        Assert.assertEquals(1, configs.size());
+
+        RepoConfiguration config = configs.get(0);
+
+        Assert.assertEquals(new RepoLocation(TEST_REPO_BETA_LOCATION), config.getLocation());
+        Assert.assertEquals(TEST_REPO_BETA_MASTER_BRANCH, config.getBranch());
+
+        Assert.assertEquals(TEST_REPO_BETA_CONFIG_FORMATS, config.getFileTypeManager().getFormats());
+
+        Assert.assertTrue(config.isStandaloneConfigIgnored());
+
+        Assert.assertEquals(config.getIgnoreCommitList(),
+                CommitHash.convertStringsToCommits(TEST_REPO_BETA_CONFIG_IGNORED_COMMITS));
+
+        Assert.assertFalse(config.isFormatsOverriding());
+        Assert.assertFalse(config.isIgnoreGlobListOverriding());
+        Assert.assertFalse(config.isIgnoreCommitListOverriding());
+    }
+
+    @Test
+    public void repoConfig_missingOptionalHeader_success() throws Exception {
+        RepoConfigCsvParser repoConfigCsvParser = new RepoConfigCsvParser(REPO_CONFIG_OPTIONAL_HEADER_MISSING_FILE);
+        List<RepoConfiguration> configs = repoConfigCsvParser.parse();
+
+        Assert.assertEquals(1, configs.size());
+
+        RepoConfiguration config = configs.get(0);
+
+        Assert.assertEquals(new RepoLocation(TEST_REPO_BETA_LOCATION), config.getLocation());
+        Assert.assertEquals(TEST_REPO_BETA_MASTER_BRANCH, config.getBranch());
+
+        Assert.assertEquals(TEST_REPO_BETA_CONFIG_FORMATS, config.getFileTypeManager().getFormats());
+
+        Assert.assertTrue(config.isStandaloneConfigIgnored());
+
+        Assert.assertFalse(config.isFormatsOverriding());
+        Assert.assertFalse(config.isIgnoreGlobListOverriding());
+        Assert.assertFalse(config.isIgnoreCommitListOverriding());
+    }
+
     @Test (expected = InvalidCsvException.class)
-    public void repoConfig_invalidHeaderSize_throwsInvalidCsvException() throws Exception {
-        RepoConfigCsvParser repoConfigCsvParser = new RepoConfigCsvParser(REPO_CONFIG_INVALID_HEADER_SIZE_FILE);
+    public void repoConfig_mandatoryHeaderMissing_throwsInvalidCsvException() throws Exception {
+        RepoConfigCsvParser repoConfigCsvParser = new RepoConfigCsvParser(REPO_CONFIG_MANDATORY_HEADER_MISSING_FILE);
         repoConfigCsvParser.parse();
     }
 

--- a/src/test/resources/AuthorConfigParserTest/authorconfig_commasAndDoubleQuotes_test.csv
+++ b/src/test/resources/AuthorConfigParserTest/authorconfig_commasAndDoubleQuotes_test.csv
@@ -1,4 +1,4 @@
-Repository's Location,Branch,Author's GitHub ID,Author's Email,Author's Display Name,Author's Git Author Name,Ignore Glob List
+Repository's Location,Branch,Author's GitHub ID,Author's Emails,Author's Display Name,Author's Git Author Name,Ignore Glob List
 https://github.com/reposense/testrepo-Beta.git,master,ProcessedCooked,,"Tay Fan Gao, Douya","Tay Fan Gao, Douya ""SOC, Y2S1""",
 https://github.com/reposense/testrepo-Beta.git,master,codeeong,abc@xyz.eu,"""""Tora, S/O,"" Doyua, T.""",,
 https://github.com/reposense/testrepo-Beta.git,master,jordancjq,,,"Borex T""ony Tong",

--- a/src/test/resources/AuthorConfigParserTest/authorconfig_differentColumnOrder_test.csv
+++ b/src/test/resources/AuthorConfigParserTest/authorconfig_differentColumnOrder_test.csv
@@ -1,0 +1,3 @@
+Branch,Ignore Glob List,Repository's Location,Author's Git Author Name,Author's Emails,Author's Display Name,Author's GitHub ID
+master,,https://github.com/reposense/testrepo-Beta.git,,,Nbr,nbriannl
+master,src/main**,https://github.com/reposense/testrepo-Beta.git,Zachary Tang,,Zac,zacharytang

--- a/src/test/resources/AuthorConfigParserTest/authorconfig_emptyLocation_test.csv
+++ b/src/test/resources/AuthorConfigParserTest/authorconfig_emptyLocation_test.csv
@@ -1,3 +1,3 @@
-Repository's Location,Branch,Author's GitHub ID,Author's Email,Author's Display Name,Author's Git Author Name,Ignore Glob List
+Repository's Location,Branch,Author's GitHub ID,Author's Emails,Author's Display Name,Author's Git Author Name,Ignore Glob List
 ,,nbriannl,,Nbr,,
 ,master,zacharytang,,Zac,Zachary Tang,

--- a/src/test/resources/AuthorConfigParserTest/authorconfig_invalidHeaderSize_test.csv
+++ b/src/test/resources/AuthorConfigParserTest/authorconfig_invalidHeaderSize_test.csv
@@ -1,3 +1,0 @@
-Repository's Location,Branch,Author's GitHub ID,Author's Email,Author's Display Name
-https://github.com/reposense/testrepo-Beta.git,master,nbriannl,,Nbr
-https://github.com/reposense/testrepo-Beta.git,master,zacharytang,,Zac

--- a/src/test/resources/AuthorConfigParserTest/authorconfig_invalidLocation_test.csv
+++ b/src/test/resources/AuthorConfigParserTest/authorconfig_invalidLocation_test.csv
@@ -1,4 +1,4 @@
-Repository's Location,Branch,Author's GitHub ID,Author's Email,Author's Display Name,Author's Git Author Name,Ignore Glob List
+Repository's Location,Branch,Author's GitHub ID,Author's Emails,Author's Display Name,Author's Git Author Name,Ignore Glob List
 https://github.com/reposense/reposense.git,master,emer7,,GILBERT,emer7,
 https://github.com/parseexception/invalid.location,master,eugenepeh,,Eugene Peh,Eugene Peh,
 https://github.com/reposense/reposense.git,master,ongspxm,,SHUPENG,ongspxm,

--- a/src/test/resources/AuthorConfigParserTest/authorconfig_missingMandatoryHeader_test.csv
+++ b/src/test/resources/AuthorConfigParserTest/authorconfig_missingMandatoryHeader_test.csv
@@ -1,0 +1,3 @@
+Repository's Location,Branch,Author's Emails,Author's Display Name,Author's Git Author Name,Ignore Glob List
+https://github.com/reposense/testrepo-Beta.git,master,,Nbr,,
+https://github.com/reposense/testrepo-Beta.git,master,,Zac,Zachary Tang,src/main**

--- a/src/test/resources/AuthorConfigParserTest/authorconfig_missingOptionalHeader_test.csv
+++ b/src/test/resources/AuthorConfigParserTest/authorconfig_missingOptionalHeader_test.csv
@@ -1,0 +1,5 @@
+Branch,Author's GitHub ID,Author's Emails,Author's Display Name,Author's Git Author Name,Ignore Glob List
+master,emer7,,GILBERT,emer7,
+master,eugenepeh,,Eugene Peh,Eugene Peh,
+master,ongspxm,,SHUPENG,ongspxm,
+master,fzdy1914,,WANG CHAO,WANG CHAO,

--- a/src/test/resources/AuthorConfigParserTest/authorconfig_multipleEmails_test.csv
+++ b/src/test/resources/AuthorConfigParserTest/authorconfig_multipleEmails_test.csv
@@ -1,2 +1,2 @@
-Repository's Location,Branch,Author's GitHub ID,Author's Email,Author's Display Name,Author's Git Author Name,Ignore Glob List
+Repository's Location,Branch,Author's GitHub ID,Author's Emails,Author's Display Name,Author's Git Author Name,Ignore Glob List
 https://github.com/reposense/testrepo-Beta.git,master,nbriannl,nbr@example.com;nbriannl@test.net,Nbr,,

--- a/src/test/resources/AuthorConfigParserTest/authorconfig_noSpecialCharacter_test.csv
+++ b/src/test/resources/AuthorConfigParserTest/authorconfig_noSpecialCharacter_test.csv
@@ -1,3 +1,3 @@
-Repository's Location,Branch,Author's GitHub ID,Author's Email,Author's Display Name,Author's Git Author Name,Ignore Glob List
+Repository's Location,Branch,Author's GitHub ID,Author's Emails,Author's Display Name,Author's Git Author Name,Ignore Glob List
 https://github.com/reposense/testrepo-Beta.git,master,nbriannl,,Nbr,,
 https://github.com/reposense/testrepo-Beta.git,master,zacharytang,,Zac,Zachary Tang,src/main**

--- a/src/test/resources/AuthorConfigParserTest/authorconfig_specialCharacter_test.csv
+++ b/src/test/resources/AuthorConfigParserTest/authorconfig_specialCharacter_test.csv
@@ -1,4 +1,4 @@
-Repository's Location,Branch,Author's GitHub ID,Author's Email,Author's Display Name,Author's Git Author Name,Ignore Glob List
+Repository's Location,Branch,Author's GitHub ID,Author's Emails,Author's Display Name,Author's Git Author Name,Ignore Glob List
 https://github.com/reposense/testrepo-Beta.git,master,‘Processed�‘Cooked�,,,,
 https://github.com/reposense/testrepo-Beta.git,master,(codeeong),,,,
 https://github.com/reposense/testrepo-Beta.git,master,^:jordancjq;$,,,,

--- a/src/test/resources/CsvParserTest/repoconfig_zeroValidRecords_test.csv
+++ b/src/test/resources/CsvParserTest/repoconfig_zeroValidRecords_test.csv
@@ -1,4 +1,4 @@
-Repository's Location,Branch,File formats,Ignore Glob List,Ignore standalone config,Ignore Commits List
+Repository's Location,Branch,File formats,Ignore Glob List,Ignore standalone config,Ignore Commit List
 https://github.com/reposense/testrepo-Beta.git,override:java;adoc;md,override:docs**,no,override:abcde12345;67890fdecba
 https://github.com/reposense/testrepo-Charlie.git,master,
 ,master,java,docs**,no,823fdd73f7d3feae86d3075ee5706f5f001b73a5

--- a/src/test/resources/GroupConfigParserTest/groupconfig_differentColumnOrder_test.csv
+++ b/src/test/resources/GroupConfigParserTest/groupconfig_differentColumnOrder_test.csv
@@ -1,0 +1,5 @@
+Group Name,Globs,Repository's Location
+Code,**/*.java;**/*.py,https://github.com/reposense/testrepo-Beta.git
+Main,src/main/**,https://github.com/reposense/testrepo-Delta.git
+Docs,docs/**,https://github.com/reposense/testrepo-Beta.git
+Test,src/test/**;src/systest/**,https://github.com/reposense/testrepo-Delta.git

--- a/src/test/resources/GroupConfigParserTest/groupconfig_emptyLocation_test.csv
+++ b/src/test/resources/GroupConfigParserTest/groupconfig_emptyLocation_test.csv
@@ -1,4 +1,4 @@
-Repo location,Group label,Globs
+Repository's Location,Group Name,Globs
 https://github.com/reposense/RepoSense.git,Code,**/*.java;**/*.py
 ,Main,**/*.py
 https://github.com/reposense/RepoSense.git,Docs,**.md

--- a/src/test/resources/GroupConfigParserTest/groupconfig_invalidHeaderSize_test.csv
+++ b/src/test/resources/GroupConfigParserTest/groupconfig_invalidHeaderSize_test.csv
@@ -1,3 +1,0 @@
-Repo location,Group label,Globs,Extra Column
-https://github.com/reposense/testrepo-Beta.git,Code,**/*.java;**/*.py,
-https://github.com/reposense/testrepo-Beta.git,Docs,docs/**,

--- a/src/test/resources/GroupConfigParserTest/groupconfig_invalidLocation_test.csv
+++ b/src/test/resources/GroupConfigParserTest/groupconfig_invalidLocation_test.csv
@@ -1,4 +1,4 @@
-Repo location,Group label,Globs
+Repository's Location,Group Name,Globs
 https://github.com/reposense/testrepo-Beta.git,Code,**/*.java;**/*.py
 https://github.com/someCoy/invalidlocation,Main,**/*.py
 https://github.com/reposense/testrepo-Beta.git,Docs,docs/**

--- a/src/test/resources/GroupConfigParserTest/groupconfig_missingMandatoryHeader_test.csv
+++ b/src/test/resources/GroupConfigParserTest/groupconfig_missingMandatoryHeader_test.csv
@@ -1,0 +1,4 @@
+Repository's Location,Group Name
+https://github.com/reposense/testrepo-Beta.git,Code
+https://github.com/someCoy/invalidlocation,Main
+https://github.com/reposense/testrepo-Beta.git,Docs

--- a/src/test/resources/GroupConfigParserTest/groupconfig_missingOptionalHeader_test.csv
+++ b/src/test/resources/GroupConfigParserTest/groupconfig_missingOptionalHeader_test.csv
@@ -1,0 +1,4 @@
+Group Name,Globs
+Code,**/*.java;**/*.py
+Main,**/*.py
+Docs,docs/**

--- a/src/test/resources/GroupConfigParserTest/groupconfig_multipleLocation_test.csv
+++ b/src/test/resources/GroupConfigParserTest/groupconfig_multipleLocation_test.csv
@@ -1,4 +1,4 @@
-Repo location,Group label,Globs
+Repository's Location,Group Name,Globs
 https://github.com/reposense/testrepo-Beta.git,Code,**/*.java;**/*.py
 https://github.com/reposense/testrepo-Delta.git,Main,src/main/**
 https://github.com/reposense/testrepo-Beta.git,Docs,docs/**

--- a/src/test/resources/RepoConfigParserTest/repoconfig_differentColumnOrder_test.csv
+++ b/src/test/resources/RepoConfigParserTest/repoconfig_differentColumnOrder_test.csv
@@ -1,0 +1,2 @@
+Ignore Glob List,Repository's Location,Ignore Commit List,Ignore standalone config,File formats,Ignore Authors List,Branch
+docs**,https://github.com/reposense/testrepo-Beta.git,abcde12345;67890fdecba,yes,java;adoc;md,zacharytang,master

--- a/src/test/resources/RepoConfigParserTest/repoconfig_differentColumnOrder_test.csv
+++ b/src/test/resources/RepoConfigParserTest/repoconfig_differentColumnOrder_test.csv
@@ -1,2 +1,2 @@
-Ignore Glob List,Repository's Location,Ignore Commit List,Ignore standalone config,File formats,Ignore Authors List,Branch
-docs**,https://github.com/reposense/testrepo-Beta.git,abcde12345;67890fdecba,yes,java;adoc;md,zacharytang,master
+Shallow Cloning,Ignore Glob List,Repository's Location,Ignore Commit List,Ignore standalone config,File formats,Ignore Authors List,Branch
+,docs**,https://github.com/reposense/testrepo-Beta.git,abcde12345;67890fdecba,yes,java;adoc;md,zacharytang,master

--- a/src/test/resources/RepoConfigParserTest/repoconfig_duplicateHeadersCaseInsensitive_test.csv
+++ b/src/test/resources/RepoConfigParserTest/repoconfig_duplicateHeadersCaseInsensitive_test.csv
@@ -1,0 +1,2 @@
+Repository's Location,Branch,branch,FILE FORMATS,File formats,Ignore Glob List,Ignore standalone config,Ignore Commit List,Ignore Authors List
+https://github.com/reposense/testrepo-Beta.git,master,something-else,py,java;adoc;md,docs**,yes,abcde12345;67890fdecba,zacharytang

--- a/src/test/resources/RepoConfigParserTest/repoconfig_duplicateHeadersCaseSensitive_test.csv
+++ b/src/test/resources/RepoConfigParserTest/repoconfig_duplicateHeadersCaseSensitive_test.csv
@@ -1,0 +1,2 @@
+Repository's Location,Branch,File FORMATS,File formats,Ignore Glob List,Ignore standalone config,Ignore standalone config,Ignore Commit List,Ignore Authors List
+https://github.com/reposense/testrepo-Beta.git,master,py,java;adoc;md,docs**,,yes,abcde12345;67890fdecba,zacharytang

--- a/src/test/resources/RepoConfigParserTest/repoconfig_invalidHeaderSize_test.csv
+++ b/src/test/resources/RepoConfigParserTest/repoconfig_invalidHeaderSize_test.csv
@@ -1,4 +1,0 @@
-Repository's Location,Branch,File formats,Ignore Glob List,Ignore standalone config
-https://github.com/reposense/testrepo-Beta.git,master,,,
-https://github.com/reposense/testrepo-Charlie.git,,,,
-https://github.com/reposense/testrepo-Delta.git,,,,yes

--- a/src/test/resources/RepoConfigParserTest/repoconfig_merge_empty_location_test/author-config.csv
+++ b/src/test/resources/RepoConfigParserTest/repoconfig_merge_empty_location_test/author-config.csv
@@ -1,3 +1,3 @@
-Repository's Location,Branch,Author's GitHub ID,Author's Email,Author's Display Name,Author's Git Author Name,Ignore Glob List
+Repository's Location,Branch,Author's GitHub ID,Author's Emails,Author's Display Name,Author's Git Author Name,Ignore Glob List
 ,master,nbriannl,,Nbr,,**.java
 https://github.com/reposense/testrepo-Beta.git,master,zacharytang,,Zac,Zachary Tang,

--- a/src/test/resources/RepoConfigParserTest/repoconfig_merge_empty_location_test/repo-config.csv
+++ b/src/test/resources/RepoConfigParserTest/repoconfig_merge_empty_location_test/repo-config.csv
@@ -1,3 +1,3 @@
-Repository's Location,Branch,File formats,Ignore Glob List,Ignore standalone config,Ignore Commits List,Ignore Authors List,Shallow Cloning
+Repository's Location,Branch,File formats,Ignore Glob List,Ignore standalone config,Ignore Commit List,Ignore Authors List,Shallow Cloning
 https://github.com/reposense/testrepo-Beta.git,master,,collated**,,,,yes
 https://github.com/reposense/testrepo-Delta.git,,java;fxml,,yes,,,

--- a/src/test/resources/RepoConfigParserTest/repoconfig_merge_empty_location_test/repo-config.csv
+++ b/src/test/resources/RepoConfigParserTest/repoconfig_merge_empty_location_test/repo-config.csv
@@ -1,3 +1,3 @@
-Repository's Location,Branch,File formats,Ignore Glob List,Ignore standalone config,Ignore Commits List,Ignore Authors List
+Repository's Location,Branch,File formats,Ignore Glob List,Ignore standalone config,Ignore Commit List,Ignore Authors List
 https://github.com/reposense/testrepo-Beta.git,master,,collated**,,,
 https://github.com/reposense/testrepo-Delta.git,,java;fxml,,yes,,

--- a/src/test/resources/RepoConfigParserTest/repoconfig_missingMandatoryHeader_test.csv
+++ b/src/test/resources/RepoConfigParserTest/repoconfig_missingMandatoryHeader_test.csv
@@ -1,0 +1,2 @@
+Branch,File formats,Ignore Glob List,Ignore standalone config,Ignore Commit List,Ignore Authors List
+master,java;adoc;md,docs**,yes,abcde12345;67890fdecba,zacharytang

--- a/src/test/resources/RepoConfigParserTest/repoconfig_missingOptionalHeader_test.csv
+++ b/src/test/resources/RepoConfigParserTest/repoconfig_missingOptionalHeader_test.csv
@@ -1,0 +1,2 @@
+Repository's Location,Branch,File formats,Ignore Glob List,Ignore standalone config,Ignore Authors List
+https://github.com/reposense/testrepo-Beta.git,master,java;adoc;md,docs**,yes,zacharytang

--- a/src/test/resources/RepoConfigParserTest/repoconfig_noSpecialCharacter_test.csv
+++ b/src/test/resources/RepoConfigParserTest/repoconfig_noSpecialCharacter_test.csv
@@ -1,2 +1,2 @@
-Repository's Location,Branch,File formats,Ignore Glob List,Ignore standalone config,Ignore Commits List,Ignore Authors List,Shallow Cloning
+Repository's Location,Branch,File formats,Ignore Glob List,Ignore standalone config,Ignore Commit List,Ignore Authors List,Shallow Cloning
 https://github.com/reposense/testrepo-Beta.git,master,java;adoc;md,docs**,yes,abcde12345;67890fdecba,zacharytang,yes

--- a/src/test/resources/RepoConfigParserTest/repoconfig_noSpecialCharacter_test.csv
+++ b/src/test/resources/RepoConfigParserTest/repoconfig_noSpecialCharacter_test.csv
@@ -1,2 +1,2 @@
-Repository's Location,Branch,File formats,Ignore Glob List,Ignore standalone config,Ignore Commits List,Ignore Authors List
+Repository's Location,Branch,File formats,Ignore Glob List,Ignore standalone config,Ignore Commit List,Ignore Authors List
 https://github.com/reposense/testrepo-Beta.git,master,java;adoc;md,docs**,yes,abcde12345;67890fdecba,zacharytang

--- a/src/test/resources/RepoConfigParserTest/repoconfig_overrideKeyword_test.csv
+++ b/src/test/resources/RepoConfigParserTest/repoconfig_overrideKeyword_test.csv
@@ -1,2 +1,2 @@
-Repository's Location,Branch,File formats,Ignore Glob List,Ignore standalone config,Ignore Commits List,Ignore Authors List,Shallow Cloning
+Repository's Location,Branch,File formats,Ignore Glob List,Ignore standalone config,Ignore Commit List,Ignore Authors List,Shallow Cloning
 https://github.com/reposense/testrepo-Beta.git,master,override:java;adoc;md,override:docs**,no,override:abcde12345;67890fdecba,override:zachrytang,

--- a/src/test/resources/RepoConfigParserTest/repoconfig_overrideKeyword_test.csv
+++ b/src/test/resources/RepoConfigParserTest/repoconfig_overrideKeyword_test.csv
@@ -1,2 +1,2 @@
-Repository's Location,Branch,File formats,Ignore Glob List,Ignore standalone config,Ignore Commits List,Ignore Authors List
+Repository's Location,Branch,File formats,Ignore Glob List,Ignore standalone config,Ignore Commit List,Ignore Authors List
 https://github.com/reposense/testrepo-Beta.git,master,override:java;adoc;md,override:docs**,no,override:abcde12345;67890fdecba,override:zacharytang

--- a/src/test/resources/RepoConfigParserTest/require_trailing_whitespaces/repoconfig_redundantLines_test.csv
+++ b/src/test/resources/RepoConfigParserTest/require_trailing_whitespaces/repoconfig_redundantLines_test.csv
@@ -1,18 +1,15 @@
-                                 ,,,,,,,
-,,,,,,,
-        ,,,,,,,
-                   ,,,,,,,
+
+
+
+
 Repository's Location,Branch,File formats,Ignore Glob List,Ignore standalone config,Ignore Commit List,Ignore Authors List,Shallow Cloning
 https://github.com/reposense/testrepo-Beta.git,master,,,,,,
-,,,,,,,
-                                           ,,,,,,,
+
+
 https://github.com/reposense/testrepo-Charlie.git,,,,,,,
 https://github.com/reposense/testrepo-Delta.git,,,,yes,,,
-,,,,,,,
-                                ,,,,,,,
-                                 ,,,,,,,
-,,,,,,,
-,,,,,,,
-                                        ,,,,,,,
-,,,,,,,
-                                       ,,,,,,,
+
+
+
+
+

--- a/src/test/resources/RepoConfigParserTest/require_trailing_whitespaces/repoconfig_redundantLines_test.csv
+++ b/src/test/resources/RepoConfigParserTest/require_trailing_whitespaces/repoconfig_redundantLines_test.csv
@@ -2,7 +2,7 @@
 
         
                    
-Repository's Location,Branch,File formats,Ignore Glob List,Ignore standalone config,Ignore Commits List,Ignore Authors List
+Repository's Location,Branch,File formats,Ignore Glob List,Ignore standalone config,Ignore Commit List,Ignore Authors List
 https://github.com/reposense/testrepo-Beta.git,master,,,,,
 
                                            

--- a/src/test/resources/RepoConfigParserTest/require_trailing_whitespaces/repoconfig_redundantLines_test.csv
+++ b/src/test/resources/RepoConfigParserTest/require_trailing_whitespaces/repoconfig_redundantLines_test.csv
@@ -1,19 +1,18 @@
-                                 
-
-        
-                   
-Repository's Location,Branch,File formats,Ignore Glob List,Ignore standalone config,Ignore Commits List,Ignore Authors List,Shallow Cloning
+                                 ,,,,,,,
+,,,,,,,
+        ,,,,,,,
+                   ,,,,,,,
+Repository's Location,Branch,File formats,Ignore Glob List,Ignore standalone config,Ignore Commit List,Ignore Authors List,Shallow Cloning
 https://github.com/reposense/testrepo-Beta.git,master,,,,,,
-
-                                           
+,,,,,,,
+                                           ,,,,,,,
 https://github.com/reposense/testrepo-Charlie.git,,,,,,,
 https://github.com/reposense/testrepo-Delta.git,,,,yes,,,
-
-                                
-                                 
-
-
-                                        
-
-                                       
-
+,,,,,,,
+                                ,,,,,,,
+                                 ,,,,,,,
+,,,,,,,
+,,,,,,,
+                                        ,,,,,,,
+,,,,,,,
+                                       ,,,,,,,

--- a/src/test/resources/RepoConfigurationTest/repoconfig_formats_test/repo-config.csv
+++ b/src/test/resources/RepoConfigurationTest/repoconfig_formats_test/repo-config.csv
@@ -1,2 +1,2 @@
-Repository's Location,Branch,File formats,Ignore Glob List,Ignore standalone config,Ignore Commits List,Ignore Authors List
+Repository's Location,Branch,File formats,Ignore Glob List,Ignore standalone config,Ignore Commit List,Ignore Authors List
 https://github.com/reposense/testrepo-Beta.git,master,    java   ;     adoc;md   ,docs**,yes,,

--- a/src/test/resources/RepoConfigurationTest/repoconfig_formats_test/repo-config.csv
+++ b/src/test/resources/RepoConfigurationTest/repoconfig_formats_test/repo-config.csv
@@ -1,2 +1,2 @@
-Repository's Location,Branch,File formats,Ignore Glob List,Ignore standalone config,Ignore Commits List,Ignore Authors List,Shallow Cloning
+Repository's Location,Branch,File formats,Ignore Glob List,Ignore standalone config,Ignore Commit List,Ignore Authors List,Shallow Cloning
 https://github.com/reposense/testrepo-Beta.git,master,    java   ;     adoc;md   ,docs**,yes,,,

--- a/src/test/resources/RepoConfigurationTest/repoconfig_groups_test/repo-config.csv
+++ b/src/test/resources/RepoConfigurationTest/repoconfig_groups_test/repo-config.csv
@@ -1,3 +1,3 @@
-Repository's Location,Branch,File formats,Ignore Glob List,Ignore standalone config,Ignore Commits List,Ignore Authors List
+Repository's Location,Branch,File formats,Ignore Glob List,Ignore standalone config,Ignore Commit List,Ignore Authors List
 https://github.com/reposense/testrepo-Beta.git,master,,,yes,,
 https://github.com/reposense/testrepo-Delta.git,master,,,yes,,

--- a/src/test/resources/RepoConfigurationTest/repoconfig_groups_test/repo-config.csv
+++ b/src/test/resources/RepoConfigurationTest/repoconfig_groups_test/repo-config.csv
@@ -1,3 +1,3 @@
-Repository's Location,Branch,File formats,Ignore Glob List,Ignore standalone config,Ignore Commits List,Ignore Authors List,Shallow Cloning
+Repository's Location,Branch,File formats,Ignore Glob List,Ignore standalone config,Ignore Commit List,Ignore Authors List,Shallow Cloning
 https://github.com/reposense/testrepo-Beta.git,master,,,yes,,,
 https://github.com/reposense/testrepo-Delta.git,master,,,yes,,,

--- a/src/test/resources/RepoConfigurationTest/repoconfig_ignoreAuthors_test/author-config.csv
+++ b/src/test/resources/RepoConfigurationTest/repoconfig_ignoreAuthors_test/author-config.csv
@@ -1,4 +1,4 @@
-Repository's Location,Branch,Author's GitHub ID,Author's Email,Author's Display Name,Author's Git Author Name,Ignore Glob List
+Repository's Location,Branch,Author's GitHub ID,Author's Emails,Author's Display Name,Author's Git Author Name,Ignore Glob List
 https://github.com/reposense/testrepo-Delta.git,master,lithiumlkid,,Ahm,Ahmad Syafiq,
 https://github.com/reposense/testrepo-Delta.git,master,jordancjq,,Jor,Jordan Chong,
 https://github.com/reposense/testrepo-Delta.git,master,eugenepeh,,Eugene Peh,Eugene Peh,

--- a/src/test/resources/RepoConfigurationTest/repoconfig_ignoreAuthors_test/repo-config.csv
+++ b/src/test/resources/RepoConfigurationTest/repoconfig_ignoreAuthors_test/repo-config.csv
@@ -1,2 +1,2 @@
-Repository's Location,Branch,File formats,Ignore Glob List,Ignore standalone config,Ignore Commits List,Ignore Authors List
+Repository's Location,Branch,File formats,Ignore Glob List,Ignore standalone config,Ignore Commit List,Ignore Authors List
 https://github.com/reposense/testrepo-Delta.git,master,java;adoc;md,collated**,yes,,jordancjq;Eugene Peh

--- a/src/test/resources/RepoConfigurationTest/repoconfig_ignoreAuthors_test/repo-config.csv
+++ b/src/test/resources/RepoConfigurationTest/repoconfig_ignoreAuthors_test/repo-config.csv
@@ -1,2 +1,2 @@
-Repository's Location,Branch,File formats,Ignore Glob List,Ignore standalone config,Ignore Commits List,Ignore Authors List,Shallow Cloning
+Repository's Location,Branch,File formats,Ignore Glob List,Ignore standalone config,Ignore Commit List,Ignore Authors List,Shallow Cloning
 https://github.com/reposense/testrepo-Delta.git,master,java;adoc;md,collated**,yes,,jordancjq;Eugene Peh,

--- a/src/test/resources/RepoConfigurationTest/repoconfig_ignoreStandAloneKeyword_test/repo-config.csv
+++ b/src/test/resources/RepoConfigurationTest/repoconfig_ignoreStandAloneKeyword_test/repo-config.csv
@@ -1,2 +1,2 @@
-Repository's Location,Branch,File formats,Ignore Glob List,Ignore standalone config,Ignore Commits List,Ignore Authors List
+Repository's Location,Branch,File formats,Ignore Glob List,Ignore standalone config,Ignore Commit List,Ignore Authors List
 https://github.com/reposense/testrepo-Delta.git,master,,collated**,yesss,,

--- a/src/test/resources/RepoConfigurationTest/repoconfig_ignoreStandAloneKeyword_test/repo-config.csv
+++ b/src/test/resources/RepoConfigurationTest/repoconfig_ignoreStandAloneKeyword_test/repo-config.csv
@@ -1,2 +1,2 @@
-Repository's Location,Branch,File formats,Ignore Glob List,Ignore standalone config,Ignore Commits List,Ignore Authors List,Shallow Cloning
+Repository's Location,Branch,File formats,Ignore Glob List,Ignore standalone config,Ignore Commit List,Ignore Authors List,Shallow Cloning
 https://github.com/reposense/testrepo-Delta.git,master,,collated**,yesss,,,

--- a/src/test/resources/RepoConfigurationTest/repoconfig_ignoreStandAlone_test/author-config.csv
+++ b/src/test/resources/RepoConfigurationTest/repoconfig_ignoreStandAlone_test/author-config.csv
@@ -1,2 +1,2 @@
-Repository's Location,Branch,Author's GitHub ID,Author's Email,Author's Display Name,Author's Git Author Name,Ignore Glob List
+Repository's Location,Branch,Author's GitHub ID,Author's Emails,Author's Display Name,Author's Git Author Name,Ignore Glob List
 https://github.com/reposense/testrepo-Delta.git,master,lithiumlkid,,Ahm,Ahmad Syafiq,

--- a/src/test/resources/RepoConfigurationTest/repoconfig_ignoreStandAlone_test/repo-config.csv
+++ b/src/test/resources/RepoConfigurationTest/repoconfig_ignoreStandAlone_test/repo-config.csv
@@ -1,2 +1,2 @@
-Repository's Location,Branch,File formats,Ignore Glob List,Ignore standalone config,Ignore Commits List,Ignore Authors List,Shallow Cloning
+Repository's Location,Branch,File formats,Ignore Glob List,Ignore standalone config,Ignore Commit List,Ignore Authors List,Shallow Cloning
 https://github.com/reposense/testrepo-Delta.git,master,java;adoc;md,collated**,yes,,,

--- a/src/test/resources/RepoConfigurationTest/repoconfig_ignoreStandAlone_test/repo-config.csv
+++ b/src/test/resources/RepoConfigurationTest/repoconfig_ignoreStandAlone_test/repo-config.csv
@@ -1,2 +1,2 @@
-Repository's Location,Branch,File formats,Ignore Glob List,Ignore standalone config,Ignore Commits List,Ignore Authors List
+Repository's Location,Branch,File formats,Ignore Glob List,Ignore standalone config,Ignore Commit List,Ignore Authors List
 https://github.com/reposense/testrepo-Delta.git,master,java;adoc;md,collated**,yes,,

--- a/src/test/resources/RepoConfigurationTest/repoconfig_ignoreStandaloneOverrideCsv_test/repo-config.csv
+++ b/src/test/resources/RepoConfigurationTest/repoconfig_ignoreStandaloneOverrideCsv_test/repo-config.csv
@@ -1,3 +1,3 @@
-Repository's Location,Branch,File formats,Ignore Glob List,Ignore standalone config,Ignore Commits List,Ignore Authors List,Shallow Cloning
+Repository's Location,Branch,File formats,Ignore Glob List,Ignore standalone config,Ignore Commit List,Ignore Authors List,Shallow Cloning
 https://github.com/reposense/testrepo-Beta.git,master,css;html,,yes,,,
 https://github.com/reposense/testrepo-Delta.git,master,,,,,,

--- a/src/test/resources/RepoConfigurationTest/repoconfig_ignoreStandaloneOverrideCsv_test/repo-config.csv
+++ b/src/test/resources/RepoConfigurationTest/repoconfig_ignoreStandaloneOverrideCsv_test/repo-config.csv
@@ -1,3 +1,3 @@
-Repository's Location,Branch,File formats,Ignore Glob List,Ignore standalone config,Ignore Commits List,Ignore Authors List
+Repository's Location,Branch,File formats,Ignore Glob List,Ignore standalone config,Ignore Commit List,Ignore Authors List
 https://github.com/reposense/testrepo-Beta.git,master,css;html,,yes,,
 https://github.com/reposense/testrepo-Delta.git,master,,,,,

--- a/src/test/resources/RepoConfigurationTest/repoconfig_overrideStandAlone_test/repo-config.csv
+++ b/src/test/resources/RepoConfigurationTest/repoconfig_overrideStandAlone_test/repo-config.csv
@@ -1,2 +1,2 @@
-Repository's Location,Branch,File formats,Ignore Glob List,Ignore standalone config,Ignore Commits List,Ignore Authors List,Shallow Cloning
+Repository's Location,Branch,File formats,Ignore Glob List,Ignore standalone config,Ignore Commit List,Ignore Authors List,Shallow Cloning
 https://github.com/reposense/testrepo-Delta.git,master,override:,override:,no,override:,override:lithiumlkid,

--- a/src/test/resources/RepoConfigurationTest/repoconfig_overrideStandAlone_test/repo-config.csv
+++ b/src/test/resources/RepoConfigurationTest/repoconfig_overrideStandAlone_test/repo-config.csv
@@ -1,2 +1,2 @@
-Repository's Location,Branch,File formats,Ignore Glob List,Ignore standalone config,Ignore Commits List,Ignore Authors List
+Repository's Location,Branch,File formats,Ignore Glob List,Ignore standalone config,Ignore Commit List,Ignore Authors List
 https://github.com/reposense/testrepo-Delta.git,master,override:,override:,no,override:,override:lithiumlkid

--- a/src/test/resources/RepoConfigurationTest/repoconfig_shallowCloningOverrideCsv_test/repo-config.csv
+++ b/src/test/resources/RepoConfigurationTest/repoconfig_shallowCloningOverrideCsv_test/repo-config.csv
@@ -1,3 +1,3 @@
-Repository's Location,Branch,File formats,Ignore Glob List,Ignore standalone config,Ignore Commits List,Ignore Authors List,Shallow Cloning
+Repository's Location,Branch,File formats,Ignore Glob List,Ignore standalone config,Ignore Commit List,Ignore Authors List,Shallow Cloning
 https://github.com/reposense/testrepo-Beta.git,master,css;html,,yes,,,yes
 https://github.com/reposense/testrepo-Delta.git,master,,,,,,

--- a/src/test/resources/RepoConfigurationTest/repoconfig_shallowCloning_test/repo-config.csv
+++ b/src/test/resources/RepoConfigurationTest/repoconfig_shallowCloning_test/repo-config.csv
@@ -1,2 +1,2 @@
-Repository's Location,Branch,File formats,Ignore Glob List,Ignore standalone config,Ignore Commits List,Ignore Authors List,Shallow Cloning
+Repository's Location,Branch,File formats,Ignore Glob List,Ignore standalone config,Ignore Commit List,Ignore Authors List,Shallow Cloning
 https://github.com/reposense/testrepo-Delta.git,master,java;adoc;md,collated**,,,,yes

--- a/src/test/resources/RepoConfigurationTest/repoconfig_withoutformats_test/repo-config.csv
+++ b/src/test/resources/RepoConfigurationTest/repoconfig_withoutformats_test/repo-config.csv
@@ -1,2 +1,2 @@
-Repository's Location,Branch,File formats,Ignore Glob List,Ignore standalone config,Ignore Commits List,Ignore Authors List,Shallow Cloning
+Repository's Location,Branch,File formats,Ignore Glob List,Ignore standalone config,Ignore Commit List,Ignore Authors List,Shallow Cloning
 https://github.com/reposense/testrepo-Beta.git,master,,docs**,yes,,,

--- a/src/test/resources/RepoConfigurationTest/repoconfig_withoutformats_test/repo-config.csv
+++ b/src/test/resources/RepoConfigurationTest/repoconfig_withoutformats_test/repo-config.csv
@@ -1,2 +1,2 @@
-Repository's Location,Branch,File formats,Ignore Glob List,Ignore standalone config,Ignore Commits List,Ignore Authors List
+Repository's Location,Branch,File formats,Ignore Glob List,Ignore standalone config,Ignore Commit List,Ignore Authors List
 https://github.com/reposense/testrepo-Beta.git,master,,docs**,yes,,

--- a/src/test/resources/cli_location_test/author-config.csv
+++ b/src/test/resources/cli_location_test/author-config.csv
@@ -1,1 +1,1 @@
-Repository's Location,Branch,Author's GitHub ID,Author's Email,Author's Display Name,Author's Git Author Name,Ignore Glob List
+Repository's Location,Branch,Author's GitHub ID,Author's Emails,Author's Display Name,Author's Git Author Name,Ignore Glob List

--- a/src/test/resources/cli_location_test/repo-config.csv
+++ b/src/test/resources/cli_location_test/repo-config.csv
@@ -1,4 +1,4 @@
-Repository's Location,Branch,File formats,Ignore Glob List,Ignore standalone config,Ignore Commits List,Ignore Authors List
+Repository's Location,Branch,File formats,Ignore Glob List,Ignore standalone config,Ignore Commit List,Ignore Authors List
 https://github.com/reposense/testrepo-Beta.git,,,,,,
 https://github.com/reposense/testrepo-Charlie.git,,,,,,
 https://github.com/reposense/testrepo-Delta.git,,,,,,

--- a/src/test/resources/cli_location_test/repo-config.csv
+++ b/src/test/resources/cli_location_test/repo-config.csv
@@ -1,4 +1,4 @@
-Repository's Location,Branch,File formats,Ignore Glob List,Ignore standalone config,Ignore Commits List,Ignore Authors List,Shallow Cloning
+Repository's Location,Branch,File formats,Ignore Glob List,Ignore standalone config,Ignore Commit List,Ignore Authors List,Shallow Cloning
 https://github.com/reposense/testrepo-Beta.git,,,,,,,
 https://github.com/reposense/testrepo-Charlie.git,,,,,,,
 https://github.com/reposense/testrepo-Delta.git,,,,,,,

--- a/src/test/resources/repoconfig_empty_branch_test/author-config.csv
+++ b/src/test/resources/repoconfig_empty_branch_test/author-config.csv
@@ -1,2 +1,2 @@
-Repository's Location,Branch,Author's GitHub ID,Author's Email,Author's Display Name,Author's Git Author Name,Ignore Glob List
+Repository's Location,Branch,Author's GitHub ID,Author's Emails,Author's Display Name,Author's Git Author Name,Ignore Glob List
 https://github.com/reposense/testrepo-Beta.git,,nbriannl,,Nbr,,

--- a/src/test/resources/repoconfig_empty_branch_test/repo-config.csv
+++ b/src/test/resources/repoconfig_empty_branch_test/repo-config.csv
@@ -1,2 +1,2 @@
-Repository's Location,Branch,File formats,Ignore Glob List,Ignore standalone config,Ignore Commits List,Ignore Authors List,Shallow Cloning
+Repository's Location,Branch,File formats,Ignore Glob List,Ignore standalone config,Ignore Commit List,Ignore Authors List,Shallow Cloning
 https://github.com/reposense/testrepo-Beta.git,,fxml,docs**,yes,,,

--- a/src/test/resources/repoconfig_empty_branch_test/repo-config.csv
+++ b/src/test/resources/repoconfig_empty_branch_test/repo-config.csv
@@ -1,2 +1,2 @@
-Repository's Location,Branch,File formats,Ignore Glob List,Ignore standalone config,Ignore Commits List,Ignore Authors List
+Repository's Location,Branch,File formats,Ignore Glob List,Ignore standalone config,Ignore Commit List,Ignore Authors List
 https://github.com/reposense/testrepo-Beta.git,,fxml,docs**,yes,,

--- a/src/test/resources/repoconfig_merge_test/author-config.csv
+++ b/src/test/resources/repoconfig_merge_test/author-config.csv
@@ -1,3 +1,3 @@
-Repository's Location,Branch,Author's GitHub ID,Author's Email,Author's Display Name,Author's Git Author Name,Ignore Glob List
+Repository's Location,Branch,Author's GitHub ID,Author's Emails,Author's Display Name,Author's Git Author Name,Ignore Glob List
 https://github.com/reposense/testrepo-Beta.git,master,nbriannl,,Nbr,,**.java
 https://github.com/reposense/testrepo-Beta.git,,zacharytang,,Zac,Zachary Tang,**.doc

--- a/src/test/resources/repoconfig_merge_test/repo-config.csv
+++ b/src/test/resources/repoconfig_merge_test/repo-config.csv
@@ -1,3 +1,3 @@
-Repository's Location,Branch,File formats,Ignore Glob List,Ignore standalone config,Ignore Commits List,Ignore Authors List,Shallow Cloning
+Repository's Location,Branch,File formats,Ignore Glob List,Ignore standalone config,Ignore Commit List,Ignore Authors List,Shallow Cloning
 https://github.com/reposense/testrepo-Beta.git,master,,collated**,,,,
 https://github.com/reposense/testrepo-Beta.git,add-config-json,,collated**,,,,

--- a/src/test/resources/repoconfig_merge_test/repo-config.csv
+++ b/src/test/resources/repoconfig_merge_test/repo-config.csv
@@ -1,3 +1,3 @@
-Repository's Location,Branch,File formats,Ignore Glob List,Ignore standalone config,Ignore Commits List,Ignore Authors List
+Repository's Location,Branch,File formats,Ignore Glob List,Ignore standalone config,Ignore Commit List,Ignore Authors List
 https://github.com/reposense/testrepo-Beta.git,master,,collated**,,,
 https://github.com/reposense/testrepo-Beta.git,add-config-json,,collated**,,,


### PR DESCRIPTION
```
Currently, RepoSense parses the config CSV files purely based on
column order. This means that every column needs to be present in the
correct order (even if the column is optional) in order for the CSV
file to be parsed. This additionally means that every time we add a
new column to a config CSV, we would break compatibility with existing
config CSV files for all users.

Let’s change the CSVParser to verify and parse the config CSV files
based on the column headers. This would allow us to parse config CSVs
with columns in a different order or with some (optional) columns
missing, and would allow us to add new columns without breaking
compatibility.
```