### PR TITLE
[#1595] Add release branch usage and hot patching instructions

### DIFF
--- a/docs/dg/architecture.md
+++ b/docs/dg/architecture.md
@@ -29,6 +29,7 @@
 [`Git`](https://github.com/reposense/RepoSense/blob/master/src/main/java/reposense/git) package contains the wrapper classes for respective *git* commands.
  * [`GitBlame`](https://github.com/reposense/RepoSense/blob/master/src/main/java/reposense/git/GitBlame.java): Wrapper class for `git blame` functionality. Traces the revision and author last modified each line of a file.
  * [`GitBranch`](https://github.com/reposense/RepoSense/blob/master/src/main/java/reposense/git/GitBranch.java): Wrapper class for `git branch` functionality. Gets the name of the working branch of the target repo.
+ * [`GitCatFile`](https://github.com/reposense/RepoSense/blob/master/src/main/java/reposense/git/GitCatFile.java): Wrapper class for `git cat-file` functionality. Obtains the parent commit hash with the given commit indicated by the commit hash.
  * [`GitCheckout`](https://github.com/reposense/RepoSense/blob/master/src/main/java/reposense/git/GitCheckout.java): Wrapper class for `git checkout` functionality. Checks out the repository by branch name or commit hash.
  * [`GitClone`](https://github.com/reposense/RepoSense/blob/master/src/main/java/reposense/git/GitClone.java): Wrapper class for `git clone` functionality. Clones the repository from *GitHub* into a temporary folder in order to run the analysis.
  * [`GitDiff`](https://github.com/reposense/RepoSense/blob/master/src/main/java/reposense/git/GitDiff.java): Wrapper class for `git diff` functionality. Obtains the changes between commits.
@@ -37,6 +38,7 @@
  * [`GitRevList`](https://github.com/reposense/RepoSense/blob/master/src/main/java/reposense/git/GitRevList.java): Wrapper class for `git rev-list` functionality. Retrieves the commit objects in reverse chronological order.
  * [`GitRevParse`](https://github.com/reposense/RepoSense/blob/master/src/main/java/reposense/git/GitRevParse.java): Wrapper class for `git rev-parse` functionality. Ensures that the branch of the repo is to be analyzed exists.
  * [`GitShortlog`](https://github.com/reposense/RepoSense/blob/master/src/main/java/reposense/git/GitShortlog.java): Wrapper class for `git shortlog` functionality. Obtains the list of authors who have contributed to the target repo.
+ * [`GitShow`](https://github.com/reposense/RepoSense/blob/master/src/main/java/reposense/git/GitShow.java): Wrapper class for `git show` functionality. Gets the date of the commit with the commit hash.
  * [`GitUtil`](https://github.com/reposense/RepoSense/blob/master/src/main/java/reposense/git/GitUtil.java): Contains helper functions used by the other Git classes above.
  * [`GitVersion`](https://github.com/reposense/RepoSense/blob/master/src/main/java/reposense/git/GitVersion.java): Wrapper class for `git --version` functionality. Obtains the current git version of the environment that RepoSense is being run on.
 

--- a/docs/dg/projectManagement.md
+++ b/docs/dg/projectManagement.md
@@ -29,7 +29,7 @@ Before making a release, please check the following prerequisites:
 * Ensure that the `JAVA_HOME` environment variable is correctly set to your JDK installation directory. You can refer to the [JDK Installation Guide](https://docs.oracle.com/cd/E19182-01/821-0917/inst_jdk_javahome_t/index.html).
 * Ensure that you have merged the [upstream](https://github.com/RepoSense/reposense) `master` branch into both the local and upstream `release` branch according to the following steps:
     1. In your local repository, reset your `master` branch to be exactly the same as the upstream `master` branch.
-    1. Switch to the local `release` branch, and merge the `master` branch into it with `git merge master --no-ff` (no fast forward to keep the commit history for releases)
+    1. Switch to the local `release` branch, and merge the `master` branch into it with `git merge master --no-ff` (no fast forward to keep the commit history for releases).
     1. Push the local `release` branch directly to the [upstream `release` branch](https://github.com/reposense/RepoSense/tree/release) (make sure you have the push access).
     
 To make a release for RepoSense on Github, please follow the `Creating a release` section in the [Github Docs](https://docs.github.com/en/github/administering-a-repository/managing-releases-in-a-repository).<br>
@@ -80,7 +80,7 @@ After each release, do the following steps to deploy the production website:
 
 ## Hot patching after the release
 
-If critical bugs are found in the release, take the following takes to hot patch it:
+If critical bugs are found in the release, take the following steps to hot patch it:
 1. Switch to the `release` branch.
 1. Implement the fixes, commit them, and create a pull request from your forked `release` branch to the upstream `release` branch.
 1. After merging, release a new version of RepoSense with the `release` branch according to the above guide.

--- a/docs/dg/projectManagement.md
+++ b/docs/dg/projectManagement.md
@@ -27,7 +27,11 @@ Before making a release, please check the following prerequisites:
 
 * Ensure that you have **JDK `1.8.0`** installed (==Not other major release versions such as **JDK `9`** or **JDK `11`**==).
 * Ensure that the `JAVA_HOME` environment variable is correctly set to your JDK installation directory. You can refer to the [JDK Installation Guide](https://docs.oracle.com/cd/E19182-01/821-0917/inst_jdk_javahome_t/index.html).
-
+* Ensure that you have merged the `master` branch to the `release` branch in the [upstream repository](https://github.com/RepoSense/reposense) according to the following stpes:
+    1. In your local repository, reset your master branch to be exactly the same as the upstream master branch.
+    1. Check out to the local release branch, and merge the master branch into it with `git merge master --no-ff` (no fast forward to keep the commit history for releases)
+    1. Push the local release branch directly to the [upstream release branch](https://github.com/reposense/RepoSense/tree/release) (make sure you have the push access).
+    
 To make a release for RepoSense on Github, please follow the `Creating a release` section in the [Github Docs](https://docs.github.com/en/github/administering-a-repository/managing-releases-in-a-repository).<br>
 
 Take note of the following when making the release according to the above guide:
@@ -37,10 +41,11 @@ Take note of the following when making the release according to the above guide:
   * Append `rc` to the version number to indicate that the release is a pre-release that is not ready to be used in production.
 * Enter the release title as `RepoSense vxxx` where `xxx` is the version number. Enter the release description by referring to the previous [RepoSense releases](https://github.com/reposense/RepoSense/releases).
 * Before launching the release, generate the `RepoSense.jar` file and attach it to the release.
-  * Change the directory to the project root directory.
-  * In the terminal, run `gradlew --version` to check that the JDK version is 1.8.0.
-  * Run `gradlew shadowJar`, and the Jar file will be generated at `{buildDir}/jar/`.
-  * Check that the Jar file is working. You may need to check that the report can be generated from the Jar file both locally and remotely by following the [Generating Reports Guide](../ug/generatingReports.html).
+  1. In your local reposio
+  1. Change the directory to the project root directory.
+  1. In the terminal, run `gradlew --version` to check that the JDK version is 1.8.0.
+  1. Run `gradlew shadowJar`, and the Jar file will be generated at `{buildDir}/jar/`.
+  1. Check that the Jar file is working. You may need to check that the report can be generated from the Jar file both locally and remotely by following the [Generating Reports Guide](../ug/generatingReports.html).
 
 After making the release, please also remember to deploy the production website using the [deploy guide](#deploying-the-production-website).
 

--- a/docs/dg/projectManagement.md
+++ b/docs/dg/projectManagement.md
@@ -42,7 +42,7 @@ Take note of the following when making the release according to the above guide:
 * Enter the release title as `RepoSense vxxx` where `xxx` is the version number. Enter the release description by referring to the previous [RepoSense releases](https://github.com/reposense/RepoSense/releases).
 * Before launching the release, generate the `RepoSense.jar` file and attach it to the release.
   1. Switch to the `release` branch.
-  1. In the terminal, Change the directory to the project root directory.
+  1. In the terminal, change the directory to the project root directory.
   1. Run `gradlew --version` to check that the JDK version is 1.8.0.
   1. Run `gradlew shadowJar`, and the Jar file will be generated at `{buildDir}/jar/`.
   1. Check that the Jar file is working. You may need to check that the report can be generated from the Jar file both locally and remotely by following the [Generating Reports Guide](../ug/generatingReports.html).

--- a/docs/dg/projectManagement.md
+++ b/docs/dg/projectManagement.md
@@ -27,10 +27,10 @@ Before making a release, please check the following prerequisites:
 
 * Ensure that you have **JDK `1.8.0`** installed (==Not other major release versions such as **JDK `9`** or **JDK `11`**==).
 * Ensure that the `JAVA_HOME` environment variable is correctly set to your JDK installation directory. You can refer to the [JDK Installation Guide](https://docs.oracle.com/cd/E19182-01/821-0917/inst_jdk_javahome_t/index.html).
-* Ensure that you have merged the `master` branch to the `release` branch in the [upstream repository](https://github.com/RepoSense/reposense) according to the following stpes:
-    1. In your local repository, reset your master branch to be exactly the same as the upstream master branch.
-    1. Check out to the local release branch, and merge the master branch into it with `git merge master --no-ff` (no fast forward to keep the commit history for releases)
-    1. Push the local release branch directly to the [upstream release branch](https://github.com/reposense/RepoSense/tree/release) (make sure you have the push access).
+* Ensure that you have merged the [upstream](https://github.com/RepoSense/reposense) `master` branch into both the local and upstream `release` branch according to the following steps:
+    1. In your local repository, reset your `master` branch to be exactly the same as the upstream `master` branch.
+    1. Switch to the local `release` branch, and merge the `master` branch into it with `git merge master --no-ff` (no fast forward to keep the commit history for releases)
+    1. Push the local `release` branch directly to the [upstream `release` branch](https://github.com/reposense/RepoSense/tree/release) (make sure you have the push access).
     
 To make a release for RepoSense on Github, please follow the `Creating a release` section in the [Github Docs](https://docs.github.com/en/github/administering-a-repository/managing-releases-in-a-repository).<br>
 
@@ -41,9 +41,9 @@ Take note of the following when making the release according to the above guide:
   * Append `rc` to the version number to indicate that the release is a pre-release that is not ready to be used in production.
 * Enter the release title as `RepoSense vxxx` where `xxx` is the version number. Enter the release description by referring to the previous [RepoSense releases](https://github.com/reposense/RepoSense/releases).
 * Before launching the release, generate the `RepoSense.jar` file and attach it to the release.
-  1. In your local reposio
-  1. Change the directory to the project root directory.
-  1. In the terminal, run `gradlew --version` to check that the JDK version is 1.8.0.
+  1. Switch to the `release` branch.
+  1. In the terminal, Change the directory to the project root directory.
+  1. Run `gradlew --version` to check that the JDK version is 1.8.0.
   1. Run `gradlew shadowJar`, and the Jar file will be generated at `{buildDir}/jar/`.
   1. Check that the Jar file is working. You may need to check that the report can be generated from the Jar file both locally and remotely by following the [Generating Reports Guide](../ug/generatingReports.html).
 
@@ -73,5 +73,15 @@ After each release, do the following steps to deploy the production website:
 1. Switch to the `release` branch
 1. `cd docs`
 1. `markbind build`
-1. `markbind deploy`
+1. `markbind deploy` (make sure you have the push access to https://github.com/reposense/reposense.github.io)
 1. After a few minutes, check https://reposense.org to ensure it has been updated as intended.
+
+<!-- ==================================================================================================== -->
+
+## Hot patching after the release
+
+If critical bugs are found in the release, take the following takes to hot patch it:
+1. Switch to the `release` branch.
+1. Implement the fixes, commit them, and create a pull request from your forked `release` branch to the upstream `release` branch.
+1. After merging, release a new version of RepoSense with the `release` branch according to the above guide.
+1. Merge the `release` branch back into the `master` branch by creating a separate pull request.


### PR DESCRIPTION
Fixes #1595.

```
There is currently no specific instruction on how to update the
release branch before making a release, or how to handle critical bugs
spotted after the release is made.

Adding these instructions will reduce the communication expenses in
the project release.

Let's adjust the release guide accordingly.
```