### PR TITLE
Frontend: combine v-for and v-if

### DIFF
--- a/frontend/src/components/v-ramp.vue
+++ b/frontend/src/components/v-ramp.vue
@@ -5,7 +5,7 @@
       a.ramp__slice(
         draggable="false",
         v-on:click="rampClick",
-        v-for="(commit, k) in slice.commitResults.filter(commitResult => commitResult.insertions>0)",
+        v-for="(commit, k) in slice.commitResults.filter(commitResult => commitResult.insertions > 0)",
         v-bind:href="getLink(commit)", target="_blank",
         v-bind:title="getContributionMessage(slice, commit)",
         v-bind:class="'ramp__slice--color' + getSliceColor(slice.date)",
@@ -20,7 +20,7 @@
   template(v-else)
     a.ramp__slice(
       draggable="false",
-      v-for="(slice, j) in user.commits.filter(commit => commit.insertions>0)",
+      v-for="(slice, j) in user.commits.filter(commit => commit.insertions > 0)",
       v-bind:title="getContributionMessage(slice)",
       v-on:click="openTabZoom(user, slice, $event)",
       v-bind:class="'ramp__slice--color' + getSliceColor(slice.date)",

--- a/frontend/src/components/v-ramp.vue
+++ b/frontend/src/components/v-ramp.vue
@@ -5,8 +5,7 @@
       a.ramp__slice(
         draggable="false",
         v-on:click="rampClick",
-        v-for="(commit, k) in slice.commitResults",
-        v-if="commit.insertions>0",
+        v-for="(commit, k) in slice.commitResults.filter(commitResult => commitResult.insertions>0)",
         v-bind:href="getLink(commit)", target="_blank",
         v-bind:title="getContributionMessage(slice, commit)",
         v-bind:class="'ramp__slice--color' + getSliceColor(slice.date)",
@@ -21,8 +20,7 @@
   template(v-else)
     a.ramp__slice(
       draggable="false",
-      v-for="(slice, j) in user.commits",
-      v-if="slice.insertions > 0",
+      v-for="(slice, j) in user.commits.filter(commit => commit.insertions>0)",
       v-bind:title="getContributionMessage(slice)",
       v-on:click="openTabZoom(user, slice, $event)",
       v-bind:class="'ramp__slice--color' + getSliceColor(slice.date)",


### PR DESCRIPTION
Part of #1627.

```
In Vue 2, when they exist on the same node, v-if has a lower priority
than v-for. However, this is the opposite in Vue 3.

Let's use the recommended filtered array to avoid ambiguity.
```

Details can be found [here](https://vuejs.org/guide/essentials/list.html#v-for-with-v-if).