### PR TITLE
[#1584] Clicking on commit message causes it to shift slightly

### DIFF
--- a/frontend/src/views/v-zoom.vue
+++ b/frontend/src/views/v-zoom.vue
@@ -449,6 +449,7 @@ export default {
 
   /* Commit Message Body in Zoom Tab */
   .commit-message {
+    border: 1px solid transparent;
     padding: 5px;
 
     &:focus,


### PR DESCRIPTION
Fixes #1584 

Solution: Add a solid transparent border to prevent it from pushing the content around when visible.

Proposed commit message:
```
Prevent commit message from shifting rightwards when clicked on.

Clicking on a commit pushes the message box rightwards, which can be
disorienting.

Let's add a solid transparent border to prevent it from pushing the 
content around when visible.
```