### PR TITLE
Update author annotation to give partial authorship for code blocks

### DIFF
--- a/src/main/java/reposense/authorship/FileInfoAnalyzer.java
+++ b/src/main/java/reposense/authorship/FileInfoAnalyzer.java
@@ -15,6 +15,7 @@ import reposense.authorship.analyzer.AnnotatorAnalyzer;
 import reposense.authorship.model.FileInfo;
 import reposense.authorship.model.FileResult;
 import reposense.authorship.model.LineInfo;
+import reposense.authorship.model.TextBlockInfo;
 import reposense.git.GitBlame;
 import reposense.git.GitLog;
 import reposense.model.Author;
@@ -100,8 +101,14 @@ public class FileInfoAnalyzer {
             Author author = line.getAuthor();
             authorContributionMap.put(author, authorContributionMap.getOrDefault(author, 0) + 1);
         }
+
+        for (TextBlockInfo block : fileInfo.getTextBlocks()) {
+            block.getAbsoluteContributionMap().forEach((author, integer)
+                    -> authorContributionMap
+                        .put(author, authorContributionMap.getOrDefault(author, 0) + integer));
+        }
         return FileResult.createTextFileResult(
-            fileInfo.getPath(), fileInfo.getFileType(), fileInfo.getLines(), authorContributionMap);
+            fileInfo.getPath(), fileInfo.getFileType(), fileInfo.getLines(), fileInfo.getTextBlocks(), authorContributionMap);
     }
 
     /**

--- a/src/main/java/reposense/authorship/FileResultAggregator.java
+++ b/src/main/java/reposense/authorship/FileResultAggregator.java
@@ -5,6 +5,7 @@ import java.util.List;
 import reposense.authorship.model.AuthorshipSummary;
 import reposense.authorship.model.FileResult;
 import reposense.authorship.model.LineInfo;
+import reposense.authorship.model.TextBlockInfo;
 import reposense.model.Author;
 import reposense.model.FileType;
 
@@ -20,16 +21,8 @@ public class FileResultAggregator {
             List<FileType> fileTypes) {
         AuthorshipSummary authorContributionSummary = new AuthorshipSummary(fileResults, authors, fileTypes);
         for (FileResult fileResult : fileResults) {
-            if (fileResult.isBinary()) {
-                continue;
-            }
-            for (LineInfo lineInfo : fileResult.getLines()) {
-                Author author = lineInfo.getAuthor();
-                if (!authors.contains(author)) {
-                    continue;
-                }
-                authorContributionSummary.addAuthorContributionCount(author, fileResult.getFileType());
-            }
+                authorContributionSummary
+                    .addAuthorContributionCount(fileResult.getAuthorContributionMap(), fileResult.getFileType());
         }
         return authorContributionSummary;
     }

--- a/src/main/java/reposense/authorship/model/AuthorshipSummary.java
+++ b/src/main/java/reposense/authorship/model/AuthorshipSummary.java
@@ -35,6 +35,16 @@ public class AuthorshipSummary {
         fileTypeContributionMap.put(fileType, fileTypeContributionMap.getOrDefault(fileType, 0) + 1);
     }
 
+    /**
+     * Increments the corresponding {@code fileType} contribution count of {@code author} by one.
+     */
+    public void addAuthorContributionCount(HashMap<Author, Integer> authorContributionMap, FileType fileType) {
+        authorContributionMap.forEach((author, integer) -> {
+            Map<FileType, Integer> fileTypeContributionMap = authorFileTypeContributionMap.get(author);
+            fileTypeContributionMap.put(fileType, fileTypeContributionMap.getOrDefault(fileType, 0) + integer);
+        });
+    }
+
     public Map<Author, LinkedHashMap<FileType, Integer>> getAuthorFileTypeContributionMap() {
         return authorFileTypeContributionMap;
     }

