### PR TITLE
[#1738] Remove dependence of Cypress tests on RepoSense master

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # RepoSense
 
 [![Build Status](https://github.com/reposense/RepoSense/actions/workflows/integration.yml/badge.svg)](https://github.com/reposense/RepoSense/actions/workflows/integration.yml)
-[![Build status](https://ci.appveyor.com/api/projects/status/gsbkj5qby3pjd6nw/branch/master?svg=true)](https://ci.appveyor.com/project/eugenepeh/reposense/branch/master)
 [![codecov.io](https://codecov.io/gh/reposense/RepoSense/branch/master/graphs/badge.svg?branch=master)](http://codecov.io/github/reposense/RepoSense?branch=master)
 [![Netlify Status](https://api.netlify.com/api/v1/badges/260983b3-589e-4619-a2e8-0bfb7a2b4422/deploy-status)](https://app.netlify.com/sites/reposense/deploys)
 

--- a/docs/dg/devOpsGuide.md
+++ b/docs/dg/devOpsGuide.md
@@ -39,6 +39,8 @@ Some of the jobs execute some commands that are too complicated to be included i
 
 This workflow is run for both incoming pull requests to any branch as well as direct commits to any branch in the repository.
 
+Cypress frontend tests are run against reports generated from config files in `frontend/cypress/config`. It uses the `cypress` branch of the RepoSense repository which is kept independent of `master` and should be updated only when there are new frontend tests that need to be accommodated.
+
 ### Report and documentation previews
 
 For each pull request to any branch in the repository, a RepoSense report and the MarkBind documentation website is generated based on the code submitted in the pull request. This is to facilitate pull request reviewers in being able to quickly preview how the RepoSense report and/or the documentation website will change after the pull request is merged.

--- a/frontend/cypress/config/repo-config.csv
+++ b/frontend/cypress/config/repo-config.csv
@@ -1,3 +1,3 @@
 Repository's Location,Branch,File formats,Ignore Glob List,Ignore standalone config,Ignore Commits List,Ignore Authors List,Shallow Cloning,Find Previous Authors
-https://github.com/reposense/RepoSense.git,master,,,,,,,
+https://github.com/reposense/RepoSense.git,cypress,,,,,,,
 https://github.com/reposense/testrepo-Empty.git,master,,,,,,,

--- a/frontend/cypress/tests/codeView/codeView_switchAuthorship.js
+++ b/frontend/cypress/tests/codeView/codeView_switchAuthorship.js
@@ -47,9 +47,8 @@ describe('switch authorship', () => {
     cy.get('#tab-authorship > .title > .contribution > .fileTypes input[id="java"]')
         .should('be.checked');
 
-    // Temporarily disabled due to #1736, since 2022-03-30
-    // cy.get('#tab-authorship > .title > .contribution > .fileTypes input[id="yml"]')
-    //     .should('be.checked');
+    cy.get('#tab-authorship > .title > .contribution > .fileTypes input[id="yml"]')
+        .should('be.checked');
   });
 
   it('switch authorship view should not retain information from previous visited tabs', () => {


### PR DESCRIPTION
Fixes #1738 

## Proposed commit message
<!--
    Propose a detailed commit message for this pull request within the triple backticks below.
    Wrap lines at 72 characters.

    Guide on how to write a good commit message:
    https://oss-generic.github.io/process/docs/FormatsAndConventions.html#commit-message
-->
```
Cypress tests depend on RepoSense master which is constantly changing.
This can break tests as it did when #1731 was merged.

Let's use a separate branch 'cypress' in the RepoSense repository to
generate fixed reports for frontend tests that are not affected by
merges to master. Changes required for testing new frontend features
can be made to the cypress branch which will be independent of master.
Let's also remove the AppVeyor CI badge since we no longer use it as
of PR #1731.
```
