### PR TITLE
Release Logger resources once RepoSense finishes processing

### DIFF
--- a/src/main/java/reposense/RepoSense.java
+++ b/src/main/java/reposense/RepoSense.java
@@ -8,6 +8,7 @@ import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Level;
+import java.util.logging.LogManager;
 import java.util.logging.Logger;
 
 import net.sourceforge.argparse4j.helper.HelpScreenException;
@@ -109,6 +110,8 @@ public class RepoSense {
         } catch (HelpScreenException e) {
             // help message was printed by the ArgumentParser; it is safe to exit.
         }
+
+        LogManager.getLogManager().reset();
     }
 
     /**


### PR DESCRIPTION
Releases the `reposense.log.0` resource for writing logs.

## Proposed commit message
<!--
    Propose a detailed commit message for this pull request within the triple backticks below.
    Wrap lines at 72 characters.

    Guide on how to write a good commit message:
    https://oss-generic.github.io/process/docs/FormatsAndConventions.html#commit-message
-->
```
Log resources are currently only fully released when the process exits.
This leads to the persistence of the reposense.log.0.lck lock file in
some scenarios.

Let's release the log file resource at the end of RepoSense execution.
```

## Other information
Necessary for #1746 as the log file is not properly released during each test case and thus cannot be deleted while running the system tests. I'm not too sure how `ConfigSystemTest` gets around it but it does not seem to have the same problem deleting the report directories. The implementation between `ConfigSystemTest` is quite different as it does not make use of `RepoSense::main`.

Right now, I believe the issue can be seen when we run `gradlew run -Dargs="-r <some repo> -v"` and then Ctrl+C the server. The lock file `.lck` can still be seen even after the execution ends. 
![image](https://user-images.githubusercontent.com/65345505/161398875-dcbf32c1-f586-492d-a498-65cb7ad156e6.png)

Solution taken from here:
https://stackoverflow.com/a/22957009