### PR TITLE
[#1202] Missing javadoc for functions - Test and Systemtest

### DIFF
--- a/src/systemtest/java/reposense/ConfigSystemTest.java
+++ b/src/systemtest/java/reposense/ConfigSystemTest.java
@@ -133,8 +133,16 @@ public class ConfigSystemTest {
     }
 
     /**
-     * Generates the testing report and then compared it with the expected report
-     * Re-generates a normal report after the testing finished if the first report is shallow-cloned
+     * Generates the testing report and compares it with the expected report.
+     * Re-generates a normal report after the testing finished if the first report is shallow-cloned.
+     *
+     * @param inputDates The date range for analysis.
+     * @param shouldIncludeModifiedDateInLines Boolean for whether to include last modified date for authorship.
+     * @param shallowCloning Boolean for whether to perform shallow cloning.
+     * @param shouldFreshClone Boolean for whether to clone repo again if it has been cloned before.
+     * @param findPreviousAuthors Boolean for whether to find and blame previous authors for ignored commits.
+     * @param pathToResource The location at which files generated during the test are stored.
+     * @throws Exception if any occur during testing.
      */
     private void runTest(String inputDates, boolean shouldIncludeModifiedDateInLines,
                         boolean shallowCloning, boolean shouldFreshClone, boolean findPreviousAuthors,
@@ -148,6 +156,13 @@ public class ConfigSystemTest {
 
     /**
      * Generates the testing report to be compared with expected report.
+     *
+     * @param inputDates The date range for analysis.
+     * @param shouldIncludeModifiedDateInLines Boolean for whether to include last modified date for authorship.
+     * @param shallowCloning Boolean for whether to perform shallow cloning.
+     * @param shouldFreshClone Boolean for whether to clone repo again if it has been cloned before.
+     * @param findPreviousAuthors Boolean for whether to find and blame previous authors for ignored commits.
+     * @throws Exception if any errors occur during testing.
      */
     private void generateReport(String inputDates, boolean shouldIncludeModifiedDateInLines,
                                 boolean shallowCloning, boolean shouldFreshClone,
@@ -207,7 +222,7 @@ public class ConfigSystemTest {
     }
 
     /**
-     * Verifies all JSON files in {@code actualDirectory} with {@code expectedDirectory}
+     * Verifies all JSON files in {@code actualRelative} with {@code expectedDirectory}.
      */
     private void verifyAllJson(Path expectedDirectory, String actualRelative) {
         try (Stream<Path> pathStream = Files.list(expectedDirectory)) {
@@ -226,7 +241,8 @@ public class ConfigSystemTest {
     }
 
     /**
-     * Asserts the correctness of given JSON file.
+     * Asserts the correctness of given JSON file at {@code actualRelative} and {@code expectedPosition} by comparing
+     * it with {@code expectedJson}.
      */
     private void assertJson(Path expectedJson, String expectedPosition, String actualRelative) {
         Path actualJson = Paths.get(actualRelative, expectedPosition);

--- a/src/test/java/reposense/commits/CommitInfoAnalyzerTest.java
+++ b/src/test/java/reposense/commits/CommitInfoAnalyzerTest.java
@@ -434,7 +434,7 @@ public class CommitInfoAnalyzerTest extends GitTestTemplate {
     }
 
     /**
-     * Returns a {@code LocalDateTime} from a string {@code gitStrictIsoDate}.
+     * Returns a {@link LocalDateTime} from a string {@code gitStrictIsoDate}.
      */
     private LocalDateTime parseGitStrictIsoDate(String gitStrictIsoDate) throws Exception {
         return ZonedDateTime.parse(gitStrictIsoDate, CommitInfoAnalyzer.GIT_STRICT_ISO_DATE_FORMAT)

--- a/src/test/java/reposense/model/RepoLocationTest.java
+++ b/src/test/java/reposense/model/RepoLocationTest.java
@@ -47,7 +47,8 @@ public class RepoLocationTest {
     }
 
     /**
-     * Compares the information parsed by the RepoLocation model with the expected information
+     * Compares the information of {@code rawLocation} parsed by the RepoLocation model with {@code expectedRepoName}
+     * and {@code expectedOrganization}.
      */
     public void assertValidLocation(String rawLocation, String expectedRepoName,
             String expectedOrganization) throws Exception {

--- a/src/test/java/reposense/parser/ArgsParserTest.java
+++ b/src/test/java/reposense/parser/ArgsParserTest.java
@@ -710,6 +710,7 @@ public class ArgsParserTest {
 
     /**
      * Ensures that {@code actualSinceDate} is exactly one month before {@code untilDate}.
+     *
      * @throws AssertionError if {@code actualSinceDate} is not one month before {@code untilDate}.
      */
     private void assertDateDiffOneMonth(LocalDateTime actualSinceDate, LocalDateTime untilDate) {
@@ -719,6 +720,7 @@ public class ArgsParserTest {
 
     /**
      * Ensures that {@code actualUntilDate} falls on the date of report generation with time at 23:59:59.
+     *
      * @throws AssertionError if {@code actualUntilDate} does not fall on the date of report generation
      * with time at 23:59:59.
      */

--- a/src/test/java/reposense/template/GitTestTemplate.java
+++ b/src/test/java/reposense/template/GitTestTemplate.java
@@ -117,7 +117,7 @@ public class GitTestTemplate {
     }
 
     /**
-     * Generates the information for test file.
+     * Generates the information for test file at {@code relativePath}.
      */
     public FileInfo generateTestFileInfo(String relativePath) {
         FileInfo fileInfo = FileInfoExtractor.generateFileInfo(config.getRepoRoot(), relativePath);
@@ -130,7 +130,7 @@ public class GitTestTemplate {
     }
 
     /**
-     * Generates the .git-blame-ignore-revs file containing {@code CommitHash}
+     * Generates the .git-blame-ignore-revs file containing {@link CommitHash}es
      * from {@code toIgnore} for the test repo.
      */
     public List<CommitHash> createTestIgnoreRevsFile(List<CommitHash> toIgnore) {
@@ -159,7 +159,7 @@ public class GitTestTemplate {
     }
 
     /**
-     * For each line in {@code FileResult}, assert that it is attributed to the expected author provided by
+     * For each line in {@link FileResult}, assert that it is attributed to the expected author provided by
      * {@code expectedLineAuthors}.
      */
     public void assertFileAnalysisCorrectness(FileResult fileResult, List<Author> expectedLineAuthors) {
@@ -175,7 +175,7 @@ public class GitTestTemplate {
     }
 
     /**
-     * Returns a {@code Author} that has git id and aliases of all authors in testrepo-Alpha, so that no commits
+     * Returns a {@link Author} that has git id and aliases of all authors in testrepo-Alpha, so that no commits
      * will be filtered out in the `git log` command.
      */
     protected Author getAlphaAllAliasAuthor() {

--- a/src/test/java/reposense/util/AssertUtil.java
+++ b/src/test/java/reposense/util/AssertUtil.java
@@ -18,7 +18,10 @@ public class AssertUtil {
      * Asserts that the {@code callable} throws the {@code expectedException} and the {@code expectedMessage}.
      * If there's no need for the verification of the exception's error message, call
      * {@code assertThrows(Class<? extends Throwable>, VoidCallable)} instead.
-     * {@see assertThrows(Class<? extends Throwable>, VoidCallable}
+     * {@see assertThrows(Class<? extends Throwable>, VoidCallable)}
+     *
+     * @throws AssertionFailedError if the {@code expectedException} is not thrown or {@code expectedMessage}
+     * is not correct after calling {@code callable}.
      */
     public static void assertThrows(Class<? extends Throwable> expectedException, String expectedMessage,
                                     VoidCallable callable) {

--- a/src/test/java/reposense/util/InputBuilder.java
+++ b/src/test/java/reposense/util/InputBuilder.java
@@ -19,7 +19,7 @@ public class InputBuilder {
     }
 
     /**
-     * Returns the {@code input} generated from this {@code InputBuilder}
+     * Returns the {@code input} generated from this {@link InputBuilder}.
      */
     public String build() {
         return input.toString();

--- a/src/test/java/reposense/util/TestUtil.java
+++ b/src/test/java/reposense/util/TestUtil.java
@@ -24,7 +24,6 @@ import reposense.model.RepoConfiguration;
 public class TestUtil {
     private static final int[] END_OF_DAY_TIME = {23, 59, 59};
     private static final int[] START_OF_DAY_TIME = {0, 0, 0};
-    private static final ZoneId TIME_ZONE_ID = getZoneId("Asia/Singapore");
     private static final String MESSAGE_COMPARING_FILES = "Comparing files %s & %s\n";
 
     private static final String MESSAGE_LINE_CONTENT_DIFFERENT = "Content different at line number %d:\n"
@@ -37,7 +36,7 @@ public class TestUtil {
     private static final int STAT_FILE_PATH_INDEX = 2;
 
     /**
-     * Returns true if the files' contents are the same.
+     * Returns true if the contents of the files at {@code expected} and {@code actual} are the same.
      * Also prints out error message if the lines count are different,
      * else prints out the first line of content difference (if any).
      */
@@ -46,7 +45,7 @@ public class TestUtil {
     }
 
     /**
-     * Returns true if the files' contents are the same.
+     * Returns true if the contents of the files at {@code expected} and {@code actual} are the same.
      * Also prints out error message if the lines count are different,
      * else prints out maximum {@code maxTraceCounts} lines of content difference (if any).
      */
@@ -103,28 +102,31 @@ public class TestUtil {
     }
 
     /**
-     * Creates and returns a {@code LocalDateTime} object with the specified {@code year}, {@code month}, {@code day}.
+     * Creates and returns a {@link LocalDateTime} object with the specified {@code year}, {@code month}, {@code day}
+     * and {@code time}.
      */
     public static LocalDateTime getDate(int year, int month, int date, int[] time) {
         return LocalDateTime.of(year, month, date, time[0], time[1], time[2], 0);
     }
 
     /**
-     * Wrapper for {@code getDate} method to get since date with time 00:00:00
+     * Wrapper for {@code getDate} method to get since date with time 00:00:00 from the parameters {@code year},
+     * {@code month}, {@code date}.
      */
     public static LocalDateTime getSinceDate(int year, int month, int date) {
         return getDate(year, month, date, START_OF_DAY_TIME);
     }
 
     /**
-     * Wrapper for {@code getDate} method to get until date with time 23:59:59
+     * Wrapper for {@code getDate} method to get until date with time 23:59:59 from the parameters {@code year},
+     * {@code month}, {@code date}.
      */
     public static LocalDateTime getUntilDate(int year, int month, int date) {
         return getDate(year, month, date, END_OF_DAY_TIME);
     }
 
     /**
-     * Returns a {@code ZoneId} object for the specified {@code timezone}.
+     * Returns a {@link ZoneId} object for the specified {@code timezone}.
      */
     public static ZoneId getZoneId(String timezone) {
         return ZoneId.of(timezone);
@@ -191,7 +193,7 @@ public class TestUtil {
     }
 
     /**
-     * Returns the {@code set} of files changed in the commit {@code rawCommitInfo}.
+     * Returns the {@link Set} of files changed in the commit {@code rawCommitInfo}.
      */
     private static Set<String> getFilesChangedInCommit(String rawCommitInfo) {
         Set<String> filesChanged = new HashSet<>();
@@ -223,7 +225,7 @@ public class TestUtil {
     }
 
     /**
-     * Returns the path to a resource
+     * Returns the {@link Path} to a resource given by {@code pathToResource} string, using {@code classForLoading}.
      */
     public static Path loadResource(Class<?> classForLoading, String pathToResource) {
         ClassLoader classLoader = classForLoading.getClassLoader();


### PR DESCRIPTION
Part of #1202 

Proposed Commit Message:
```
Some Javadoc in test and systemtest code is inconsistent or missing.

Let's add missing Javadoc and standardise the style.
```

Proposed Javadoc standard for RepoSense (in addition to what is already covered in [SE-EDU](https://se-education.org/guides/conventions/java/index.html#comments) and [Google](https://google.github.io/styleguide/javaguide.html#s7-javadoc)) can be found in:

* Raw styleGuides.md file: https://github.com/reposense/RepoSense/pull/1650/files#diff-bd63b2861c8a46fbd8a67f313e555901c8d6d06762d1c0551c3254467f45b484
* Style Guides on surge.sh: https://docs-1650-pr-reposense-reposense.surge.sh/dg/styleGuides.html