### PR TITLE
[#1202] Missing javadoc for functions - Commits

### DIFF
--- a/src/main/java/reposense/commits/CommitInfoAnalyzer.java
+++ b/src/main/java/reposense/commits/CommitInfoAnalyzer.java
@@ -60,7 +60,7 @@ public class CommitInfoAnalyzer {
     private static final Pattern MESSAGEBODY_LEADING_PATTERN = Pattern.compile("^ {4}", Pattern.MULTILINE);
 
     /**
-     * Analyzes each {@code CommitInfo} in {@code commitInfos} and returns a list of {@code CommitResult} that is not
+     * Analyzes each {@link CommitInfo} in {@code commitInfos} and returns a list of {@link CommitResult} that is not
      * specified to be ignored or the author is inside {@code config}.
      */
     public static List<CommitResult> analyzeCommits(List<CommitInfo> commitInfos, RepoConfiguration config) {
@@ -76,7 +76,8 @@ public class CommitInfoAnalyzer {
     }
 
     /**
-     * Extracts the relevant data from {@code commitInfo} into a {@code CommitResult}.
+     * Extracts the relevant data from {@code commitInfo} into a {@link CommitResult}. Retrieves the author of the
+     * commit from {@code config}.
      */
     public static CommitResult analyzeCommit(CommitInfo commitInfo, RepoConfiguration config) {
         String infoLine = commitInfo.getInfoLine();
@@ -124,7 +125,8 @@ public class CommitInfoAnalyzer {
     }
 
     /**
-     * Returns the number of lines added and deleted for the specified file types in {@code config}.
+     * Returns the number of lines added and deleted in {@code filePathContributions} for the specified file types
+     * in {@code config}.
      */
     private static Map<FileType, ContributionPair> getFileTypesAndContribution(String[] filePathContributions,
             RepoConfiguration config) {
@@ -153,7 +155,7 @@ public class CommitInfoAnalyzer {
     }
 
     /**
-     * Extracts the correct file path from the unprocessed git log {@code filePath}
+     * Extracts the correct file path from the unprocessed git log {@code filePath}.
      */
     private static String extractFilePath(String filePath) {
         String filteredFilePath = filePath;

--- a/src/main/java/reposense/commits/CommitInfoExtractor.java
+++ b/src/main/java/reposense/commits/CommitInfoExtractor.java
@@ -44,7 +44,7 @@ public class CommitInfoExtractor {
     }
 
     /**
-     * Parses the {@code gitLogResult} into a list of {@code CommitInfo} and returns it.
+     * Parses the {@code gitLogResult} into a list of {@link CommitInfo} and returns it.
      */
     private static ArrayList<CommitInfo> parseGitLogResults(String gitLogResult) {
         ArrayList<CommitInfo> commitInfos = new ArrayList<>();


### PR DESCRIPTION
Part of #1202

Proposed Commit Message:
```
Some Javadoc in commits package is inconsistent or missing.

Let's add missing Javadoc and standardise the style.
```

Proposed Javadoc standard for RepoSense (in addition to what is already covered in [SE-EDU](https://se-education.org/guides/conventions/java/index.html#comments) and [Google](https://google.github.io/styleguide/javaguide.html#s7-javadoc)) can be found in:

* Raw styleGuides.md file: https://github.com/reposense/RepoSense/pull/1650/files#diff-bd63b2861c8a46fbd8a67f313e555901c8d6d06762d1c0551c3254467f45b484
* Style Guides on surge.sh: https://docs-1650-pr-reposense-reposense.surge.sh/dg/styleGuides.html