### PR TITLE
Temporary Hotfix - Remove --since d1 from tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -171,7 +171,7 @@ def serveTestReportInBackground = tasks.register('serveTestReportInBackground', 
     tasks.compileJava.mustRunAfter(zipReport)
     main = mainClassName
     classpath = sourceSets.main.runtimeClasspath
-    args = ['--config', './frontend/cypress/config', '--since', 'd1', '--view']
+    args = ['--config', './frontend/cypress/config', '--since', '30/9/2017', '--view']
     String versionJvmArgs = '-Dversion=' + getRepoSenseVersion()
     jvmArgs = [ versionJvmArgs ]
     killDescendants = false // Kills descendants of started process using methods only found in Java 9 and beyond.

--- a/docs/ug/cli.md
+++ b/docs/ug/cli.md
@@ -216,8 +216,13 @@ Cannot be used with `--last-modified-date`. This may result in an incorrect last
 <box type="info" seamless>
 
 * If the start date is not specified, only commits made one month before the end date (if specified) or the date of generating the report, will be captured and analyzed.
-* If `d1` is specified as the start date (`--since d1` or `-s d1`), then the earliest commit date of all repositories will be taken as the start date.
+* ~~If `d1` is specified as the start date (`--since d1` or `-s d1`), then the earliest commit date of all repositories will be taken as the start date.~~
 </box>
+
+<box type="warning" seamless>
+The use of `d1` with this flag is currently buggy and may not work as intended. You are advised not to use it for the time being.
+</box>
+
 <!-- ------------------------------------------------------------------------------------------------------ -->
 
 ### `--timezone`, `-t`

--- a/src/systemtest/java/reposense/ConfigSystemTest.java
+++ b/src/systemtest/java/reposense/ConfigSystemTest.java
@@ -25,7 +25,6 @@ import reposense.parser.AuthorConfigCsvParser;
 import reposense.parser.GroupConfigCsvParser;
 import reposense.parser.RepoConfigCsvParser;
 import reposense.parser.ReportConfigJsonParser;
-import reposense.parser.SinceDateArgumentType;
 import reposense.report.ErrorSummary;
 import reposense.report.ReportGenerator;
 import reposense.util.FileUtil;
@@ -54,17 +53,6 @@ public class ConfigSystemTest {
         FileUtil.deleteDirectory(FT_TEMP_DIR);
     }
 
-    /**
-     * System test with a specified until date and a {@link SinceDateArgumentType#FIRST_COMMIT_DATE_SHORTHAND}
-     * since date to capture from the first commit.
-     */
-    @Test
-    public void testSinceBeginningDateRange() throws Exception {
-        runTest(getInputWithDates(SinceDateArgumentType.FIRST_COMMIT_DATE_SHORTHAND, "2/3/2019"),
-                false, false, false, false,
-                "ConfigSystemTest/sinceBeginningDateRange/expected");
-    }
-
     @Test
     public void test30DaysFromUntilDate() throws Exception {
         runTest(getInputWithUntilDate("1/11/2017"), false,
@@ -83,33 +71,11 @@ public class ConfigSystemTest {
                 "ConfigSystemTest/dateRangeWithModifiedDateTimeInLines/expected");
     }
 
-    /**
-     * System test with a specified until date and a {@link SinceDateArgumentType#FIRST_COMMIT_DATE_SHORTHAND}
-     * since date to capture from the first commit, using shallow cloning.
-     */
-    @Test
-    public void testSinceBeginningDateRangeWithShallowCloning() throws Exception {
-        runTest(getInputWithDates(SinceDateArgumentType.FIRST_COMMIT_DATE_SHORTHAND, "2/3/2019"),
-                false, true, true, false,
-                "ConfigSystemTest/sinceBeginningDateRangeWithShallowCloning/expected");
-    }
-
     @Test
     public void test30DaysFromUntilDateWithShallowCloning() throws Exception {
         runTest(getInputWithUntilDate("1/11/2017"), false,
                 true, true, false,
                 "ConfigSystemTest/30daysFromUntilDateWithShallowCloning/expected");
-    }
-
-    /**
-     * System test with a specified until date and a {@link SinceDateArgumentType#FIRST_COMMIT_DATE_SHORTHAND}
-     * since date to capture from the first commit, using find previous authors.
-     */
-    @Test
-    public void testSinceBeginningDateRangeWithFindPreviousAuthors() throws Exception {
-        runTest(getInputWithDates(SinceDateArgumentType.FIRST_COMMIT_DATE_SHORTHAND, "2/3/2019"),
-                false, false, true, true,
-                "ConfigSystemTest/sinceBeginningDateRangeFindPreviousAuthors/expected");
     }
 
     @Test


### PR DESCRIPTION
<!--
    If this pull request fully addresses an issue, use:
    Fixes #xxxx

    If this pull request partially addresses an issue, use:
    Part of #xxxx

    If this pull request addresses multiple issues, put them in multiple lines:
    Fixes #xxxx
    Fixes #yyyy

    Format the title of the pull request with most relevant issue number as follows:
    [#xxxx] Title
-->
Part of #1774 

## Proposed commit message
<!--
    Propose a detailed commit message for this pull request within the triple backticks below.
    Wrap lines at 72 characters.

    Guide on how to write a good commit message:
    https://oss-generic.github.io/process/docs/FormatsAndConventions.html#commit-message
-->
```
The CIs are failed by tests that use --since d1. This issue may also affect
the release version.

Let's remove them temporarily or change d1 to an actual date so that
other developers can still continue work without worrying about failing
CIs while the issue is investigated further.

Let's also put a warning in the user guide about --since d1 not working.
```

## Other information
<!--
    Are there other relevant information, such as special testing instructions, 
    which will help the reviewer better understand the code?

    You may also include a brief description of why the problem occurred.
-->

* A [separate branch](https://github.com/reposense/RepoSense/tree/1774-investigate-failing-ci) without this hotfix has been created for anyone to investigate #1774
* Any changes to the `--since d1` functionality outside of the above-mentioned branch will not be covered by tests
* Since there are no changes to the main code in this hotfix, it suffices to simply [update the production website](https://reposense.org/RepoSense/dg/projectManagement.html#deploying-the-production-website) after merging this PR