### PR TITLE
Test: remove redundant throws Exception clauses

### DIFF
--- a/src/test/java/reposense/git/GitCloneTest.java
+++ b/src/test/java/reposense/git/GitCloneTest.java
@@ -12,7 +12,7 @@ import reposense.template.GitTestTemplate;
 public class GitCloneTest extends GitTestTemplate {
 
     @Test
-    public void cloneTest_validRepo_success() throws Exception {
+    public void cloneTest_validRepo_success() {
         // As the clone has been performed in the {@code GitTestTemplate},
         // this checks whether the clone has been executed successfully by performing a file system check.
         Path dir = Paths.get(config.getRepoRoot());

--- a/src/test/java/reposense/util/TimeUtilTest.java
+++ b/src/test/java/reposense/util/TimeUtilTest.java
@@ -9,7 +9,7 @@ import org.junit.Test;
 
 public class TimeUtilTest {
     @Test
-    public void extractDate_validDate_success() throws Exception {
+    public void extractDate_validDate_success() {
         String expectedDate = "20/05/2019";
         String actualDate = TimeUtil.extractDate(expectedDate);
         Assert.assertEquals(expectedDate, actualDate);

--- a/src/test/java/reposense/util/TimeUtilTest.java
+++ b/src/test/java/reposense/util/TimeUtilTest.java
@@ -16,7 +16,7 @@ public class TimeUtilTest {
     }
 
     @Test
-    public void extractDate_validDateAndTime_success() throws Exception {
+    public void extractDate_validDateAndTime_success() {
         String originalDateAndTime = "20/05/2020 12:34:56";
         String expectedDate = "20/05/2020";
         String actualDate = TimeUtil.extractDate(originalDateAndTime);


### PR DESCRIPTION
Commit Message:
```
The current test code for RepoSense contains two methods that include
a redundant throws clause.

Let's remove both redundant throws clauses in GitCloneTest.java and
TimeUtilTest.java.
```