### PR TITLE
Frontend: remove browsersify and vueify

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -97,13 +97,12 @@ shadowJar {
     }
 }
 
-task zipReport(dependsOn: 'npmRunBrowserify', type: Zip) {
+task zipReport(dependsOn: 'npmRunSpuild', type: Zip) {
     from 'frontend/build/'
     baseName = 'templateZip'
     destinationDir = file('src/main/resources')
 }
 
-tasks.npmRunBrowserify.dependsOn('npmRunSpuild');
 tasks.shadowJar.dependsOn('zipReport');
 tasks.compileJava.dependsOn('zipReport');
 tasks.run.dependsOn('compileJava');

--- a/frontend/src/index.pug
+++ b/frontend/src/index.pug
@@ -19,7 +19,7 @@ html
     script(src="https://cdn.jsdelivr.net/npm/es6-promise@4/dist/es6-promise.auto.js")
     script(src="https://use.fontawesome.com/releases/v5.0.13/js/all.js", defer=True)
 
-    script(src="https://cdn.jsdelivr.net/npm/minimatch@0.2.14/minimatch.min.js")
+    script(src="https://cdn.jsdelivr.net/npm/minimatch@1.0.0/minimatch.min.js")
     script(src="https://cdn.jsdelivr.net/npm/@fortawesome/vue-fontawesome@0.1.9/index.min.js")
     script(src="https://cdn.jsdelivr.net/npm/jszip@3.1/dist/jszip.min.js")
     script(src="https://cdn.jsdelivr.net/npm/seedrandom@3.0.5/seedrandom.min.js")

--- a/frontend/src/index.pug
+++ b/frontend/src/index.pug
@@ -19,6 +19,7 @@ html
     script(src="https://cdn.jsdelivr.net/npm/es6-promise@4/dist/es6-promise.auto.js")
     script(src="https://use.fontawesome.com/releases/v5.0.13/js/all.js", defer=True)
 
+    script(src="https://cdn.jsdelivr.net/npm/minimatch@0.2.14/minimatch.min.js")
     script(src="https://cdn.jsdelivr.net/npm/@fortawesome/vue-fontawesome@0.1.9/index.min.js")
     script(src="https://cdn.jsdelivr.net/npm/jszip@3.1/dist/jszip.min.js")
     script(src="https://cdn.jsdelivr.net/npm/seedrandom@3.0.5/seedrandom.min.js")

--- a/frontend/src/static/js/v_authorship.js
+++ b/frontend/src/static/js/v_authorship.js
@@ -6,7 +6,7 @@ const filesSortDict = {
   fileType: (file) => file.fileType,
 };
 
-function initialState() {
+function authorshipInitialState() {
   return {
     isLoaded: false,
     files: [],
@@ -29,7 +29,7 @@ const repoCache = [];
 window.vAuthorship = {
   template: window.$('v_authorship').innerHTML,
   data() {
-    return initialState();
+    return authorshipInitialState();
   },
 
   watch: {
@@ -54,7 +54,7 @@ window.vAuthorship = {
     },
 
     authorshipOwnerWatchable() {
-      Object.assign(this.$data, initialState());
+      Object.assign(this.$data, authorshipInitialState());
       this.initiate();
     },
   },

--- a/frontend/src/static/js/v_authorship.js
+++ b/frontend/src/static/js/v_authorship.js
@@ -1,4 +1,4 @@
-/* global Vuex */
+/* global Vuex minimatch */
 const filesSortDict = {
   lineOfCode: (file) => file.lineCount,
   path: (file) => file.path,
@@ -25,7 +25,6 @@ function initialState() {
 }
 
 const repoCache = [];
-const minimatch = require('minimatch');
 
 window.vAuthorship = {
   template: window.$('v_authorship').innerHTML,

--- a/frontend/src/static/js/v_zoom.js
+++ b/frontend/src/static/js/v_zoom.js
@@ -3,7 +3,6 @@
 function initialState() {
   return {
     showAllCommitMessageBody: true,
-    expandedCommitMessagesCount: this.totalCommitMessageBodyCount,
     commitsSortType: 'time',
     toReverseSortedCommits: true,
     isCommitsFinalized: false,
@@ -15,7 +14,10 @@ function initialState() {
 window.vZoom = {
   template: window.$('v_zoom').innerHTML,
   data() {
-    return initialState();
+    return {
+      expandedCommitMessagesCount: this.totalCommitMessageBodyCount,
+      ...initialState(),
+    };
   },
 
   computed: {
@@ -96,7 +98,11 @@ window.vZoom = {
 
   watch: {
     zoomOwnerWatchable() {
-      Object.assign(this.$data, initialState());
+      const newData = {
+        expandedCommitMessagesCount: this.totalCommitMessageBodyCount,
+        ...initialState(),
+      };
+      Object.assign(this.$data, newData);
       this.initiate();
       this.setInfoHash();
     },

--- a/frontend/src/static/js/v_zoom.js
+++ b/frontend/src/static/js/v_zoom.js
@@ -1,6 +1,6 @@
 /* global Vuex */
 
-function initialState() {
+function zoomInitialState() {
   return {
     showAllCommitMessageBody: true,
     commitsSortType: 'time',
@@ -16,7 +16,7 @@ window.vZoom = {
   data() {
     return {
       expandedCommitMessagesCount: this.totalCommitMessageBodyCount,
-      ...initialState(),
+      ...zoomInitialState(),
     };
   },
 
@@ -100,7 +100,7 @@ window.vZoom = {
     zoomOwnerWatchable() {
       const newData = {
         expandedCommitMessagesCount: this.totalCommitMessageBodyCount,
-        ...initialState(),
+        ...zoomInitialState(),
       };
       Object.assign(this.$data, newData);
       this.initiate();
@@ -207,7 +207,6 @@ window.vZoom = {
         zAvgCommitSize, zSince, zUntil, zFilterGroup,
         zTimeFrame, zIsMerge, zAuthor, zRepo, zFromRamp, zFilterSearch,
       } = this.info;
-
       addHash('zA', zAuthor);
       addHash('zR', zRepo);
       addHash('zACS', zAvgCommitSize);

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "homepage": "https://github.com/reposense/RepoSense#readme",
   "dependencies": {
-    "minimatch": "^3.0.4",
+    "minimatch": "1.0.0",
     "pug-lint": "^2.6.0",
     "spuild": "1.0.2",
     "stylelint-config-standard": "^18.3.0"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
     "lint": "eslint frontend/src/**/*js frontend/cypress/**.js && stylelint frontend/src/**/*.scss && npm run puglint",
     "puglint": "pug-lint frontend/src/index.pug frontend/src/ramp.pug frontend/src/summary.pug frontend/src/summary_charts.pug frontend/src/resizer.pug frontend/src/tabs/authorship.pug frontend/src/tabs/segment.pug frontend/src/tabs/zoom.pug",
     "lintfix": "eslint --fix frontend/src/**/*js frontend/cypress/**.js && stylelint --fix frontend/src/**/*.scss",
-    "browserify": "browserify -t vueify -e frontend/src/static/js/v_authorship.js -o frontend/build/static/js/v_authorship.js",
     "spuild": "spuild frontend"
   },
   "repository": {
@@ -30,12 +29,10 @@
     "stylelint-config-standard": "^18.3.0"
   },
   "devDependencies": {
-    "browserify": "^16.2.3",
     "eslint": "^4.19.1",
     "eslint-config-airbnb-base": "^13.0.0",
     "eslint-plugin-import": "^2.13.0",
     "stylelint": "^10.1.0",
-    "stylelint-order": "^3.0.1",
-    "vueify": "^9.4.1"
+    "stylelint-order": "^3.0.1"
   }
 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/16630400/111304680-f9d79580-8690-11eb-834b-904dc07cc5bd.png)

```
browsersify and vueify is used solely to import minimatch.

Given that vueify is deprecated, and that it is used solely
to import minimatch in only v_authorship.js, it is better
to simply make minimatch work with the current 
implementation of imports by using a older version
of minimatch, as it is not critical to the functioning
of Reposense.

Lets remove browsersify and vueify.
```
There should not be any change to user experience.