### PR TITLE
Docs: update documentation for frontend architecture

### DIFF
--- a/docs/dg/report.md
+++ b/docs/dg/report.md
@@ -8,8 +8,6 @@
 
 The report's source files are located in [`frontend/src`](https://github.com/reposense/RepoSense/blob/master/frontend/src) and are built by [vue-cli](https://github.com/vuejs/vue-cli) before being packaged into the JAR file to be extracted as part of the report.
 
-Please note that there are plans to migrate the frontend to use Vue 3 and TypeScript, and better integration with Vuex is being considered. Hence, the information here may not be up to date. 
-
 [Vue](https://vuejs.org/v2/api/) (pronounced /vjuː/, like view) is a progressive framework for building user interfaces. It is heavily utilized in the report to update the information in the various views dynamically. (Style guide available [here](https://vuejs.org/v2/style-guide/), Developer tool available [here](https://chrome.google.com/webstore/detail/vuejs-devtools/nhdogjmejiglipccpnnnanhbledajbpd)). Vue lifecycle hooks are the defined methods that get executed in a particular stage of the Vue object lifespan. The following is the Vue lifecycle diagram taken from [here](https://vuejs.org/v2/guide/instance.html#Lifecycle-Diagram) indicating the hook sequence:
 ![vue lifecycle diagram](../images/vue-lifecycle-diagram.png)
 

--- a/docs/dg/report.md
+++ b/docs/dg/report.md
@@ -33,7 +33,8 @@ The tabbed interface is responsible for loading various modules such as authorsh
 
 ## Javascript and Vue files
 
-- [**main.js**](#main-main-js) - sets up plugins and 3rd party components used in the report
+- **main.js** - sets up plugins and 3rd party components used in the report
+- [**app.vue**](#app-app-vue) - module that supports the GUI
 - [**api.js**](#data-loader-api-js) - loading and parsing of the report content
 - [**v_summary.vue**](#summary-view-v-summary-vue) - module that supports the summary view
 - [**v_authorship.vue**](#authorship-view-v-authorship-vue) - module that supports the authorship tab view
@@ -53,7 +54,7 @@ The tabbed interface is responsible for loading various modules such as authorsh
 
 ## App ([app.vue](https://github.com/reposense/RepoSense/blob/master/frontend/src/app.vue))
 
-This contains the logic for the main VueJS object, `app.vue`, which is responsible for loading the relevant modules.
+This contains the logic for the main VueJS object, `app.vue`, which is the entrypoint for the web application.
 
 Vuex in `store.js` is used to pass the necessary data into the relevant modules.
 

--- a/docs/dg/report.md
+++ b/docs/dg/report.md
@@ -6,9 +6,9 @@
 
 <h1 class="display-4"><md>{{ title }}</md></h1>
 
-The report's source files are located in [`frontend/src`](https://github.com/reposense/RepoSense/blob/master/frontend/src) and are built by [spuild](https://github.com/ongspxm/spuild2) before being packaged into the JAR file to be extracted as part of the report.
+The report's source files are located in [`frontend/src`](https://github.com/reposense/RepoSense/blob/master/frontend/src) and are built by [vue-cli](https://github.com/vuejs/vue-cli) before being packaged into the JAR file to be extracted as part of the report.
 
-The main HTML file is generated from [`frontend/src/index.pug`](https://github.com/reposense/RepoSense/blob/master/frontend/src/index.pug).
+Please note that there are plans to migrate the frontend to use Vue 3 and TypeScript, and better integration with Vuex is being considered. Hence, the information here may not be up to date. 
 
 [Vue](https://vuejs.org/v2/api/) (pronounced /vjuː/, like view) is a progressive framework for building user interfaces. It is heavily utilized in the report to update the information in the various views dynamically. (Style guide available [here](https://vuejs.org/v2/style-guide/), Developer tool available [here](https://chrome.google.com/webstore/detail/vuejs-devtools/nhdogjmejiglipccpnnnanhbledajbpd)). Vue lifecycle hooks are the defined methods that get executed in a particular stage of the Vue object lifespan. The following is the Vue lifecycle diagram taken from [here](https://vuejs.org/v2/guide/instance.html#Lifecycle-Diagram) indicating the hook sequence:
 ![vue lifecycle diagram](../images/vue-lifecycle-diagram.png)
@@ -22,9 +22,9 @@ The following is a snapshot of the report:
 
 ![report architecture](../images/report-architecture.png)
 
-The main Vue object (`window.app`) is responsible for loading the report (through `summary.json`). Its `repos` attribute is tied to the global `window.REPOS`, and is passed into the various other modules when the information is needed.
+The main Vue object (`app.vue`) is responsible for loading the report via an async call to `api.js`, which parses `summary.json`. Its `repos` attribute is tied to the global `window.REPOS`, and is passed into the various other modules when the information is needed.
 
-`window.app` is broken down into two main parts
+The GUI is broken down into two main parts
 - the summary view
 - and the tabbed interface
 
@@ -35,7 +35,7 @@ The tabbed interface is responsible for loading various modules such as authorsh
 
 ## Javascript and Vue files
 
-- [**main.js**](#main-main-js) - main controller that pushes content into different modules
+- [**main.js**](#main-main-js) - sets up plugins and 3rd party components used in the report
 - [**api.js**](#data-loader-api-js) - loading and parsing of the report content
 - [**v_summary.vue**](#summary-view-v-summary-vue) - module that supports the summary view
 - [**v_authorship.vue**](#authorship-view-v-authorship-vue) - module that supports the authorship tab view
@@ -53,11 +53,13 @@ The tabbed interface is responsible for loading various modules such as authorsh
 
 <!-- ==================================================================================================== -->
 
-## Main ([main.js](https://github.com/reposense/RepoSense/blob/master/frontend/src/main.js))
+## App ([app.vue](https://github.com/reposense/RepoSense/blob/master/frontend/src/app.vue))
 
-This contains the logic for the main VueJS object, `window.app`, which is responsible for passing the necessary data into the relevant modules to be loaded.
+This contains the logic for the main VueJS object, `app.vue`, which is responsible for loading the relevant modules.
 
-`v_summary`, `v_authorship`, `v_zoom`, `v_segment`, and `v_ramp` are components embedded into the report and will render the corresponding content based on the data passed into it from the main `window.app`.
+Vuex in `store.js` is used to pass the necessary data into the relevant modules.
+
+`v_summary`, `v_authorship`, `v_zoom`, `v_segment`, and `v_ramp` are components embedded into the report and will render the corresponding content based on the data passed into it from Vuex.
 
 ### Loading of report information
 The main Vue object depends on the `summary.json` data to determine the right `commits.json` files to load into memory. This is handled by `api.js`, which loads the relevant file information from the network files if available; otherwise, a report archive, `archive.zip`, has to be used.
@@ -65,7 +67,7 @@ The main Vue object depends on the `summary.json` data to determine the right `c
 Once the relevant `commit.json` files are loaded, all the repo information will be passed into `v_summary` to be loaded in the summary view as the relevant ramp charts.
 
 ### Activating additional view modules
-Most activity or actions should happen within the module itself, but in the case where there is a need to spawn or alter the view of another module, an event is emitted from the first module to the main Vue object (`window.app`), which then handles the data received and passes it along to the relevant modules.
+Most activity or actions should happen within the module itself, but in the case where there is a need to spawn or alter the view of another module, an event is emitted from the first module to the Vuex store, which then handles the data received and passes it along to the relevant modules.
 
 ### Hash link
 Other than the global main Vue object, another global variable we have is the `window.hashParams`. This object is responsible for generating the relevant permalink for a specific view of the report's summary module.

--- a/docs/dg/report.md
+++ b/docs/dg/report.md
@@ -22,7 +22,7 @@ The following is a snapshot of the report:
 
 The main Vue object (`app.vue`) is responsible for loading the report via an async call to `api.js`, which parses `summary.json`. Its `repos` attribute is tied to the global `window.REPOS`, and is passed into the various other modules when the information is needed.
 
-The GUI is broken down into two main parts
+The report interface is broken down into two main parts
 - the summary view
 - and the tabbed interface
 
@@ -34,7 +34,7 @@ The tabbed interface is responsible for loading various modules such as authorsh
 ## Javascript and Vue files
 
 - **main.js** - sets up plugins and 3rd party components used in the report
-- [**app.vue**](#app-app-vue) - module that supports the GUI
+- [**app.vue**](#app-app-vue) - module that supports the report interface
 - [**api.js**](#data-loader-api-js) - loading and parsing of the report content
 - [**v_summary.vue**](#summary-view-v-summary-vue) - module that supports the summary view
 - [**v_authorship.vue**](#authorship-view-v-authorship-vue) - module that supports the authorship tab view
@@ -54,7 +54,7 @@ The tabbed interface is responsible for loading various modules such as authorsh
 
 ## App ([app.vue](https://github.com/reposense/RepoSense/blob/master/frontend/src/app.vue))
 
-This contains the logic for the main VueJS object, `app.vue`, which is the entrypoint for the web application.
+This contains the logic for the main VueJS object, `app.vue`, which is the entry point for the web application.
 
 Vuex in `store.js` is used to pass the necessary data into the relevant modules.
 


### PR DESCRIPTION
Commit message:
```
In the developer documentation, report.md lists spuild as a dependency
even though it is no longer being used anywhere in the project.

Furthermore, some of the descriptions for how data is managed is
outdated.

Let's correct some of the outdated information in the documentation.
```

Additional information:

Every sequence diagram in `report.md` is wrong as no data actually passes through `app.vue`.