### PR TITLE
Remove authorshipOwnerWatchable 

### DIFF
--- a/frontend/src/static/js/v_authorship.js
+++ b/frontend/src/static/js/v_authorship.js
@@ -54,7 +54,7 @@ window.vAuthorship = {
       this.updateSelectedFiles();
     },
 
-    authorshipOwnerWatchable() {
+    info() {
       Object.assign(this.$data, initialState());
       this.initiate();
     },
@@ -393,10 +393,6 @@ window.vAuthorship = {
   },
 
   computed: {
-    authorshipOwnerWatchable() {
-      return `${this.info.author}|${this.info.repo}|${this.info.isMergeGroup}`;
-    },
-
     sortingFunction() {
       return (a, b) => (this.toReverseSortFiles ? -1 : 1)
         * window.comparator(filesSortDict[this.filesSortType])(a, b);


### PR DESCRIPTION
Regression by #1390.
```
Currently authorship tab does not update properly if one of the
authorship watchables do not change.

Let's watch the tabAuthorshipInfo stored in vuex instead of 
authorshipOwnerWatchable.

This works as we ensure that every change to tabAuthorshipInfo
stored in vuex replaces tabAuthorshipInfo with a new object. 

Hence watching the object pointer stored in tabAuthorshipInfo
is sufficient.
```
Changes in behavior:
Clicking on an already highlighted authorship tab icon on the summary chart will reset the tab even if there is no changes to summary chart.