--- a/src/main/java/reposense/authorship/model/FileInfo.java
+++ b/src/main/java/reposense/authorship/model/FileInfo.java
@@ -14,6 +14,7 @@ import reposense.util.SystemUtil;
 public class FileInfo {
     private final String path;
     private final ArrayList<LineInfo> lines;
+    private final ArrayList<TextBlockInfo> blocks = new ArrayList<>();
 
     private FileType fileType;
 
@@ -42,12 +43,28 @@ public class FileInfo {
         lines.add(line);
     }
 
+    public void removeLine(LineInfo line) {
+        lines.remove(line);
+    }
+
+    public void addTextBlock(TextBlockInfo block) {
+        blocks.add(block);
+    }
+
+    public void removeTextBlock(TextBlockInfo block) {
+        blocks.remove(block);
+    }
+
     public int getNumOfLines() {
         return lines.size();
     }
 
     public ArrayList<LineInfo> getLines() {
         return lines;
+    }
+
+    public ArrayList<TextBlockInfo> getTextBlocks() {
+        return blocks;
     }
 
     public String getPath() {

--- a/src/main/java/reposense/authorship/model/FileResult.java
+++ b/src/main/java/reposense/authorship/model/FileResult.java
@@ -15,13 +15,15 @@ public class FileResult {
     private FileType fileType;
     private Boolean isBinary = null; // Should only be true or null to prevent it from being serialized
     private final ArrayList<LineInfo> lines;
+    private final ArrayList<TextBlockInfo> blocks;
     private final HashMap<Author, Integer> authorContributionMap;
 
-    public FileResult(String path, FileType fileType, ArrayList<LineInfo> lines,
+    public FileResult(String path, FileType fileType, ArrayList<LineInfo> lines, ArrayList<TextBlockInfo> blocks,
             HashMap<Author, Integer> authorContributionMap, boolean isBinary) {
         this.path = path;
         this.fileType = fileType;
         this.lines = lines;
+        this.blocks = blocks;
         this.authorContributionMap = authorContributionMap;
         if (isBinary) {
             this.isBinary = true;
@@ -29,13 +31,13 @@ public class FileResult {
     }
 
     public static FileResult createTextFileResult(String path, FileType fileType, ArrayList<LineInfo> lines,
-            HashMap<Author, Integer> authorContributionMap) {
-        return new FileResult(path, fileType, lines, authorContributionMap, false);
+                                                  ArrayList<TextBlockInfo> textBlocks, HashMap<Author, Integer> authorContributionMap) {
+        return new FileResult(path, fileType, lines, textBlocks, authorContributionMap, false);
     }
 
     public static FileResult createBinaryFileResult(String path, FileType fileType, HashMap<Author,
             Integer> authorContributionMap) {
-        return new FileResult(path, fileType, new ArrayList<>(), authorContributionMap, true);
+        return new FileResult(path, fileType, new ArrayList<>(), null, authorContributionMap, true);
     }
 
     public boolean isBinary() {
@@ -44,6 +46,10 @@ public class FileResult {
 
     public List<LineInfo> getLines() {
         return lines;
+    }
+
+    public List<TextBlockInfo> getBlocks() {
+        return blocks;
     }
 
     public String getPath() {

--- a/src/main/java/reposense/authorship/model/TextBlockInfo.java
+++ b/src/main/java/reposense/authorship/model/TextBlockInfo.java
@@ -1,0 +1,119 @@
+package reposense.authorship.model;
+
+import reposense.model.Author;
+
+import java.util.*;
+
+public class TextBlockInfo {
+    private int startLineNumber;
+    private int endLineNumber;
+    private HashMap<Author, Integer> contributionMap;
+    private HashMap<Author, Integer> absoluteContributionMap = null;
+    private ArrayList<LineInfo> lines;
+    private Date lastModifiedDate;
+
+    private transient boolean isTracked;
+
+    public TextBlockInfo(int startLineNumber, int endLineNumber, ArrayList<LineInfo> lines) {
+        this.startLineNumber = startLineNumber;
+        this.endLineNumber = endLineNumber;
+        this.lines = lines;
+
+        isTracked = true;
+    }
+
+    public TextBlockInfo() {
+        this.lines = new ArrayList<>();
+        this.contributionMap = new HashMap<>();
+
+        isTracked = true;
+    }
+
+    public HashMap<Author, Integer> getContributionMap() {
+        return contributionMap;
+    }
+
+    public HashMap<Author, Integer> getAbsoluteContributionMap() {
+        if (this.absoluteContributionMap == null) {
+            int sum = 0;
+            Iterator<Map.Entry<Author, Integer>> iterator = contributionMap.entrySet().iterator();
+            while (iterator.hasNext()) {
+                Map.Entry<Author, Integer> element = iterator.next();
+                sum += element.getValue();
+            }
+
+            int totalLines = endLineNumber - startLineNumber;
+            int finalSum = sum;
+            contributionMap.forEach((author, integer) ->
+                contributionMap.put(author, (integer * totalLines) / finalSum));
+        }
+        return this.absoluteContributionMap;
+
+    }
+
+    public void setContributionMap(HashMap<Author, Integer> contributionMap) {
+        this.contributionMap = contributionMap;
+    }
+
+    public int getStartLineNumber() {
+        return startLineNumber;
+    }
+
+    public void setStartLineNumber(int startLineNumber) {
+        this.startLineNumber = startLineNumber;
+    }
+
+    public int getEndLineNumber() {
+        return endLineNumber;
+    }
+
+    public void setEndLineNumber(int endLineNumber) {
+        this.endLineNumber = endLineNumber;
+    }
+
+    public void setTracked(boolean isTracked) {
+        this.isTracked = isTracked;
+    }
+
+    public Date getLastModifiedDate() {
+        return lastModifiedDate;
+    }
+
+    public void setLastModifiedDate(Date lastModifiedDate) {
+        this.lastModifiedDate = lastModifiedDate;
+    }
+
+    public boolean isTracked() {
+        return isTracked;
+    }
+
+    public void addLine(LineInfo line) {
+        this.lines.add(line);
+    }
+
+    public void removeLine(LineInfo line) {
+        this.lines.remove(line);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (this == other) {
+            return true;
+        }
+
+        if (!(other instanceof TextBlockInfo)) {
+            return false;
+        }
+
+        TextBlockInfo otherTextBlockInfo = (TextBlockInfo) other;
+        return startLineNumber == otherTextBlockInfo.startLineNumber
+                && endLineNumber == otherTextBlockInfo.endLineNumber
+                && contributionMap.equals(otherTextBlockInfo.contributionMap)
+                && absoluteContributionMap.equals(otherTextBlockInfo.absoluteContributionMap)
+                && lines.equals(otherTextBlockInfo.lines)
+                && isTracked == otherTextBlockInfo.isTracked
+                && ((lastModifiedDate == null && otherTextBlockInfo.lastModifiedDate == null)
+                || (lastModifiedDate.equals(otherTextBlockInfo.lastModifiedDate)));
+    }
+
+}


### PR DESCRIPTION
A particular code block might have input from more than 1 person.
For example, another person might have resolved conflicts that arose
from a merge. Current assignment is all or nothing for any particular
line.

Let's extend the author notation to credit multiple contributors
with fields to enter a percentage representation of contribution.

Example of an annotation:
"@@author @hpkoh 30 @xyz 70" of a particular code block give
@hpkoh authorship of 30% of the total lines and @xyz authorship of
70 percent of the total lines.

`TextBlockInfo class`