### PR TITLE
[#1485] Watch tab info directly

### DIFF
--- a/frontend/src/static/js/v_authorship.js
+++ b/frontend/src/static/js/v_authorship.js
@@ -54,7 +54,7 @@ window.vAuthorship = {
       this.updateSelectedFiles();
     },
 
-    authorshipOwnerWatchable() {
+    info() {
       Object.assign(this.$data, initialState());
       this.initiate();
     },
@@ -393,10 +393,6 @@ window.vAuthorship = {
   },
 
   computed: {
-    authorshipOwnerWatchable() {
-      return `${this.info.author}|${this.info.repo}|${this.info.isMergeGroup}`;
-    },
-
     sortingFunction() {
       return (a, b) => (this.toReverseSortFiles ? -1 : 1)
         * window.comparator(filesSortDict[this.filesSortType])(a, b);

--- a/frontend/src/static/js/v_zoom.js
+++ b/frontend/src/static/js/v_zoom.js
@@ -19,10 +19,6 @@ window.vZoom = {
   },
 
   computed: {
-    zoomOwnerWatchable() {
-      return `${this.info.zRepo}|${this.info.zAuthor}|${this.info.zFilterGroup}|${this.info.zTimeFrame}`;
-    },
-
     sortingFunction() {
       const commitSortFunction = this.commitsSortType === 'time'
         ? (commit) => commit.date
@@ -95,7 +91,7 @@ window.vZoom = {
   },
 
   watch: {
-    zoomOwnerWatchable() {
+    info() {
       Object.assign(this.$data, initialState());
       this.initiate();
       this.setInfoHash();


### PR DESCRIPTION
Resolves #1485
```
Regression by #1390.

Currently zoom tab does not update properly if one of the
zoom watchables do not change.

Let's watch the tabZoomInfo stored in vuex instead of 
zoomOwnerWatchable.

This works as we ensure that every change to tabZoomInfo 
stored in vuex replaces tabZoomInfo with a new object. 

Hence watching the object pointer stored in tabZoomInfo 
is sufficient.

Everything here also applies to the authorship tab with
authorshipOwnerWatchable and tabAuthorshipInfo instead.
```

Changes in behavior:
Clicking on an already highlighted zoom/authorship tab icon on the summary chart will reset the tab even if there is no changes to summary chart.