### PR TITLE
Cypress: replace nonexistent input element with pug id in selector in codeView_reload.js

### DIFF
--- a/frontend/cypress/tests/codeView/codeView_reload.js
+++ b/frontend/cypress/tests/codeView/codeView_reload.js
@@ -29,7 +29,7 @@ describe('reload page', () => {
         .uncheck()
         .should('not.be.checked');
 
-    cy.get('#tab-authorship > .title > .contribution > .fileTypes input[id="pug"]')
+    cy.get('#tab-authorship > .title > .contribution > .fileTypes input[id="java"]')
         .should('be.checked');
 
     cy.reload();
@@ -49,7 +49,7 @@ describe('reload page', () => {
     cy.get('#tab-authorship > .title > .contribution > .fileTypes input[id="gradle"]')
         .should('not.be.checked');
 
-    cy.get('#tab-authorship > .title > .contribution > .fileTypes input[id="pug"]')
+    cy.get('#tab-authorship > .title > .contribution > .fileTypes input[id="java"]')
         .should('be.checked');
   });
 });


### PR DESCRIPTION
Fixes failing Cypress test in ```codeView_reload.js``` which occurs after merging in [PR#1412](https://github.com/reposense/RepoSense/pull/1412)

Commit Message:
```
Fix failing Cypress test in codeView_reload.js

Cypress test in codeView.js is failing because the test analyzes
RepoSense's repository itself to run tests on. When PR#1412
was merged in, RepoSense no longer has any pug files whereas
the test case assumes pug files are still there thus leading to an
error. The selector utilized in the test refers to an input element
with id pug that no longer exists.

Let's change the selector in the test to refer to an input element
with id java that still exists in RepoSense's repository.
```