### PR TITLE
Add flag to pretty print JSON files

### DIFF
--- a/src/main/java/reposense/RepoSense.java
+++ b/src/main/java/reposense/RepoSense.java
@@ -74,6 +74,8 @@ public class RepoSense {
                     cliArguments.isLastModifiedDateIncluded());
             RepoConfiguration.setIsShallowCloningPerformedToRepoConfigs(configs,
                     cliArguments.isShallowCloningPerformed());
+            RepoConfiguration.setIsPrettifyJsonPerformedToRepoConfigs(configs,
+                    cliArguments.isPrettifyJsonPerformed());
             List<Path> reportFoldersAndFiles = ReportGenerator.generateReposReport(configs,
                     cliArguments.getOutputFilePath().toAbsolutePath().toString(),
                     cliArguments.getAssetsFilePath().toAbsolutePath().toString(), reportConfig,

--- a/src/main/java/reposense/model/CliArguments.java
+++ b/src/main/java/reposense/model/CliArguments.java
@@ -20,6 +20,7 @@ public abstract class CliArguments {
     protected boolean isShallowCloningPerformed;
     protected boolean isAutomaticallyLaunching;
     protected boolean isStandaloneConfigIgnored;
+    protected boolean isPrettifyJsonPerformed;
     protected int numCloningThreads;
     protected int numAnalysisThreads;
     protected ZoneId zoneId;
@@ -58,6 +59,10 @@ public abstract class CliArguments {
 
     public boolean isShallowCloningPerformed() {
         return isShallowCloningPerformed;
+    }
+
+    public boolean isPrettifyJsonPerformed() {
+        return isPrettifyJsonPerformed;
     }
 
     public List<FileType> getFormats() {
@@ -102,6 +107,7 @@ public abstract class CliArguments {
                 && this.formats.equals(otherCliArguments.formats)
                 && this.isLastModifiedDateIncluded == otherCliArguments.isLastModifiedDateIncluded
                 && this.isShallowCloningPerformed == otherCliArguments.isShallowCloningPerformed
+                && this.isPrettifyJsonPerformed == otherCliArguments.isPrettifyJsonPerformed
                 && this.isAutomaticallyLaunching == otherCliArguments.isAutomaticallyLaunching
                 && this.isStandaloneConfigIgnored == otherCliArguments.isStandaloneConfigIgnored
                 && this.numCloningThreads == otherCliArguments.numCloningThreads

--- a/src/main/java/reposense/model/ConfigCliArguments.java
+++ b/src/main/java/reposense/model/ConfigCliArguments.java
@@ -27,8 +27,8 @@ public class ConfigCliArguments extends CliArguments {
     public ConfigCliArguments(Path configFolderPath, Path outputFilePath, Path assetsFilePath, Date sinceDate,
             Date untilDate, boolean isSinceDateProvided, boolean isUntilDateProvided, int numCloningThreads,
             int numAnalysisThreads, List<FileType> formats, boolean isLastModifiedDateIncluded,
-            boolean isShallowCloningPerformed, boolean isAutomaticallyLaunching,
-            boolean isStandaloneConfigIgnored, boolean isPrettifyJsonPerformed, ZoneId zoneId,
+            boolean isShallowCloningPerformed, boolean isPrettifyJsonPerformed,
+            boolean isAutomaticallyLaunching, boolean isStandaloneConfigIgnored, ZoneId zoneId,
             ReportConfiguration reportConfiguration) {
         this.configFolderPath = configFolderPath.equals(EMPTY_PATH)
                 ? configFolderPath.toAbsolutePath()

--- a/src/main/java/reposense/model/ConfigCliArguments.java
+++ b/src/main/java/reposense/model/ConfigCliArguments.java
@@ -28,7 +28,8 @@ public class ConfigCliArguments extends CliArguments {
             Date untilDate, boolean isSinceDateProvided, boolean isUntilDateProvided, int numCloningThreads,
             int numAnalysisThreads, List<FileType> formats, boolean isLastModifiedDateIncluded,
             boolean isShallowCloningPerformed, boolean isAutomaticallyLaunching,
-            boolean isStandaloneConfigIgnored, ZoneId zoneId, ReportConfiguration reportConfiguration) {
+            boolean isStandaloneConfigIgnored, boolean isPrettifyJsonPerformed, ZoneId zoneId,
+            ReportConfiguration reportConfiguration) {
         this.configFolderPath = configFolderPath.equals(EMPTY_PATH)
                 ? configFolderPath.toAbsolutePath()
                 : configFolderPath;
@@ -45,6 +46,7 @@ public class ConfigCliArguments extends CliArguments {
         this.formats = formats;
         this.isLastModifiedDateIncluded = isLastModifiedDateIncluded;
         this.isShallowCloningPerformed = isShallowCloningPerformed;
+        this.isPrettifyJsonPerformed = isPrettifyJsonPerformed;
         this.isAutomaticallyLaunching = isAutomaticallyLaunching;
         this.isStandaloneConfigIgnored = isStandaloneConfigIgnored;
         this.numCloningThreads = numCloningThreads;

--- a/src/main/java/reposense/model/LocationsCliArguments.java
+++ b/src/main/java/reposense/model/LocationsCliArguments.java
@@ -14,7 +14,7 @@ public class LocationsCliArguments extends CliArguments {
     public LocationsCliArguments(List<String> locations, Path outputFilePath, Path assetsFilePath, Date sinceDate,
             Date untilDate, boolean isSinceDateProvided, boolean isUntilDateProvided, int numCloningThreads,
             int numAnalysisThreads, List<FileType> formats, boolean isLastModifiedDateIncluded,
-            boolean isShallowCloningPerformed, boolean isAutomaticallyLaunching,
+            boolean isShallowCloningPerformed, boolean isPrettifyJsonPerformed ,boolean isAutomaticallyLaunching,
             boolean isStandaloneConfigIgnored, ZoneId zoneId) {
         this.locations = locations;
         this.outputFilePath = outputFilePath;
@@ -25,6 +25,7 @@ public class LocationsCliArguments extends CliArguments {
         this.isUntilDateProvided = isUntilDateProvided;
         this.isLastModifiedDateIncluded = isLastModifiedDateIncluded;
         this.isShallowCloningPerformed = isShallowCloningPerformed;
+        this.isPrettifyJsonPerformed = isPrettifyJsonPerformed;
         this.formats = formats;
         this.isAutomaticallyLaunching = isAutomaticallyLaunching;
         this.isStandaloneConfigIgnored = isStandaloneConfigIgnored;

--- a/src/main/java/reposense/model/LocationsCliArguments.java
+++ b/src/main/java/reposense/model/LocationsCliArguments.java
@@ -14,7 +14,7 @@ public class LocationsCliArguments extends CliArguments {
     public LocationsCliArguments(List<String> locations, Path outputFilePath, Path assetsFilePath, Date sinceDate,
             Date untilDate, boolean isSinceDateProvided, boolean isUntilDateProvided, int numCloningThreads,
             int numAnalysisThreads, List<FileType> formats, boolean isLastModifiedDateIncluded,
-            boolean isShallowCloningPerformed, boolean isPrettifyJsonPerformed ,boolean isAutomaticallyLaunching,
+            boolean isShallowCloningPerformed, boolean isPrettifyJsonPerformed, boolean isAutomaticallyLaunching,
             boolean isStandaloneConfigIgnored, ZoneId zoneId) {
         this.locations = locations;
         this.outputFilePath = outputFilePath;

--- a/src/main/java/reposense/model/RepoConfiguration.java
+++ b/src/main/java/reposense/model/RepoConfiguration.java
@@ -38,6 +38,7 @@ public class RepoConfiguration {
     private transient List<CommitHash> ignoreCommitList;
     private transient boolean isLastModifiedDateIncluded;
     private transient boolean isShallowCloningPerformed;
+    private transient boolean isPrettifyJsonPerformed;
     private transient boolean isFormatsOverriding;
     private transient boolean isIgnoreGlobListOverriding;
     private transient boolean isIgnoreCommitListOverriding;
@@ -105,6 +106,13 @@ public class RepoConfiguration {
                                                                  boolean isShallowCloningPerformed) {
         if (isShallowCloningPerformed) {
             configs.stream().forEach(config -> config.setIsShallowCloningPerformed(true));
+        }
+    }
+
+    public static void setIsPrettifyJsonPerformedToRepoConfigs(List<RepoConfiguration> configs,
+                                                               boolean isPrettifyJsonPerformed) {
+        if (isPrettifyJsonPerformed) {
+            configs.stream().forEach(config -> config.setIsPrettifyJsonPerformed(true));
         }
     }
 
@@ -319,6 +327,7 @@ public class RepoConfiguration {
                 && isLastModifiedDateIncluded == otherRepoConfig.isLastModifiedDateIncluded
                 && isFormatsOverriding == otherRepoConfig.isFormatsOverriding
                 && isShallowCloningPerformed == otherRepoConfig.isShallowCloningPerformed
+                && isPrettifyJsonPerformed == otherRepoConfig.isPrettifyJsonPerformed
                 && isIgnoreGlobListOverriding == otherRepoConfig.isIgnoreGlobListOverriding
                 && isIgnoreCommitListOverriding == otherRepoConfig.isIgnoreCommitListOverriding
                 && isIgnoredAuthorsListOverriding == otherRepoConfig.isIgnoredAuthorsListOverriding;
@@ -395,12 +404,20 @@ public class RepoConfiguration {
         this.isShallowCloningPerformed = isShallowCloningPerformed;
     }
 
+    public void setIsPrettifyJsonPerformed(boolean isPrettifyJsonPerformed) {
+        this.isPrettifyJsonPerformed = isPrettifyJsonPerformed;
+    }
+
     public boolean isLastModifiedDateIncluded() {
         return this.isLastModifiedDateIncluded;
     }
 
     public boolean isShallowCloningPerformed() {
         return this.isShallowCloningPerformed;
+    }
+
+    public boolean isPrettifyJsonPerformed() {
+        return this.isPrettifyJsonPerformed;
     }
 
     public void setIsIgnoredAuthorsListOverriding(boolean isIgnoredAuthorsListOverriding) {

--- a/src/main/java/reposense/parser/ArgsParser.java
+++ b/src/main/java/reposense/parser/ArgsParser.java
@@ -56,6 +56,7 @@ public class ArgsParser {
     public static final String[] TIMEZONE_FLAGS = new String[]{"--timezone", "-t"};
     public static final String[] VERSION_FLAGS = new String[]{"--version", "-V"};
     public static final String[] LAST_MODIFIED_DATE_FLAGS = new String[]{"--last-modified-date", "-l"};
+    public static final String[] PRETTIFY_JSON_FLAGS = new String[]{"--use-json-pretty-printing", "-j"};
 
     public static final String[] CLONING_THREADS_FLAG = new String[]{"--cloning-threads"};
     public static final String[] ANALYSIS_THREADS_FLAG = new String[]{"--analysis-threads"};
@@ -138,6 +139,11 @@ public class ArgsParser {
                 .setDefault(Paths.get(ArgsParser.DEFAULT_REPORT_NAME))
                 .help("The directory to output the report folder, reposense-report. "
                         + "If not provided, the report folder will be created in the current working directory.");
+
+        parser.addArgument(PRETTIFY_JSON_FLAGS)
+                .dest(PRETTIFY_JSON_FLAGS[0])
+                .action(Arguments.storeTrue())
+                .help("Pretty-print the JSON file");
 
         parser.addArgument(ASSETS_FLAGS)
                 .dest(ASSETS_FLAGS[0])
@@ -257,6 +263,7 @@ public class ArgsParser {
             boolean isStandaloneConfigIgnored = results.get(IGNORE_FLAGS[0]);
             boolean shouldIncludeLastModifiedDate = results.get(LAST_MODIFIED_DATE_FLAGS[0]);
             boolean shouldPerformShallowCloning = results.get(SHALLOW_CLONING_FLAGS[0]);
+            boolean shouldPrettifyJson = results.get(PRETTIFY_JSON_FLAGS[0]);
 
             // Report config is ignored if --repos is provided
             if (locations == null) {
@@ -324,8 +331,8 @@ public class ArgsParser {
             if (locations != null) {
                 return new LocationsCliArguments(locations, outputFolderPath, assetsFolderPath, sinceDate, untilDate,
                         isSinceDateProvided, isUntilDateProvided, numCloningThreads, numAnalysisThreads, formats,
-                        shouldIncludeLastModifiedDate, shouldPerformShallowCloning, isAutomaticallyLaunching,
-                        isStandaloneConfigIgnored, zoneId);
+                        shouldIncludeLastModifiedDate, shouldPerformShallowCloning, shouldPrettifyJson,
+                        isAutomaticallyLaunching, isStandaloneConfigIgnored, zoneId);
             }
 
             if (configFolderPath.equals(EMPTY_PATH)) {
@@ -333,8 +340,8 @@ public class ArgsParser {
             }
             return new ConfigCliArguments(configFolderPath, outputFolderPath, assetsFolderPath, sinceDate, untilDate,
                     isSinceDateProvided, isUntilDateProvided, numCloningThreads, numAnalysisThreads, formats,
-                    shouldIncludeLastModifiedDate, shouldPerformShallowCloning, isAutomaticallyLaunching,
-                    isStandaloneConfigIgnored, zoneId, reportConfig);
+                    shouldIncludeLastModifiedDate, shouldPerformShallowCloning, shouldPrettifyJson,
+                    isAutomaticallyLaunching, isStandaloneConfigIgnored, zoneId, reportConfig);
         } catch (HelpScreenException hse) {
             throw hse;
         } catch (ArgumentParserException ape) {

--- a/src/main/java/reposense/report/ReportGenerator.java
+++ b/src/main/java/reposense/report/ReportGenerator.java
@@ -111,6 +111,10 @@ public class ReportGenerator {
             FileUtil.copyDirectoryContents(assetsPath, outputPath, assetsFilesWhiteList);
         }
 
+        if (configs != null && !configs.isEmpty()) {
+            FileUtil.setPrettifyPrintingMode(configs.get(0).isPrettifyJsonPerformed());
+        }
+
         earliestSinceDate = null;
         progressTracker = new ProgressTracker(configs.size());
 

--- a/src/main/java/reposense/util/FileUtil.java
+++ b/src/main/java/reposense/util/FileUtil.java
@@ -53,6 +53,8 @@ public class FileUtil {
     private static final String MESSAGE_FAIL_TO_COPY_ASSETS =
             "Exception occurred while attempting to copy custom assets.";
 
+    private static boolean isPrettifyJsonPerformed = false;
+
     /**
      * Zips all files of type {@code fileTypes} that are in the directory {@code pathsToZip} into a single file and
      * output it to {@code sourceAndOutputPath}.
@@ -94,10 +96,16 @@ public class FileUtil {
      *         if there was an error while writing the JSON file.
      */
     public static Optional<Path> writeJsonFile(Object object, String path) {
-        Gson gson = new GsonBuilder()
+        GsonBuilder gsonBuilder = new GsonBuilder()
                 .setDateFormat(GITHUB_API_DATE_FORMAT)
-                .registerTypeAdapter(FileType.class, new FileType.FileTypeSerializer())
-                .create();
+                .registerTypeAdapter(FileType.class, new FileType.FileTypeSerializer());
+
+        Gson gson;
+        if (isPrettifyJsonPerformed) {
+            gson = gsonBuilder.setPrettyPrinting().create();
+        } else {
+            gson = gsonBuilder.create();
+        }
         String result = gson.toJson(object);
 
         try (PrintWriter out = new PrintWriter(path)) {
@@ -298,5 +306,9 @@ public class FileUtil {
      */
     private static boolean isFileTypeInPath(Path path, String... fileTypes) {
         return Arrays.stream(fileTypes).anyMatch(path.toString()::endsWith);
+    }
+
+    public static void setPrettifyPrintingMode(boolean isPrettifyJsonPerformed) {
+        FileUtil.isPrettifyJsonPerformed = isPrettifyJsonPerformed;
     }
 }

--- a/src/test/java/reposense/parser/ArgsParserTest.java
+++ b/src/test/java/reposense/parser/ArgsParserTest.java
@@ -20,6 +20,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import net.sourceforge.argparse4j.annotation.Arg;
 import net.sourceforge.argparse4j.helper.HelpScreenException;
 import reposense.RepoSense;
 import reposense.model.CliArguments;
@@ -755,6 +756,24 @@ public class ArgsParserTest {
         CliArguments cliArgumentsShallow = ArgsParser.parse(translateCommandline(inputShallow));
         Assert.assertTrue(cliArgumentsShallow instanceof ConfigCliArguments);
         Assert.assertEquals(true, cliArgumentsShallow.isShallowCloningPerformed());
+    }
+
+    @Test
+    public void parse_prettifyJson_success() throws Exception {
+        String input = new InputBuilder().addConfig(CONFIG_FOLDER_ABSOLUTE)
+                .addOutput(OUTPUT_DIRECTORY_ABSOLUTE)
+                .build();
+        CliArguments cliArguments = ArgsParser.parse(translateCommandline(input));
+        Assert.assertTrue(cliArguments instanceof ConfigCliArguments);
+        Assert.assertEquals(false, cliArguments.isPrettifyJsonPerformed());
+
+        String inputPrettify = new InputBuilder().addConfig(CONFIG_FOLDER_ABSOLUTE)
+                .addOutput(OUTPUT_DIRECTORY_ABSOLUTE)
+                .addPrettifyJson()
+                .build();
+        CliArguments cliArgumentsPrettify = ArgsParser.parse(translateCommandline(inputPrettify));
+        Assert.assertTrue(cliArgumentsPrettify instanceof ConfigCliArguments);
+        Assert.assertEquals(true, cliArgumentsPrettify.isPrettifyJsonPerformed());
     }
 
     /**

--- a/src/test/java/reposense/parser/ArgsParserTest.java
+++ b/src/test/java/reposense/parser/ArgsParserTest.java
@@ -20,7 +20,6 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-import net.sourceforge.argparse4j.annotation.Arg;
 import net.sourceforge.argparse4j.helper.HelpScreenException;
 import reposense.RepoSense;
 import reposense.model.CliArguments;

--- a/src/test/java/reposense/util/InputBuilder.java
+++ b/src/test/java/reposense/util/InputBuilder.java
@@ -184,6 +184,15 @@ public class InputBuilder {
     }
 
     /**
+     * Adds the flag to enable JSON prettify mode
+     * This medthod should only be called once in one build.
+     */
+    public InputBuilder addPrettifyJson() {
+        input.append(ArgsParser.PRETTIFY_JSON_FLAGS[0] + WHITESPACE);
+        return this;
+    }
+
+    /**
      * Adds {@code content} to the input.
      */
     public InputBuilder add(String content) {


### PR DESCRIPTION
Add a --use-json-pretty-printing CLI flag to allow the JSON report files to be printed in a more human-readable way.

Syntax: add --use-json-pretty-printing or -j to the command to enable the pretty-printing mode

Before/Without the flag:
![image](https://user-images.githubusercontent.com/58925632/121469594-5aa40f00-c9ef-11eb-8a62-5499ada5173d.png)
The JSON will be stored in one line, which makes it difficult for someone who wants to manually evaluate the JSON files generated by the report

With the flag:
![image](https://user-images.githubusercontent.com/58925632/121469887-dbfba180-c9ef-11eb-826e-b1e843624500.png)
The JSON files are more human-readable