### PR TITLE
[#1202] Missing javadoc for functions - Git

### DIFF
--- a/src/main/java/reposense/git/GitBranch.java
+++ b/src/main/java/reposense/git/GitBranch.java
@@ -16,6 +16,8 @@ public class GitBranch {
 
     /**
      * Returns the current working branch of the repository at {@code root}.
+     *
+     * @throws GitBranchException if command execution is unsuccessful.
      */
     public static String getCurrentBranch(String root) throws GitBranchException {
         Path rootPath = Paths.get(root);

--- a/src/main/java/reposense/git/GitCatFile.java
+++ b/src/main/java/reposense/git/GitCatFile.java
@@ -20,7 +20,10 @@ public class GitCatFile {
     private static final Logger logger = LogsManager.getLogger(GitCatFile.class);
 
     /**
-     * Returns parent commits for the commit associated with the input commit hash.
+     * Returns parent commits for the commit associated with the input {@code commitHash}.
+     * The {@link Path} given by {@code root} is the working directory.
+     *
+     * @throws CommitNotFoundException if there is no commit associated with {@code commitHash}.
      */
     public static List<String> getParentCommits(String root, String commitHash) throws CommitNotFoundException {
         Path rootPath = Paths.get(root);
@@ -40,8 +43,9 @@ public class GitCatFile {
     }
 
     /**
-     * Given the input list of commit hashes, return a list of commit hashes for the parent
+     * Given the input list of {@code commitHashes}, return a list of commit hashes for the parent
      * commits of all the commits.
+     * The {@link Path} given by {@code root} is the working directory.
      */
     public static List<String> getParentsOfCommits(String root, List<String> commitHashes) {
         List<String> parentCommits = new ArrayList<>();

--- a/src/main/java/reposense/git/GitCheckout.java
+++ b/src/main/java/reposense/git/GitCheckout.java
@@ -30,6 +30,7 @@ public class GitCheckout {
 
     /**
      * Checkouts to the hash revision given in the {@code commit}.
+     * The {@link Path} given by {@code root} is the working directory.
      */
     public static void checkoutCommit(String root, CommitResult commit) {
         logger.info("Checking out " + commit.getHash() + "time:" + commit.getTime());
@@ -38,6 +39,7 @@ public class GitCheckout {
 
     /**
      * Checkouts to the given {@code hash} revision.
+     * The {@link Path} given by {@code root} is the working directory.
      */
     public static void checkout(String root, String hash) {
         Path rootPath = Paths.get(root);
@@ -45,8 +47,10 @@ public class GitCheckout {
     }
 
     /**
-     * Checks out to the latest commit before {@code untilDate} in {@code branchName} branch
-     * if {@code untilDate} is not null.
+     * Checks out to the latest commit before {@code untilDate}, associated with timezone given by {@code zoneId} in
+     * {@code branchName} branch if {@code untilDate} is not null.
+     * The {@link Path} given by {@code root} is the working directory.
+     *
      * @throws CommitNotFoundException if commits before {@code untilDate} cannot be found.
      */
     public static void checkoutDate(String root, String branchName, LocalDateTime untilDate, ZoneId zoneId)

--- a/src/main/java/reposense/git/GitClone.java
+++ b/src/main/java/reposense/git/GitClone.java
@@ -29,11 +29,11 @@ public class GitClone {
     private static final Logger logger = LogsManager.getLogger(GitClone.class);
 
     /**
-     * Runs "git clone --bare" command asynchronously to clone a bare repo specified in the {@code config}
-     * into the folder {@code outputFolderName}.
+     * Runs "git clone --bare" command asynchronously with {@code rootPath} as working directory to clone a bare repo
+     * specified in the {@code config} into the folder {@code outputFolderName}.
      *
-     * @return an instance of {@code CommandRunnerProcess} to allow tracking the status of the cloning process.
-     * @throws GitCloneException when an error occurs during command execution.
+     * @return an instance of {@link CommandRunnerProcess} to allow tracking the status of the cloning process.
+     * @throws GitCloneException when an error occurs while attempting to clone the repo.
      */
     public static CommandRunnerProcess cloneBareAsync(RepoConfiguration config, Path rootPath,
             String outputFolderName) throws GitCloneException {
@@ -45,11 +45,12 @@ public class GitClone {
     }
 
     /**
-     * Runs "git clone --bare" command asynchronously to clone a bare repo specified in the {@code config}
-     * into the folder {@code outputFolderName}.
+     * Runs "git clone --bare --shallow-since=" command asynchronously with {@code rootPath} as working directory
+     * to clone a bare repo specified in the {@code config} into the folder {@code outputFolderName}.
+     * Uses {@code sinceDate} for the "--shallow-since=" flag.
      *
-     * @return an instance of {@code CommandRunnerProcess} to allow tracking the status of the cloning process.
-     * @throws GitCloneException when an error occurs during command execution.
+     * @return an instance of {@link CommandRunnerProcess} to allow tracking the status of the cloning process.
+     * @throws GitCloneException when an error occurs while attempting to clone the repo.
      */
     public static CommandRunnerProcess cloneShallowBareAsync(RepoConfiguration config, Path rootPath,
             String outputFolderName, LocalDateTime sinceDate) throws GitCloneException {
@@ -62,10 +63,10 @@ public class GitClone {
     }
 
     /**
-     * Runs "git clone --bare" command asynchronously to clone a bare repo specified in the {@code config}
-     * into the folder {@code outputFolderName}.
+     * Runs "git clone --bare" command asynchronously with {@code rootPath} as working directory to clone a bare repo
+     * specified in the {@code config} into the folder {@code outputFolderName}.
      *
-     * @throws GitCloneException when an error occurs during command execution.
+     * @throws GitCloneException when an error occurs while attempting to clone the repo.
      */
     public static void clonePartialBare(RepoConfiguration config, Path rootPath,
             String outputFolderName) throws GitCloneException {
@@ -78,10 +79,11 @@ public class GitClone {
     }
 
     /**
-     * Runs "git clone --bare" command asynchronously to clone a bare repo specified in the {@code config}
-     * into the folder {@code outputFolderName}.
+     * Runs "git clone --bare" command asynchronously with {@code rootPath} as working directory to clone a bare repo
+     * specified in the {@code config} into the folder {@code outputFolderName}.
+     * Uses {@code sinceDate} for the "--shallow-since=" flag.
      *
-     * @throws GitCloneException when an error occurs during command execution.
+     * @throws GitCloneException when an error occurs while attempting to clone the repo.
      */
     public static void cloneShallowPartialBare(RepoConfiguration config, Path rootPath,
             String outputFolderName, LocalDateTime sinceDate) throws GitCloneException {
@@ -95,6 +97,8 @@ public class GitClone {
 
     /**
      * Clones repo specified in the {@code config} and updates it with the branch info.
+     *
+     * @throws GitCloneException when an error occurs while attempting to clone the repo.
      */
     public static void clone(RepoConfiguration config) throws GitCloneException {
         try {
@@ -136,8 +140,10 @@ public class GitClone {
     }
 
     /**
-     * Clones a bare repo specified in {@code config} into the folder {@code outputFolderName}.
-     * @throws IOException if it fails to delete a directory.
+     * Clones a bare repo, with {@code rootPath} as working directory, specified in {@code config}
+     * into the folder {@code outputFolderName}.
+     *
+     * @throws IOException if it fails to delete or create a directory.
      */
     public static void cloneBare(RepoConfiguration config, Path rootPath,
             String outputFolderName) throws IOException {
@@ -153,10 +159,12 @@ public class GitClone {
     }
 
     /**
-     * Performs a full clone from {@code clonedBareRepoLocation} into the folder {@code outputFolderName} and
-     * directly branches out to {@code targetBranch}.
+     * Performs a full clone with {@code rootPath} as working directory relative to the location of the bare repo
+     * version of {@code config} into the folder {@code outputFolderName} and checks out the branch specified in
+     * {@code config}.
+     *
+     * @throws GitCloneException when an error occurs while attempting to clone the repo.
      * @throws IOException if it fails to delete a directory.
-     * @throws GitCloneException when an error occurs during command execution.
      */
     public static void cloneFromBareAndUpdateBranch(Path rootPath, RepoConfiguration config)
             throws GitCloneException, IOException {
@@ -184,8 +192,7 @@ public class GitClone {
     }
 
     /**
-     * Constructs the command to clone a repo specified in the {@code config}
-     * into the folder {@code outputFolderName}.
+     * Constructs the command to clone a repo specified in the {@code config} into the folder {@code outputFolderName}.
      */
     private static String getCloneCommand(RepoConfiguration config, String outputFolderName) {
         return "git clone " + addQuotesForFilePath(config.getLocation().toString()) + " "
@@ -204,8 +211,8 @@ public class GitClone {
     }
 
     /**
-     * Constructs the command to shallow clone a bare repo specified in the {@code config}
-     * into the folder {@code outputFolderName}.
+     * Constructs the command to shallow clone a bare repo specified in the {@code config} with
+     * {@code shallowSinceDate} into the folder {@code outputFolderName}.
      */
     private static String getCloneShallowBareCommand(RepoConfiguration config,
             String outputFolderName, LocalDateTime shallowSinceDate) {
@@ -227,7 +234,7 @@ public class GitClone {
 
     /**
      * Constructs the command to shallow partial clone a bare repo specified in the {@code config}
-     * into the folder {@code outputFolderName}.
+     * with {@code shallowSinceDate} into the folder {@code outputFolderName}.
      */
     private static String getCloneShallowPartialBareCommand(RepoConfiguration config,
             String outputFolderName, LocalDateTime shallowSinceDate) {

--- a/src/main/java/reposense/git/GitDiff.java
+++ b/src/main/java/reposense/git/GitDiff.java
@@ -17,6 +17,7 @@ public class GitDiff {
 
     /**
      * Returns the git diff result of the current commit compared to {@code lastCommitHash}, without any context.
+     * The {@link Path} given by {@code root} is the working directory.
      */
     public static String diffCommit(String root, String lastCommitHash) {
         Path rootPath = Paths.get(root);

--- a/src/main/java/reposense/git/GitLog.java
+++ b/src/main/java/reposense/git/GitLog.java
@@ -21,7 +21,7 @@ public class GitLog {
             "\">>>COMMIT INFO<<<%n%H|%n|%aN|%n|%aE|%n|%cI|%n|%s|%n|%w(0,4,4)%b%w(0,0,0)|%n|%D|\"";
 
     /**
-     * Returns the git commit log info of {@code Author}, in the repository specified in {@code config}.
+     * Returns the git commit log info of {@code author}, in the repository specified in {@code config}.
      */
     public static String get(RepoConfiguration config, Author author) {
         Path rootPath = Paths.get(config.getRepoRoot());
@@ -38,7 +38,7 @@ public class GitLog {
     }
 
     /**
-     * Returns the git commit log info of {@code Author}, with the files changed, in the repository specified in
+     * Returns the git commit log info of {@code author}, with the files changed, in the repository specified in
      * {@code config}.
      */
     public static String getWithFiles(RepoConfiguration config, Author author) {

--- a/src/main/java/reposense/git/GitRevList.java
+++ b/src/main/java/reposense/git/GitRevList.java
@@ -19,8 +19,13 @@ public class GitRevList {
     private static final String REVISION_PATH_SEPARATOR = " -- ";
 
     /**
-     * Returns the latest commit hash before {@code date}, with {@code ZoneId} taken into account.
-     * Returns an empty {@code String} if {@code date} is null, or there is no such commit.
+     * Returns the latest commit hash at {@code branchName} before {@code date}.
+     * Returns an empty {@link String} if {@code date} is null, or there is no such commit.
+     *
+     * @param root The name of the working directory.
+     * @param branchName The name of the branch to find the commit hash in.
+     * @param date The date before which the commit hash must be found.
+     * @param zoneId The timezone of the date.
      */
     public static String getCommitHashBeforeDate(String root, String branchName, LocalDateTime date, ZoneId zoneId) {
         if (date == null) {
@@ -35,9 +40,13 @@ public class GitRevList {
     }
 
     /**
-     * Returns the latest commit hash inclusive and until the end of the day of {@code date},
-     * with {@code ZoneId} taken into account.
-     * Returns an empty {@code String} if {@code date} is null, or there is no such commit.
+     * Returns the latest commit hash at {@code branchName} before {@code date}.
+     * Returns an empty {@link String} if {@code date} is null, or there is no such commit.
+     *
+     * @param root The name of the working directory.
+     * @param branchName The name of the branch to find the commit hash in.
+     * @param date The cut-off date before which the commit hash must be found.
+     * @param zoneId The timezone of the date.
      */
     public static String getCommitHashUntilDate(String root, String branchName, LocalDateTime date, ZoneId zoneId) {
         if (date == null) {
@@ -52,8 +61,10 @@ public class GitRevList {
     }
 
     /**
-     * Returns a list of commit hashes separated by newline that are within the range of {@code startHash} and
-     * {@code endHash}. Both the {@code startHash} and {@code endHash} are guaranteed to be in the list.
+     * Returns a list of commit hashes at the branch given by {@code branchName}, separated by newlines,
+     * that are within the range of {@code startHash} and {@code endHash}.
+     * The {@code root} is the name of the working directory.
+     * Both the {@code startHash} and {@code endHash} are guaranteed to be in the list.
      */
     public static String getCommitHashInRange(String root, String branchName, String startHash, String endHash) {
         if (startHash == null && endHash == null) {
@@ -92,7 +103,9 @@ public class GitRevList {
     }
 
     /**
-     * Returns a list of commit hashes separated by newline that exist since {@code hash} until HEAD.
+     * Returns a list of commit hashes at the branch given by {@code branchName} separated by newlines that exist
+     * since {@code hash} until HEAD.
+     * The {@code root} is the name of the working directory.
      */
     private static String getAllCommitHashSince(String root, String branchName, String hash) {
         Path rootPath = Paths.get(root);
@@ -107,7 +120,8 @@ public class GitRevList {
     }
 
     /**
-     * Returns a list of commit hashes for the root commits in the tree.
+     * Returns a list of commit hashes for the root commits in the tree, with the {@link Path} given by {@code root}
+     * as working directory.
      */
     public static List<String> getRootCommits(String root) {
         String revListCommand = "git rev-list --max-parents=0 HEAD";
@@ -117,7 +131,7 @@ public class GitRevList {
     }
 
     /**
-     * Returns true if the repository is empty.
+     * Returns true if the repository is empty, with the {@link Path} given by {@code root} as working directory.
      */
     public static boolean checkIsEmptyRepo(String root) {
         String revListCommand = "git rev-list -n 1 --all";

--- a/src/main/java/reposense/git/GitRevParse.java
+++ b/src/main/java/reposense/git/GitRevParse.java
@@ -12,7 +12,8 @@ import reposense.system.CommandRunner;
  */
 public class GitRevParse {
     /**
-     * Asserts that the branch in {@code config} exists.
+     * Asserts that the branch in {@code config} exists, with {@code repoRoot} as working directory.
+     *
      * @throws GitBranchException when the branch does not exist.
      */
     public static void assertBranchExists(RepoConfiguration config, Path repoRoot) throws GitBranchException {

--- a/src/main/java/reposense/git/GitShortlog.java
+++ b/src/main/java/reposense/git/GitShortlog.java
@@ -39,6 +39,10 @@ public class GitShortlog {
                 .collect(Collectors.toList());
     }
 
+    /**
+     * Obtains summarised version of git log from the repository at {@code root} for the date range
+     * given by {@code sinceDate} and {@code untilDate}, with {@code zoneId} taken into account for both dates.
+     */
     private static String getShortlogSummary(String root, LocalDateTime sinceDate,
             LocalDateTime untilDate, ZoneId zoneId) {
         Path rootPath = Paths.get(root);

--- a/src/main/java/reposense/git/GitShow.java
+++ b/src/main/java/reposense/git/GitShow.java
@@ -25,7 +25,10 @@ public class GitShow {
     private static final Logger logger = LogsManager.getLogger(GitShow.class);
 
     /**
-     * Returns expanded form of the commit hash associated with the {@code shortCommitHash}
+     * Returns expanded form of the {@link CommitHash} associated with the {@code shortCommitHash}, with
+     * the {@link Path} given by {@code root} as the working directory.
+     *
+     * @throws CommitNotFoundException if there is no commit associated with {@code shortCommitHash}.
      */
     public static CommitHash getExpandedCommitHash(String root, String shortCommitHash) throws CommitNotFoundException {
         Path rootPath = Paths.get(root);
@@ -48,7 +51,12 @@ public class GitShow {
     }
 
     /**
-     * Returns date of commit associated with commit hash.
+     * Returns {@link LocalDateTime} of the commit associated with commit hash, with {@link Path} given by {@code root}
+     * as the working directory.
+     *
+     * @throws CommitNotFoundException if no commit exists for the given {@code commitHash}.
+     * @throws ParseException if the date string for the given {@code commitHash} could not be parsed into
+     * a {@link LocalDateTime} object.
      */
     public static LocalDateTime getCommitDate(String root, String commitHash)
             throws CommitNotFoundException, ParseException {
@@ -64,7 +72,11 @@ public class GitShow {
     }
 
     /**
-     * Returns date of earliest commit out of the input list of commits.
+     * Returns {@link LocalDateTime} of the earliest commit out of the input list of commits in {@code commitHashes},
+     * with the {@code root} string denoting the working directory.
+     *
+     * @throws CommitNotFoundException if no commit exists for a given hash in {@code commitHashes}
+     * or if no date string was successfully parsed to a {@link LocalDateTime} for earliest date.
      */
     public static LocalDateTime getEarliestCommitDate(String root, List<String> commitHashes)
             throws CommitNotFoundException {

--- a/src/main/java/reposense/git/GitUtil.java
+++ b/src/main/java/reposense/git/GitUtil.java
@@ -38,8 +38,8 @@ class GitUtil {
     private static final String OR_OPERATOR_PATTERN = "\\|";
 
     /**
-     * Returns the {@code String} command to specify the date range of commits to analyze for `git` commands,
-     * with {@code zoneId} taken into account.
+     * Returns the command to specify the date range of commits to analyze for `git` commands.
+     * Date range is given by {@code sinceDate} and {@code untilDate}, with {@code zoneId} taken into account.
      */
     static String convertToGitDateRangeArgs(LocalDateTime sinceDate, LocalDateTime untilDate, ZoneId zoneId) {
         String gitDateRangeArgs = "";
@@ -57,7 +57,7 @@ class GitUtil {
     }
 
     /**
-     * Returns the {@code String} command to specify the authors to analyze for `git log` command.
+     * Returns the command to specify the {@code author} to analyze for `git log` command.
      */
     static String convertToFilterAuthorArgs(Author author) {
         StringBuilder filterAuthorArgsBuilder = new StringBuilder(" --author=\"");
@@ -79,7 +79,7 @@ class GitUtil {
     }
 
     /**
-     * Returns the {@code String} command to specify the file formats to analyze for `git` commands.
+     * Returns the command to specify the file {@code formats} to analyze for `git` commands.
      */
     public static String convertToGitFormatsArgs(List<FileType> formats) {
         StringBuilder gitFormatsArgsBuilder = new StringBuilder();
@@ -92,9 +92,9 @@ class GitUtil {
     }
 
     /**
-     * Returns the {@code String} command to specify the globs to exclude for `git log` command.
-     * Also checks that every glob in {@code ignoreGlobList} only targets files within the given repository
-     * {@code root}.
+     * Returns the command to specify the globs to exclude for `git log` command.
+     * Also checks that every glob in {@code ignoreGlobList} only targets files within the given
+     * repository's {@code root} directory.
      */
     public static String convertToGitExcludeGlobArgs(File root, List<String> ignoreGlobList) {
         StringBuilder gitExcludeGlobArgsBuilder = new StringBuilder();
@@ -108,7 +108,8 @@ class GitUtil {
     }
 
     /**
-     * Returns true if the {@code ignoreGlob} is inside the current repository.
+     * Returns true if the {@code ignoreGlob} is inside the current repository with reference to the {@code repoRoot}
+     * directory.
      * Produces log messages when the invalid {@code ignoreGlob} is skipped.
      */
     private static boolean isValidIgnoreGlob(File repoRoot, String ignoreGlob) {

--- a/src/main/java/reposense/git/GitVersion.java
+++ b/src/main/java/reposense/git/GitVersion.java
@@ -19,7 +19,7 @@ public class GitVersion {
             Pattern.compile("(((2\\d*\\.(2[3-9]\\d*|[3-9]\\d+|\\d{3,}))|((([3-9]\\d*)|(1\\d+))\\.\\d+))\\.\\d*)");
 
     /**
-     * Get current git version of RepoSense user
+     * Get current git version of RepoSense user.
      */
     public static String getGitVersion() {
         Path rootPath = Paths.get("/");


### PR DESCRIPTION
Part of #1202

Proposed Commit Message:
```
Some Javadoc in git package is inconsistent or missing.

Let's add missing Javadoc and standardise the style.
```

Proposed Javadoc standard for RepoSense (in addition to what is already covered in [SE-EDU](https://se-education.org/guides/conventions/java/index.html#comments) and [Google](https://google.github.io/styleguide/javaguide.html#s7-javadoc)) can be found in:

* Raw styleGuides.md file: https://github.com/reposense/RepoSense/pull/1650/files#diff-bd63b2861c8a46fbd8a67f313e555901c8d6d06762d1c0551c3254467f45b484
* Style Guides on surge.sh: https://docs-1650-pr-reposense-reposense.surge.sh/dg/styleGuides.html