### PR TITLE
[#1202] Missing javadoc for functions - Util

### DIFF
--- a/src/main/java/reposense/util/FileUtil.java
+++ b/src/main/java/reposense/util/FileUtil.java
@@ -95,8 +95,9 @@ public class FileUtil {
 
     /**
      * Writes the JSON file representing the {@code object} at the given {@code path}.
-     * @return An Optional containing the Path to the JSON file, or an empty Optional
-     *         if there was an error while writing the JSON file.
+     *
+     * @return An {@link Optional} containing the {@link Path} to the JSON file, or an empty {@link Optional} if there
+     * was an error while writing the JSON file.
      */
     public static Optional<Path> writeJsonFile(Object object, String path) {
         Gson gson = new GsonBuilder()
@@ -120,8 +121,9 @@ public class FileUtil {
 
     /**
      * Writes the ignore revs file containing the {@code ignoreCommitList} at the given {@code path}.
-     * @return An Optional containing the Path to the ignore revs file, or an empty Optional
-     *         if there was an error while writing the ignore revs file.
+     *
+     * @return An {@link Optional} containing the {@link Path} to the ignore revs file, or an empty {@link Optional}
+     * if there was an error while writing the ignore revs file.
      */
     public static Optional<Path> writeIgnoreRevsFile(String path, List<CommitHash> ignoreCommitList) {
         String contentOfIgnoreRevsFile = ignoreCommitList.stream()
@@ -139,6 +141,7 @@ public class FileUtil {
 
     /**
      * Deletes the {@code root} directory.
+     *
      * @throws IOException if the root path does not exist.
      */
     public static void deleteDirectory(String root) throws IOException {
@@ -160,6 +163,7 @@ public class FileUtil {
 
     /**
      * Unzips the contents of the {@code zipSourcePath} into {@code outputPath}.
+     *
      * @throws IOException if {@code zipSourcePath} is an invalid path.
      */
     public static void unzip(Path zipSourcePath, Path outputPath) throws IOException {
@@ -170,6 +174,7 @@ public class FileUtil {
 
     /**
      * Unzips the contents of the {@code is} into {@code outputPath}.
+     *
      * @throws IOException if {@code is} refers to an invalid path.
      */
     public static void unzip(InputStream is, Path outputPath) throws IOException {
@@ -199,7 +204,8 @@ public class FileUtil {
     }
 
     /**
-     * Copies the template files from {@code sourcePath} to the {@code outputPath}.
+     * Copies the template files from the {@code is} to the {@code outputPath}.
+     *
      * @throws IOException if {@code is} refers to an invalid path.
      */
     public static void copyTemplate(InputStream is, String outputPath) throws IOException {
@@ -208,6 +214,7 @@ public class FileUtil {
 
     /**
      * Copies files from {@code sourcePath} to the {@code outputPath}.
+     *
      * @throws IOException if {@code is} refers to an invalid path.
      */
     public static void copyDirectoryContents(String sourcePath, String outputPath) throws IOException {
@@ -217,6 +224,7 @@ public class FileUtil {
     /**
      * Copies files from {@code sourcePath} to the {@code outputPath}.
      * If {@code whiteList} is provided, only filenames specified by the whitelist will be copied.
+     *
      * @throws IOException if {@code is} refers to an invalid path.
      */
     public static void copyDirectoryContents(String sourcePath, String outputPath, List<String> whiteList)
@@ -236,6 +244,8 @@ public class FileUtil {
     }
     /**
      * Creates the {@code dest} directory if it does not exist.
+     *
+     * @throws IOException if the directory could not be created.
      */
     public static void createDirectory(Path dest) throws IOException {
         Files.createDirectories(dest);
@@ -312,7 +322,9 @@ public class FileUtil {
     }
 
     /**
-     * Returns a list of {@code Path} of {@code fileTypes} contained in the given {@code directoryPath} directory.
+     * Returns a list of {@link Path} of {@code fileTypes} contained in the given {@code directoryPath} directory.
+     *
+     * @throws IOException if an error occurs while trying to access {@code directoryPath}.
      */
     private static List<Path> getFilePaths(Path directoryPath, String... fileTypes) throws IOException {
         return Files.walk(directoryPath)

--- a/src/main/java/reposense/util/SystemUtil.java
+++ b/src/main/java/reposense/util/SystemUtil.java
@@ -13,7 +13,7 @@ public class SystemUtil {
     }
 
     /**
-     * Returns true if the current environment is a test environment (defined by build.gradle)
+     * Returns true if the current environment is a test environment (defined by build.gradle).
      */
     public static boolean isTestEnvironment() {
         String environment = System.getenv("REPOSENSE_ENVIRONMENT");

--- a/src/main/java/reposense/util/TimeUtil.java
+++ b/src/main/java/reposense/util/TimeUtil.java
@@ -27,14 +27,14 @@ public class TimeUtil {
             "\"Since Date\" must not be later than today's date.";
 
     /**
-     * Sets the {@code startTime} to be the current time
+     * Sets the {@code startTime} to be the current time.
      */
     public static void startTimer() {
         startTime = System.nanoTime();
     }
 
     /**
-     * Returns the formatted elapsed time from {@code startTime} until current time
+     * Returns the formatted elapsed time from {@code startTime} until current time.
      */
     public static String getElapsedTime() {
         long endTime = System.nanoTime();
@@ -65,7 +65,9 @@ public class TimeUtil {
     }
 
     /**
-     * Returns a {@code LocalDateTime} that is set to midnight.
+     * Returns a {@link LocalDateTime} that is set to midnight for the given {@code sinceDate}.
+     * If {@code sinceDate} is {@link SinceDateArgumentType#ARBITRARY_FIRST_COMMIT_DATE}, it is simply returned
+     * as such.
      */
     public static LocalDateTime getSinceDate(LocalDateTime sinceDate) {
         if (sinceDate.equals(SinceDateArgumentType.ARBITRARY_FIRST_COMMIT_DATE)) {
@@ -76,14 +78,14 @@ public class TimeUtil {
     }
 
     /**
-     * Returns a {@code LocalDateTime} that is set to 23:59:59.
+     * Returns a {@link LocalDateTime} that is set to 23:59:59 for the given {@code untilDate}.
      */
     public static LocalDateTime getUntilDate(LocalDateTime untilDate) {
         return untilDate.withHour(23).withMinute(59).withSecond(59);
     }
 
     /**
-     * Returns a {@code LocalDateTime} that is one month before {@code cliUntilDate} (if present) or one month
+     * Returns a {@link LocalDateTime} that is one month before {@code cliUntilDate} (if present) or one month
      * before report generation date otherwise.
      */
     public static LocalDateTime getDateMinusAMonth(LocalDateTime cliUntilDate) {
@@ -91,7 +93,7 @@ public class TimeUtil {
     }
 
     /**
-     * Returns a {@code LocalDateTime} that is {@code numOfDays} before {@code cliUntilDate} (if present) or one month
+     * Returns a {@link LocalDateTime} that is {@code numOfDays} before {@code cliUntilDate} (if present) or one month
      * before report generation date otherwise.
      */
     public static LocalDateTime getDateMinusNDays(LocalDateTime cliUntilDate, int numOfDays) {
@@ -99,7 +101,7 @@ public class TimeUtil {
     }
 
     /**
-     * Returns a {@code LocalDateTime} that is {@code numOfDays} after {@code cliSinceDate} (if present).
+     * Returns a {@link LocalDateTime} that is {@code numOfDays} after {@code cliSinceDate} (if present).
      */
     public static LocalDateTime getDatePlusNDays(LocalDateTime cliSinceDate, int numOfDays) {
         return getUntilDate(cliSinceDate.plusDays(numOfDays));
@@ -125,7 +127,7 @@ public class TimeUtil {
     }
 
     /**
-     * Verifies that {@code sinceDate} is no later than the date of report generation.
+     * Verifies that {@code sinceDate} is no later than the date of report generation, given by {@code currentDate}.
      *
      * @throws ParseException if {@code sinceDate} supplied is later than date of report generation.
      */
@@ -137,7 +139,7 @@ public class TimeUtil {
     }
 
     /**
-     * Extracts the first substring that matches the {@code DATE_FORMAT_REGEX}.
+     * Extracts the first substring of {@code date} string that matches the {@code DATE_FORMAT_REGEX}.
      */
     public static String extractDate(String date) {
         Matcher matcher = Pattern.compile(DATE_FORMAT_REGEX).matcher(date);
@@ -149,8 +151,10 @@ public class TimeUtil {
     }
 
     /**
-     * Parses the given String as a Date based on the {@code CLI_ARGS_DATE_FORMAT}.
-     * Uses {@code ResolverStyle.STRICT} to avoid unexpected dates like 31/02/2020.
+     * Parses the given {@code date} string as a {@link LocalDateTime} based on the {@code CLI_ARGS_DATE_FORMAT}.
+     * Uses {@link ResolverStyle#STRICT} to avoid unexpected dates like 31/02/2020.
+     *
+     * @throws java.text.ParseException if date cannot be parsed by the required format.
      */
     public static LocalDateTime parseDate(String date) throws java.text.ParseException {
         try {


### PR DESCRIPTION
Part of #1202

Proposed Commit Message:
```
Some Javadoc in util package is inconsistent or missing.

Let's add missing Javadoc and standardise the style.
```

Proposed Javadoc standard for RepoSense (in addition to what is already covered in [SE-EDU](https://se-education.org/guides/conventions/java/index.html#comments) and [Google](https://google.github.io/styleguide/javaguide.html#s7-javadoc)) can be found in:

* Raw styleGuides.md file: https://github.com/reposense/RepoSense/pull/1650/files#diff-bd63b2861c8a46fbd8a67f313e555901c8d6d06762d1c0551c3254467f45b484
* Style Guides on surge.sh: https://docs-1650-pr-reposense-reposense.surge.sh/dg/styleGuides.html