### PR TITLE
[#634] Extract time-based functionalities to TimeUtil

### DIFF
--- a/src/main/java/reposense/parser/DateArgumentType.java
+++ b/src/main/java/reposense/parser/DateArgumentType.java
@@ -1,50 +1,24 @@
 package reposense.parser;
 
-import java.text.DateFormat;
-import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Optional;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import net.sourceforge.argparse4j.inf.Argument;
 import net.sourceforge.argparse4j.inf.ArgumentParser;
 import net.sourceforge.argparse4j.inf.ArgumentParserException;
 import net.sourceforge.argparse4j.inf.ArgumentType;
+import reposense.util.TimeUtil;
 
 /**
  * Verifies and parses a string-formatted date to a {@code Date} object.
  */
 public class DateArgumentType implements ArgumentType<Optional<Date>> {
-    protected static final String DATE_FORMAT_REGEX =
-            "^((0[1-9]|[12][0-9]|3[01])\\/(0[1-9]|1[012])\\/(19|2[0-9])[0-9]{2})";
     private static final String PARSE_EXCEPTION_MESSAGE_INVALID_DATE_STRING_FORMAT = "Invalid Date: %s";
-    private static final DateFormat CLI_ARGS_DATE_FORMAT = new SimpleDateFormat("dd/MM/yyyy HH:mm:ss");
-
-    static {
-        /*
-         * Setting setLenient to false prevents unexpected results.
-         * Without it, even with "dd/MM/yyyy HH:mm:ss" format, 11/31/2017 00:00:00 will be parsed to 11/7/2019 00:00:00.
-         * */
-        CLI_ARGS_DATE_FORMAT.setLenient(false);
-    }
-
-    /**
-     * Extracts the first substring that matches the {@code DATE_FORMAT_REGEX}.
-     */
-    protected String extractDate(String date) {
-        Matcher matcher = Pattern.compile(DATE_FORMAT_REGEX).matcher(date);
-        String extractedDate = date;
-        if (matcher.find()) {
-            extractedDate = matcher.group(1);
-        }
-        return extractedDate;
-    }
 
     @Override
     public Optional<Date> convert(ArgumentParser parser, Argument arg, String value) throws ArgumentParserException {
         try {
-            return Optional.of(CLI_ARGS_DATE_FORMAT.parse(value));
+            return Optional.of(TimeUtil.parseDate(value));
         } catch (java.text.ParseException pe) {
             throw new ArgumentParserException(
                     String.format(PARSE_EXCEPTION_MESSAGE_INVALID_DATE_STRING_FORMAT, value), parser);

--- a/src/main/java/reposense/parser/PeriodArgumentType.java
+++ b/src/main/java/reposense/parser/PeriodArgumentType.java
@@ -14,7 +14,7 @@ import net.sourceforge.argparse4j.inf.ArgumentType;
 public class PeriodArgumentType implements ArgumentType<Optional<Integer>> {
     private static final String PARSE_EXCEPTION_MESSAGE_NOT_IN_NUMERIC =
             "Invalid format. Period must be in the format of nd (n days) or nw (n weeks), "
-            + "where n is a number greater than 0.";
+                    + "where n is a number greater than 0.";
     private static final String PARSE_EXCEPTION_MESSAGE_SMALLER_THAN_ZERO =
             "Invalid format. Period must be greater than 0.";
     private static final String PARSE_EXCEPTION_MESSAGE_NUMBER_TOO_LARGE =
@@ -23,23 +23,32 @@ public class PeriodArgumentType implements ArgumentType<Optional<Integer>> {
 
     @Override
     public Optional<Integer> convert(ArgumentParser parser, Argument arg, String value) throws ArgumentParserException {
-        if (!PERIOD_PATTERN.matcher(value).matches()) {
-            throw new ArgumentParserException(
-                    String.format(PARSE_EXCEPTION_MESSAGE_NOT_IN_NUMERIC, value), parser);
+        try {
+            return parse(value);
+        } catch (ParseException pe) {
+            throw new ArgumentParserException(pe.getMessage(), parser);
+        }
+    }
+
+    /**
+     * This function parses a {@code period} String and returns an Integer representing the number of days.
+     */
+    public static Optional<Integer> parse(String period) throws ParseException {
+        if (!PERIOD_PATTERN.matcher(period).matches()) {
+            throw new ParseException(String.format(PARSE_EXCEPTION_MESSAGE_NOT_IN_NUMERIC, period));
         }
 
-        int multiplier = value.substring(value.length() - 1).equals("d") ? 1 : 7;
+        int multiplier = period.substring(period.length() - 1).equals("d") ? 1 : 7;
+
         try {
-            int convertedValue = Integer.parseInt(value.substring(0, value.length() - 1)) * multiplier;
+            int convertedValue = Integer.parseInt(period.substring(0, period.length() - 1)) * multiplier;
             if (convertedValue <= 0) {
-                throw new ArgumentParserException(
-                        String.format(PARSE_EXCEPTION_MESSAGE_SMALLER_THAN_ZERO, value), parser);
+                throw new ParseException(String.format(PARSE_EXCEPTION_MESSAGE_SMALLER_THAN_ZERO, period));
             }
 
             return Optional.of(convertedValue);
         } catch (NumberFormatException e) {
-            throw new ArgumentParserException(
-                    String.format(PARSE_EXCEPTION_MESSAGE_NUMBER_TOO_LARGE, value), parser);
+            throw new ParseException(String.format(PARSE_EXCEPTION_MESSAGE_NUMBER_TOO_LARGE, period));
         }
     }
 }

--- a/src/main/java/reposense/parser/PeriodArgumentType.java
+++ b/src/main/java/reposense/parser/PeriodArgumentType.java
@@ -14,7 +14,7 @@ import net.sourceforge.argparse4j.inf.ArgumentType;
 public class PeriodArgumentType implements ArgumentType<Optional<Integer>> {
     private static final String PARSE_EXCEPTION_MESSAGE_NOT_IN_NUMERIC =
             "Invalid format. Period must be in the format of nd (n days) or nw (n weeks), "
-                    + "where n is a number greater than 0.";
+            + "where n is a number greater than 0.";
     private static final String PARSE_EXCEPTION_MESSAGE_SMALLER_THAN_ZERO =
             "Invalid format. Period must be greater than 0.";
     private static final String PARSE_EXCEPTION_MESSAGE_NUMBER_TOO_LARGE =

--- a/src/main/java/reposense/parser/SinceDateArgumentType.java
+++ b/src/main/java/reposense/parser/SinceDateArgumentType.java
@@ -6,6 +6,7 @@ import java.util.Optional;
 import net.sourceforge.argparse4j.inf.Argument;
 import net.sourceforge.argparse4j.inf.ArgumentParser;
 import net.sourceforge.argparse4j.inf.ArgumentParserException;
+import reposense.util.TimeUtil;
 
 /**
  * Verifies and parses a string-formatted since date to a {@code Date} object.
@@ -28,7 +29,7 @@ public class SinceDateArgumentType extends DateArgumentType {
         if (FIRST_COMMIT_DATE_SHORTHAND.equals(value)) {
             return Optional.of(ARBITRARY_FIRST_COMMIT_DATE);
         }
-        String sinceDate = extractDate(value);
+        String sinceDate = TimeUtil.extractDate(value);
         return super.convert(parser, arg, sinceDate + " 00:00:00");
     }
 }

--- a/src/main/java/reposense/parser/UntilDateArgumentType.java
+++ b/src/main/java/reposense/parser/UntilDateArgumentType.java
@@ -6,6 +6,7 @@ import java.util.Optional;
 import net.sourceforge.argparse4j.inf.Argument;
 import net.sourceforge.argparse4j.inf.ArgumentParser;
 import net.sourceforge.argparse4j.inf.ArgumentParserException;
+import reposense.util.TimeUtil;
 
 /**
  * Verifies and parses a string-formatted until date to a {@code Date} object.
@@ -14,7 +15,7 @@ import net.sourceforge.argparse4j.inf.ArgumentParserException;
 public class UntilDateArgumentType extends DateArgumentType {
     @Override
     public Optional<Date> convert(ArgumentParser parser, Argument arg, String value) throws ArgumentParserException {
-        String untilDate = extractDate(value);
+        String untilDate = TimeUtil.extractDate(value);
         return super.convert(parser, arg, untilDate + " 23:59:59");
     }
 }

--- a/src/main/java/reposense/util/TimeUtil.java
+++ b/src/main/java/reposense/util/TimeUtil.java
@@ -1,15 +1,31 @@
 package reposense.util;
 
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
+import java.util.Calendar;
 import java.util.Date;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import reposense.parser.ParseException;
+import reposense.parser.SinceDateArgumentType;
 
 /**
  * Contains time related functionalities.
  */
 public class TimeUtil {
     private static Long startTime;
+    private static final String DATE_FORMAT_REGEX =
+            "^((0[1-9]|[12][0-9]|3[01])\\/(0[1-9]|1[012])\\/(19|2[0-9])[0-9]{2})";
+    private static final DateFormat CLI_ARGS_DATE_FORMAT = new SimpleDateFormat("dd/MM/yyyy HH:mm:ss");
+    private static final String MESSAGE_SINCE_DATE_LATER_THAN_UNTIL_DATE =
+            "\"Since Date\" cannot be later than \"Until Date\".";
+    private static final String MESSAGE_SINCE_DATE_LATER_THAN_TODAY_DATE =
+            "\"Since Date\" must not be later than today's date.";
 
     /**
      * Sets the {@code startTime} to be the current time
@@ -65,5 +81,138 @@ public class TimeUtil {
         int zoneRawOffset = getZoneRawOffset(zoneId);
         int systemRawOffset = getZoneRawOffset(ZoneId.systemDefault());
         return new Date(current.getTime() + zoneRawOffset - systemRawOffset);
+    }
+
+    /**
+     * Returns a {@code Date} that is set to midnight for the given {@code zoneId}.
+     */
+    public static Date getZonedSinceDate(Date sinceDate, ZoneId zoneId) {
+        if (sinceDate.equals(SinceDateArgumentType.ARBITRARY_FIRST_COMMIT_DATE)) {
+            return sinceDate;
+        }
+
+        int zoneRawOffset = getZoneRawOffset(zoneId);
+        int systemRawOffset = getZoneRawOffset(ZoneId.systemDefault());
+
+        Calendar cal = new Calendar
+                .Builder()
+                .setInstant(sinceDate.getTime())
+                .build();
+        cal.set(Calendar.HOUR_OF_DAY, 0);
+        cal.set(Calendar.MINUTE, 0);
+        cal.set(Calendar.SECOND, 0);
+        cal.set(Calendar.MILLISECOND, 0);
+        cal.add(Calendar.MILLISECOND, systemRawOffset - zoneRawOffset);
+        return cal.getTime();
+    }
+
+    /**
+     * Returns a {@code Date} that is set to 23:59:59 for the given {@code zoneId}.
+     */
+    public static Date getZonedUntilDate(Date untilDate, ZoneId zoneId) {
+        int zoneRawOffset = getZoneRawOffset(zoneId);
+        int systemRawOffset = getZoneRawOffset(ZoneId.systemDefault());
+
+        Calendar cal = new Calendar
+                .Builder()
+                .setInstant(untilDate.getTime())
+                .build();
+        cal.set(Calendar.HOUR_OF_DAY, 23);
+        cal.set(Calendar.MINUTE, 59);
+        cal.set(Calendar.SECOND, 59);
+        cal.set(Calendar.MILLISECOND, 0);
+        cal.add(Calendar.MILLISECOND, systemRawOffset - zoneRawOffset);
+        return cal.getTime();
+    }
+
+    /**
+     * Returns a {@code Date} that is one month before {@code cliUntilDate} (if present) or one month before report
+     * generation date otherwise. The time zone is adjusted to the given {@code zoneId}.
+     */
+    public static Date getDateMinusAMonth(Optional<Date> cliUntilDate, ZoneId zoneId) {
+        Calendar cal = Calendar.getInstance();
+        cliUntilDate.ifPresent(cal::setTime);
+        cal.setTime(getZonedSinceDate(cal.getTime(), zoneId));
+        cal.add(Calendar.MONTH, -1);
+        return cal.getTime();
+    }
+
+    /**
+     * Returns a {@code Date} that is {@code numOfDays} before {@code cliUntilDate} (if present) or one month before
+     * report generation date otherwise. The time zone is adjusted to the given {@code zoneId}.
+     */
+    public static Date getDateMinusNDays(Optional<Date> cliUntilDate, ZoneId zoneId, int numOfDays) {
+        Calendar cal = Calendar.getInstance();
+        cliUntilDate.ifPresent(cal::setTime);
+        cal.setTime(getZonedSinceDate(cal.getTime(), zoneId));
+        cal.add(Calendar.DATE, -numOfDays + 1);
+        return cal.getTime();
+    }
+
+    /**
+     * Returns a {@code Date} that is {@code numOfDays} after {@code cliSinceDate} (if present). The time zone is
+     * adjusted to the given {@code zoneId}.
+     */
+    public static Date getDatePlusNDays(Optional<Date> cliSinceDate, ZoneId zoneId, int numOfDays) {
+        Calendar cal = Calendar.getInstance();
+        cliSinceDate.ifPresent(cal::setTime);
+        cal.setTime(getZonedUntilDate(cal.getTime(), zoneId));
+        cal.add(Calendar.DATE, numOfDays - 1);
+        return cal.getTime();
+    }
+
+    /**
+     * Returns current date with time set to 23:59:59. The time zone is adjusted to the given {@code zoneId}.
+     */
+    public static Date getCurrentDate(ZoneId zoneId) {
+        Calendar cal = Calendar.getInstance();
+        cal.setTime(getZonedUntilDate(cal.getTime(), zoneId));
+        return cal.getTime();
+    }
+
+    /**
+     * Verifies that {@code sinceDate} is earlier than {@code untilDate}.
+     *
+     * @throws ParseException if {@code sinceDate} supplied is later than {@code untilDate}.
+     */
+    public static void verifyDatesRangeIsCorrect(Date sinceDate, Date untilDate)
+            throws ParseException {
+        if (sinceDate.getTime() > untilDate.getTime()) {
+            throw new ParseException(MESSAGE_SINCE_DATE_LATER_THAN_UNTIL_DATE);
+        }
+    }
+
+    /**
+     * Verifies that {@code sinceDate} is no later than the date of report generation.
+     *
+     * @throws ParseException if {@code sinceDate} supplied is later than date of report generation.
+     */
+    public static void verifySinceDateIsValid(Date sinceDate) throws ParseException {
+        Date dateToday = new Date();
+        if (sinceDate.getTime() > dateToday.getTime()) {
+            throw new ParseException(MESSAGE_SINCE_DATE_LATER_THAN_TODAY_DATE);
+        }
+    }
+
+    /**
+     * Extracts the first substring that matches the {@code DATE_FORMAT_REGEX}.
+     */
+    public static String extractDate(String date) {
+        Matcher matcher = Pattern.compile(DATE_FORMAT_REGEX).matcher(date);
+        String extractedDate = date;
+        if (matcher.find()) {
+            extractedDate = matcher.group(1);
+        }
+        return extractedDate;
+    }
+
+    /**
+     * Parses the given String as a Date based on the {@code CLI_ARGS_DATE_FORMAT}.
+     * Setting setLenient to false prevents unexpected results.
+     * Without it, even with "dd/MM/yyyy HH:mm:ss" format, 11/31/2017 00:00:00 will be parsed to 11/7/2019 00:00:00.
+     */
+    public static Date parseDate(String date) throws java.text.ParseException {
+        CLI_ARGS_DATE_FORMAT.setLenient(false);
+        return CLI_ARGS_DATE_FORMAT.parse(date);
     }
 }

--- a/src/test/java/reposense/util/TestUtil.java
+++ b/src/test/java/reposense/util/TestUtil.java
@@ -134,6 +134,36 @@ public class TestUtil {
     }
 
     /**
+     * Creates and returns a {@code Date} object with the specified {@code year}, {@code month}, {@code day} that is not
+     * dependent on the time zone of the current system, in cases where adjusting for the time zone is not necessary.
+     */
+    public static Date getLocalDate(int year, int month, int date, int[] time) {
+        Calendar cal = Calendar.getInstance();
+        cal.set(Calendar.YEAR, year);
+        cal.set(Calendar.MONTH, month);
+        cal.set(Calendar.DAY_OF_MONTH, date);
+        cal.set(Calendar.HOUR_OF_DAY, time[0]);
+        cal.set(Calendar.MINUTE, time[1]);
+        cal.set(Calendar.SECOND, time[2]);
+        cal.set(Calendar.MILLISECOND, 0);
+        return cal.getTime();
+    }
+
+    /**
+     * Wrapper for {@code getLocalDate} method to get since date with time 00:00:00
+     */
+    public static Date getLocalSinceDate(int year, int month, int date) {
+        return getLocalDate(year, month, date, START_OF_DAY_TIME);
+    }
+
+    /**
+     * Wrapper for {@code getLocalDate} method to get until date with time 23:59:59
+     */
+    public static Date getLocalUntilDate(int year, int month, int date) {
+        return getLocalDate(year, month, date, END_OF_DAY_TIME);
+    }
+
+    /**
      * Returns a {@code ZoneId} object for the specified {@code timezone}.
      */
     public static ZoneId getZoneId(String timezone) {

--- a/src/test/java/reposense/util/TimeUtilTest.java
+++ b/src/test/java/reposense/util/TimeUtilTest.java
@@ -1,0 +1,43 @@
+package reposense.util;
+
+import java.text.ParseException;
+import java.util.Calendar;
+import java.util.Date;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TimeUtilTest {
+    @Test
+    public void extractDate_validDate_success() throws Exception {
+        String expectedDate = "20/05/2019";
+        String actualDate = TimeUtil.extractDate(expectedDate);
+        Assert.assertEquals(expectedDate, actualDate);
+    }
+
+    @Test
+    public void extractDate_validDateAndTime_success() throws Exception {
+        String originalDateAndTime = "20/05/2020 12:34:56";
+        String expectedDate = "20/05/2020";
+        String actualDate = TimeUtil.extractDate(originalDateAndTime);
+        Assert.assertEquals(expectedDate, actualDate);
+    }
+
+    @Test
+    public void parseDate_validDateAndTime_success() throws Exception {
+        String originalDateAndTime = "20/05/2020 00:00:00";
+        Date expectedDate = TestUtil.getLocalSinceDate(2020, Calendar.MAY, 20);
+        Date actualDate = TimeUtil.parseDate(originalDateAndTime);
+        Assert.assertEquals(expectedDate, actualDate);
+    }
+
+    @Test (expected = ParseException.class)
+    public void parseDate_invalidDate_throwsParseException() throws Exception {
+        TimeUtil.parseDate("31/02/2020 00:00:00");
+    }
+
+    @Test (expected = ParseException.class)
+    public void parseDate_invalidTime_throwsParseException() throws Exception {
+        TimeUtil.parseDate("20/05/2020 23:69:70");
+    }
+}


### PR DESCRIPTION
Part of #634.
Part of #1360.
Part of #1501.

```
Many of the time-based functionality and logic are scattered
about in various files, which increases code duplication and is a
maintenance burden.

Let's abstract all time-based functionalities into the TimeUtil
class such that multiple places in the code can reuse the same
logic.
```