### PR TITLE
[#1543] Remove the "Show ramp chart for this period" feature

### DIFF
--- a/frontend/src/views/v-zoom.vue
+++ b/frontend/src/views/v-zoom.vue
@@ -29,7 +29,6 @@
     .period
       span &#8627; &nbsp;
       span {{ info.zSince }} to {{ info.zUntil }} &nbsp;
-      a(v-on:click="openSummary") [Show ramp chart for this period]
   .zoom__title
     .zoom__title--granularity granularity: one ramp per {{ info.zTimeFrame }}
     .zoom__title--tags
@@ -264,11 +263,6 @@ export default {
       // This code crashes if info.zUser is not defined
       this.updateFileTypes();
       this.selectedFileTypes = this.fileTypes.slice();
-    },
-
-    openSummary() {
-      const info = { since: this.info.zSince, until: this.info.zUntil };
-      this.$store.commit('updateSummaryDates', info);
     },
 
     getSliceLink(slice) {


### PR DESCRIPTION
Fixes #1543 

**Summary**

Removes the "Show ramp chart for this period" anchor and `openSummary` method that only seems to be used by this feature. There does not appear to be deeper implementation for this feature beyond the above.

**Proposed commit message:**
```
The "Show ramp chart for this period" feature does not seem to be
particularly intuitive, and as discussed in #1543, may not be very
useful since users can do this manually. 

Let's remove this option from the front end and the associated 
`openSummary` method.
```