### PR TITLE
[#1736] Temporary adjust cypress test codeView_switchAuthorship

### DIFF
--- a/frontend/cypress/tests/codeView/codeView_switchAuthorship.js
+++ b/frontend/cypress/tests/codeView/codeView_switchAuthorship.js
@@ -47,8 +47,9 @@ describe('switch authorship', () => {
     cy.get('#tab-authorship > .title > .contribution > .fileTypes input[id="java"]')
         .should('be.checked');
 
-    cy.get('#tab-authorship > .title > .contribution > .fileTypes input[id="yml"]')
-        .should('be.checked');
+    // Temporarily disabled due to #1736, since 2022-03-30
+    // cy.get('#tab-authorship > .title > .contribution > .fileTypes input[id="yml"]')
+    //     .should('be.checked');
   });
 
   it('switch authorship view should not retain information from previous visited tabs', () => {


### PR DESCRIPTION
<!--
    If this pull request fully addresses an issue, use:
    Fixes #xxxx

    If this pull request partially addresses an issue, use:
    Part of #xxxx

    If this pull request addresses multiple issues, put them in multiple lines:
    Fixes #xxxx
    Fixes #yyyy

    Format the title of the pull request with most relevant issue number as follows:
    [#xxxx] Title
-->
Part of #1736.

## Proposed commit message
<!--
    Propose a detailed commit message for this pull request within the triple backticks below.
    Wrap lines at 72 characters.

    Guide on how to write a good commit message:
    https://oss-generic.github.io/process/docs/FormatsAndConventions.html#commit-message
-->
```
Due to the removal of the appveyor.yml file in #1731, the
codeView_switchAuthorship cypress test no longer works, as it expects
yml files to be present in the RepoSense repository.

Let's temporarily adjust the codeView_switchAuthorship cypress test so
that the frontend CI tests can pass, by removing the check on yml files.
In the longer term, the frontend tests' dependency on the RepoSense
repository should be removed, as it can make the CI tests unstable.
```

## Other information
<!--
    Are there other relevant information, such as special testing instructions, 
    which will help the reviewer better understand the code?

    You may also include a brief description of why the problem occurred.
-->
The yml file removed is the appveyor.yml file, which was removed in #1731. In the long term, CI tests should not be affected by changes to the RepoSense repository.