### PR TITLE
[#1202] Missing javadoc for functions - Authorship

### DIFF
--- a/src/main/java/reposense/authorship/FileInfoAnalyzer.java
+++ b/src/main/java/reposense/authorship/FileInfoAnalyzer.java
@@ -25,7 +25,7 @@ import reposense.system.LogsManager;
 import reposense.util.FileUtil;
 
 /**
- * Analyzes the target and information given in the {@code FileInfo}.
+ * Analyzes the target and information given in the {@link FileInfo}.
  */
 public class FileInfoAnalyzer {
     private static final Logger logger = LogsManager.getLogger(FileInfoAnalyzer.class);
@@ -46,7 +46,7 @@ public class FileInfoAnalyzer {
      * Analyzes the lines of the file, given in the {@code fileInfo}, that has changed in the time period provided
      * by {@code config}.
      * Returns null if the file is missing from the local system, or none of the
-     * {@code Author} specified in {@code config} contributed to the file in {@code fileInfo}.
+     * {@link Author} specified in {@code config} contributed to the file in {@code fileInfo}.
      */
     public static FileResult analyzeTextFile(RepoConfiguration config, FileInfo fileInfo) {
         String relativePath = fileInfo.getPath();
@@ -75,8 +75,8 @@ public class FileInfoAnalyzer {
     /**
      * Analyzes the binary file, given in the {@code fileInfo}, that has changed in the time period provided
      * by {@code config}.
-     * Returns null if the file is missing from the local system, or none of the
-     * {@code Author} specified in {@code config} contributed to the file in {@code fileInfo}.
+     * Returns null if the file is missing from the local system, or none of the {@link Author} specified in
+     * {@code config} contributed to the file in {@code fileInfo}.
      */
     public static FileResult analyzeBinaryFile(RepoConfiguration config, FileInfo fileInfo) {
         String relativePath = fileInfo.getPath();
@@ -92,7 +92,7 @@ public class FileInfoAnalyzer {
     }
 
     /**
-     * Generates and returns a {@code FileResult} with the authorship results from {@code fileInfo} consolidated.
+     * Generates and returns a {@link FileResult} with the authorship results from {@code fileInfo} consolidated.
      */
     private static FileResult generateTextFileResult(FileInfo fileInfo) {
         HashMap<Author, Integer> authorContributionMap = new HashMap<>();
@@ -105,9 +105,9 @@ public class FileInfoAnalyzer {
     }
 
     /**
-     * Generates and returns a {@code FileResult} with the authorship results from binary {@code fileInfo} consolidated.
+     * Generates and returns a {@link FileResult} with the authorship results from binary {@code fileInfo} consolidated.
      * Authorship results are indicated in the {@code authorContributionMap} as contributions with zero line counts.
-     * Returns {@code null} if none of the {@code Author} specified in {@code config} contributed to the file in
+     * Returns {@code null} if none of the {@link Author} specified in {@code config} contributed to the file in
      * {@code fileInfo}.
      */
     private static FileResult generateBinaryFileResult(RepoConfiguration config, FileInfo fileInfo) {
@@ -134,8 +134,11 @@ public class FileInfoAnalyzer {
     }
 
     /**
-     * Sets the {@code Author} and {@code Date} for each line in {@code fileInfo} based on the git blame analysis
-     * on the file.
+     * Sets the {@link Author} and {@link LocalDateTime} for each line in {@code fileInfo} based on the git blame
+     * analysis of the file.
+     * The {@code config} is used to obtain the root directory for running git blame as well as other parameters used
+     * in determining which author to assign to each line and whether to set the last modified date for a
+     * {@code lineInfo}.
      */
     private static void aggregateBlameAuthorModifiedAndDateInfo(RepoConfiguration config, FileInfo fileInfo) {
         String blameResults;
@@ -180,14 +183,16 @@ public class FileInfoAnalyzer {
     }
 
     /**
-     * Returns the analysis result from running git blame on {@code filePath}.
+     * Returns the analysis result from running git blame on {@code filePath} with reference to the root directory
+     * given in {@code config}.
      */
     private static String getGitBlameResult(RepoConfiguration config, String filePath) {
         return GitBlame.blame(config.getRepoRoot(), filePath);
     }
 
     /**
-     * Returns the analysis result from running git blame with finding previous authors enabled on {@code filePath}.
+     * Returns the analysis result from running git blame with finding previous authors enabled on {@code filePath}
+     * with reference to the root directory given in {@code config}.
      */
     private static String getGitBlameWithPreviousAuthorsResult(RepoConfiguration config, String filePath) {
         return GitBlame.blameWithPreviousAuthors(config.getRepoRoot(), filePath);

--- a/src/main/java/reposense/authorship/FileInfoExtractor.java
+++ b/src/main/java/reposense/authorship/FileInfoExtractor.java
@@ -89,9 +89,9 @@ public class FileInfoExtractor {
     }
 
     /**
-     * Generates a list of relevant {@code FileInfo} for all files that were edited in between the current
-     * commit and the {@code lastCommitHash} commit, marks each {@code LineInfo} for each {@code FileInfo} on
-     * whether they have been inserted within the commit range or not, and returns it.
+     * Returns a list of {@link FileInfo}s for all files in the repo with lines marked indicating if they were edited
+     * in between the current commit and the commit given by {@code lastCommitHash}.
+     * The repo is given by {@code config}.
      */
     public static List<FileInfo> getEditedFileInfos(RepoConfiguration config, String lastCommitHash) {
         List<FileInfo> fileInfos = new ArrayList<>();
@@ -134,9 +134,9 @@ public class FileInfoExtractor {
     }
 
     /**
-     * Returns a {@code Set} of non-binary files for the repo {@code repoConfig}
+     * Returns a {@link Set} of non-binary files for the repo {@code repoConfig}
      * if {@code isBinaryFiles} is set to `false`.
-     * Otherwise, returns a {@code Set} of binary files for the repo {@code repoConfig}
+     * Otherwise, returns a {@link Set} of binary files for the repo {@code repoConfig}.
      */
     public static Set<Path> getFiles(RepoConfiguration repoConfig, boolean isBinaryFile) {
         List<String> modifiedFileList = GitDiff.getModifiedFilesList(Paths.get(repoConfig.getRepoRoot()));
@@ -187,8 +187,10 @@ public class FileInfoExtractor {
     }
 
     /**
-     * Traverses each file from the repo root directory, generates the {@code FileInfo} for each relevant file found
+     * Traverses each file from the repo root directory, generates the {@link FileInfo} for each relevant file found
      * based on {@code config} and inserts it into {@code fileInfos}.
+     * Adds binary files to {@link List} if {@code isBinaryFiles} is true. Otherwise, adds non-binary files
+     * to {@link List}.
      */
     private static List<FileInfo> getAllFileInfo(RepoConfiguration config, boolean isBinaryFiles) {
         List<FileInfo> fileInfos = new ArrayList<>();
@@ -205,8 +207,8 @@ public class FileInfoExtractor {
     }
 
     /**
-     * Generates and returns a {@code FileInfo} with a list of {@code LineInfo} for each line content in the
-     * {@code relativePath} file.
+     * Returns a {@link FileInfo} with a list of {@link LineInfo} for each line content in the
+     * file located at the {@link Path} given by {@code repoRoot}/{@code relativePath}.
      */
     public static FileInfo generateFileInfo(String repoRoot, String relativePath) {
         FileInfo fileInfo = new FileInfo(relativePath);
@@ -240,7 +242,7 @@ public class FileInfoExtractor {
     }
 
     /**
-     * Returns true if {@code filePath} is valid and the file is not in binary.
+     * Returns true if {@code filePath} is valid and the file is not in binary (i.e. part of {@code textFilesSet}).
      */
     private static boolean isValidTextFile(String filePath, Set<Path> textFilesSet) {
         boolean isValidFilePath;

--- a/src/main/java/reposense/authorship/FileResultAggregator.java
+++ b/src/main/java/reposense/authorship/FileResultAggregator.java
@@ -14,7 +14,8 @@ import reposense.model.FileType;
 public class FileResultAggregator {
 
     /**
-     * Returns the {@code AuthorshipSummary} generated from aggregating the {@code fileResults}.
+     * Returns the {@link AuthorshipSummary} generated from aggregating the {@code fileResults} and {@code fileTypes}
+     * for each {@link Author} in the list of {@code authors}.
      */
     public static AuthorshipSummary aggregateFileResult(List<FileResult> fileResults, List<Author> authors,
             List<FileType> fileTypes) {

--- a/src/main/java/reposense/authorship/model/FileInfo.java
+++ b/src/main/java/reposense/authorship/model/FileInfo.java
@@ -9,7 +9,7 @@ import reposense.model.FileType;
 import reposense.util.SystemUtil;
 
 /**
- * Stores the path to the file and the list of {@code LineInfo} for each line in the file.
+ * Stores the path to the file and the list of {@link LineInfo} for each line in the file.
  */
 public class FileInfo {
     private final String path;
@@ -28,7 +28,7 @@ public class FileInfo {
     }
 
     /**
-     * Returns true if none of the {@code Author} in {@code listedAuthors} contributed to this file.
+     * Returns true if none of the {@link Author} in {@code listedAuthors} contributed to this file.
      */
     public boolean isAllAuthorsIgnored(List<Author> listedAuthors) {
         return lines.stream().noneMatch(line -> listedAuthors.contains(line.getAuthor()));
@@ -63,21 +63,21 @@ public class FileInfo {
     }
 
     /**
-     * Sets the {@code Author} of the {@code LineInfo} in {@code lineNumber} for this {@code FileInfo}.
+     * Sets the {@link Author} of the {@link LineInfo} in {@code lineNumber} for this {@link FileInfo}.
      */
     public void setLineAuthor(int lineNumber, Author author) {
         lines.get(lineNumber).setAuthor(author);
     }
 
     /**
-     * Sets the {@code lastModifiedDate} of the {@code LineInfo} in {@code lineNumber} for this {@code FileInfo}.
+     * Sets the {@code lastModifiedDate} of the {@link LineInfo} in {@code lineNumber} for this {@link FileInfo}.
      */
     public void setLineLastModifiedDate(int lineNumber, LocalDateTime lastModifiedDate) {
         lines.get(lineNumber).setLastModifiedDate(lastModifiedDate);
     }
 
     /**
-     * Returns true if the {@code LineInfo} in {@code lineNumber} index is being tracked.
+     * Returns true if the {@link LineInfo} in {@code lineNumber} index is being tracked.
      */
     public boolean isFileLineTracked(int lineNumber) {
         return getLines().get(lineNumber).isTracked();

--- a/src/main/java/reposense/authorship/model/FileResult.java
+++ b/src/main/java/reposense/authorship/model/FileResult.java
@@ -8,7 +8,7 @@ import reposense.model.Author;
 import reposense.model.FileType;
 
 /**
- * Stores the result from analyzing a {@code FileInfo}.
+ * Stores the result from analyzing a {@link FileInfo}.
  */
 public class FileResult {
     private final String path;

--- a/src/main/java/reposense/authorship/model/LineInfo.java
+++ b/src/main/java/reposense/authorship/model/LineInfo.java
@@ -6,7 +6,7 @@ import java.util.Objects;
 import reposense.model.Author;
 
 /**
- * Stores the information of a line in a {@code FileInfo}.
+ * Stores the information of a line in a {@link FileInfo}.
  */
 public class LineInfo {
     private int lineNumber;


### PR DESCRIPTION
Part of #1202 

Proposed Commit Message:
```
Some Javadoc in authorship package is inconsistent or missing.

Let's add missing Javadoc and standardise the style.
```

Proposed Javadoc standard for RepoSense (in addition to what is already covered in [SE-EDU](https://se-education.org/guides/conventions/java/index.html#comments) and [Google](https://google.github.io/styleguide/javaguide.html#s7-javadoc)) can be found in:

* Raw styleGuides.md file: https://github.com/reposense/RepoSense/pull/1650/files#diff-bd63b2861c8a46fbd8a67f313e555901c8d6d06762d1c0551c3254467f45b484
* Style Guides on surge.sh: https://docs-1650-pr-reposense-reposense.surge.sh/dg/styleGuides.html