### PR TITLE
[#1540] Remove Cypress.wait() at the start of cypress tests

### DIFF
--- a/frontend/cypress/support.js
+++ b/frontend/cypress/support.js
@@ -8,13 +8,3 @@ Cypress.Screenshot.defaults({
 beforeEach(() => {
   cy.visit('/');
 });
-
-// Slows down test execution on non-CI environment.
-Cypress.wait = (() => {
-  if (Cypress.env('ci') === true) {
-    return;
-  }
-
-  cy.log('Slowing down test...');
-  cy.wait(1500);
-});

--- a/frontend/cypress/tests/chartView/chartView_contributionBar.js
+++ b/frontend/cypress/tests/chartView/chartView_contributionBar.js
@@ -11,8 +11,6 @@ describe('contribution bar', () => {
     cy.get('#summary-wrapper label').contains('breakdown by file type').siblings().filter('input')
         .check();
 
-    Cypress.wait();
-
     let actualWidthSum = 0;
     cy.get('.summary-chart__contrib--bar').then((ele) => {
       let i;
@@ -46,8 +44,6 @@ describe('contribution bar', () => {
 
     cy.get('#summary-wrapper label').contains('gradle').siblings().filter('input')
         .check();
-
-    Cypress.wait();
 
     let actualWidthSum = 0;
     cy.get('.summary-chart__contrib--bar').then((ele) => {

--- a/frontend/cypress/tests/chartView/chartView_errorSummary_messageBox.js
+++ b/frontend/cypress/tests/chartView/chartView_errorSummary_messageBox.js
@@ -24,8 +24,6 @@ describe('error summary', () => {
     cy.get('#summary-wrapper > #summary > .error-message-box > .error-message-box__close-button')
         .click();
 
-    Cypress.wait();
-
     cy.get('.error-message-box')
         .should('not.be.visible');
   });

--- a/frontend/cypress/tests/chartView/chartView_filterBreakdown.js
+++ b/frontend/cypress/tests/chartView/chartView_filterBreakdown.js
@@ -1,6 +1,5 @@
 describe('filter breakdown', () => {
   it('check breakdown by file type should show file types', () => {
-    Cypress.wait();
 
     cy.get('#summary label.filter-breakdown input:visible')
         .should('be.visible')
@@ -17,7 +16,6 @@ describe('filter breakdown', () => {
   });
 
   it('check, uncheck and recheck breakdown by file type should check all file types', () => {
-    Cypress.wait();
 
     cy.get('#summary label.filter-breakdown input:visible')
         .should('be.visible')
@@ -44,7 +42,6 @@ describe('filter breakdown', () => {
   });
 
   it('uncheck all file types should show no file types', () => {
-    Cypress.wait();
 
     cy.get('#summary label.filter-breakdown input:visible')
         .should('be.visible')
@@ -62,7 +59,6 @@ describe('filter breakdown', () => {
   });
 
   it('uncheck file type should uncheck all option and not show legend', () => {
-    Cypress.wait();
 
     cy.get('#summary label.filter-breakdown input:visible')
         .should('be.visible')

--- a/frontend/cypress/tests/chartView/chartView_filterBreakdown.js
+++ b/frontend/cypress/tests/chartView/chartView_filterBreakdown.js
@@ -1,6 +1,5 @@
 describe('filter breakdown', () => {
   it('check breakdown by file type should show file types', () => {
-
     cy.get('#summary label.filter-breakdown input:visible')
         .should('be.visible')
         .check()
@@ -16,7 +15,6 @@ describe('filter breakdown', () => {
   });
 
   it('check, uncheck and recheck breakdown by file type should check all file types', () => {
-
     cy.get('#summary label.filter-breakdown input:visible')
         .should('be.visible')
         .check()
@@ -42,7 +40,6 @@ describe('filter breakdown', () => {
   });
 
   it('uncheck all file types should show no file types', () => {
-
     cy.get('#summary label.filter-breakdown input:visible')
         .should('be.visible')
         .check()
@@ -59,7 +56,6 @@ describe('filter breakdown', () => {
   });
 
   it('uncheck file type should uncheck all option and not show legend', () => {
-
     cy.get('#summary label.filter-breakdown input:visible')
         .should('be.visible')
         .check()

--- a/frontend/cypress/tests/chartView/chartView_mergeGroup.js
+++ b/frontend/cypress/tests/chartView/chartView_mergeGroup.js
@@ -1,6 +1,5 @@
 describe('merge group', () => {
   it('check and uncheck merge group when group by repos', () => {
-    Cypress.wait();
 
     cy.get('div.mui-select.grouping > select:visible')
         .select('groupByRepos');
@@ -14,8 +13,6 @@ describe('merge group', () => {
     cy.get('#summary-charts').find('.summary-chart')
         .should('have.length', 1);
 
-    Cypress.wait();
-
     cy.get('#summary label.merge-group > input:visible')
         .should('be.visible')
         .uncheck()
@@ -27,7 +24,6 @@ describe('merge group', () => {
   });
 
   it('check and uncheck merge group when group by authors', () => {
-    Cypress.wait();
 
     cy.get('div.mui-select.grouping > select:visible')
         .select('groupByAuthors');
@@ -41,8 +37,6 @@ describe('merge group', () => {
     cy.get('#summary-charts').find('.summary-chart')
         .should('have.length', 5);
 
-    Cypress.wait();
-
     cy.get('#summary label.merge-group > input:visible')
         .first()
         .should('be.visible')
@@ -55,7 +49,6 @@ describe('merge group', () => {
   });
 
   it('merge group option should be disabled when group by none', () => {
-    Cypress.wait();
 
     cy.get('div.mui-select.grouping > select:visible')
         .select('groupByNone');

--- a/frontend/cypress/tests/chartView/chartView_mergeGroup.js
+++ b/frontend/cypress/tests/chartView/chartView_mergeGroup.js
@@ -1,6 +1,5 @@
 describe('merge group', () => {
   it('check and uncheck merge group when group by repos', () => {
-
     cy.get('div.mui-select.grouping > select:visible')
         .select('groupByRepos');
 
@@ -24,7 +23,6 @@ describe('merge group', () => {
   });
 
   it('check and uncheck merge group when group by authors', () => {
-
     cy.get('div.mui-select.grouping > select:visible')
         .select('groupByAuthors');
 
@@ -49,7 +47,6 @@ describe('merge group', () => {
   });
 
   it('merge group option should be disabled when group by none', () => {
-
     cy.get('div.mui-select.grouping > select:visible')
         .select('groupByNone');
 

--- a/frontend/cypress/tests/chartView/chartView_percentage.js
+++ b/frontend/cypress/tests/chartView/chartView_percentage.js
@@ -1,6 +1,5 @@
 describe('sort by contribution', () => {
   it('percentage should only be displayed when sort by contribution', () => {
-
     cy.get('#summary .summary-chart__title--percentile')
         .should('not.exist');
 
@@ -36,7 +35,6 @@ describe('sort by contribution', () => {
   });
 
   it('percentage is NOT shown even after changing other fields', () => {
-
     cy.get('div.mui-select.grouping > select:visible')
         .select('None');
 
@@ -63,7 +61,6 @@ describe('sort by contribution', () => {
   });
 
   it('percentage is NOT hidden even after changing other fields', () => {
-
     cy.get('div.mui-select.sort-group > select:visible')
         .select('↓ contribution');
 

--- a/frontend/cypress/tests/chartView/chartView_percentage.js
+++ b/frontend/cypress/tests/chartView/chartView_percentage.js
@@ -1,6 +1,5 @@
 describe('sort by contribution', () => {
   it('percentage should only be displayed when sort by contribution', () => {
-    Cypress.wait();
 
     cy.get('#summary .summary-chart__title--percentile')
         .should('not.exist');
@@ -37,7 +36,6 @@ describe('sort by contribution', () => {
   });
 
   it('percentage is NOT shown even after changing other fields', () => {
-    Cypress.wait();
 
     cy.get('div.mui-select.grouping > select:visible')
         .select('None');
@@ -65,7 +63,6 @@ describe('sort by contribution', () => {
   });
 
   it('percentage is NOT hidden even after changing other fields', () => {
-    Cypress.wait();
 
     cy.get('div.mui-select.sort-group > select:visible')
         .select('↓ contribution');

--- a/frontend/cypress/tests/chartView/chartView_reload.js
+++ b/frontend/cypress/tests/chartView/chartView_reload.js
@@ -1,6 +1,5 @@
 describe('reload page', () => {
   it('reload page should restore all controls', () => {
-    Cypress.wait();
 
     // search
     cy.get('div.mui-textfield.search_box > input:visible')

--- a/frontend/cypress/tests/chartView/chartView_reload.js
+++ b/frontend/cypress/tests/chartView/chartView_reload.js
@@ -1,6 +1,5 @@
 describe('reload page', () => {
   it('reload page should restore all controls', () => {
-
     // search
     cy.get('div.mui-textfield.search_box > input:visible')
         .should('be.visible')

--- a/frontend/cypress/tests/chartView/chartView_toolBar_searchBox.js
+++ b/frontend/cypress/tests/chartView/chartView_toolBar_searchBox.js
@@ -5,14 +5,10 @@ describe('search bar', () => {
         .type('abcdef')
         .type('{enter}');
 
-    Cypress.wait();
-
     // Enter does not work. Related issue: https://github.com/cypress-io/cypress/issues/3405
     // Let's manually submit form
     cy.get('#summary-wrapper form.summary-picker')
         .submit();
-
-    Cypress.wait();
 
     cy.get('#summary-wrapper #summary-charts').then(($ele) => {
       const content = $ele.html();
@@ -27,14 +23,10 @@ describe('search bar', () => {
         .type('Yong Hao TENG')
         .type('{enter}');
 
-    Cypress.wait();
-
     // Enter does not work. Related issue: https://github.com/cypress-io/cypress/issues/3405
     // Let's manually submit form
     cy.get('#summary-wrapper form.summary-picker')
         .submit();
-
-    Cypress.wait();
 
     cy.get('#summary-wrapper #summary-charts').then(($ele) => {
       const children = $ele.children().length;

--- a/frontend/cypress/tests/chartView/chartView_zoomFeature.js
+++ b/frontend/cypress/tests/chartView/chartView_zoomFeature.js
@@ -1,7 +1,6 @@
 describe('zoom features in code view', () => {
   const zoomKey = Cypress.platform === 'darwin' ? '{meta}' : '{ctrl}';
   it('click on view commits button', () => {
-    Cypress.wait();
 
     cy.get('.icon-button.fa-list-ul')
         .should('be.visible')
@@ -13,7 +12,6 @@ describe('zoom features in code view', () => {
   });
 
   it('zoom into ramp', () => {
-    Cypress.wait();
 
     // clicking from the 10th px to the 50th px in the ramp
     cy.get('body').type(zoomKey, { release: false })
@@ -27,7 +25,6 @@ describe('zoom features in code view', () => {
   });
 
   it('zoom into ramp when merge group', () => {
-    Cypress.wait();
 
     cy.get('#summary label.merge-group > input:visible')
         .should('be.visible')

--- a/frontend/cypress/tests/chartView/chartView_zoomFeature.js
+++ b/frontend/cypress/tests/chartView/chartView_zoomFeature.js
@@ -1,7 +1,6 @@
 describe('zoom features in code view', () => {
   const zoomKey = Cypress.platform === 'darwin' ? '{meta}' : '{ctrl}';
   it('click on view commits button', () => {
-
     cy.get('.icon-button.fa-list-ul')
         .should('be.visible')
         .first()
@@ -12,7 +11,6 @@ describe('zoom features in code view', () => {
   });
 
   it('zoom into ramp', () => {
-
     // clicking from the 10th px to the 50th px in the ramp
     cy.get('body').type(zoomKey, { release: false })
         .get('#summary-charts .summary-chart__ramp .ramp')
@@ -25,7 +23,6 @@ describe('zoom features in code view', () => {
   });
 
   it('zoom into ramp when merge group', () => {
-
     cy.get('#summary label.merge-group > input:visible')
         .should('be.visible')
         .check()

--- a/frontend/cypress/tests/codeView/codeView.js
+++ b/frontend/cypress/tests/codeView/codeView.js
@@ -20,26 +20,19 @@ describe('code view', () => {
     cy.get('#tabs-wrapper')
         .should('be.visible');
 
-    Cypress.wait();
-
     cy.get('#app #tab-resize .tab-close')
         .click();
-
-    Cypress.wait();
 
     cy.get('#tabs-wrapper')
         .should('not.exist');
   });
 
   it('merge group and view code for entire repository', () => {
-    Cypress.wait(); // ensure everything is loaded
 
     cy.get('#summary label.merge-group > input')
         .should('be.visible')
         .check({ force: true })
         .should('be.checked');
-
-    Cypress.wait();
 
     cy.get('.icon-button.fa-code')
         .should('be.visible')

--- a/frontend/cypress/tests/codeView/codeView.js
+++ b/frontend/cypress/tests/codeView/codeView.js
@@ -28,7 +28,6 @@ describe('code view', () => {
   });
 
   it('merge group and view code for entire repository', () => {
-
     cy.get('#summary label.merge-group > input')
         .should('be.visible')
         .check({ force: true })

--- a/frontend/cypress/tests/codeView/codeView_checkFileTypes.js
+++ b/frontend/cypress/tests/codeView/codeView_checkFileTypes.js
@@ -1,6 +1,5 @@
 describe('check file types', () => {
   it('check if all files types are visible by default', () => {
-    Cypress.wait();
 
     // open the code panel
     cy.get('.icon-button.fa-code')
@@ -16,7 +15,6 @@ describe('check file types', () => {
   });
 
   it('uncheck all files types should show no files', () => {
-    Cypress.wait();
 
     // open the code panel
     cy.get('.icon-button.fa-code')
@@ -36,7 +34,6 @@ describe('check file types', () => {
   });
 
   it('uncheck file type should uncheck all option and not show legend', () => {
-    Cypress.wait();
 
     // open the code panel
     cy.get('.icon-button.fa-code')

--- a/frontend/cypress/tests/codeView/codeView_checkFileTypes.js
+++ b/frontend/cypress/tests/codeView/codeView_checkFileTypes.js
@@ -1,6 +1,5 @@
 describe('check file types', () => {
   it('check if all files types are visible by default', () => {
-
     // open the code panel
     cy.get('.icon-button.fa-code')
         .should('be.visible')
@@ -15,7 +14,6 @@ describe('check file types', () => {
   });
 
   it('uncheck all files types should show no files', () => {
-
     // open the code panel
     cy.get('.icon-button.fa-code')
         .should('be.visible')
@@ -34,7 +32,6 @@ describe('check file types', () => {
   });
 
   it('uncheck file type should uncheck all option and not show legend', () => {
-
     // open the code panel
     cy.get('.icon-button.fa-code')
         .should('be.visible')

--- a/frontend/cypress/tests/codeView/codeView_hideFileDetails.js
+++ b/frontend/cypress/tests/codeView/codeView_hideFileDetails.js
@@ -1,6 +1,5 @@
 describe('hide all file details', () => {
   it('check hide all file details hides the content of all the files', () => {
-
     // open the code panel
     cy.get('.icon-button.fa-code')
         .should('be.visible')
@@ -28,7 +27,6 @@ describe('hide all file details', () => {
   });
 
   it('check details of one file are shown, rest are hidden', () => {
-
     cy.get('.icon-button.fa-code')
         .should('be.visible')
         .first()
@@ -69,7 +67,6 @@ describe('hide all file details', () => {
   });
 
   it('check show all file details shows the content of all the files', () => {
-
     cy.get('.icon-button.fa-code')
         .should('be.visible')
         .first()

--- a/frontend/cypress/tests/codeView/codeView_hideFileDetails.js
+++ b/frontend/cypress/tests/codeView/codeView_hideFileDetails.js
@@ -1,6 +1,5 @@
 describe('hide all file details', () => {
   it('check hide all file details hides the content of all the files', () => {
-    Cypress.wait();
 
     // open the code panel
     cy.get('.icon-button.fa-code')
@@ -29,7 +28,6 @@ describe('hide all file details', () => {
   });
 
   it('check details of one file are shown, rest are hidden', () => {
-    Cypress.wait();
 
     cy.get('.icon-button.fa-code')
         .should('be.visible')
@@ -71,7 +69,6 @@ describe('hide all file details', () => {
   });
 
   it('check show all file details shows the content of all the files', () => {
-    Cypress.wait();
 
     cy.get('.icon-button.fa-code')
         .should('be.visible')

--- a/frontend/cypress/tests/codeView/codeView_load_benchmark.js
+++ b/frontend/cypress/tests/codeView/codeView_load_benchmark.js
@@ -17,9 +17,6 @@ describe('load code view benchmark', () => {
   const timeTrial = function (i) {
     let startTime;
 
-    // ensure that icons are loaded
-    Cypress.wait();
-
     cy.get('#summary-wrapper .sort-within-group select').select(
         'totalCommits dsc',
     );

--- a/frontend/cypress/tests/codeView/codeView_reload.js
+++ b/frontend/cypress/tests/codeView/codeView_reload.js
@@ -1,6 +1,5 @@
 describe('reload page', () => {
   it('reload page should restore all controls', () => {
-    Cypress.wait();
 
     // open the code panel
     cy.get('.icon-button.fa-code')

--- a/frontend/cypress/tests/codeView/codeView_reload.js
+++ b/frontend/cypress/tests/codeView/codeView_reload.js
@@ -1,6 +1,5 @@
 describe('reload page', () => {
   it('reload page should restore all controls', () => {
-
     // open the code panel
     cy.get('.icon-button.fa-code')
         .should('be.visible')

--- a/frontend/cypress/tests/codeView/codeView_switchAuthorship.js
+++ b/frontend/cypress/tests/codeView/codeView_switchAuthorship.js
@@ -1,6 +1,5 @@
 describe('switch authorship', () => {
   it('switch authorship view should restore all default controls', () => {
-
     // open the code panel
     cy.get('.icon-button.fa-code')
         .should('be.visible')
@@ -53,7 +52,6 @@ describe('switch authorship', () => {
   });
 
   it('switch authorship view should not retain information from previous visited tabs', () => {
-
     // Assumptions:
     // The first repository has more than one person listed.
     // The first displayed file which the first and last person worked on is different.

--- a/frontend/cypress/tests/codeView/codeView_switchAuthorship.js
+++ b/frontend/cypress/tests/codeView/codeView_switchAuthorship.js
@@ -1,6 +1,5 @@
 describe('switch authorship', () => {
   it('switch authorship view should restore all default controls', () => {
-    Cypress.wait();
 
     // open the code panel
     cy.get('.icon-button.fa-code')
@@ -54,7 +53,6 @@ describe('switch authorship', () => {
   });
 
   it('switch authorship view should not retain information from previous visited tabs', () => {
-    Cypress.wait();
 
     // Assumptions:
     // The first repository has more than one person listed.

--- a/frontend/cypress/tests/zoomView/zoomView_hideCommitMessages.js
+++ b/frontend/cypress/tests/zoomView/zoomView_hideCommitMessages.js
@@ -1,6 +1,5 @@
 describe('hide all commit messages ', () => {
   it('check hide all commit messages hides the commit messages', () => {
-
     // open the commit panel
     cy.get('.icon-button.fa-list-ul')
         .should('be.visible')
@@ -28,7 +27,6 @@ describe('hide all commit messages ', () => {
   });
 
   it('check show all commit messages show the commit messages', () => {
-
     // open the commit panel
     cy.get('.icon-button.fa-list-ul')
         .should('be.visible')

--- a/frontend/cypress/tests/zoomView/zoomView_hideCommitMessages.js
+++ b/frontend/cypress/tests/zoomView/zoomView_hideCommitMessages.js
@@ -1,6 +1,5 @@
 describe('hide all commit messages ', () => {
   it('check hide all commit messages hides the commit messages', () => {
-    Cypress.wait();
 
     // open the commit panel
     cy.get('.icon-button.fa-list-ul')
@@ -29,7 +28,6 @@ describe('hide all commit messages ', () => {
   });
 
   it('check show all commit messages show the commit messages', () => {
-    Cypress.wait();
 
     // open the commit panel
     cy.get('.icon-button.fa-list-ul')

--- a/frontend/cypress/tests/zoomView/zoomView_reload.js
+++ b/frontend/cypress/tests/zoomView/zoomView_reload.js
@@ -1,6 +1,5 @@
 describe('reload page', () => {
   it('reload page should restore all controls', () => {
-    Cypress.wait();
 
     // open the commit panel
     cy.get('.icon-button.fa-list-ul')

--- a/frontend/cypress/tests/zoomView/zoomView_reload.js
+++ b/frontend/cypress/tests/zoomView/zoomView_reload.js
@@ -1,6 +1,5 @@
 describe('reload page', () => {
   it('reload page should restore all controls', () => {
-
     // open the commit panel
     cy.get('.icon-button.fa-list-ul')
         .should('be.visible')

--- a/frontend/cypress/tests/zoomView/zoomView_selectFileTypes.js
+++ b/frontend/cypress/tests/zoomView/zoomView_selectFileTypes.js
@@ -1,6 +1,5 @@
 describe('check file types ', () => {
   it('check if all file types are visible by default', () => {
-
     cy.get('.icon-button.fa-list-ul')
         .should('be.visible')
         .first()
@@ -14,7 +13,6 @@ describe('check file types ', () => {
   });
 
   it('uncheck all file types should show no files', () => {
-
     cy.get('.icon-button.fa-list-ul')
         .should('be.visible')
         .first()
@@ -33,7 +31,6 @@ describe('check file types ', () => {
   it('uncheck file type should uncheck all option and not show legend', () => {
     // Assumptions: the first author of the first repo
     // committed .java, .js and .gradle files.
-
     cy.get('.icon-button.fa-list-ul')
         .should('be.visible')
         .first()

--- a/frontend/cypress/tests/zoomView/zoomView_selectFileTypes.js
+++ b/frontend/cypress/tests/zoomView/zoomView_selectFileTypes.js
@@ -1,6 +1,5 @@
 describe('check file types ', () => {
   it('check if all file types are visible by default', () => {
-    Cypress.wait();
 
     cy.get('.icon-button.fa-list-ul')
         .should('be.visible')
@@ -15,7 +14,6 @@ describe('check file types ', () => {
   });
 
   it('uncheck all file types should show no files', () => {
-    Cypress.wait();
 
     cy.get('.icon-button.fa-list-ul')
         .should('be.visible')
@@ -35,7 +33,6 @@ describe('check file types ', () => {
   it('uncheck file type should uncheck all option and not show legend', () => {
     // Assumptions: the first author of the first repo
     // committed .java, .js and .gradle files.
-    Cypress.wait();
 
     cy.get('.icon-button.fa-list-ul')
         .should('be.visible')

--- a/frontend/cypress/tests/zoomView/zoomView_switchZoom.js
+++ b/frontend/cypress/tests/zoomView/zoomView_switchZoom.js
@@ -1,6 +1,5 @@
 describe('switch zoom', () => {
   it('switch zoom view should restore all default controls', () => {
-    Cypress.wait();
 
     // open the commit panel
     cy.get('.icon-button.fa-list-ul')
@@ -54,7 +53,6 @@ describe('switch zoom', () => {
   });
 
   it('switch zoom view should not retain information from previous visited tabs', () => {
-    Cypress.wait();
 
     // Assumptions:
     // The first repository has more than one person listed.

--- a/frontend/cypress/tests/zoomView/zoomView_switchZoom.js
+++ b/frontend/cypress/tests/zoomView/zoomView_switchZoom.js
@@ -1,6 +1,5 @@
 describe('switch zoom', () => {
   it('switch zoom view should restore all default controls', () => {
-
     // open the commit panel
     cy.get('.icon-button.fa-list-ul')
         .should('be.visible')
@@ -53,7 +52,6 @@ describe('switch zoom', () => {
   });
 
   it('switch zoom view should not retain information from previous visited tabs', () => {
-
     // Assumptions:
     // The first repository has more than one person listed.
     // The first day in which the first and last person contributed is different.


### PR DESCRIPTION
Fixes #1540 

Proposed commit message:
```
Cypress.wait() is placed at the start of every cypress test. However,
they do not serve any purpose other than to slow down the tests.

Let's remove them to speed up frontend testing.
```