### PR TITLE
[#1202] Missing javadoc for functions - Model

### DIFF
--- a/src/main/java/reposense/model/Author.java
+++ b/src/main/java/reposense/model/Author.java
@@ -67,6 +67,7 @@ public class Author {
 
     /**
      * Checks that all the strings in the {@code emails} only contains commonly used email patterns.
+     *
      * @throws IllegalArgumentException if any of the values do not meet the criteria.
      */
     private static void validateEmails(List<String> emails) throws IllegalArgumentException {
@@ -79,6 +80,7 @@ public class Author {
 
     /**
      * Checks that all the strings in the {@code ignoreGlobList} only contains commonly used glob patterns.
+     *
      * @throws IllegalArgumentException if any of the values do not meet the criteria.
      */
     private static void validateIgnoreGlobs(List<String> ignoreGlobList) throws IllegalArgumentException {
@@ -130,7 +132,7 @@ public class Author {
     }
 
     /**
-     * Validates and adds a list of ignore glob into the {@code Author} class instance variable without duplicates
+     * Validates and adds {@code ignoreGlobList} into the {@link Author} class instance variable without duplicates
      * and updates the ignore glob matcher.
      */
     public void importIgnoreGlobList(List<String> ignoreGlobList) {
@@ -177,7 +179,7 @@ public class Author {
     }
 
     /**
-     * Updates the {@code PathMatcher} to the new ignore glob list set.
+     * Updates the {@link PathMatcher} to the new ignore glob list set.
      * Called after a new ignore glob list is set.
      */
     private void updateIgnoreGlobMatcher() {
@@ -186,7 +188,7 @@ public class Author {
     }
 
     /**
-     * Adds the standard github email to {@code emails} if doesn't exist.
+     * Adds the standard github email to {@code emails} if it doesn't exist.
      */
     private void addStandardGitHubEmail(List<String> emails) {
         String standardGitHubEmail = getGitId() + STANDARD_GITHUB_EMAIL_DOMAIN;

--- a/src/main/java/reposense/model/AuthorConfiguration.java
+++ b/src/main/java/reposense/model/AuthorConfiguration.java
@@ -41,6 +41,7 @@ public class AuthorConfiguration {
 
     /**
      * Clears authors information and use the information provided from {@code standaloneConfig}.
+     * Also updates each author's {@code ignoreGlobList}.
      */
     public void update(StandaloneConfig standaloneConfig, List<String> ignoreGlobList) {
         List<Author> newAuthorList = new ArrayList<>();
@@ -69,9 +70,12 @@ public class AuthorConfiguration {
     }
 
     /**
-     * Checks for duplicate aliases in {@code authorDetailsToAuthorMap} and generates warnings
-     * @param authorDetailsToAuthorMap
-     * @param alias
+     * Checks if {@code alias} of {@code gitId} is already being used by another author in
+     * {@code authorDetailsToAuthorMap}.
+     *
+     * @param authorDetailsToAuthorMap Map to be checked for duplicate aliases.
+     * @param alias Alias for duplicate-checking.
+     * @param gitId GitId of author which {@code alias} is mapped to.
      */
     public void checkDuplicateAliases(Map<String, Author> authorDetailsToAuthorMap, String alias, String gitId) {
         if (authorDetailsToAuthorMap.containsKey(alias)) {
@@ -120,7 +124,7 @@ public class AuthorConfiguration {
     }
 
     /**
-     * Sets the details of {@code author} to {@code AuthorConfiguration} including the default alias, aliases
+     * Sets the details of {@code author} to {@link AuthorConfiguration} including the default alias, aliases
      * and display name.
      */
     private void setAuthorDetails(Author author) {
@@ -141,7 +145,7 @@ public class AuthorConfiguration {
     }
 
     /**
-     * Adds author to the {@code AuthorList}.
+     * Adds author to the {@code authorList}.
      */
     public void addAuthor(Author author) {
         authorList.add(author);
@@ -149,7 +153,7 @@ public class AuthorConfiguration {
     }
 
     /**
-     * Adds {@code author} to the {@code AuthorList}, and propagates {@code ignoreGlobList} to the {@code author}.
+     * Adds {@code author} to the {@code authorList}, and propagates {@code ignoreGlobList} to the {@code author}.
      */
     public void addAuthor(Author author, List<String> ignoreGlobList) {
         addAuthor(author);
@@ -168,9 +172,10 @@ public class AuthorConfiguration {
     }
 
     /**
-     * Removes all information of the {@code author} from the configs
-     * Precondition: {@code author} must be present in {@code authorDetailsToAuthorMap}
-     * @param author Can be an author's git ID, email, or alias
+     * Removes all information of the {@code author} from the configs.
+     * Precondition: {@code author} must be present in {@code authorDetailsToAuthorMap}.
+     *
+     * @param author Can be an author's git ID, email, or alias.
      */
     public void removeAuthorInformation(String author) {
         Author authorToRemove = authorDetailsToAuthorMap.get(author);
@@ -186,8 +191,9 @@ public class AuthorConfiguration {
     }
 
     /**
-     * Adds new authors from {@code authorList} and sets the default alias, aliases, emails and display name
-     * of the new authors. Skips authors that have already been added previously.
+     * Adds new authors from {@code authorList}.
+     * Sets the default alias, aliases, emails and display name as well as {@code ignoreGlobList}
+     * of the new authors. Skips the authors that have already been added previously.
      */
     public void addAuthors(List<Author> authorList, List<String> ignoreGlobList) {
         for (Author author : authorList) {
@@ -237,9 +243,7 @@ public class AuthorConfiguration {
     }
 
     /**
-     * Adds {@code aliases} of {@code author} into the map
-     * @param author
-     * @param values
+     * Adds {@code values} as aliases of {@code author} into the map.
      */
     public void addAuthorDetailsToAuthorMapEntry(Author author, List<String> values) {
         values.forEach(value -> {
@@ -253,8 +257,8 @@ public class AuthorConfiguration {
     }
 
     /**
-     * Attempts to find matching {@code Author} given a name and an email.
-     * If no matching {@code Author} is found, {@code Author#UNKNOWN_AUTHOR} is returned.
+     * Attempts to find matching {@link Author} given a {@code name} and an {@code email}.
+     * If no matching {@link Author} is found, {@link Author#UNKNOWN_AUTHOR} is returned.
      */
     public Author getAuthor(String name, String email) {
         if (authorDetailsToAuthorMap.containsKey(name)) {

--- a/src/main/java/reposense/model/CommitHash.java
+++ b/src/main/java/reposense/model/CommitHash.java
@@ -50,8 +50,9 @@ public class CommitHash {
     }
 
     /**
-     * Converts all the strings in {@code commits} into {@code CommitHash} objects.
+     * Converts all the strings in {@code commits} into {@link CommitHash} objects.
      * Returns null if {@code commits} is null.
+     *
      * @throws IllegalArgumentException if any of the strings are in invalid formats.
      */
     public static List<CommitHash> convertStringsToCommits(List<String> commits) throws IllegalArgumentException {
@@ -65,7 +66,8 @@ public class CommitHash {
     }
 
     /**
-     * Converts a commit {@code entry} into either itself, or a stream of CommitHashes if a range was provided.
+     * Converts a commit {@code entry} into either itself, or a stream of {@link CommitHash} objects if a range was
+     * provided.
      */
     public static Stream<CommitHash> getHashes(String root, String branchName, CommitHash entry) {
         if (entry.toString().matches(COMMIT_HASH_REGEX)) {
@@ -79,7 +81,7 @@ public class CommitHash {
     }
 
     /**
-     * Checks if {@code commitList} contains {@code commitHash}
+     * Checks if {@code commitList} contains {@code commitHash}.
      */
     public static boolean isInsideCommitList(String commitHash, List<CommitHash> commitList) {
         return commitList.stream().map(CommitHash::toString).anyMatch(commitHash::startsWith);
@@ -87,6 +89,7 @@ public class CommitHash {
 
     /**
      * Checks that all the strings in the {@code ignoreCommitList} are in valid formats.
+     *
      * @throws IllegalArgumentException if any of the values do not meet the criteria.
      */
     public static void validateCommits(List<String> commits) throws IllegalArgumentException {
@@ -97,6 +100,7 @@ public class CommitHash {
 
     /**
      * Checks that {@code commitHash} is in a valid format.
+     *
      * @throws IllegalArgumentException if {@code commitHash} does not meet the criteria.
      */
     private static void validateCommit(String commitHash) throws IllegalArgumentException {

--- a/src/main/java/reposense/model/FileType.java
+++ b/src/main/java/reposense/model/FileType.java
@@ -33,7 +33,7 @@ public class FileType {
     }
 
     /**
-     * Returns a list of {@code FileType} from {@code formats}, with each {@code FileType}
+     * Returns a list of {@link FileType} from {@code formats}, with each {@link FileType}
      * containing the format name and associated files ending with the format.
      */
     public static List<FileType> convertFormatStringsToFileTypes(List<String> formats) {
@@ -41,7 +41,7 @@ public class FileType {
     }
 
     /**
-     * Returns a {@code FileType} with label named {@code format} and globs that include all files that end with
+     * Returns a {@link FileType} with label named {@code format} and globs that include all files that end with
      * {@code format}.
      */
     public static FileType convertStringFormatToFileType(String format) {
@@ -51,9 +51,10 @@ public class FileType {
 
     /**
      * Ensures that the string {@code label} is a valid file type.
+     *
      * @throws IllegalArgumentException if {@code label} is an empty string.
      */
-    public static void validateFileTypeLabel(String label) {
+    public static void validateFileTypeLabel(String label) throws IllegalArgumentException {
         if (label.isEmpty()) {
             throw new IllegalArgumentException();
         }
@@ -61,6 +62,7 @@ public class FileType {
 
     /**
      * Ensures that {@code format} is a valid file format.
+     *
      * @throws IllegalArgumentException if {@code format} is not alphanumeric.
      */
     public static void validateFileFormat(String format) throws IllegalArgumentException {

--- a/src/main/java/reposense/model/FileTypeManager.java
+++ b/src/main/java/reposense/model/FileTypeManager.java
@@ -5,8 +5,7 @@ import java.util.Collections;
 import java.util.List;
 
 /**
- * {@code FileTypeManager} is responsible for holding a list of whitelisted formats and user-specified custom
- * groupings.
+ * Holds a list of whitelisted formats and user-specified custom groupings.
  */
 public class FileTypeManager {
     private static final String DEFAULT_GROUP = "other";
@@ -40,8 +39,10 @@ public class FileTypeManager {
     /**
      * Returns the file format of the given {@code fileName}.
      * Returns the file type "other" if the format of the file is not of the standard type.
+     *
+     * @throws AssertionError if whitelisted formats check somehow fails, which may be due to bugs.
      */
-    private FileType getFileFormat(String fileName) {
+    private FileType getFileFormat(String fileName) throws AssertionError {
         if (hasSpecifiedFormats()) {
             for (FileType format : formats) {
                 if (format.isFileGlobMatching(fileName)) {

--- a/src/main/java/reposense/model/RepoConfiguration.java
+++ b/src/main/java/reposense/model/RepoConfiguration.java
@@ -123,8 +123,8 @@ public class RepoConfiguration {
     }
 
     /**
-     * Merges a {@code RepoConfiguration} from {@code repoConfigs} with an {@code AuthorConfiguration} from
-     * {@code authorConfigs} if their {@code RepoLocation} and branch matches
+     * Merges a {@link RepoConfiguration} from {@code repoConfigs} with an {@link AuthorConfiguration} from
+     * {@code authorConfigs} if their {@link RepoLocation} and branch matches.
      */
     public static void merge(List<RepoConfiguration> repoConfigs, List<AuthorConfiguration> authorConfigs) {
         for (AuthorConfiguration authorConfig : authorConfigs) {
@@ -191,7 +191,7 @@ public class RepoConfiguration {
     }
 
     /**
-     * Iterates through {@code repoConfigs} to find a {@code RepoConfiguration} with {@code RepoLocation} and branch
+     * Iterates through {@code repoConfigs} to find a {@link RepoConfiguration} with {@link RepoLocation} and branch
      * that matches {@code authorConfig}. Returns {@code null} if no match is found.
      */
     private static RepoConfiguration getMatchingRepoConfig(
@@ -209,7 +209,8 @@ public class RepoConfiguration {
     }
 
     /**
-     * Returns a list of {@link RepoConfiguration} where the {@link RepoLocation} matches {@code targetRepoLocation}.
+     * Returns a list of {@link RepoConfiguration} where the {@link RepoLocation} of a {@link RepoConfiguration}
+     * in the list of {@code configs} matches {@code targetRepoLocation}.
      */
     private static List<RepoConfiguration> getMatchingRepoConfigsByLocation(
             List<RepoConfiguration> configs, RepoLocation targetRepoLocation) {
@@ -218,7 +219,7 @@ public class RepoConfiguration {
     }
 
     /**
-     * Sets {@code formats} to {@code RepoConfiguration} in {@code configs} if its format list is empty.
+     * Sets {@code formats} to {@link RepoConfiguration} in {@code configs} if its format list is empty.
      */
     public static void setFormatsToRepoConfigs(List<RepoConfiguration> configs, List<FileType> formats) {
         for (RepoConfiguration config : configs) {
@@ -229,7 +230,7 @@ public class RepoConfiguration {
     }
 
     /**
-     * Sets each {@code RepoConfiguration} in {@code configs} to ignore its standalone config, if
+     * Sets each {@link RepoConfiguration} in {@code configs} to ignore its standalone config, if
      * {@code ignoreAllStandaloneConfigs} is true.
      */
     public static void setStandaloneConfigIgnoredToRepoConfigs(
@@ -239,12 +240,15 @@ public class RepoConfiguration {
         }
     }
 
+    /**
+     * Checks if any of the {@code configs} is finding previous authors for commit analysis.
+     */
     public static boolean isAnyRepoFindingPreviousAuthors(List<RepoConfiguration> configs) {
         return configs.stream().anyMatch(RepoConfiguration::isFindingPreviousAuthorsPerformed);
     }
 
     /**
-     * Clears existing information related to this repository and its authors, and replaces it with information from the
+     * Clears existing information related to this repository and its authors, and replaces it with information from
      * {@code standaloneConfig}.
      */
     public void update(StandaloneConfig standaloneConfig) {
@@ -268,8 +272,8 @@ public class RepoConfiguration {
     }
 
     /**
-     * Attempts to find matching {@code Author} given a name and an email.
-     * If no matching {@code Author} is found, {@code Author#UNKNOWN_AUTHOR} is returned.
+     * Returns the matching {@link Author} given a {@code name} and an {@code email}.
+     * If no matching {@link Author} is found, {@link Author#UNKNOWN_AUTHOR} is returned.
      */
     public Author getAuthor(String name, String email) {
         return authorConfig.getAuthor(name, email);
@@ -286,6 +290,8 @@ public class RepoConfiguration {
 
     /**
      * Gets the current branch and updates branch with current branch if default branch is specified.
+     *
+     * @throws GitBranchException if current branch cannot be retrieved.
      */
     public void updateBranch() throws GitBranchException {
         if (branch.equals(DEFAULT_BRANCH)) {
@@ -362,16 +368,14 @@ public class RepoConfiguration {
     }
 
     /**
-     * Updates the branch in the {@code displayName} to the
-     * current {@code branch}.
+     * Updates the branch in the {@code displayName} to the current {@code branch}.
      */
     public void updateDisplayName(String branch) {
         this.displayName = displayName.substring(0, displayName.lastIndexOf('[') + 1) + branch + "]";
     }
 
     /**
-     * Updates the branch in the {@code outputFolderName} to the
-     * current {@code branch}.
+     * Updates the branch in the {@code outputFolderName} to the current {@code branch}.
      */
     public void updateOutputFolderName(String branch) {
         this.outputFolderName = outputFolderName.substring(0, outputFolderName.lastIndexOf('_') + 1) + branch;
@@ -457,7 +461,7 @@ public class RepoConfiguration {
     }
 
     /**
-     * Clears authors information and sets the {@code authorList} to {@code RepoConfiguration}.
+     * Clears authors information and sets the {@code authorList} to {@link RepoConfiguration}.
      */
     public void setAuthorList(List<Author> authorList) {
         authorConfig.clear();

--- a/src/main/java/reposense/model/RepoLocation.java
+++ b/src/main/java/reposense/model/RepoLocation.java
@@ -26,7 +26,10 @@ public class RepoLocation {
     private String organization;
 
     /**
-     * @throws InvalidLocationException if {@code location} cannot be represented by a {@code URL} or {@code Path}.
+     * Creates {@link RepoLocation} based on the {@code location}, which is represented by a {@code URL}
+     * or {@link Path}.
+     *
+     * @throws InvalidLocationException if {@code location} cannot be represented by a {@code URL} or {@link Path}.
      */
     public RepoLocation(String location) throws InvalidLocationException {
         if (SystemUtil.isWindows()) {
@@ -57,7 +60,8 @@ public class RepoLocation {
     }
 
     /**
-     * Verifies {@code location} can be presented as a {@code URL} or {@code Path}.
+     * Verifies {@code location} can be presented as a {@code URL} or {@link Path}.
+     *
      * @throws InvalidLocationException if otherwise.
      */
     private void verifyLocation(String location) throws InvalidLocationException {

--- a/src/main/java/reposense/model/StandaloneAuthor.java
+++ b/src/main/java/reposense/model/StandaloneAuthor.java
@@ -4,7 +4,7 @@ import java.util.Collections;
 import java.util.List;
 
 /**
- * Represents an author in {@code StandaloneConfig}.
+ * Represents an author in {@link StandaloneConfig}.
  */
 public class StandaloneAuthor {
     private String githubId;

--- a/src/main/java/reposense/model/StandaloneConfig.java
+++ b/src/main/java/reposense/model/StandaloneConfig.java
@@ -5,7 +5,7 @@ import java.util.List;
 import java.util.Objects;
 
 /**
- * Represents the structure of a config.json in _reposense folder.
+ * Represents the structure of a config.json in the _reposense folder.
  */
 public class StandaloneConfig {
     private List<StandaloneAuthor> authors;


### PR DESCRIPTION
Part of #1202

Proposed Commit Message:
```
Some Javadoc in model package is inconsistent or missing.

Let's add missing Javadoc and standardise the style.
```

Proposed Javadoc standard for RepoSense (in addition to what is already covered in [SE-EDU](https://se-education.org/guides/conventions/java/index.html#comments) and [Google](https://google.github.io/styleguide/javaguide.html#s7-javadoc)) can be found in:

* Raw styleGuides.md file: https://github.com/reposense/RepoSense/pull/1650/files#diff-bd63b2861c8a46fbd8a67f313e555901c8d6d06762d1c0551c3254467f45b484
* Style Guides on surge.sh: https://docs-1650-pr-reposense-reposense.surge.sh/dg/styleGuides.html