### PR TITLE
Extract zoom commit messages as a separate component

### DIFF
--- a/frontend/src/index.pug
+++ b/frontend/src/index.pug
@@ -122,6 +122,9 @@ html
     vuetemplate#v_ramp
       include ramp.pug
 
+    vuetemplate#v_zoom_commit
+      include zoom_commit.pug
+
     vuetemplate#v_zoom
       include tabs/zoom.pug
 
@@ -136,6 +139,7 @@ html
     script(src="static/js/safari_date.js")
     script(src="static/js/v_resizer.js")
     script(src="static/js/v_ramp.js")
+    script(src="static/js/v_zoom_commit.js")
     script(src="static/js/v_zoom.js")
     script(src="static/js/v_summary_charts.js")
     script(src="static/js/v_segment.js")

--- a/frontend/src/static/js/api.js
+++ b/frontend/src/static/js/api.js
@@ -103,23 +103,6 @@ window.comparator = (fn, sortingOption = '') => function compare(a, b) {
   return 1;
 };
 
-window.toggleNext = function toggleNext(ele) {
-  // function for toggling unopened code
-  const targetClass = 'active';
-
-  const parent = ele.parentNode;
-  const classes = parent.className.split(' ');
-  const idx = classes.indexOf(targetClass);
-
-  if (idx === -1) {
-    classes.push(targetClass);
-  } else {
-    classes.splice(idx, 1);
-  }
-
-  parent.className = classes.join(' ');
-};
-
 window.getBaseLink = function getBaseLink(repoId) {
   return `${window.BASE_URL}/${
     window.REPOS[repoId].location.organization}/${

--- a/frontend/src/static/js/v_zoom.js
+++ b/frontend/src/static/js/v_zoom.js
@@ -16,6 +16,7 @@ window.vZoom = {
   template: window.$('v_zoom').innerHTML,
   data() {
     return {
+      defaultExpansionStateSignal: false,
       expandedCommitMessagesCount: 0,
       ...initialState(),
     };
@@ -214,6 +215,7 @@ window.vZoom = {
 
     toggleAllCommitMessagesBody(isActive) {
       this.showAllCommitMessageBody = isActive;
+      this.defaultExpansionStateSignal = !this.defaultExpansionStateSignal;
 
       // const toRename = this.showAllCommitMessageBody
       // ? 'commit-message message-body active' : 'commit-message message-body';

--- a/frontend/src/static/js/v_zoom.js
+++ b/frontend/src/static/js/v_zoom.js
@@ -2,8 +2,8 @@
 
 function initialState() {
   return {
-    showAllCommitMessageBody: true,
-    // expandedCommitMessagesCount: 0,
+    showAllCommitMessageBody: 1,
+    // 1 means all expanded, 0 means all collapsed, -1 means inconsistent
     commitsSortType: 'time',
     toReverseSortedCommits: true,
     isCommitsFinalized: false,
@@ -16,7 +16,6 @@ window.vZoom = {
   template: window.$('v_zoom').innerHTML,
   data() {
     return {
-      defaultExpansionStateSignal: false,
       expandedCommitMessagesCount: 0,
       ...initialState(),
     };
@@ -111,6 +110,9 @@ window.vZoom = {
     toReverseSortedCommits() {
       window.addHash('zRSC', this.toReverseSortedCommits);
       window.encodeHash();
+    },
+    expandedCommitMessagesCount() {
+      this.showAllCommitMessageBody = -1;
     },
   },
 
@@ -207,8 +209,7 @@ window.vZoom = {
     },
 
     toggleAllCommitMessagesBody(isActive) {
-      this.showAllCommitMessageBody = isActive;
-      this.defaultExpansionStateSignal = !this.defaultExpansionStateSignal;
+      this.showAllCommitMessageBody = isActive ? 1 : 0;
     },
 
     removeZoomHashes() {

--- a/frontend/src/static/js/v_zoom.js
+++ b/frontend/src/static/js/v_zoom.js
@@ -2,8 +2,8 @@
 
 function initialState() {
   return {
-    showAllCommitMessageBody: 1,
-    // 1 means all expanded, 0 means all collapsed, -1 means inconsistent
+    showAllCommitMessageBody: true,
+    // expandedCommitMessagesCount: 0,
     commitsSortType: 'time',
     toReverseSortedCommits: true,
     isCommitsFinalized: false,
@@ -16,6 +16,7 @@ window.vZoom = {
   template: window.$('v_zoom').innerHTML,
   data() {
     return {
+      defaultExpansionStateSignal: false,
       expandedCommitMessagesCount: 0,
       ...initialState(),
     };
@@ -110,9 +111,6 @@ window.vZoom = {
     toReverseSortedCommits() {
       window.addHash('zRSC', this.toReverseSortedCommits);
       window.encodeHash();
-    },
-    expandedCommitMessagesCount() {
-      this.showAllCommitMessageBody = -1;
     },
   },
 
@@ -209,7 +207,8 @@ window.vZoom = {
     },
 
     toggleAllCommitMessagesBody(isActive) {
-      this.showAllCommitMessageBody = isActive ? 1 : 0;
+      this.showAllCommitMessageBody = isActive;
+      this.defaultExpansionStateSignal = !this.defaultExpansionStateSignal;
     },
 
     removeZoomHashes() {

--- a/frontend/src/static/js/v_zoom.js
+++ b/frontend/src/static/js/v_zoom.js
@@ -17,6 +17,7 @@ window.vZoom = {
   data() {
     return {
       defaultExpansionStateSignal: false,
+      // Signal to reset the expansion state of all v_zoom_commit.
       expandedCommitMessagesCount: 0,
       ...initialState(),
     };

--- a/frontend/src/static/js/v_zoom.js
+++ b/frontend/src/static/js/v_zoom.js
@@ -3,7 +3,7 @@
 function initialState() {
   return {
     showAllCommitMessageBody: true,
-    expandedCommitMessagesCount: this.totalCommitMessageBodyCount,
+    // expandedCommitMessagesCount: 0,
     commitsSortType: 'time',
     toReverseSortedCommits: true,
     isCommitsFinalized: false,
@@ -15,7 +15,10 @@ function initialState() {
 window.vZoom = {
   template: window.$('v_zoom').innerHTML,
   data() {
-    return initialState();
+    return {
+      expandedCommitMessagesCount: 0,
+      ...initialState(),
+    };
   },
 
   computed: {
@@ -99,12 +102,6 @@ window.vZoom = {
       Object.assign(this.$data, initialState());
       this.initiate();
       this.setInfoHash();
-    },
-
-    selectedFileTypes() {
-      this.$nextTick(() => {
-        this.updateExpandedCommitMessagesCount();
-      });
     },
     commitsSortType() {
       window.addHash('zCST', this.commitsSortType);
@@ -218,19 +215,16 @@ window.vZoom = {
     toggleAllCommitMessagesBody(isActive) {
       this.showAllCommitMessageBody = isActive;
 
-      const toRename = this.showAllCommitMessageBody ? 'commit-message message-body active' : 'commit-message message-body';
+      // const toRename = this.showAllCommitMessageBody
+      // ? 'commit-message message-body active' : 'commit-message message-body';
 
-      const commitMessageClasses = document.getElementsByClassName('commit-message message-body');
-      Array.from(commitMessageClasses).forEach((commitMessageClass) => {
-        commitMessageClass.className = toRename;
-      });
+      // const commitMessageClasses =
+      // document.getElementsByClassName('commit-message message-body');
+      // Array.from(commitMessageClasses).forEach((commitMessageClass) => {
+      //   commitMessageClass.className = toRename;
+      // });
 
-      this.expandedCommitMessagesCount = isActive ? this.totalCommitMessageBodyCount : 0;
-    },
-
-    updateExpandedCommitMessagesCount() {
-      this.expandedCommitMessagesCount = document.getElementsByClassName('commit-message message-body active')
-          .length;
+      // this.expandedCommitMessagesCount = isActive ? this.totalCommitMessageBodyCount : 0;
     },
 
     removeZoomHashes() {
@@ -263,5 +257,6 @@ window.vZoom = {
   },
   components: {
     vRamp: window.vRamp,
+    vZoomCommit: window.vZoomCommit,
   },
 };

--- a/frontend/src/static/js/v_zoom.js
+++ b/frontend/src/static/js/v_zoom.js
@@ -131,13 +131,6 @@ window.vZoom = {
       this.$store.commit('updateSummaryDates', info);
     },
 
-    getSliceLink(slice) {
-      if (this.info.zIsMerge) {
-        return `${window.getBaseLink(slice.repoId)}/commit/${slice.hash}`;
-      }
-      return `${window.getBaseLink(this.info.zUser.repoId)}/commit/${slice.hash}`;
-    },
-
     scrollToCommit(tag, commit) {
       const el = this.$el.getElementsByClassName(`${commit} ${tag}`)[0];
       if (el) {
@@ -216,17 +209,6 @@ window.vZoom = {
     toggleAllCommitMessagesBody(isActive) {
       this.showAllCommitMessageBody = isActive;
       this.defaultExpansionStateSignal = !this.defaultExpansionStateSignal;
-
-      // const toRename = this.showAllCommitMessageBody
-      // ? 'commit-message message-body active' : 'commit-message message-body';
-
-      // const commitMessageClasses =
-      // document.getElementsByClassName('commit-message message-body');
-      // Array.from(commitMessageClasses).forEach((commitMessageClass) => {
-      //   commitMessageClass.className = toRename;
-      // });
-
-      // this.expandedCommitMessagesCount = isActive ? this.totalCommitMessageBodyCount : 0;
     },
 
     removeZoomHashes() {
@@ -243,10 +225,6 @@ window.vZoom = {
       window.removeHash('zCST');
       window.removeHash('zRSC');
       window.encodeHash();
-    },
-
-    filterSelectedFileTypes(fileTypes) {
-      return fileTypes.filter((fileType) => this.selectedFileTypes.includes(fileType));
     },
   },
   created() {

--- a/frontend/src/static/js/v_zoom_commit.js
+++ b/frontend/src/static/js/v_zoom_commit.js
@@ -3,7 +3,6 @@
 window.vZoomCommit = {
   props: [
       'defaultExpansionState',
-      'defaultExpansionStateSignal',
       'slice',
       'selectedFileTypes',
   ],
@@ -38,8 +37,12 @@ window.vZoomCommit = {
   },
 
   watch: {
-    defaultExpansionStateSignal() {
-      if (this.isExpanded !== this.defaultExpansionState) {
+    defaultExpansionState() {
+      // 1 means all expanded, 0 means all collapsed, -1 means inconsistent
+      if (this.defaultExpansionState === -1) {
+        return;
+      }
+      if (this.isExpanded !== (this.defaultExpansionState === 1)) {
         this.toggleExpansion();
       }
     },

--- a/frontend/src/static/js/v_zoom_commit.js
+++ b/frontend/src/static/js/v_zoom_commit.js
@@ -62,7 +62,7 @@ window.vZoomCommit = {
     },
   },
   created() {
-    if (this.defaultExpansionState) {
+    if (this.defaultExpansionState === 1) {
       this.toggleExpansion();
     }
   },

--- a/frontend/src/static/js/v_zoom_commit.js
+++ b/frontend/src/static/js/v_zoom_commit.js
@@ -62,7 +62,7 @@ window.vZoomCommit = {
     },
   },
   created() {
-    if (this.defaultExpansionState === 1) {
+    if (this.defaultExpansionState) {
       this.toggleExpansion();
     }
   },

--- a/frontend/src/static/js/v_zoom_commit.js
+++ b/frontend/src/static/js/v_zoom_commit.js
@@ -3,6 +3,7 @@
 window.vZoomCommit = {
   props: [
       'defaultExpansionState',
+      'defaultExpansionStateSignal',
       'slice',
       'selectedFileTypes',
   ],
@@ -37,12 +38,8 @@ window.vZoomCommit = {
   },
 
   watch: {
-    defaultExpansionState() {
-      // 1 means all expanded, 0 means all collapsed, -1 means inconsistent
-      if (this.defaultExpansionState === -1) {
-        return;
-      }
-      if (this.isExpanded !== (this.defaultExpansionState === 1)) {
+    defaultExpansionStateSignal() {
+      if (this.isExpanded !== this.defaultExpansionState) {
         this.toggleExpansion();
       }
     },

--- a/frontend/src/static/js/v_zoom_commit.js
+++ b/frontend/src/static/js/v_zoom_commit.js
@@ -1,7 +1,12 @@
 /* global Vuex */
 
 window.vZoomCommit = {
-  props: ['defaultExpansionState', 'slice', 'selectedFileTypes'],
+  props: [
+      'defaultExpansionState',
+      'defaultExpansionStateSignal',
+      'slice',
+      'selectedFileTypes',
+  ],
   emits: [
       'increment-expanded-count',
       'decrement-expanded-count',
@@ -33,8 +38,7 @@ window.vZoomCommit = {
   },
 
   watch: {
-    defaultExpansionState() {
-      console.log(this.defaultExpansionState);
+    defaultExpansionStateSignal() {
       if (this.isExpanded !== this.defaultExpansionState) {
         this.toggleExpansion();
       }

--- a/frontend/src/static/js/v_zoom_commit.js
+++ b/frontend/src/static/js/v_zoom_commit.js
@@ -1,0 +1,67 @@
+/* global Vuex */
+
+window.vZoomCommit = {
+  props: ['defaultExpansionState', 'slice', 'selectedFileTypes'],
+  emits: [
+      'increment-expanded-count',
+      'decrement-expanded-count',
+  ],
+  data() {
+    return {
+      isExpanded: false,
+    };
+  },
+  template: window.$('v_zoom_commit').innerHTML,
+
+  computed: {
+    filteredSelectedFileTypes() {
+      const fileTypes = Object.keys(this.slice.fileTypesAndContributionMap);
+      return fileTypes.filter((fileType) => this.selectedFileTypes.includes(fileType));
+    },
+
+    sliceLink() {
+      let baseLink;
+      if (this.tabZoomInfo.zIsMerge) {
+        baseLink = window.getBaseLink(this.slice.repoId);
+      } else {
+        baseLink = this.tabZoomInfo.zUser.repoId;
+      }
+      return `${baseLink}/commit/${this.slice.hash}`;
+    },
+
+    ...Vuex.mapState(['fileTypeColors', 'tabZoomInfo']),
+  },
+
+  watch: {
+    defaultExpansionState() {
+      console.log(this.defaultExpansionState);
+      if (this.isExpanded !== this.defaultExpansionState) {
+        this.toggleExpansion();
+      }
+    },
+  },
+
+  methods: {
+    toggleExpansion() {
+      if (this.slice.messageBody === '') {
+        return;
+      }
+      this.isExpanded = !this.isExpanded;
+      if (this.isExpanded) {
+        this.$emit('increment-expanded-count');
+      } else {
+        this.$emit('decrement-expanded-count');
+      }
+    },
+  },
+  created() {
+    if (this.defaultExpansionState) {
+      this.toggleExpansion();
+    }
+  },
+  beforeDestroy() {
+    if (this.isExpanded) {
+      this.$emit('decrement-expanded-count');
+    }
+  },
+};

--- a/frontend/src/tabs/zoom.pug
+++ b/frontend/src/tabs/zoom.pug
@@ -85,38 +85,12 @@
   .zoom__day(v-for="day in selectedCommits", v-bind:key="day.date")
     h3(v-if="info.zTimeFrame === 'week'") Week of {{ day.date }}
     h3(v-else) {{ day.date }}
-    template
-      //- use tabindex to enable focus property on div
-      .commit-message(
-        tabindex="-1",
-        v-for="slice in day.commitResults",
+    template(v-for="slice in day.commitResults")
+      v-zoom-commit(
         v-bind:key="slice.hash",
-        v-bind:class="{ 'message-body active': slice.messageBody !== '' }"
+        v-bind:default-expansion-state='showAllCommitMessageBody', 
+        v-bind:slice='slice',
+        v-bind:selected-file-types='selectedFileTypes',
+        v-on:increment-expanded-count='expandedCommitMessagesCount += 1',
+        v-on:decrement-expanded-count='expandedCommitMessagesCount -= 1'
       )
-        a.message-title(v-bind:href="getSliceLink(slice)", target="_blank")
-          .within-border {{ slice.messageTitle.substr(0, 50) }}
-          .not-within-border(v-if="slice.messageTitle.length > 50") {{ slice.messageTitle.substr(50) }}
-        span &nbsp; ({{ slice.insertions }} lines) &nbsp;
-        template
-          span.fileTypeLabel(
-            v-for="fileType in filterSelectedFileTypes(Object.keys(slice.fileTypesAndContributionMap))",
-            v-bind:style="{\
-              'background-color': fileTypeColors[fileType],\
-              'color': this.getFontColor(fileTypeColors[fileType])\
-              }"
-          ) {{ fileType }}
-        template(v-if="slice.tags", v-for="tag in slice.tags")
-          .tag(tabindex="-1", v-bind:class="[`${slice.hash}`, tag]")
-            font-awesome-icon(icon="tags")
-            span &nbsp;{{ tag }}
-        a(
-          v-if="slice.messageBody !== ''",
-          v-on:click="updateExpandedCommitMessagesCount",
-          onclick="toggleNext(this)"
-        )
-          .tooltip
-            font-awesome-icon.commit-message--button(icon="ellipsis-h")
-            span.tooltip-text Click to show/hide the commit message body
-        .body(v-if="slice.messageBody !== ''")
-          pre {{ slice.messageBody }}
-            .dashed-border

--- a/frontend/src/tabs/zoom.pug
+++ b/frontend/src/tabs/zoom.pug
@@ -88,7 +88,8 @@
     template(v-for="slice in day.commitResults")
       v-zoom-commit(
         v-bind:key="slice.hash",
-        v-bind:default-expansion-state='showAllCommitMessageBody', 
+        v-bind:default-expansion-state='showAllCommitMessageBody',
+        v-bind:default-expansion-state-signal='defaultExpansionStateSignal',
         v-bind:slice='slice',
         v-bind:selected-file-types='selectedFileTypes',
         v-on:increment-expanded-count='expandedCommitMessagesCount += 1',

--- a/frontend/src/tabs/zoom.pug
+++ b/frontend/src/tabs/zoom.pug
@@ -89,7 +89,6 @@
       v-zoom-commit(
         v-bind:key="slice.hash",
         v-bind:default-expansion-state='showAllCommitMessageBody',
-        v-bind:default-expansion-state-signal='defaultExpansionStateSignal',
         v-bind:slice='slice',
         v-bind:selected-file-types='selectedFileTypes',
         v-on:increment-expanded-count='expandedCommitMessagesCount += 1',

--- a/frontend/src/tabs/zoom.pug
+++ b/frontend/src/tabs/zoom.pug
@@ -89,6 +89,7 @@
       v-zoom-commit(
         v-bind:key="slice.hash",
         v-bind:default-expansion-state='showAllCommitMessageBody',
+        v-bind:default-expansion-state-signal='defaultExpansionStateSignal',
         v-bind:slice='slice',
         v-bind:selected-file-types='selectedFileTypes',
         v-on:increment-expanded-count='expandedCommitMessagesCount += 1',

--- a/frontend/src/zoom_commit.pug
+++ b/frontend/src/zoom_commit.pug
@@ -24,7 +24,7 @@
       span &nbsp;{{ tag }}
   a(
     v-if="slice.messageBody !== ''",
-    v-on:click="toggleExpansion",
+    v-on:click="toggleExpansion"
   )
     .tooltip
       font-awesome-icon.commit-message--button(icon="ellipsis-h")

--- a/frontend/src/zoom_commit.pug
+++ b/frontend/src/zoom_commit.pug
@@ -1,0 +1,31 @@
+//- use tabindex to enable focus property on div
+.commit-message(
+  tabindex="-1",
+  v-bind:class="{ 'message-body active': slice.messageBody !== '' }"
+)
+  a.message-title(v-bind:href="sliceLink", target="_blank")
+    .within-border {{ slice.messageTitle.substr(0, 50) }}
+    .not-within-border(v-if="slice.messageTitle.length > 50") {{ slice.messageTitle.substr(50) }}
+  span &nbsp; ({{ slice.insertions }} lines) &nbsp;
+  template
+    span.fileTypeLabel(
+      v-for="fileType in filteredSelectedFileTypes",
+      v-bind:style="{\
+        'background-color': fileTypeColors[fileType],\
+        'color': this.getFontColor(fileTypeColors[fileType])\
+        }"
+    ) {{ fileType }}
+  template(v-if="slice.tags", v-for="tag in slice.tags")
+    .tag(tabindex="-1", v-bind:class="[`${slice.hash}`, tag]")
+      font-awesome-icon(icon="tags")
+      span &nbsp;{{ tag }}
+  a(
+    v-if="slice.messageBody !== ''",
+    v-on:click="toggleExpansion",
+  )
+    .tooltip
+      font-awesome-icon.commit-message--button(icon="ellipsis-h")
+      span.tooltip-text Click to show/hide the commit message body
+  .body(v-if="isExpanded")
+    pre {{ slice.messageBody }}
+      .dashed-border

--- a/frontend/src/zoom_commit.pug
+++ b/frontend/src/zoom_commit.pug
@@ -1,7 +1,10 @@
 //- use tabindex to enable focus property on div
 .commit-message(
   tabindex="-1",
-  v-bind:class="{ 'message-body active': slice.messageBody !== '' }"
+  v-bind:class="{\
+    'message-body': slice.messageBody !== '',\
+    'active': isExpanded\
+  }"
 )
   a.message-title(v-bind:href="sliceLink", target="_blank")
     .within-border {{ slice.messageTitle.substr(0, 50) }}

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "lint": "eslint frontend/src/**/*js frontend/cypress/**.js && stylelint frontend/src/**/*.scss && npm run puglint",
-    "puglint": "pug-lint frontend/src/index.pug frontend/src/ramp.pug frontend/src/summary.pug frontend/src/summary_charts.pug frontend/src/resizer.pug frontend/src/tabs/authorship.pug frontend/src/tabs/segment.pug frontend/src/tabs/zoom.pug",
+    "puglint": "pug-lint frontend/src/index.pug frontend/src/ramp.pug frontend/src/summary.pug frontend/src/summary_charts.pug frontend/src/resizer.pug frontend/src/tabs/authorship.pug frontend/src/tabs/segment.pug frontend/src/tabs/zoom.pug frontend/src/zoom_commit.pug",
     "lintfix": "eslint --fix frontend/src/**/*js frontend/cypress/**.js && stylelint --fix frontend/src/**/*.scss",
     "browserify": "browserify -t vueify -e frontend/src/static/js/v_authorship.js -o frontend/build/static/js/v_authorship.js",
     "spuild": "spuild frontend"


### PR DESCRIPTION
Fixes [#1340]
```
v-zoom currently uses window.toggleNext() to show and
hide commit messages.

window.toggleNext() directly modifies html (add classes and
elements directly), and so might conflict with how Vue works.

As a result, using window.toggleNext() creates code which is
hard to debug and maintain.

Lets rewrite v-zoom to use the Vue way of hiding and showing
elements by using v-if.

In order to do this, the code which handles the display of zoom
commit messages has been moved into a separate file. This also
helps with code readability.

Let's remove window.toggleNext().
```