### PR TITLE
Frontend: remove deprecated beforeDestroy() syntax

### DIFF
--- a/frontend/src/views/v-zoom.vue
+++ b/frontend/src/views/v-zoom.vue
@@ -391,7 +391,7 @@ export default {
     this.retrieveHashes();
     this.setInfoHash();
   },
-  beforeDestroy() {
+  beforeUnmount() {
     this.removeZoomHashes();
   },
 };


### PR DESCRIPTION
Part of #1627.

```
beforeDestroy() is replaced by beforeUnmount() and it is not supported
in Vue 3.

Let's update the usages of beforeDestroy() and replace it with
beforeUnmount().
```

Details can be found [here](https://v3-migration.vuejs.org/migration-build.html#fully-compatible).