### PR TITLE
[#1575] Fix misidentification of deleted files as edited files

### DIFF
--- a/src/main/java/reposense/authorship/FileInfoExtractor.java
+++ b/src/main/java/reposense/authorship/FileInfoExtractor.java
@@ -38,7 +38,7 @@ public class FileInfoExtractor {
     private static final String LINE_INSERTED_SYMBOL = "+";
     private static final String STARTING_LINE_NUMBER_GROUP_NAME = "startingLineNumber";
     private static final String FILE_CHANGED_GROUP_NAME = "filePath";
-    private static final String FILE_DELETED_SYMBOL = "/dev/null";
+    private static final String FILE_DELETED_SYMBOL = "dev/null";
     private static final String MATCH_GROUP_FAIL_MESSAGE_FORMAT = "Failed to match the %s group for:\n%s";
     private static final String BINARY_FILE_LINE_DIFF_RESULT = "-\t-\t";
 


### PR DESCRIPTION
Fixes #1575 

A normal file path looks like `+++ b/file/path/` while a deleted file shows up as `+++ /dev/null/`

The current regex will instead parse out the string `dev/null` without the initial slash for deleted files and attempt to match it to `/dev/null/`.

This change has no direct impact on the output of the program at the moment as the relevant lines of code (linked below) has an additional `if` statement where the `dev/null` filepaths are discarded unintentionally. However, if there is a change in the program flow then it might become an issue in the future.
https://github.com/reposense/RepoSense/blob/6b94f82545bbd84852f7bd110af72e495ad23652/src/main/java/reposense/authorship/FileInfoExtractor.java#L114-L121

Commit message:
```
Current regex expression matches dev/null/ while the variable is
/dev/null/. This causes files to be wrongly treated as being edited
instead of being deleted.

Let's fix the misidentification of deleted files.
```