### PR TITLE
Support frontend hot reload on Linux

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,4 @@
-import org.apache.tools.ant.taskdefs.condition.Os
+import org.gradle.nativeplatform.platform.internal.DefaultNativePlatform
 
 plugins {
     id 'application'
@@ -228,22 +228,36 @@ task syncFrontendPublic(type: Sync) {
 
 task macHotReloadFrontend(type: Exec) {
     dependsOn(installFrontend)
-    onlyIf {Os.isFamily(Os.FAMILY_MAC)}
+
+    OperatingSystem os = DefaultNativePlatform.currentOperatingSystem;
+    onlyIf {os.isMacOsX()}
     workingDir 'frontend/'
     commandLine 'osascript', '-e', '"tell application "Terminal" to do script "npm run serveOpen""'
 }
 
 task windowsHotReloadFrontend(type: Exec) {
     dependsOn(installFrontend)
-    onlyIf {Os.isFamily(Os.FAMILY_WINDOWS)}
+
+    OperatingSystem os = DefaultNativePlatform.currentOperatingSystem;
+    onlyIf {os.isWindows()}
     workingDir 'frontend/'
     commandLine 'cmd','/c', 'START', '"hotreload RepoSense frontend"', 'npm', 'run', 'serveOpen'
+}
+
+task linuxHotReloadFrontend(type: Exec) {
+    dependsOn(installFrontend)
+
+    OperatingSystem os = DefaultNativePlatform.currentOperatingSystem;
+    onlyIf {os.isLinux()}
+    workingDir 'frontend/'
+    commandLine 'npm', 'run', 'serveOpen'
 }
 
 task hotReloadFrontend() {
     dependsOn syncFrontendPublic
     finalizedBy windowsHotReloadFrontend
     finalizedBy macHotReloadFrontend
+    finalizedBy linuxHotReloadFrontend
 }
 // End of hot reload Tasks
 

--- a/build.gradle
+++ b/build.gradle
@@ -12,6 +12,8 @@ plugins {
     id 'com.palantir.git-version' version '0.12.3'
 }
 
+OperatingSystem os = DefaultNativePlatform.currentOperatingSystem;
+
 mainClassName = 'reposense.RepoSense'
 
 node.nodeVersion = '10.16.0'
@@ -228,8 +230,6 @@ task syncFrontendPublic(type: Sync) {
 
 task macHotReloadFrontend(type: Exec) {
     dependsOn(installFrontend)
-
-    OperatingSystem os = DefaultNativePlatform.currentOperatingSystem;
     onlyIf {os.isMacOsX()}
     workingDir 'frontend/'
     commandLine 'osascript', '-e', '"tell application "Terminal" to do script "npm run serveOpen""'
@@ -237,8 +237,6 @@ task macHotReloadFrontend(type: Exec) {
 
 task windowsHotReloadFrontend(type: Exec) {
     dependsOn(installFrontend)
-
-    OperatingSystem os = DefaultNativePlatform.currentOperatingSystem;
     onlyIf {os.isWindows()}
     workingDir 'frontend/'
     commandLine 'cmd','/c', 'START', '"hotreload RepoSense frontend"', 'npm', 'run', 'serveOpen'
@@ -246,8 +244,6 @@ task windowsHotReloadFrontend(type: Exec) {
 
 task linuxHotReloadFrontend(type: Exec) {
     dependsOn(installFrontend)
-
-    OperatingSystem os = DefaultNativePlatform.currentOperatingSystem;
     onlyIf {os.isLinux()}
     workingDir 'frontend/'
     commandLine 'npm', 'run', 'serveOpen'

--- a/build.gradle
+++ b/build.gradle
@@ -232,7 +232,7 @@ task macHotReloadFrontend(type: Exec) {
     dependsOn(installFrontend)
     onlyIf {os.isMacOsX()}
     workingDir 'frontend/'
-    commandLine 'osascript', '-e', '"tell application "Terminal" to do script "npm run serveOpen""'
+    commandLine 'npm', 'run', 'serveOpen'
 }
 
 task windowsHotReloadFrontend(type: Exec) {


### PR DESCRIPTION
**Proposed commit message:**

```
The hotReloadFrontend gradle task does not support Linux. Apache
ant's `Os` class does not have an OS family specifically for Linux.
The Mac hot reload feature also does not appear to work.

Let's:
- add hot reload for Linux using gradle's OperatingSystem::isLinux
- use `npm run serveOpen` command for both Mac and Linux
```

Tested on Windows, Mac and Fedora Linux