### PR TITLE
Fix missing space and use of raw types

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -172,6 +172,11 @@ tasks.withType(Copy) {
     includeEmptyDirs = true
 }
 
+tasks.withType(JavaCompile) {
+    options.compilerArgs << '-Xlint:unchecked'
+    options.deprecation = true
+}
+
 task coverage(type: JacocoReport) {
     sourceDirectories.from files(sourceSets.main.allSource.srcDirs)
     classDirectories.from files(sourceSets.main.output)

--- a/build.gradle
+++ b/build.gradle
@@ -172,11 +172,6 @@ tasks.withType(Copy) {
     includeEmptyDirs = true
 }
 
-tasks.withType(JavaCompile) {
-    options.compilerArgs << '-Xlint:unchecked'
-    options.deprecation = true
-}
-
 task coverage(type: JacocoReport) {
     sourceDirectories.from files(sourceSets.main.allSource.srcDirs)
     classDirectories.from files(sourceSets.main.output)

--- a/src/main/java/reposense/git/GitCatFile.java
+++ b/src/main/java/reposense/git/GitCatFile.java
@@ -27,7 +27,7 @@ public class GitCatFile {
         String catFileCommand = "git cat-file -p " + commitHash;
         try {
             String output = runCommand(rootPath, catFileCommand);
-            List<String> parentCommits = new ArrayList();
+            List<String> parentCommits = new ArrayList<>();
             for (String line : output.split("\n")) {
                 if (line.startsWith("parent")) {
                     parentCommits.add(line.substring(7).trim());
@@ -44,7 +44,7 @@ public class GitCatFile {
      * commits of all the commits.
      */
     public static List<String> getParentsOfCommits(String root, List<String> commitHashes) {
-        List<String> parentCommits = new ArrayList();
+        List<String> parentCommits = new ArrayList<>();
         for (String commitHash : commitHashes) {
             try {
                 parentCommits.addAll(getParentCommits(root, commitHash));

--- a/src/main/java/reposense/parser/CsvParser.java
+++ b/src/main/java/reposense/parser/CsvParser.java
@@ -49,7 +49,7 @@ public abstract class CsvParser<T> {
     private static final String MESSAGE_ZERO_VALID_CONFIGS = "No valid configurations in the %s.";
 
     private Path csvFilePath;
-    private Map<String, Integer> headerMap = new HashMap();
+    private Map<String, Integer> headerMap = new HashMap<>();
     private int numOfLinesBeforeFirstRecord = 0;
 
     /**

--- a/src/main/java/reposense/system/CommandRunnerProcess.java
+++ b/src/main/java/reposense/system/CommandRunnerProcess.java
@@ -39,7 +39,7 @@ public class CommandRunnerProcess {
             return outputGobbler.getValue();
         } else {
             String errorMessage = "Error returned from command ";
-            errorMessage += command + "on path ";
+            errorMessage += command + " on path ";
             errorMessage += path.toString() + " :\n" + errorGobbler.getValue();
             throw new CommandRunnerProcessException(errorMessage);
         }

--- a/src/test/java/reposense/git/GitUtilTest.java
+++ b/src/test/java/reposense/git/GitUtilTest.java
@@ -19,7 +19,7 @@ public class GitUtilTest extends GitTestTemplate {
         final String cmdFormat = " " + addQuote(":(exclude)%s");
         final String emptyResult = "";
 
-        String result = convertToGitExcludeGlobArgs(repoRoot, Collections.EMPTY_LIST);
+        String result = convertToGitExcludeGlobArgs(repoRoot, Collections.emptyList());
         Assert.assertEquals(emptyResult, result);
 
         result = convertToGitExcludeGlobArgs(repoRoot, Collections.singletonList("**.js"));

--- a/src/test/java/reposense/parser/AuthorConfigParserTest.java
+++ b/src/test/java/reposense/parser/AuthorConfigParserTest.java
@@ -3,6 +3,7 @@ package reposense.parser;
 import static reposense.util.TestUtil.loadResource;
 
 import java.nio.file.Path;
+import java.util.AbstractMap.SimpleEntry;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -64,19 +65,18 @@ public class AuthorConfigParserTest {
     private static final List<String> SECOND_COMMAS_AND_DOUBLEQUOTES_ALIAS = Collections.emptyList();
     private static final List<String> THIRD_COMMAS_AND_DOUBLEQUOTES_ALIAS =
             Arrays.asList("Borex T\"ony Tong");
-    @SuppressWarnings("unchecked")
     private static final Map<Author, List<String>> AUTHOR_ALIAS_COMMAS_AND_DOUBLE_QUOTES_MAP =
-            Stream.of(new Object[][]{
-                    {FIRST_COMMAS_AND_DOUBLEQUOTES_AUTHOR, FIRST_COMMAS_AND_DOUBLEQUOTES_ALIAS},
-                    {SECOND_COMMAS_AND_DOUBLEQUOTES_AUTHOR, SECOND_COMMAS_AND_DOUBLEQUOTES_ALIAS},
-                    {THIRD_COMMAS_AND_DOUBLEQUOTES_AUTHOR, THIRD_COMMAS_AND_DOUBLEQUOTES_ALIAS}
-            }).collect(Collectors.toMap(data -> (Author) data[0], data -> (List<String>) data[1]));
+            Stream.of(new SimpleEntry<>(FIRST_COMMAS_AND_DOUBLEQUOTES_AUTHOR, FIRST_COMMAS_AND_DOUBLEQUOTES_ALIAS),
+                    new SimpleEntry<>(SECOND_COMMAS_AND_DOUBLEQUOTES_AUTHOR, SECOND_COMMAS_AND_DOUBLEQUOTES_ALIAS),
+                    new SimpleEntry<>(THIRD_COMMAS_AND_DOUBLEQUOTES_AUTHOR, THIRD_COMMAS_AND_DOUBLEQUOTES_ALIAS))
+                    .collect(Collectors.toMap(entry -> entry.getKey(), entry -> entry.getValue()));
     private static final Map<Author, String> AUTHOR_DISPLAY_NAME_COMMAS_AND_DOUBLE_QUOTES_MAP =
-            Stream.of(new Object[][]{
-                    {FIRST_COMMAS_AND_DOUBLEQUOTES_AUTHOR, FIRST_COMMAS_AND_DOUBLEQUOTES_DISPLAY_NAME},
-                    {SECOND_COMMAS_AND_DOUBLEQUOTES_AUTHOR, SECOND_COMMAS_AND_DOUBLEQUOTES_DISPLAY_NAME},
-                    {THIRD_COMMAS_AND_DOUBLEQUOTES_AUTHOR, THIRD_COMMAS_AND_DOUBLEQUOTES_DISPLAY_NAME}
-            }).collect(Collectors.toMap(data -> (Author) data[0], data -> (String) data[1]));
+            Stream.of(new SimpleEntry<>(FIRST_COMMAS_AND_DOUBLEQUOTES_AUTHOR,
+                            FIRST_COMMAS_AND_DOUBLEQUOTES_DISPLAY_NAME),
+                    new SimpleEntry<>(SECOND_COMMAS_AND_DOUBLEQUOTES_AUTHOR,
+                            SECOND_COMMAS_AND_DOUBLEQUOTES_DISPLAY_NAME),
+                    new SimpleEntry<>(THIRD_COMMAS_AND_DOUBLEQUOTES_AUTHOR, THIRD_COMMAS_AND_DOUBLEQUOTES_DISPLAY_NAME))
+                    .collect(Collectors.toMap(entry -> entry.getKey(), entry -> entry.getValue()));
 
     private static final List<String> FIRST_AUTHOR_EMAIL_LIST =
             Arrays.asList("nbr@example.com", "nbriannl@test.net", "nbriannl@users.noreply.github.com");

--- a/src/test/java/reposense/parser/AuthorConfigParserTest.java
+++ b/src/test/java/reposense/parser/AuthorConfigParserTest.java
@@ -64,6 +64,7 @@ public class AuthorConfigParserTest {
     private static final List<String> SECOND_COMMAS_AND_DOUBLEQUOTES_ALIAS = Collections.emptyList();
     private static final List<String> THIRD_COMMAS_AND_DOUBLEQUOTES_ALIAS =
             Arrays.asList("Borex T\"ony Tong");
+    @SuppressWarnings("unchecked")
     private static final Map<Author, List<String>> AUTHOR_ALIAS_COMMAS_AND_DOUBLE_QUOTES_MAP =
             Stream.of(new Object[][]{
                     {FIRST_COMMAS_AND_DOUBLEQUOTES_AUTHOR, FIRST_COMMAS_AND_DOUBLEQUOTES_ALIAS},


### PR DESCRIPTION
Fixes some minor issues I found while working on other pull requests.
1. removed use of raw types
2.  add missing space from error message in `CommandRunnerProcess::waitForProcess()`

Commit Message:
```
Fix missing space and use of raw types

There are multiple occurrences of use of raw type within the code
which results in compilation warnings. Additionally, there is a 
missing space in one of the error messages.

Let's address these minor issues in the code.
```