### PR TITLE
[#1202] Missing javadoc for functions - Report and Main

### DIFF
--- a/src/main/java/reposense/RepoSense.java
+++ b/src/main/java/reposense/RepoSense.java
@@ -46,6 +46,7 @@ public class RepoSense {
 
     /**
      * The entry point of the program.
+     * Additional flags are provided by the user in {@code args}.
      */
     public static void main(String[] args) {
         try {
@@ -109,10 +110,11 @@ public class RepoSense {
     }
 
     /**
-     * Constructs a list of {@code RepoConfiguration} if {@code cliArguments} is a {@code ConfigCliArguments}.
+     * Constructs a list of {@link RepoConfiguration} if {@code cliArguments} is a {@link ConfigCliArguments}.
      *
-     * @throws IOException if user-supplied csv file does not exists or is not readable.
+     * @throws IOException if user-supplied csv file does not exist or is not readable.
      * @throws InvalidCsvException if user-supplied repo-config csv is malformed.
+     * @throws InvalidHeaderException if user-supplied csv file has header that cannot be parsed.
      */
     public static List<RepoConfiguration> getRepoConfigurations(ConfigCliArguments cliArguments)
             throws IOException, InvalidCsvException, InvalidHeaderException {
@@ -147,7 +149,7 @@ public class RepoSense {
     }
 
     /**
-     * Constructs a list of {@code RepoConfiguration} if {@code cliArguments} is a {@code LocationsCliArguments}.
+     * Constructs a list of {@link RepoConfiguration} if {@code cliArguments} is a {@link LocationsCliArguments}.
      *
      * @throws ParseException if all repo locations are invalid.
      */

--- a/src/main/java/reposense/report/RepoCloner.java
+++ b/src/main/java/reposense/report/RepoCloner.java
@@ -73,6 +73,7 @@ public class RepoCloner {
     /**
      * Spawns a process to clone the bare repository specified by {@code config}.
      * Does not wait for process to finish executing.
+     * For test environments, cloning is skipped if it has been done before and {@code shouldFreshClone} is false.
      */
     public void cloneBare(RepoConfiguration config, boolean shouldFreshClone) {
         configs[currentIndex] = config;
@@ -114,8 +115,8 @@ public class RepoCloner {
     }
 
     /**
-     * Waits for current clone process to finish executing and returns the {@code RepoLocation} of the corresponding
-     * {@code RepoConfiguration}.
+     * Waits for current clone process to finish executing and returns the {@link RepoLocation} of the corresponding
+     * {@link RepoConfiguration}.
      */
     public RepoLocation getClonedRepoLocation() {
         if (isCurrentRepoCloned) {
@@ -144,7 +145,7 @@ public class RepoCloner {
     }
 
     /**
-     * Cleans up data associated with a particular repo.
+     * Cleans up data associated with a particular repo given by {@code config}.
      */
     public void cleanupRepo(RepoConfiguration config) {
         deleteDirectory(getRepoParentFolder(config).toString());
@@ -160,6 +161,7 @@ public class RepoCloner {
     /**
      * Spawns a process to clone repo specified in {@code config}. Does not wait for process to finish executing.
      * Should only handle a maximum of one spawned process at any time.
+     * For test environments, cloning is skipped if it has been done before and {@code shouldFreshClone} is false.
      */
     private boolean spawnCloneProcess(RepoConfiguration config, boolean shouldFreshClone) {
         assert(crp == null);
@@ -194,9 +196,10 @@ public class RepoCloner {
     }
 
     /**
-     * Spawns a process to shallow clone repo specified in {@code config}.
+     * Spawns a process to shallow clone repo specified in {@code config} based on {@code shallowSinceDate}.
      * Does not wait for process to finish executing.
      * Should only handle a maximum of one spawned process at any time.
+     * For test environments, cloning is skipped if it has been done before and {@code shouldFreshClone} is false.
      */
     private boolean spawnShallowCloneProcess(RepoConfiguration config, LocalDateTime shallowSinceDate,
                                              boolean shouldFreshClone) {
@@ -234,6 +237,7 @@ public class RepoCloner {
     /**
      * Spawns a process to create partial clone of repo specified in {@code config}.
      * Waits for process to finish executing.
+     * For test environments, cloning is skipped if it has been done before and {@code shouldFreshClone} is false.
      */
     private boolean spawnPartialCloneProcess(RepoConfiguration config, boolean shouldFreshClone) {
         assert(crp == null);
@@ -269,6 +273,7 @@ public class RepoCloner {
     /**
      * Spawns a process to create shallow partial clone of repo specified in {@code config}.
      * Waits for process to finish executing.
+     * For test environments, cloning is skipped if it has been done before and {@code shouldFreshClone} is false.
      */
     private boolean spawnShallowPartialCloneProcess(RepoConfiguration config, boolean shouldFreshClone) {
         assert(crp == null);
@@ -303,6 +308,7 @@ public class RepoCloner {
 
     /**
      * Waits for previously spawned clone process to finish executing.
+     * Uses {@code config} to find the locations of both the original and cloned repo as well as repo name.
      * Should only be called after {@code spawnCloneProcess} has been called.
      */
     private boolean waitForCloneProcess(RepoConfiguration config) {


### PR DESCRIPTION
Part of #1202

Proposed Commit Message:
```
Some Javadoc in report package and RepoSense.java is inconsistent
or missing.

Let's add missing Javadoc and standardise the style.
```

Proposed Javadoc standard for RepoSense (in addition to what is already covered in [SE-EDU](https://se-education.org/guides/conventions/java/index.html#comments) and [Google](https://google.github.io/styleguide/javaguide.html#s7-javadoc)) can be found in:

* Raw styleGuides.md file: https://github.com/reposense/RepoSense/pull/1650/files#diff-bd63b2861c8a46fbd8a67f313e555901c8d6d06762d1c0551c3254467f45b484
* Style Guides on surge.sh: https://docs-1650-pr-reposense-reposense.surge.sh/dg/styleGuides.html