### PR TITLE
[#1202] Missing javadoc for functions - Parser

### DIFF
--- a/src/main/java/reposense/parser/AlphanumericArgumentType.java
+++ b/src/main/java/reposense/parser/AlphanumericArgumentType.java
@@ -8,7 +8,7 @@ import net.sourceforge.argparse4j.inf.ArgumentParserException;
 import net.sourceforge.argparse4j.inf.ArgumentType;
 
 /**
- * Represents an alphanumeric type String argument.
+ * Represents an alphanumeric type {@link String} argument.
  */
 public class AlphanumericArgumentType implements ArgumentType<String> {
     private static final String PARSE_EXCEPTION_MESSAGE_NOT_IN_ALPLANUMERIC =

--- a/src/main/java/reposense/parser/AnalysisThreadsArgumentType.java
+++ b/src/main/java/reposense/parser/AnalysisThreadsArgumentType.java
@@ -6,7 +6,7 @@ import net.sourceforge.argparse4j.inf.ArgumentParserException;
 import net.sourceforge.argparse4j.inf.ArgumentType;
 
 /**
- * Verifies and parses a string-formatted integer to an {@code Integer} object.
+ * Verifies and parses a string-formatted integer to an {@link Integer} object.
  */
 public class AnalysisThreadsArgumentType implements ArgumentType<Integer> {
     public Integer convert(ArgumentParser parser, Argument arg, String value) throws ArgumentParserException {

--- a/src/main/java/reposense/parser/ArgsParser.java
+++ b/src/main/java/reposense/parser/ArgsParser.java
@@ -34,7 +34,7 @@ import reposense.system.LogsManager;
 import reposense.util.TimeUtil;
 
 /**
- * Verifies and parses a string-formatted date to a {@code CliArguments} object.
+ * Verifies and parses a string-formatted date to a {@link CliArguments} object.
  */
 public class ArgsParser {
     public static final String DEFAULT_REPORT_NAME = "reposense-report";
@@ -225,11 +225,11 @@ public class ArgsParser {
     }
 
     /**
-     * Parses the given string arguments to a {@code CliArguments} object.
+     * Parses the given string {@code args} to a {@link CliArguments} object.
      *
      * @throws HelpScreenException if given args contain the --help flag. Help message will be printed out
-     * by the {@code ArgumentParser} hence this is to signal to the caller that the program is safe to exit.
-     * @throws ParseException if the given string arguments fails to parse to a {@code CliArguments} object.
+     * by the {@link ArgumentParser} hence this is to signal to the caller that the program is safe to exit.
+     * @throws ParseException if the given string arguments fails to parse to a {@link CliArguments} object.
      */
     public static CliArguments parse(String[] args) throws HelpScreenException, ParseException {
         try {

--- a/src/main/java/reposense/parser/AuthorConfigCsvParser.java
+++ b/src/main/java/reposense/parser/AuthorConfigCsvParser.java
@@ -1,6 +1,6 @@
 package reposense.parser;
 
-import java.io.IOException;
+import java.io.FileNotFoundException;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
@@ -28,7 +28,7 @@ public class AuthorConfigCsvParser extends CsvParser<AuthorConfiguration> {
     private static final String ALIAS_HEADER = "Author's Git Author Name";
     private static final String IGNORE_GLOB_LIST_HEADER = "Ignore Glob List";
 
-    public AuthorConfigCsvParser(Path csvFilePath) throws IOException {
+    public AuthorConfigCsvParser(Path csvFilePath) throws FileNotFoundException {
         super(csvFilePath);
     }
 
@@ -54,9 +54,9 @@ public class AuthorConfigCsvParser extends CsvParser<AuthorConfiguration> {
     }
 
     /**
-     * Processes the csv file line by line and add created {@code AuthorConfiguration} into {@code results} but
-     * skips {@code author} already exists in a {@code AuthorConfiguration} that has same {@code location} and
-     * {@code branch}.
+     * Processes the csv {@code record} line by line and add created {@link AuthorConfiguration} into {@code results}
+     * but skips {@code author} already exists in a {@link AuthorConfiguration} that has same {@code location}
+     * and {@code branch}.
      */
     @Override
     protected void processLine(List<AuthorConfiguration> results, CSVRecord record)
@@ -94,8 +94,8 @@ public class AuthorConfigCsvParser extends CsvParser<AuthorConfiguration> {
 
 
     /**
-     * Gets an existing {@code AuthorConfiguration} from {@code results} if {@code location} and {@code branch} matches.
-     * Otherwise adds a newly created {@code AuthorConfiguration} into {@code results} and returns it.
+     * Gets an existing {@link AuthorConfiguration} from {@code results} if {@code location} and {@code branch} matches.
+     * Otherwise, adds a newly created {@link AuthorConfiguration} into {@code results} and returns it.
      *
      * @throws InvalidLocationException if {@code location} is invalid.
      */

--- a/src/main/java/reposense/parser/CloningThreadsArgumentType.java
+++ b/src/main/java/reposense/parser/CloningThreadsArgumentType.java
@@ -6,7 +6,7 @@ import net.sourceforge.argparse4j.inf.ArgumentParserException;
 import net.sourceforge.argparse4j.inf.ArgumentType;
 
 /**
- * Verifies and parses a string-formatted integer to an {@code Integer} object.
+ * Verifies and parses a string-formatted integer to an {@link Integer} object.
  */
 public class CloningThreadsArgumentType implements ArgumentType<Integer> {
     public Integer convert(ArgumentParser parser, Argument arg, String value) throws ArgumentParserException {

--- a/src/main/java/reposense/parser/CsvParser.java
+++ b/src/main/java/reposense/parser/CsvParser.java
@@ -56,9 +56,11 @@ public abstract class CsvParser<T> {
     private int numOfLinesBeforeFirstRecord = 0;
 
     /**
-     * @throws IOException if {@code csvFilePath} is an invalid path.
+     * Creates {@link CsvParser} with given {@code csvFilepath}.
+     *
+     * @throws FileNotFoundException if the csv file cannot be found in the provided {@code csvFilePath}.
      */
-    public CsvParser(Path csvFilePath) throws IOException {
+    public CsvParser(Path csvFilePath) throws FileNotFoundException {
         if (csvFilePath == null || !Files.exists(csvFilePath)) {
             throw new FileNotFoundException("Csv file does not exist at the given path.\n"
                     + "Use '-help' to list all the available subcommands and some concept guides.");
@@ -68,11 +70,12 @@ public abstract class CsvParser<T> {
     }
 
     /**
-     * Parses the csv file associated with this instance of the {@code CsvParser} and returns a {@code List}
+     * Parses the csv file associated with this instance of the {@link CsvParser} and returns a {@link List}
      * containing the records in this file.
      *
      * @throws IOException if there are errors accessing the given csv file.
      * @throws InvalidCsvException if the csv is malformed.
+     * @throws InvalidHeaderException if header of csv file cannot be read.
      */
     public List<T> parse() throws IOException, InvalidCsvException, InvalidHeaderException {
         List<T> results = new ArrayList<>();
@@ -112,11 +115,13 @@ public abstract class CsvParser<T> {
     }
 
     /**
-     * Returns the header of a CSV file, which is assumed to be the first non-empty / non-whitespace line in the file.
-     * The line is split into an array of Strings, using the comma symbol as delimiter.
+     * Returns the header of a CSV file, which is assumed to be the first non-empty / non-whitespace line in the file
+     * read by {@code reader}.
+     * The line is split into an array of {@link String}s, using the comma symbol as delimiter.
      *
      * @throws IOException if there is an error accessing the file.
      * @throws InvalidCsvException if the file has only empty or blank lines.
+     * @throws InvalidHeaderException if header of csv file cannot be read.
      */
     private String[] getHeader(BufferedReader reader) throws IOException, InvalidCsvException, InvalidHeaderException {
         String currentLine = "";
@@ -171,9 +176,9 @@ public abstract class CsvParser<T> {
     }
 
     /**
-     * Returns the value of {@code record} at the column with the header {@code header} as a {@code List},
+     * Returns the value of {@code record} at the column with the header {@code header} as a list,
      * delimited by {@code COLUMN_VALUES_SEPARATOR} if it is in {@code record} and not empty, or
-     * returns an empty {@code List} otherwise.
+     * returns an empty list otherwise.
      */
     protected List<String> getAsList(final CSVRecord record, String header) {
         if (get(record, header).isEmpty()) {
@@ -224,7 +229,9 @@ public abstract class CsvParser<T> {
 
     /**
      * Generates map of column header to position number for input {@code possibleHeader}.
+     *
      * @throws InvalidCsvException if {@code possibleHeader} does not contain all the mandatory headers.
+     * @throws InvalidHeaderException if a column in {@code possibleHeader} cannot be parsed.
      */
     private void validateHeader(String[] possibleHeader) throws InvalidCsvException, InvalidHeaderException {
         int headerSize = possibleHeader.length;
@@ -280,9 +287,11 @@ public abstract class CsvParser<T> {
 
     /**
      * Processes the csv file line by line.
-     * All CsvParsers must use {@link CsvParser#get}, {@link CsvParser#getOrDefault},
+     * All {@link CsvParser}s must use {@link CsvParser#get}, {@link CsvParser#getOrDefault},
      * {@link CsvParser#getAsList} or {@link CsvParser#getAsListWithoutOverridePrefix} to read contents in
      * {@code record} and add created objects into {@code results}.
+     *
+     * @throws ParseException if any line does not get read successfully.
      */
     protected abstract void processLine(List<T> results, final CSVRecord record) throws ParseException;
 }

--- a/src/main/java/reposense/parser/DateArgumentType.java
+++ b/src/main/java/reposense/parser/DateArgumentType.java
@@ -10,7 +10,7 @@ import net.sourceforge.argparse4j.inf.ArgumentType;
 import reposense.util.TimeUtil;
 
 /**
- * Verifies and parses a string-formatted date to a {@code Date} object.
+ * Verifies and parses a string-formatted date to a {@link LocalDateTime} object.
  */
 public class DateArgumentType implements ArgumentType<Optional<LocalDateTime>> {
     private static final String PARSE_EXCEPTION_MESSAGE_INVALID_DATE_STRING_FORMAT = "Invalid Date: %s";

--- a/src/main/java/reposense/parser/GroupConfigCsvParser.java
+++ b/src/main/java/reposense/parser/GroupConfigCsvParser.java
@@ -1,6 +1,6 @@
 package reposense.parser;
 
-import java.io.IOException;
+import java.io.FileNotFoundException;
 import java.nio.file.Path;
 import java.util.List;
 
@@ -23,7 +23,7 @@ public class GroupConfigCsvParser extends CsvParser<GroupConfiguration> {
     private static final String GROUP_NAME_HEADER = "Group Name";
     private static final String FILES_GLOB_HEADER = "Globs";
 
-    public GroupConfigCsvParser(Path csvFilePath) throws IOException {
+    public GroupConfigCsvParser(Path csvFilePath) throws FileNotFoundException {
         super(csvFilePath);
     }
 
@@ -48,7 +48,7 @@ public class GroupConfigCsvParser extends CsvParser<GroupConfiguration> {
     }
 
     /**
-     * Processes the csv file line by line and adds created {@code Group} into {@code results}.
+     * Processes the csv {@code record} line by line and adds created {@link GroupConfiguration} into {@code results}.
      */
     @Override
     protected void processLine(List<GroupConfiguration> results, CSVRecord record) throws InvalidLocationException {
@@ -71,8 +71,8 @@ public class GroupConfigCsvParser extends CsvParser<GroupConfiguration> {
     }
 
     /**
-     * Gets an existing {@code GroupConfiguration} from {@code results} if {@code location} matches.
-     * Otherwise adds a newly created {@code GroupConfiguration} into {@code results} and returns it.
+     * Gets an existing {@link GroupConfiguration} from {@code results} if {@code location} matches.
+     * Otherwise, adds a newly created {@link GroupConfiguration} into {@code results} and returns it.
      *
      * @throws InvalidLocationException if {@code location} is invalid.
      */

--- a/src/main/java/reposense/parser/JsonParser.java
+++ b/src/main/java/reposense/parser/JsonParser.java
@@ -9,7 +9,7 @@ import com.google.gson.Gson;
 import com.google.gson.stream.JsonReader;
 
 /**
- * Represents a {@code JsonParser} that is able to parse json file from a {@code Path} into an object of type {@code T}.
+ * Represents a json parser that is able to parse json file from a {@link Path} into an object of type {@code T}.
  */
 public abstract class JsonParser<T> {
 
@@ -20,6 +20,7 @@ public abstract class JsonParser<T> {
 
     /**
      * Converts json file from the given {@code path} into an object and returns it.
+     *
      * @throws IOException if {@code path} is invalid.
      */
     public abstract T parse(Path path) throws IOException;

--- a/src/main/java/reposense/parser/PeriodArgumentType.java
+++ b/src/main/java/reposense/parser/PeriodArgumentType.java
@@ -31,7 +31,9 @@ public class PeriodArgumentType implements ArgumentType<Optional<Integer>> {
     }
 
     /**
-     * This function parses a {@code period} String and returns an Integer representing the number of days.
+     * Parses a {@code period} String and returns an {@link Integer} representing the number of days.
+     *
+     * @throws ParseException if period format or number is invalid.
      */
     public static Optional<Integer> parse(String period) throws ParseException {
         if (!PERIOD_PATTERN.matcher(period).matches()) {

--- a/src/main/java/reposense/parser/RepoConfigCsvParser.java
+++ b/src/main/java/reposense/parser/RepoConfigCsvParser.java
@@ -1,6 +1,6 @@
 package reposense.parser;
 
-import java.io.IOException;
+import java.io.FileNotFoundException;
 import java.nio.file.Path;
 import java.util.List;
 
@@ -33,7 +33,7 @@ public class RepoConfigCsvParser extends CsvParser<RepoConfiguration> {
     private static final String SHALLOW_CLONING_CONFIG_HEADER = "Shallow Cloning";
     private static final String FIND_PREVIOUS_AUTHORS_CONFIG_HEADER = "Find Previous Authors";
 
-    public RepoConfigCsvParser(Path csvFilePath) throws IOException {
+    public RepoConfigCsvParser(Path csvFilePath) throws FileNotFoundException {
         super(csvFilePath);
     }
 
@@ -60,9 +60,11 @@ public class RepoConfigCsvParser extends CsvParser<RepoConfiguration> {
     }
 
     /**
-     * Processes the csv file line by line and add created {@code RepoConfiguration} into {@code results} but
-     * ignores duplicated {@code RepoConfiguration} if there exists one that has same {@code location} and
+     * Processes the csv {@code record} line by line and add created {@link RepoConfiguration} into {@code results} but
+     * ignores duplicated {@link RepoConfiguration} if there exists one that has same {@code location} and
      * {@code branch}.
+     *
+     * @throws InvalidLocationException if the location represented in {@code record} is invalid.
      */
     @Override
     protected void processLine(List<RepoConfiguration> results, CSVRecord record) throws InvalidLocationException {

--- a/src/main/java/reposense/parser/ReportConfigJsonParser.java
+++ b/src/main/java/reposense/parser/ReportConfigJsonParser.java
@@ -9,13 +9,13 @@ import com.google.gson.reflect.TypeToken;
 import reposense.model.ReportConfiguration;
 
 /**
- * Parses json file from {@code Path} and creates a new {@code ReportConfiguration} object.
+ * Parses json file from {@link Path} and creates a new {@link ReportConfiguration} object.
  */
 public class ReportConfigJsonParser extends JsonParser<ReportConfiguration> {
     public static final String REPORT_CONFIG_FILENAME = "report-config.json";
 
     /**
-     * Gets the type of {@code ReportConfiguration} for json conversion.
+     * Gets the type of {@link ReportConfiguration} for json conversion.
      */
     @Override
     public Type getType() {
@@ -24,6 +24,7 @@ public class ReportConfigJsonParser extends JsonParser<ReportConfiguration> {
 
     /**
      * Converts json file from the given {@code path} and returns a {@code ReportConfiguration} object.
+     *
      * @throws IOException if {@code path} is invalid.
      */
     @Override

--- a/src/main/java/reposense/parser/SinceDateArgumentType.java
+++ b/src/main/java/reposense/parser/SinceDateArgumentType.java
@@ -11,7 +11,7 @@ import net.sourceforge.argparse4j.inf.ArgumentParserException;
 import reposense.util.TimeUtil;
 
 /**
- * Verifies and parses a string-formatted since date to a {@code Date} object.
+ * Verifies and parses a string-formatted since date to a {@link LocalDateTime} object.
  */
 public class SinceDateArgumentType extends DateArgumentType {
     /*
@@ -26,6 +26,8 @@ public class SinceDateArgumentType extends DateArgumentType {
      * Returns an arbitrary year {@link SinceDateArgumentType#ARBITRARY_FIRST_COMMIT_DATE} if user specifies
      * {@link SinceDateArgumentType#FIRST_COMMIT_DATE_SHORTHAND} in {@code value}, or attempts to return the
      * desired date otherwise.
+     *
+     * @throws ArgumentParserException if the given date cannot be parsed.
      */
     @Override
     public Optional<LocalDateTime> convert(ArgumentParser parser, Argument arg, String value)

--- a/src/main/java/reposense/parser/StandaloneConfigJsonParser.java
+++ b/src/main/java/reposense/parser/StandaloneConfigJsonParser.java
@@ -9,12 +9,12 @@ import com.google.gson.reflect.TypeToken;
 import reposense.model.StandaloneConfig;
 
 /**
- * Parses json file from {@code Path} and creates a new {@code StandaloneConfig} object.
+ * Parses json file from {@link  Path} and creates a new {@link StandaloneConfig} object.
  */
 public class StandaloneConfigJsonParser extends JsonParser<StandaloneConfig> {
 
     /**
-     * Gets the type of {@code StandaloneConfig} for json conversion.
+     * Gets the type of {@link StandaloneConfig} for json conversion.
      */
     @Override
     public Type getType() {
@@ -22,7 +22,8 @@ public class StandaloneConfigJsonParser extends JsonParser<StandaloneConfig> {
     }
 
     /**
-     * Converts json file from the given {@code path} and returns a {@code StandaloneConfig} object.
+     * Converts json file from the given {@code path} and returns a {@link StandaloneConfig} object.
+     *
      * @throws IOException if {@code path} is invalid.
      */
     @Override

--- a/src/main/java/reposense/parser/UntilDateArgumentType.java
+++ b/src/main/java/reposense/parser/UntilDateArgumentType.java
@@ -9,7 +9,7 @@ import net.sourceforge.argparse4j.inf.ArgumentParserException;
 import reposense.util.TimeUtil;
 
 /**
- * Verifies and parses a string-formatted until date to a {@code Date} object.
+ * Verifies and parses a string-formatted until date to a {@link LocalDateTime} object.
  */
 
 public class UntilDateArgumentType extends DateArgumentType {

--- a/src/main/java/reposense/parser/ZoneIdArgumentType.java
+++ b/src/main/java/reposense/parser/ZoneIdArgumentType.java
@@ -9,7 +9,7 @@ import net.sourceforge.argparse4j.inf.ArgumentParserException;
 import net.sourceforge.argparse4j.inf.ArgumentType;
 
 /**
- * Verifies and parses a string-formatted zone id to a {@code ZoneId} object.
+ * Verifies and parses a string-formatted zone id to a {@link ZoneId} object.
  */
 public class ZoneIdArgumentType implements ArgumentType<ZoneId> {
     private static final String MESSAGE_TIMEZONE_INVALID =


### PR DESCRIPTION
Part of #1202

Proposed Commit Message:
```
Some Javadoc in parser package is inconsistent or missing.

Let's add missing Javadoc and standardise the style.
```

Proposed Javadoc standard for RepoSense (in addition to what is already covered in [SE-EDU](https://se-education.org/guides/conventions/java/index.html#comments) and [Google](https://google.github.io/styleguide/javaguide.html#s7-javadoc)) can be found in:

* Raw styleGuides.md file: https://github.com/reposense/RepoSense/pull/1650/files#diff-bd63b2861c8a46fbd8a67f313e555901c8d6d06762d1c0551c3254467f45b484
* Style Guides on surge.sh: https://docs-1650-pr-reposense-reposense.surge.sh/dg/styleGuides.html