### PR TITLE
Include the frontend gradle hot reload feature in DG

### DIFF
--- a/docs/dg/workflow.md
+++ b/docs/dg/workflow.md
@@ -65,6 +65,12 @@ The issues for first timers usually have guidance provided in the comment or hav
 
 ## Debugging (front-end)
 
+**You can use the hot reloading feature to see how your code changes the functionality of the website in real time.**
+1. Navigate to the project root in your terminal.
+1. Generate the desired data for the report using `gradlew run` with the appropriate flags.
+1. Run `gradlew hotReloadFrontend`.
+1. The website will be automatically opened in your browser shortly.
+
 **You can use Vue.js devtools for frontend debugging on Chrome.** Here are the steps:
 1. On your Chrome, visit the website of [Vue.js devtools](https://chrome.google.com/webstore/detail/vuejs-devtools/nhdogjmejiglipccpnnnanhbledajbpd) and add the extension.
 1. Go to the detail page of this extension in Chrome's extension management panel and select `Allow access to file URLs`. If you are unable to locate it, copy the link: `chrome://extensions/?id=nhdogjmejiglipccpnnnanhbledajbpd` and visit it on your Chrome.

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -6,5 +6,6 @@ package-lock.json
 
 build/
 
-!*/public/favicon.ico
-!*/public/index.html
+public/
+!public/favicon.ico
+!public/index.html


### PR DESCRIPTION
Includes a feature added in #1412.

The gradle hot reload feature is only tested to be working for Windows (what I use to develop Reposense), not tested on Mac, and not working on Linux.

This is due to gradle needing to use OS specific commands to ensure that the website does not become an orphaned process with no way of killing it other than by pid.

Refer to https://github.com/srs/gradle-node-plugin/issues/238 for more information about the orphaned process problem

Users who can't run the gradlew version can just run `npm run serveOpen` in the frontend folder.

```
Frontend hot reload is a new feature added in #1412,
which will significantly help frontend developers.

Let's add it to to the documentation.

Let's also update the gitignore.
```