### PR TITLE
[#1622] Upgrade highlight.js to version 11

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -31,7 +31,7 @@
     "@fortawesome/free-solid-svg-icons": "^5.15.2",
     "@fortawesome/vue-fontawesome": "^2.0.2",
     "core-js": "^3.6.5",
-    "highlight.js": "^10.5.0",
+    "highlight.js": "^11.4.0",
     "jszip": "^3.5.0",
     "minimatch": "^3.0.4",
     "pug-lint-vue": "^0.4.0",


### PR DESCRIPTION
Fixes https://github.com/reposense/RepoSense/issues/1622

Proposed commit message:

```
The highlight.js package used by the frontend is currently
version 10.7.3, which is no longer supported. 

Upgraded highlight.js to 11.4.0 for better compatibility.
```