### PR TITLE
[#1606] GitHub Actions: update list of runners

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -15,7 +15,7 @@ jobs:
     name: ${{ matrix.os }} JDK 8
     strategy:
       matrix:
-        os: [ubuntu-16.04, ubuntu-18.04, ubuntu-20.04]
+        os: [ubuntu-18.04, ubuntu-20.04]
     runs-on: ${{ matrix.os }}
     env:
       NODE_VERSION: "lts/*"

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -101,7 +101,7 @@ jobs:
     name: ${{ matrix.os }} JDK 8
     strategy:
       matrix:
-        os: [macos-10.15]
+        os: [macos-10.15, macos-11]
     runs-on: ${{ matrix.os }}
     env:
       HOMEBREW_NO_AUTO_UPDATE: 1 # Prevent time-consuming brew update


### PR DESCRIPTION
Fixes #1606.

The status checks has also been updated in the repository settings.

Proposed commit message:
```
The Ubuntu 16.04 LTS runner for GitHub Actions is no longer supported
as at 16 October 2021. This is a breaking change that caused all
GitHub Actions checks to not complete.

The macOS 11 runner is also available for use now, and will be made
default on 13 December 2021.

Let's update the list of runners based on these changes.
```