### PR TITLE
[#634] Move logic for getting ReportConfiguration to ArgsParser

### DIFF
--- a/src/main/java/reposense/RepoSense.java
+++ b/src/main/java/reposense/RepoSense.java
@@ -10,8 +10,6 @@ import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import com.google.gson.JsonSyntaxException;
-
 import net.sourceforge.argparse4j.helper.HelpScreenException;
 import reposense.model.AuthorConfiguration;
 import reposense.model.CliArguments;
@@ -29,7 +27,6 @@ import reposense.parser.InvalidCsvException;
 import reposense.parser.InvalidLocationException;
 import reposense.parser.ParseException;
 import reposense.parser.RepoConfigCsvParser;
-import reposense.parser.ReportConfigJsonParser;
 import reposense.report.ReportGenerator;
 import reposense.system.LogsManager;
 import reposense.system.ReportServer;
@@ -44,7 +41,6 @@ public class RepoSense {
     private static final int SERVER_PORT_NUMBER = 9000;
     private static final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("E MMM d HH:mm:ss yyyy z");
     private static final String VERSION_UNSPECIFIED = "unspecified";
-    private static final String MESSAGE_INVALID_CONFIG_JSON = "%s Ignoring the report config provided.";
 
     /**
      * The entry point of the program.
@@ -62,7 +58,7 @@ public class RepoSense {
                 return;
             } else if (cliArguments instanceof ConfigCliArguments) {
                 configs = getRepoConfigurations((ConfigCliArguments) cliArguments);
-                reportConfig = getReportConfigurations((ConfigCliArguments) cliArguments);
+                reportConfig = ((ConfigCliArguments) cliArguments).getReportConfiguration();
             } else if (cliArguments instanceof LocationsCliArguments) {
                 configs = getRepoConfigurations((LocationsCliArguments) cliArguments);
             } else {
@@ -159,24 +155,6 @@ public class RepoSense {
         }
 
         return configs;
-    }
-
-    /**
-     * Constructs {@code ReportConfiguration} if {@code cliArguments} is a {@code ConfigCliArguments}.
-     */
-    public static ReportConfiguration getReportConfigurations(ConfigCliArguments cliArguments) {
-        ReportConfiguration reportConfig = new ReportConfiguration();
-        try {
-            reportConfig = new ReportConfigJsonParser().parse(cliArguments.getReportConfigFilePath());
-        } catch (JsonSyntaxException jse) {
-            logger.warning(String.format("%s is malformed.", cliArguments.getReportConfigFilePath()));
-        } catch (IllegalArgumentException iae) {
-            logger.warning(String.format(MESSAGE_INVALID_CONFIG_JSON, iae.getMessage()));
-        } catch (IOException ioe) {
-            // IOException thrown as report-config.json is not found.
-            // Ignore exception as the file is optional.
-        }
-        return reportConfig;
     }
 
     public static String getVersion() {

--- a/src/main/java/reposense/model/ConfigCliArguments.java
+++ b/src/main/java/reposense/model/ConfigCliArguments.java
@@ -22,12 +22,13 @@ public class ConfigCliArguments extends CliArguments {
     private Path authorConfigFilePath;
     private Path groupConfigFilePath;
     private Path reportConfigFilePath;
+    private ReportConfiguration reportConfiguration;
 
     public ConfigCliArguments(Path configFolderPath, Path outputFilePath, Path assetsFilePath, Date sinceDate,
-            Date untilDate, boolean isSinceDateProvided, boolean isUntilDateProvided, int numCloningThreads,
-            int numAnalysisThreads, List<FileType> formats, boolean isLastModifiedDateIncluded,
-            boolean isShallowCloningPerformed, boolean isAutomaticallyLaunching,
-            boolean isStandaloneConfigIgnored, ZoneId zoneId) {
+                              Date untilDate, boolean isSinceDateProvided, boolean isUntilDateProvided, int numCloningThreads,
+                              int numAnalysisThreads, List<FileType> formats, boolean isLastModifiedDateIncluded,
+                              boolean isShallowCloningPerformed, boolean isAutomaticallyLaunching,
+                              boolean isStandaloneConfigIgnored, ZoneId zoneId, ReportConfiguration reportConfiguration) {
         this.configFolderPath = configFolderPath.equals(EMPTY_PATH)
                 ? configFolderPath.toAbsolutePath()
                 : configFolderPath;
@@ -49,6 +50,7 @@ public class ConfigCliArguments extends CliArguments {
         this.numCloningThreads = numCloningThreads;
         this.numAnalysisThreads = numAnalysisThreads;
         this.zoneId = zoneId;
+        this.reportConfiguration = reportConfiguration;
     }
 
     public Path getConfigFolderPath() {
@@ -69,6 +71,10 @@ public class ConfigCliArguments extends CliArguments {
 
     public Path getReportConfigFilePath() {
         return reportConfigFilePath;
+    }
+
+    public ReportConfiguration getReportConfiguration() {
+        return reportConfiguration;
     }
 
     @Override

--- a/src/main/java/reposense/model/ConfigCliArguments.java
+++ b/src/main/java/reposense/model/ConfigCliArguments.java
@@ -25,10 +25,10 @@ public class ConfigCliArguments extends CliArguments {
     private ReportConfiguration reportConfiguration;
 
     public ConfigCliArguments(Path configFolderPath, Path outputFilePath, Path assetsFilePath, Date sinceDate,
-                              Date untilDate, boolean isSinceDateProvided, boolean isUntilDateProvided, int numCloningThreads,
-                              int numAnalysisThreads, List<FileType> formats, boolean isLastModifiedDateIncluded,
-                              boolean isShallowCloningPerformed, boolean isAutomaticallyLaunching,
-                              boolean isStandaloneConfigIgnored, ZoneId zoneId, ReportConfiguration reportConfiguration) {
+            Date untilDate, boolean isSinceDateProvided, boolean isUntilDateProvided, int numCloningThreads,
+            int numAnalysisThreads, List<FileType> formats, boolean isLastModifiedDateIncluded,
+            boolean isShallowCloningPerformed, boolean isAutomaticallyLaunching,
+            boolean isStandaloneConfigIgnored, ZoneId zoneId, ReportConfiguration reportConfiguration) {
         this.configFolderPath = configFolderPath.equals(EMPTY_PATH)
                 ? configFolderPath.toAbsolutePath()
                 : configFolderPath;

--- a/src/main/java/reposense/parser/ArgsParser.java
+++ b/src/main/java/reposense/parser/ArgsParser.java
@@ -1,6 +1,7 @@
 package reposense.parser;
 
 import java.io.File;
+import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Instant;
@@ -12,6 +13,8 @@ import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 import java.util.logging.Logger;
+
+import com.google.gson.JsonSyntaxException;
 
 import net.sourceforge.argparse4j.ArgumentParsers;
 import net.sourceforge.argparse4j.helper.HelpScreenException;
@@ -28,6 +31,7 @@ import reposense.model.CliArguments;
 import reposense.model.ConfigCliArguments;
 import reposense.model.FileType;
 import reposense.model.LocationsCliArguments;
+import reposense.model.ReportConfiguration;
 import reposense.model.ViewCliArguments;
 import reposense.system.LogsManager;
 
@@ -72,6 +76,17 @@ public class ArgsParser {
             "\"Since Date\", \"Until Date\", and \"Period\" cannot be applied together.";
     private static final String MESSAGE_USING_DEFAULT_CONFIG_PATH =
             "Config path not provided, using the config folder as default.";
+    private static final String MESSAGE_INVALID_CONFIG_PATH = "%s is malformed.";
+    private static final String MESSAGE_INVALID_CONFIG_JSON = "%s Ignoring the report config provided.";
+    private static final String MESSAGE_IGNORING_REPORT_CONFIG_SINCE_DATE =
+            "Ignoring \"Since Date\" in report config, it has already been provided as a command line argument.";
+    private static final String MESSAGE_IGNORING_REPORT_CONFIG_UNTIL_DATE =
+            "Ignoring \"Until Date\" in report config, it has already been provided as a command line argument.";
+    private static final String MESSAGE_IGNORING_REPORT_CONFIG_PERIOD =
+            "Ignoring \"Period\" in report config, it has already been provided as a command line argument.";
+    private static final String MESSAGE_IGNORING_REPORT_SINCE_DATE_UNTIL_DATE_AND_PERIOD =
+            "Ignoring \"Since Date\", \"Until Date\" and/or \"Period\" in report config as they cannot be applied "
+                    + "together.";
     private static final Path EMPTY_PATH = Paths.get("");
     private static final Path DEFAULT_CONFIG_PATH = Paths.get(System.getProperty("user.dir")
             + File.separator + "config" + File.separator);
@@ -225,6 +240,7 @@ public class ArgsParser {
      */
     public static CliArguments parse(String[] args) throws HelpScreenException, ParseException {
         try {
+            ReportConfiguration reportConfig = new ReportConfiguration();
             ArgumentParser parser = getArgumentParser();
             Namespace results = parser.parseArgs(args);
             Date sinceDate;
@@ -237,9 +253,31 @@ public class ArgsParser {
             Path assetsFolderPath = results.get(ASSETS_FLAGS[0]);
             Optional<Date> cliSinceDate = results.get(SINCE_FLAGS[0]);
             Optional<Date> cliUntilDate = results.get(UNTIL_FLAGS[0]);
+            Optional<Integer> cliPeriod = results.get(PERIOD_FLAGS[0]);
+            List<String> locations = results.get(REPO_FLAGS[0]);
+            List<FileType> formats = FileType.convertFormatStringsToFileTypes(results.get(FORMAT_FLAGS[0]));
+            boolean isStandaloneConfigIgnored = results.get(IGNORE_FLAGS[0]);
+            boolean shouldIncludeLastModifiedDate = results.get(LAST_MODIFIED_DATE_FLAGS[0]);
+            boolean shouldPerformShallowCloning = results.get(SHALLOW_CLONING_FLAGS[0]);
+
+            // Report config is ignored if --repos is provided
+            if (locations == null) {
+                Path reportConfigFilePath = configFolderPath.resolve(ReportConfigJsonParser.REPORT_CONFIG_FILENAME);
+
+                try {
+                    reportConfig = new ReportConfigJsonParser().parse(reportConfigFilePath);
+                } catch (JsonSyntaxException jse) {
+                    logger.warning(String.format(MESSAGE_INVALID_CONFIG_PATH, reportConfigFilePath));
+                } catch (IllegalArgumentException iae) {
+                    logger.warning(String.format(MESSAGE_INVALID_CONFIG_JSON, iae.getMessage()));
+                } catch (IOException ioe) {
+                    // IOException thrown as report-config.json is not found.
+                    // Ignore exception as the file is optional.
+                }
+            }
+
             boolean isSinceDateProvided = cliSinceDate.isPresent();
             boolean isUntilDateProvided = cliUntilDate.isPresent();
-            Optional<Integer> cliPeriod = results.get(PERIOD_FLAGS[0]);
             boolean isPeriodProvided = cliPeriod.isPresent();
             if (isSinceDateProvided && isUntilDateProvided && isPeriodProvided) {
                 throw new ParseException(MESSAGE_HAVE_SINCE_DATE_UNTIL_DATE_AND_PERIOD);
@@ -268,11 +306,6 @@ public class ArgsParser {
             untilDate = untilDate.compareTo(currentDate) < 0
                     ? untilDate
                     : currentDate;
-            List<String> locations = results.get(REPO_FLAGS[0]);
-            List<FileType> formats = FileType.convertFormatStringsToFileTypes(results.get(FORMAT_FLAGS[0]));
-            boolean isStandaloneConfigIgnored = results.get(IGNORE_FLAGS[0]);
-            boolean shouldIncludeLastModifiedDate = results.get(LAST_MODIFIED_DATE_FLAGS[0]);
-            boolean shouldPerformShallowCloning = results.get(SHALLOW_CLONING_FLAGS[0]);
 
             LogsManager.setLogFolderLocation(outputFolderPath);
 
@@ -303,7 +336,7 @@ public class ArgsParser {
             return new ConfigCliArguments(configFolderPath, outputFolderPath, assetsFolderPath, sinceDate, untilDate,
                     isSinceDateProvided, isUntilDateProvided, numCloningThreads, numAnalysisThreads, formats,
                     shouldIncludeLastModifiedDate, shouldPerformShallowCloning, isAutomaticallyLaunching,
-                    isStandaloneConfigIgnored, zoneId);
+                    isStandaloneConfigIgnored, zoneId, reportConfig);
         } catch (HelpScreenException hse) {
             throw hse;
         } catch (ArgumentParserException ape) {


### PR DESCRIPTION
Part of #634.
Part of #1360.
Part of #1501.

```
The current design of getting the ReportConfiguration object in
the main RepoSense class is flawed and the design is not ideal,
as it meant that configuration has to be set and parsed twice.

Let's move the logic for getting the ReportConfiguration object
into ArgsParser to avoid having to duplicate configuration parsing
in the future.
```