### PR TITLE
Frontend: fix vue-fontawesome Vue 3 compatibility

### DIFF
--- a/frontend/cypress/tests/codeView/codeView_switchAuthorship.js
+++ b/frontend/cypress/tests/codeView/codeView_switchAuthorship.js
@@ -107,7 +107,7 @@ describe('switch authorship', () => {
 
     cy.get('#tab-authorship > .files > .file > .title > .path')
         .children('span')
-        .first()
+        .last()
         .should(($span) => {
           const lastFilename = $span.text();
           expect(firstFilename, 'First displayed filenames should be different for different authors')

--- a/frontend/cypress/tests/codeView/codeView_switchAuthorship.js
+++ b/frontend/cypress/tests/codeView/codeView_switchAuthorship.js
@@ -107,7 +107,7 @@ describe('switch authorship', () => {
 
     cy.get('#tab-authorship > .files > .file > .title > .path')
         .children('span')
-        .last()
+        .first()
         .should(($span) => {
           const lastFilename = $span.text();
           expect(firstFilename, 'First displayed filenames should be different for different authors')

--- a/frontend/src/views/v-authorship.vue
+++ b/frontend/src/views/v-authorship.vue
@@ -97,14 +97,12 @@
       .file(v-bind:key="file.path")
         .title
           span.path(v-on:click="toggleFileActiveProperty(file)")
-            span(v-show="file.active")
-              .tooltip
-                font-awesome-icon(icon="caret-down", fixed-width)
-                span.tooltip-text Click to hide file details
-            span(v-show="!file.active")
-              .tooltip
-                font-awesome-icon(icon="caret-right", fixed-width)
-                span.tooltip-text Click to show file details
+            .tooltip(v-show="file.active")
+              font-awesome-icon(icon="caret-down", fixed-width)
+              span.tooltip-text Click to hide file details
+            .tooltip(v-show="!file.active")
+              font-awesome-icon(icon="caret-right", fixed-width)
+              span.tooltip-text Click to show file details
             span {{ i + 1 }}. &nbsp;&nbsp; {{ file.path }} &nbsp;
           span.icons
             a(

--- a/frontend/src/views/v-authorship.vue
+++ b/frontend/src/views/v-authorship.vue
@@ -97,11 +97,14 @@
       .file(v-bind:key="file.path")
         .title
           span.path(v-on:click="toggleFileActiveProperty(file)")
-            .tooltip
-              font-awesome-icon(icon="caret-down", fixed-width, v-show="file.active")
-              span.tooltip-text(v-show="file.active") Click to hide file details
-              font-awesome-icon(icon="caret-right", fixed-width, v-show="!file.active")
-              span.tooltip-text(v-show="!file.active") Click to show file details
+            span(v-show="file.active")
+              .tooltip
+                font-awesome-icon(icon="caret-down", fixed-width)
+                span.tooltip-text Click to hide file details
+            span(v-show="!file.active")
+              .tooltip
+                font-awesome-icon(icon="caret-right", fixed-width)
+                span.tooltip-text Click to show file details
             span {{ i + 1 }}. &nbsp;&nbsp; {{ file.path }} &nbsp;
           span.icons
             a(


### PR DESCRIPTION
Needed for #1627

## Proposed commit message
<!--
    Propose a detailed commit message for this pull request within the triple backticks below.
    Wrap lines at 72 characters.

    Guide on how to write a good commit message:
    https://oss-generic.github.io/process/docs/FormatsAndConventions.html#commit-message
-->
```
vue-fontawesome cannot be used directly in another component in Vue 3.
Cypress test is updated to ensure the correct element is fetched during
testing.

Let's move the condition check one level above to avoid this problem.
```

## Other information
<!--
    Are there other relevant information, such as special testing instructions, 
    which will help the reviewer better understand the code?

    You may also include a brief description of why the problem occurred.
-->
You can find the `vue-fontawesome` issue [here](https://github.com/FortAwesome/vue-fontawesome/issues/313).