### PR TITLE
[#1212] RepoLocation: Remove redundant backslashes in regex

### DIFF
--- a/src/main/java/reposense/model/RepoLocation.java
+++ b/src/main/java/reposense/model/RepoLocation.java
@@ -17,7 +17,7 @@ public class RepoLocation {
     private static final String GIT_LINK_SUFFIX = ".git";
     private static final String MESSAGE_INVALID_LOCATION = "%s is an invalid location.";
     private static final Pattern GIT_REPOSITORY_LOCATION_PATTERN =
-            Pattern.compile("^https?:\\/\\/github.com\\/(?<org>.+?)\\/(?<repoName>.+?)\\.git$");
+            Pattern.compile("^https?://github.com/(?<org>.+?)/(?<repoName>.+?)\\.git$");
 
     private final String location;
     private final String repoName;

--- a/src/test/java/reposense/model/RepoLocationTest.java
+++ b/src/test/java/reposense/model/RepoLocationTest.java
@@ -7,13 +7,13 @@ import reposense.parser.InvalidLocationException;
 import reposense.util.AssertUtil;
 
 public class RepoLocationTest {
-    private static final String TEST_REPO_BETA = "https://github.com/reposense/testrepo-Beta.git";
-    private static final String TEST_REPO_DELTA = "https://github.com/reposense/testrepo-Delta.git";
-
     @Test
     public void repoLocation_validRepoUrl_success() throws Exception {
-        assertValidLocation(TEST_REPO_BETA, "testrepo-Beta", "reposense");
-        assertValidLocation(TEST_REPO_DELTA, "testrepo-Delta", "reposense");
+        // valid url without specifying branch
+        assertValidLocation("https://github.com/reposense/testrepo-Beta.git",
+                "testrepo-Beta", "reposense");
+        assertValidLocation("https://github.com/reposense/testrepo-Delta.git",
+                "testrepo-Delta", "reposense");
     }
 
     @Test
@@ -35,18 +35,10 @@ public class RepoLocationTest {
     }
 
     @Test
-    public void repoLocation_invalidBranchUrl_throwsInvalidLocationException() {
-        // ftp url should be rejected
-        assertInvalidLocation("ftp://github.com/reposense/RepoSense/tree/feature_branch_issue#1010");
-        // url without branch name should be rejected
-        assertInvalidLocation("https://github.com/reposense/RepoSense/tree/");
-        assertInvalidLocation("https://github.com/reposense/RepoSense/tree");
-        // url without the 'tree' keyword should be rejected
-        assertInvalidLocation("https://github.com/reposense/RepoSense/feature_branch_issue#1010");
-        assertInvalidLocation("https://github.com/reposense/RepoSense/TREE/feature_branch_issue#1010");
-        assertInvalidLocation("https://github.com/reposense/RepoSense/tre/feature_branch_issue#1010");
-        // non GitHub url should be rejected
-        assertInvalidLocation("https://gitlab.com/reposense/RepoSense/tree/feature_branch_issue#1010");
+    public void repoLocation_repoUrlWithASpecifiedBranch_throwsInvalidLocationException() {
+        // reject both repos with and without .git
+        assertInvalidLocation("https://github.com/reposense/testrepo-Beta/tree/add-config-json");
+        assertInvalidLocation("https://github.com/reposense/testrepo-Beta.git/tree/add-config-json");
     }
 
     @Test

--- a/src/test/java/reposense/model/RepoLocationTest.java
+++ b/src/test/java/reposense/model/RepoLocationTest.java
@@ -1,0 +1,35 @@
+package reposense.model;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import reposense.parser.InvalidLocationException;
+
+public class RepoLocationTest {
+    private static final String TEST_REPO_BETA = "https://github.com/reposense/testrepo-Beta.git";
+    private static final String TEST_REPO_DELTA = "https://github.com/reposense/testrepo-Delta.git";
+    private static final String TEST_REPO_INVALID_LOCATION = "ftp://github.com/reposense/testrepo-Delta.git";
+
+    @Test
+    public void repoLocation_validLocation_success() throws Exception {
+        assertValidLocation(TEST_REPO_BETA, "testrepo-Beta", "reposense");
+        assertValidLocation(TEST_REPO_DELTA, "testrepo-Delta", "reposense");
+    }
+
+    @Test(expected = InvalidLocationException.class)
+    public void repoLocation_invalidLocation_throwsInvalidLocationException() throws Exception {
+        RepoLocation repoLocation = new RepoLocation(TEST_REPO_INVALID_LOCATION);
+    }
+
+
+    /**
+     * Compares the information parsed by the RepoLocation model with the expected information
+     */
+    public void assertValidLocation(String rawLocation, String expectedRepoName,
+            String expectedOrganization) throws Exception {
+        RepoLocation repoLocation = new RepoLocation(rawLocation);
+        Assert.assertEquals(repoLocation.getRepoName(), expectedRepoName);
+        Assert.assertEquals(repoLocation.getOrganization(), expectedOrganization);
+
+    }
+}

--- a/src/test/java/reposense/model/RepoLocationTest.java
+++ b/src/test/java/reposense/model/RepoLocationTest.java
@@ -42,7 +42,7 @@ public class RepoLocationTest {
     }
 
     @Test
-    public void repoLocationParser_parseEmptyString_noInvalidLocationException() throws Exception {
+    public void repoLocationParser_parseEmptyString_success() throws Exception {
         RepoLocation repoLocation = new RepoLocation("");
     }
 

--- a/src/test/java/reposense/model/RepoLocationTest.java
+++ b/src/test/java/reposense/model/RepoLocationTest.java
@@ -4,21 +4,54 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import reposense.parser.InvalidLocationException;
+import reposense.util.AssertUtil;
 
 public class RepoLocationTest {
     private static final String TEST_REPO_BETA = "https://github.com/reposense/testrepo-Beta.git";
     private static final String TEST_REPO_DELTA = "https://github.com/reposense/testrepo-Delta.git";
-    private static final String TEST_REPO_INVALID_LOCATION = "ftp://github.com/reposense/testrepo-Delta.git";
 
     @Test
-    public void repoLocation_validLocation_success() throws Exception {
+    public void repoLocation_validRepoUrl_success() throws Exception {
         assertValidLocation(TEST_REPO_BETA, "testrepo-Beta", "reposense");
         assertValidLocation(TEST_REPO_DELTA, "testrepo-Delta", "reposense");
     }
 
-    @Test(expected = InvalidLocationException.class)
-    public void repoLocation_invalidLocation_throwsInvalidLocationException() throws Exception {
-        RepoLocation repoLocation = new RepoLocation(TEST_REPO_INVALID_LOCATION);
+    @Test
+    public void repoLocation_invalidRepoUrl_throwsInvalidLocationException() {
+        // ftp url should be rejected
+        assertInvalidLocation("ftp://github.com/reposense/testrepo-Delta.git");
+        // non GitHub url should rejected
+        assertInvalidLocation("https://gitlab.com/reposense/RepoSense.git");
+        // url without organisation name should be rejected
+        assertInvalidLocation("https://github.com/reposense.git");
+        // url without repo name should be rejected
+        assertInvalidLocation("https://github.com/reposense/.git");
+        assertInvalidLocation("https://github.com/reposense");
+        // url without a .git suffix should be rejected
+        assertInvalidLocation("https://github.com/reposense/RepoSensegit");
+        assertInvalidLocation("https://github.com/reposense/RepoSense-git");
+        assertInvalidLocation("https://github.com/reposense/RepoSense.gi");
+        assertInvalidLocation("https://github.com/reposense/RepoSense");
+    }
+
+    @Test
+    public void repoLocation_invalidBranchUrl_throwsInvalidLocationException() {
+        // ftp url should be rejected
+        assertInvalidLocation("ftp://github.com/reposense/RepoSense/tree/feature_branch_issue#1010");
+        // url without branch name should be rejected
+        assertInvalidLocation("https://github.com/reposense/RepoSense/tree/");
+        assertInvalidLocation("https://github.com/reposense/RepoSense/tree");
+        // url without the 'tree' keyword should be rejected
+        assertInvalidLocation("https://github.com/reposense/RepoSense/feature_branch_issue#1010");
+        assertInvalidLocation("https://github.com/reposense/RepoSense/TREE/feature_branch_issue#1010");
+        assertInvalidLocation("https://github.com/reposense/RepoSense/tre/feature_branch_issue#1010");
+        // non GitHub url should be rejected
+        assertInvalidLocation("https://gitlab.com/reposense/RepoSense/tree/feature_branch_issue#1010");
+    }
+
+    @Test
+    public void repoLocationParser_parseEmptyString_noInvalidLocationException() throws Exception {
+        RepoLocation repoLocation = new RepoLocation("");
     }
 
 
@@ -30,6 +63,9 @@ public class RepoLocationTest {
         RepoLocation repoLocation = new RepoLocation(rawLocation);
         Assert.assertEquals(repoLocation.getRepoName(), expectedRepoName);
         Assert.assertEquals(repoLocation.getOrganization(), expectedOrganization);
+    }
 
+    private void assertInvalidLocation(String rawLocation) {
+        AssertUtil.assertThrows(InvalidLocationException.class, () -> new RepoLocation(rawLocation));
     }
 }


### PR DESCRIPTION
Resolves #1212 

Commit message:
```
RepoLocation: Remove redundant backslashes in regex

In RepoLocation.java, our current regex is 
"^https?:\\/\\/github.com\\/(?<org>.+?)\\/(?<repoName>.+?)\\.git$".

There is no need to escape the forward slash "/" character with the
"\\" characters, as the forward slash does not have a special meaning
when used on its own.

Let's remove the redundant backslashes and add more tests for
different types of repository URLs.
```