### PR TITLE
Standardise PUML usage

### DIFF
--- a/docs/dg/report.md
+++ b/docs/dg/report.md
@@ -18,7 +18,7 @@ The following is a snapshot of the report:
 
 ## Report architecture
 
-![report architecture](../images/report-architecture.png)
+<puml src="../diagrams/ReportArchitecture.puml"/>
 
 The main Vue object (`app.vue`) is responsible for loading the report via an async call to `api.js`, which parses `summary.json`. Its `repos` attribute is tied to the global `window.REPOS`, and is passed into the various other modules when the information is needed.
 


### PR DESCRIPTION
Proposed Commit Message:
```
Overall report architecture image is a static image while other
PUML diagrams are rendered using MarkBind.

Let's change the report architecture image to use MarkBind
PUML rendering.
```