### PR TITLE
[#1638] Replace parseInt with Math.floor for contribution bars

### DIFF
--- a/frontend/src/components/v-summary-charts.vue
+++ b/frontend/src/components/v-summary-charts.vue
@@ -288,7 +288,7 @@ export default {
       const res = [];
       const contributionLimit = (this.avgContributionSize * 2);
 
-      const cnt = parseInt(totalContribution / contributionLimit, 10);
+      const cnt = Math.floor(totalContribution / contributionLimit);
       for (let cntId = 0; cntId < cnt; cntId += 1) {
         res.push(100);
       }


### PR DESCRIPTION
Fixes #1638 

**Proposed commit message:**
```
To calculate the number of contribution bars to display in 
getContributionBars, a parseInt of the ratio of a user's contribution
to the contribution limit is used. However, if the contribution is
much lower than average, the ratio is represented in scientific
notation and parseInt does not return the integer part of the number
(parseInt of 3.2301723943006836e-7 would return 3).

Let's use Math.floor to get the integer part of the contribution ratio 
instead of parseInt in getContributionBars, as is currently done in 
getFileTypeContributionBars.
```
Before:

![image](https://user-images.githubusercontent.com/34594184/151713508-fff51035-8081-4301-9e27-4c1131e459a4.png)

After:

![image](https://user-images.githubusercontent.com/34594184/151759502-28dadd6c-30e4-42e1-a030-d78e976a33a3.png)
