### PR TITLE
[#1774] Fix unintended behavior related to --since d1

### DIFF
--- a/docs/ug/cli.md
+++ b/docs/ug/cli.md
@@ -172,7 +172,7 @@ This flag overrides the `Ignore file size limit` field in the CSV config file.
 <box type="info" seamless>
 
 * If both start date and end date are not specified, the date of generating the report will be taken as the end date.
-* May analyse the incorrect date range if used with `--since d1`. The program will throw a warning.
+* May analyze the incorrect date range if used with `--since d1`. The program will throw a warning.
 * Cannot be used with both `--since` and `--until`. The program will throw an exception.
 </box>
 <!-- ------------------------------------------------------------------------------------------------------ -->
@@ -218,7 +218,7 @@ Cannot be used with `--last-modified-date`. This may result in an incorrect last
 
 * If the start date is not specified, only commits made one month before the end date (if specified) or the date of generating the report, will be captured and analyzed.
 * If `d1` is specified as the start date (`--since d1` or `-s d1`), then the program will search for the earliest commit date of all repositories and use that as the start date.
-* If `d1` is specified together with `--period`, then the program will warn that the date range being analysed may be incorrect.
+* If `d1` is specified together with `--period`, then the program will warn that the date range being analyzed may be incorrect.
 </box>
 <!-- ------------------------------------------------------------------------------------------------------ -->
 

--- a/docs/ug/cli.md
+++ b/docs/ug/cli.md
@@ -172,6 +172,7 @@ This flag overrides the `Ignore file size limit` field in the CSV config file.
 <box type="info" seamless>
 
 * If both start date and end date are not specified, the date of generating the report will be taken as the end date.
+* May analyse the incorrect date range if used with `--since d1`. The program will throw a warning.
 * Cannot be used with both `--since` and `--until`. The program will throw an exception.
 </box>
 <!-- ------------------------------------------------------------------------------------------------------ -->
@@ -216,7 +217,8 @@ Cannot be used with `--last-modified-date`. This may result in an incorrect last
 <box type="info" seamless>
 
 * If the start date is not specified, only commits made one month before the end date (if specified) or the date of generating the report, will be captured and analyzed.
-* If `d1` is specified as the start date (`--since d1` or `-s d1`), then the earliest commit date of all repositories will be taken as the start date.
+* If `d1` is specified as the start date (`--since d1` or `-s d1`), then the program will search for the earliest commit date of all repositories and use that as the start date.
+* If `d1` is specified together with `--period`, then the program will warn that the date range being analysed may be incorrect.
 </box>
 <!-- ------------------------------------------------------------------------------------------------------ -->
 

--- a/src/main/java/reposense/commits/CommitResultAggregator.java
+++ b/src/main/java/reposense/commits/CommitResultAggregator.java
@@ -14,8 +14,8 @@ import reposense.commits.model.CommitContributionSummary;
 import reposense.commits.model.CommitResult;
 import reposense.model.Author;
 import reposense.model.RepoConfiguration;
-import reposense.parser.SinceDateArgumentType;
 import reposense.report.ReportGenerator;
+import reposense.util.TimeUtil;
 
 /**
  * Uses the commit analysis results to generate the summary information of a repository.
@@ -31,7 +31,7 @@ public class CommitResultAggregator {
             RepoConfiguration config, List<CommitResult> commitResults) {
         LocalDateTime startDate;
         ZoneId zoneId = ZoneId.of(config.getZoneId());
-        startDate = (config.getSinceDate().equals(SinceDateArgumentType.getArbitraryFirstCommitDateConverted(zoneId)))
+        startDate = (TimeUtil.isEqualToArbitraryFirstDateConverted(config.getSinceDate(), zoneId))
                 ? getStartOfDate(getStartDate(commitResults, zoneId), zoneId)
                 : config.getSinceDate();
         ReportGenerator.setEarliestSinceDate(startDate);
@@ -159,7 +159,7 @@ public class CommitResultAggregator {
      * timezone given by {@code zoneId}. Otherwise, return a {@link LocalDateTime} adjusted to have a time of 00:00:00.
      */
     private static LocalDateTime getStartOfDate(LocalDateTime current, ZoneId zoneId) {
-        if (current.equals(SinceDateArgumentType.getArbitraryFirstCommitDateConverted(zoneId))) {
+        if (TimeUtil.isEqualToArbitraryFirstDateConverted(current, zoneId)) {
             return current;
         }
 
@@ -174,7 +174,7 @@ public class CommitResultAggregator {
      */
     private static LocalDateTime getStartDate(List<CommitResult> commitInfos, ZoneId zoneId) {
         return (commitInfos.isEmpty())
-                ? SinceDateArgumentType.getArbitraryFirstCommitDateConverted(zoneId)
+                ? TimeUtil.getArbitraryFirstCommitDateConverted(zoneId)
                 : commitInfos.get(0).getTime();
     }
 }

--- a/src/main/java/reposense/commits/CommitResultAggregator.java
+++ b/src/main/java/reposense/commits/CommitResultAggregator.java
@@ -22,8 +22,6 @@ import reposense.report.ReportGenerator;
  */
 public class CommitResultAggregator {
     private static final int DAYS_IN_MS = 24 * 60 * 60 * 1000;
-    private static final ZonedDateTime ARBITRARY_FIRST_COMMIT_DATE_UTC =
-            ZonedDateTime.of(SinceDateArgumentType.ARBITRARY_FIRST_COMMIT_DATE, ZoneId.of("Z"));
 
     /**
      * Returns the {@link CommitContributionSummary} generated from aggregating the {@code commitResults}.
@@ -33,7 +31,7 @@ public class CommitResultAggregator {
             RepoConfiguration config, List<CommitResult> commitResults) {
         LocalDateTime startDate;
         ZoneId zoneId = ZoneId.of(config.getZoneId());
-        startDate = (config.getSinceDate().equals(SinceDateArgumentType.ARBITRARY_FIRST_COMMIT_DATE))
+        startDate = (config.getSinceDate().equals(SinceDateArgumentType.getArbitraryFirstCommitDateConverted(zoneId)))
                 ? getStartOfDate(getStartDate(commitResults, zoneId), zoneId)
                 : config.getSinceDate();
         ReportGenerator.setEarliestSinceDate(startDate);
@@ -157,11 +155,11 @@ public class CommitResultAggregator {
     /**
      * Gets the starting point of the {@code current} date.
      *
-     * @return the {@code current} date if it is equal to the {@code ARBITRARY_FIRST_COMMIT_DATE_UTC} adjusted to the
+     * @return the {@code current} date if it is equal to the {@code ARBITRARY_FIRST_COMMIT_DATE} adjusted to the
      * timezone given by {@code zoneId}. Otherwise, return a {@link LocalDateTime} adjusted to have a time of 00:00:00.
      */
     private static LocalDateTime getStartOfDate(LocalDateTime current, ZoneId zoneId) {
-        if (current.equals(ARBITRARY_FIRST_COMMIT_DATE_UTC.withZoneSameInstant(zoneId).toLocalDateTime())) {
+        if (current.equals(SinceDateArgumentType.getArbitraryFirstCommitDateConverted(zoneId))) {
             return current;
         }
 
@@ -172,11 +170,11 @@ public class CommitResultAggregator {
      * Gets the earliest commit date from {@code commitInfos}.
      *
      * @return First commit date if there is at least one {@link CommitResult}. Otherwise, return
-     * the {@code ARBITRARY_FIRST_COMMIT_DATE_UTC} converted to the timezone given by {@code zoneId}.
+     * the {@code ARBITRARY_FIRST_COMMIT_DATE} converted to the timezone given by {@code zoneId}.
      */
     private static LocalDateTime getStartDate(List<CommitResult> commitInfos, ZoneId zoneId) {
         return (commitInfos.isEmpty())
-                ? ARBITRARY_FIRST_COMMIT_DATE_UTC.withZoneSameInstant(zoneId).toLocalDateTime()
+                ? SinceDateArgumentType.getArbitraryFirstCommitDateConverted(zoneId)
                 : commitInfos.get(0).getTime();
     }
 }

--- a/src/main/java/reposense/parser/ArgsParser.java
+++ b/src/main/java/reposense/parser/ArgsParser.java
@@ -74,6 +74,8 @@ public class ArgsParser {
             "Config path not provided, using the config folder as default.";
     private static final String MESSAGE_INVALID_CONFIG_PATH = "%s is malformed.";
     private static final String MESSAGE_INVALID_CONFIG_JSON = "%s Ignoring the report config provided.";
+    private static final String MESSAGE_SINCE_D1_WITH_PERIOD = "You may be using --since d1 with the --period flag. "
+            + "This may result in an incorrect date range being analysed.";
     private static final Path EMPTY_PATH = Paths.get("");
     private static final Path DEFAULT_CONFIG_PATH = Paths.get(System.getProperty("user.dir")
             + File.separator + "config" + File.separator);
@@ -292,6 +294,9 @@ public class ArgsParser {
                 sinceDate = TimeUtil.getSinceDate(cliSinceDate.get());
                 // For --since d1, need to adjust the arbitrary date based on timezone
                 if (TimeUtil.isEqualToArbitraryFirstDateUtc(sinceDate)) {
+                    if (isPeriodProvided) {
+                        logger.warning(MESSAGE_SINCE_D1_WITH_PERIOD);
+                    }
                     sinceDate = TimeUtil.getArbitraryFirstCommitDateConverted(zoneId);
                 }
             } else {

--- a/src/main/java/reposense/parser/ArgsParser.java
+++ b/src/main/java/reposense/parser/ArgsParser.java
@@ -282,6 +282,7 @@ public class ArgsParser {
             boolean isSinceDateProvided = cliSinceDate.isPresent();
             boolean isUntilDateProvided = cliUntilDate.isPresent();
             boolean isPeriodProvided = cliPeriod.isPresent();
+            boolean isUsingArbitraryDate = false;
             if (isSinceDateProvided && isUntilDateProvided && isPeriodProvided) {
                 throw new ParseException(MESSAGE_HAVE_SINCE_DATE_UNTIL_DATE_AND_PERIOD);
             }
@@ -294,9 +295,7 @@ public class ArgsParser {
                 sinceDate = TimeUtil.getSinceDate(cliSinceDate.get());
                 // For --since d1, need to adjust the arbitrary date based on timezone
                 if (TimeUtil.isEqualToArbitraryFirstDateUtc(sinceDate)) {
-                    if (isPeriodProvided) {
-                        logger.warning(MESSAGE_SINCE_D1_WITH_PERIOD);
-                    }
+                    isUsingArbitraryDate = true;
                     sinceDate = TimeUtil.getArbitraryFirstCommitDateConverted(zoneId);
                 }
             } else {
@@ -310,6 +309,10 @@ public class ArgsParser {
                             : TimeUtil.getDateMinusAMonth(currentDate);
                 }
 
+            }
+
+            if (isPeriodProvided && isUsingArbitraryDate) {
+                logger.warning(MESSAGE_SINCE_D1_WITH_PERIOD);
             }
 
             if (isUntilDateProvided) {

--- a/src/main/java/reposense/parser/ArgsParser.java
+++ b/src/main/java/reposense/parser/ArgsParser.java
@@ -290,6 +290,10 @@ public class ArgsParser {
 
             if (isSinceDateProvided) {
                 sinceDate = TimeUtil.getSinceDate(cliSinceDate.get());
+                // For --since d1, need to adjust the arbitrary date based on timezone
+                if (sinceDate.equals(SinceDateArgumentType.getArbitraryFirstCommitDateUtcLocal())) {
+                    sinceDate = SinceDateArgumentType.getArbitraryFirstCommitDateConverted(zoneId);
+                }
             } else {
                 if (isUntilDateProvided) {
                     sinceDate = isPeriodProvided

--- a/src/main/java/reposense/parser/ArgsParser.java
+++ b/src/main/java/reposense/parser/ArgsParser.java
@@ -291,8 +291,8 @@ public class ArgsParser {
             if (isSinceDateProvided) {
                 sinceDate = TimeUtil.getSinceDate(cliSinceDate.get());
                 // For --since d1, need to adjust the arbitrary date based on timezone
-                if (sinceDate.equals(SinceDateArgumentType.getArbitraryFirstCommitDateUtcLocal())) {
-                    sinceDate = SinceDateArgumentType.getArbitraryFirstCommitDateConverted(zoneId);
+                if (TimeUtil.isEqualToArbitraryFirstDateUtc(sinceDate)) {
+                    sinceDate = TimeUtil.getArbitraryFirstCommitDateConverted(zoneId);
                 }
             } else {
                 if (isUntilDateProvided) {

--- a/src/main/java/reposense/parser/SinceDateArgumentType.java
+++ b/src/main/java/reposense/parser/SinceDateArgumentType.java
@@ -17,6 +17,7 @@ import reposense.util.TimeUtil;
 public class SinceDateArgumentType extends DateArgumentType {
     /*
      * When user specifies "d1", arbitrary first commit date will be returned.
+     * This date is equivalent to 1970-01-01 00:00:00 in UTC time.
      * Then, ReportGenerator will replace the arbitrary since date with the earliest commit date.
      */
     public static final String FIRST_COMMIT_DATE_SHORTHAND = "d1";

--- a/src/main/java/reposense/parser/SinceDateArgumentType.java
+++ b/src/main/java/reposense/parser/SinceDateArgumentType.java
@@ -21,13 +21,13 @@ public class SinceDateArgumentType extends DateArgumentType {
      * Then, ReportGenerator will replace the arbitrary since date with the earliest commit date.
      */
     public static final String FIRST_COMMIT_DATE_SHORTHAND = "d1";
-    private static final ZonedDateTime ARBITRARY_FIRST_COMMIT_DATE = ZonedDateTime.ofInstant(
+    private static final ZonedDateTime ARBITRARY_FIRST_COMMIT_DATE_UTC = ZonedDateTime.ofInstant(
             Instant.ofEpochMilli(0), ZoneId.of("Z"));
-    private static final LocalDateTime ARBITRARY_FIRST_COMMIT_DATE_UTC_LOCAL = ARBITRARY_FIRST_COMMIT_DATE
+    private static final LocalDateTime ARBITRARY_FIRST_COMMIT_DATE_LOCAL = ARBITRARY_FIRST_COMMIT_DATE_UTC
             .toLocalDateTime();
 
     /**
-     * Returns an arbitrary year {@link SinceDateArgumentType#ARBITRARY_FIRST_COMMIT_DATE_UTC_LOCAL} if user specifies
+     * Returns an arbitrary year {@link SinceDateArgumentType#ARBITRARY_FIRST_COMMIT_DATE_LOCAL} if user specifies
      * {@link SinceDateArgumentType#FIRST_COMMIT_DATE_SHORTHAND} in {@code value}, or attempts to return the
      * desired date otherwise.
      *
@@ -37,25 +37,25 @@ public class SinceDateArgumentType extends DateArgumentType {
     public Optional<LocalDateTime> convert(ArgumentParser parser, Argument arg, String value)
             throws ArgumentParserException {
         if (FIRST_COMMIT_DATE_SHORTHAND.equals(value)) {
-            return Optional.of(ARBITRARY_FIRST_COMMIT_DATE_UTC_LOCAL);
+            return Optional.of(ARBITRARY_FIRST_COMMIT_DATE_LOCAL);
         }
         String sinceDate = TimeUtil.extractDate(value);
         return super.convert(parser, arg, sinceDate + " 00:00:00");
     }
 
     /**
-     * Returns the {@link SinceDateArgumentType#ARBITRARY_FIRST_COMMIT_DATE_UTC_LOCAL}, which is the
-     * {@link LocalDateTime} of {@link SinceDateArgumentType#ARBITRARY_FIRST_COMMIT_DATE}.
+     * Returns the {@link SinceDateArgumentType#ARBITRARY_FIRST_COMMIT_DATE_LOCAL}, which is the
+     * {@link LocalDateTime} of {@link SinceDateArgumentType#ARBITRARY_FIRST_COMMIT_DATE_UTC}.
      */
-    public static LocalDateTime getArbitraryFirstCommitDateUtcLocal() {
-        return ARBITRARY_FIRST_COMMIT_DATE_UTC_LOCAL;
+    public static LocalDateTime getArbitraryFirstCommitDateLocal() {
+        return ARBITRARY_FIRST_COMMIT_DATE_LOCAL;
     }
 
     /**
-     * Returns the {@link SinceDateArgumentType#ARBITRARY_FIRST_COMMIT_DATE} adjusted for the time zone based on
+     * Returns the {@link SinceDateArgumentType#ARBITRARY_FIRST_COMMIT_DATE_UTC} adjusted for the time zone based on
      * {@code toZoneId} and converted to a {@link LocalDateTime} object.
      */
     public static LocalDateTime getArbitraryFirstCommitDateConverted(ZoneId toZoneId) {
-        return ARBITRARY_FIRST_COMMIT_DATE.withZoneSameInstant(toZoneId).toLocalDateTime();
+        return ARBITRARY_FIRST_COMMIT_DATE_UTC.withZoneSameInstant(toZoneId).toLocalDateTime();
     }
 }

--- a/src/main/java/reposense/parser/SinceDateArgumentType.java
+++ b/src/main/java/reposense/parser/SinceDateArgumentType.java
@@ -3,6 +3,7 @@ package reposense.parser;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.Optional;
 
 import net.sourceforge.argparse4j.inf.Argument;
@@ -18,12 +19,14 @@ public class SinceDateArgumentType extends DateArgumentType {
      * When user specifies "d1", arbitrary first commit date will be returned.
      * Then, ReportGenerator will replace the arbitrary since date with the earliest commit date.
      */
-    public static final LocalDateTime ARBITRARY_FIRST_COMMIT_DATE = LocalDateTime.ofInstant(
-            Instant.ofEpochMilli(Long.MIN_VALUE), ZoneId.of("Z"));
     public static final String FIRST_COMMIT_DATE_SHORTHAND = "d1";
+    private static final ZonedDateTime ARBITRARY_FIRST_COMMIT_DATE = ZonedDateTime.ofInstant(
+            Instant.ofEpochMilli(0), ZoneId.of("Z"));
+    private static final LocalDateTime ARBITRARY_FIRST_COMMIT_DATE_UTC_LOCAL = ARBITRARY_FIRST_COMMIT_DATE
+            .toLocalDateTime();
 
     /**
-     * Returns an arbitrary year {@link SinceDateArgumentType#ARBITRARY_FIRST_COMMIT_DATE} if user specifies
+     * Returns an arbitrary year {@link SinceDateArgumentType#ARBITRARY_FIRST_COMMIT_DATE_UTC_LOCAL} if user specifies
      * {@link SinceDateArgumentType#FIRST_COMMIT_DATE_SHORTHAND} in {@code value}, or attempts to return the
      * desired date otherwise.
      *
@@ -33,9 +36,25 @@ public class SinceDateArgumentType extends DateArgumentType {
     public Optional<LocalDateTime> convert(ArgumentParser parser, Argument arg, String value)
             throws ArgumentParserException {
         if (FIRST_COMMIT_DATE_SHORTHAND.equals(value)) {
-            return Optional.of(ARBITRARY_FIRST_COMMIT_DATE);
+            return Optional.of(ARBITRARY_FIRST_COMMIT_DATE_UTC_LOCAL);
         }
         String sinceDate = TimeUtil.extractDate(value);
         return super.convert(parser, arg, sinceDate + " 00:00:00");
+    }
+
+    /**
+     * Returns the {@link SinceDateArgumentType#ARBITRARY_FIRST_COMMIT_DATE_UTC_LOCAL}, which is the
+     * {@link LocalDateTime} of {@link SinceDateArgumentType#ARBITRARY_FIRST_COMMIT_DATE}.
+     */
+    public static LocalDateTime getArbitraryFirstCommitDateUtcLocal() {
+        return ARBITRARY_FIRST_COMMIT_DATE_UTC_LOCAL;
+    }
+
+    /**
+     * Returns the {@link SinceDateArgumentType#ARBITRARY_FIRST_COMMIT_DATE} adjusted for the time zone based on
+     * {@code toZoneId} and converted to a {@link LocalDateTime} object.
+     */
+    public static LocalDateTime getArbitraryFirstCommitDateConverted(ZoneId toZoneId) {
+        return ARBITRARY_FIRST_COMMIT_DATE.withZoneSameInstant(toZoneId).toLocalDateTime();
     }
 }

--- a/src/main/java/reposense/report/ReportGenerator.java
+++ b/src/main/java/reposense/report/ReportGenerator.java
@@ -46,12 +46,12 @@ import reposense.model.RepoConfiguration;
 import reposense.model.RepoLocation;
 import reposense.model.ReportConfiguration;
 import reposense.model.StandaloneConfig;
-import reposense.parser.SinceDateArgumentType;
 import reposense.parser.StandaloneConfigJsonParser;
 import reposense.report.exception.NoAuthorsWithCommitsFoundException;
 import reposense.system.LogsManager;
 import reposense.util.FileUtil;
 import reposense.util.ProgressTracker;
+import reposense.util.TimeUtil;
 
 /**
  * Contains report generation related functionalities.
@@ -160,8 +160,7 @@ public class ReportGenerator {
         List<Path> reportFoldersAndFiles = cloneAndAnalyzeRepos(configs, outputPath,
                 numCloningThreads, numAnalysisThreads, shouldFreshClone);
 
-        LocalDateTime reportSinceDate = (cliSinceDate.equals(SinceDateArgumentType
-                .getArbitraryFirstCommitDateConverted(zoneId)))
+        LocalDateTime reportSinceDate = (TimeUtil.isEqualToArbitraryFirstDateConverted(cliSinceDate, zoneId))
                 ? earliestSinceDate : cliSinceDate;
 
         Optional<Path> summaryPath = FileUtil.writeJsonFile(

--- a/src/main/java/reposense/report/ReportGenerator.java
+++ b/src/main/java/reposense/report/ReportGenerator.java
@@ -160,7 +160,8 @@ public class ReportGenerator {
         List<Path> reportFoldersAndFiles = cloneAndAnalyzeRepos(configs, outputPath,
                 numCloningThreads, numAnalysisThreads, shouldFreshClone);
 
-        LocalDateTime reportSinceDate = (cliSinceDate.equals(SinceDateArgumentType.ARBITRARY_FIRST_COMMIT_DATE))
+        LocalDateTime reportSinceDate = (cliSinceDate.equals(SinceDateArgumentType
+                .getArbitraryFirstCommitDateConverted(zoneId)))
                 ? earliestSinceDate : cliSinceDate;
 
         Optional<Path> summaryPath = FileUtil.writeJsonFile(

--- a/src/main/java/reposense/util/TimeUtil.java
+++ b/src/main/java/reposense/util/TimeUtil.java
@@ -111,8 +111,8 @@ public class TimeUtil {
     /**
      * Returns the {@link LocalDateTime} of {@code ARBITRARY_FIRST_COMMIT_DATE} in the UTC time zone.
      */
-    public static LocalDateTime getArbitraryFirstCommitDateUtcLocal() {
-        return SinceDateArgumentType.getArbitraryFirstCommitDateUtcLocal();
+    public static LocalDateTime getArbitraryFirstCommitDateLocal() {
+        return SinceDateArgumentType.getArbitraryFirstCommitDateLocal();
     }
 
     /**
@@ -127,7 +127,7 @@ public class TimeUtil {
      * Checks whether the given {@code dateTime} is the {@code ARBITRARY_FIRST_COMMIT_DATE} in UTC time.
      */
     public static boolean isEqualToArbitraryFirstDateUtc(LocalDateTime dateTime) {
-        return dateTime.equals(getArbitraryFirstCommitDateUtcLocal());
+        return dateTime.equals(getArbitraryFirstCommitDateLocal());
     }
 
     /**

--- a/src/main/java/reposense/util/TimeUtil.java
+++ b/src/main/java/reposense/util/TimeUtil.java
@@ -66,11 +66,11 @@ public class TimeUtil {
 
     /**
      * Returns a {@link LocalDateTime} that is set to midnight for the given {@code sinceDate}.
-     * If {@code sinceDate} is {@link SinceDateArgumentType#ARBITRARY_FIRST_COMMIT_DATE}, it is simply returned
-     * as such.
+     * If {@code sinceDate} is {@code ARBITRARY_FIRST_COMMIT_DATE_UTC_LOCAL}, it is simply
+     * returned as such.
      */
     public static LocalDateTime getSinceDate(LocalDateTime sinceDate) {
-        if (sinceDate.equals(SinceDateArgumentType.ARBITRARY_FIRST_COMMIT_DATE)) {
+        if (sinceDate.equals(SinceDateArgumentType.getArbitraryFirstCommitDateUtcLocal())) {
             return sinceDate;
         }
 

--- a/src/main/java/reposense/util/TimeUtil.java
+++ b/src/main/java/reposense/util/TimeUtil.java
@@ -66,14 +66,8 @@ public class TimeUtil {
 
     /**
      * Returns a {@link LocalDateTime} that is set to midnight for the given {@code sinceDate}.
-     * If {@code sinceDate} is {@code ARBITRARY_FIRST_COMMIT_DATE_UTC_LOCAL}, it is simply
-     * returned as such.
      */
     public static LocalDateTime getSinceDate(LocalDateTime sinceDate) {
-        if (isEqualToArbitraryFirstDateUtc(sinceDate)) {
-            return sinceDate;
-        }
-
         return sinceDate.withHour(0).withMinute(0).withSecond(0);
     }
 

--- a/src/main/java/reposense/util/TimeUtil.java
+++ b/src/main/java/reposense/util/TimeUtil.java
@@ -70,7 +70,7 @@ public class TimeUtil {
      * returned as such.
      */
     public static LocalDateTime getSinceDate(LocalDateTime sinceDate) {
-        if (sinceDate.equals(SinceDateArgumentType.getArbitraryFirstCommitDateUtcLocal())) {
+        if (isEqualToArbitraryFirstDateUtc(sinceDate)) {
             return sinceDate;
         }
 
@@ -112,6 +112,36 @@ public class TimeUtil {
      */
     public static LocalDateTime getCurrentDate(ZoneId zoneId) {
         return LocalDateTime.now(zoneId).withHour(23).withMinute(59).withSecond(59).withNano(0);
+    }
+
+    /**
+     * Returns the {@link LocalDateTime} of {@code ARBITRARY_FIRST_COMMIT_DATE} in the UTC time zone.
+     */
+    public static LocalDateTime getArbitraryFirstCommitDateUtcLocal() {
+        return SinceDateArgumentType.getArbitraryFirstCommitDateUtcLocal();
+    }
+
+    /**
+     * Returns the {@link LocalDateTime} of {@code ARBITRARY_FIRST_COMMIT_DATE} adjusted for the time zone based on
+     * {@code toZoneId}.
+     */
+    public static LocalDateTime getArbitraryFirstCommitDateConverted(ZoneId toZoneId) {
+        return SinceDateArgumentType.getArbitraryFirstCommitDateConverted(toZoneId);
+    }
+
+    /**
+     * Checks whether the given {@code dateTime} is the {@code ARBITRARY_FIRST_COMMIT_DATE} in UTC time.
+     */
+    public static boolean isEqualToArbitraryFirstDateUtc(LocalDateTime dateTime) {
+        return dateTime.equals(getArbitraryFirstCommitDateUtcLocal());
+    }
+
+    /**
+     * Checks whether the given {@code dateTime} is the {@code ARBITRARY_FIRST_COMMIT_DATE} in the time zone given by
+     * {@code zoneId}.
+     */
+    public static boolean isEqualToArbitraryFirstDateConverted(LocalDateTime dateTime, ZoneId zoneId) {
+        return dateTime.equals(getArbitraryFirstCommitDateConverted(zoneId));
     }
 
     /**

--- a/src/test/java/reposense/parser/ArgsParserTest.java
+++ b/src/test/java/reposense/parser/ArgsParserTest.java
@@ -91,7 +91,6 @@ public class ArgsParserTest {
         Assertions.assertEquals(expectedSinceDate, cliArguments.getSinceDate());
         Assertions.assertEquals(expectedUntilDate, cliArguments.getUntilDate());
 
-
         Assertions.assertEquals(DEFAULT_TIME_ZONE_ID, cliArguments.getZoneId());
     }
 

--- a/src/test/java/reposense/parser/ArgsParserTest.java
+++ b/src/test/java/reposense/parser/ArgsParserTest.java
@@ -31,6 +31,7 @@ import reposense.model.ViewCliArguments;
 import reposense.util.FileUtil;
 import reposense.util.InputBuilder;
 import reposense.util.TestUtil;
+import reposense.util.TimeUtil;
 
 public class ArgsParserTest {
 
@@ -85,8 +86,7 @@ public class ArgsParserTest {
         Assertions.assertTrue(Files.isSameFile(
                 AUTHOR_CONFIG_CSV_FILE, ((ConfigCliArguments) cliArguments).getAuthorConfigFilePath()));
 
-        LocalDateTime expectedSinceDate = SinceDateArgumentType
-                .getArbitraryFirstCommitDateConverted(DEFAULT_TIME_ZONE_ID);
+        LocalDateTime expectedSinceDate = TimeUtil.getArbitraryFirstCommitDateConverted(DEFAULT_TIME_ZONE_ID);
         LocalDateTime expectedUntilDate = TestUtil.getUntilDate(2017, Month.NOVEMBER.getValue(), 30);
         Assertions.assertEquals(expectedSinceDate, cliArguments.getSinceDate());
         Assertions.assertEquals(expectedUntilDate, cliArguments.getUntilDate());

--- a/src/test/java/reposense/parser/ArgsParserTest.java
+++ b/src/test/java/reposense/parser/ArgsParserTest.java
@@ -72,6 +72,30 @@ public class ArgsParserTest {
     }
 
     @Test
+    public void parse_d1CorrectTimeZone_success() throws Exception {
+        String input = new InputBuilder().addConfig(CONFIG_FOLDER_ABSOLUTE)
+                .addSinceDate(SinceDateArgumentType.FIRST_COMMIT_DATE_SHORTHAND)
+                .addUntilDate("30/11/2017")
+                .addTimezone(DEFAULT_TIME_ZONE_STRING)
+                .build();
+        CliArguments cliArguments = ArgsParser.parse(translateCommandline(input));
+        Assertions.assertTrue(cliArguments instanceof ConfigCliArguments);
+        Assertions.assertTrue(Files.isSameFile(
+                REPO_CONFIG_CSV_FILE, ((ConfigCliArguments) cliArguments).getRepoConfigFilePath()));
+        Assertions.assertTrue(Files.isSameFile(
+                AUTHOR_CONFIG_CSV_FILE, ((ConfigCliArguments) cliArguments).getAuthorConfigFilePath()));
+
+        LocalDateTime expectedSinceDate = SinceDateArgumentType
+                .getArbitraryFirstCommitDateConverted(DEFAULT_TIME_ZONE_ID);
+        LocalDateTime expectedUntilDate = TestUtil.getUntilDate(2017, Month.NOVEMBER.getValue(), 30);
+        Assertions.assertEquals(expectedSinceDate, cliArguments.getSinceDate());
+        Assertions.assertEquals(expectedUntilDate, cliArguments.getUntilDate());
+
+
+        Assertions.assertEquals(DEFAULT_TIME_ZONE_ID, cliArguments.getZoneId());
+    }
+
+    @Test
     public void parse_allCorrectInputs_success() throws Exception {
         String input = new InputBuilder().addConfig(CONFIG_FOLDER_ABSOLUTE)
                 .addOutput(OUTPUT_DIRECTORY_ABSOLUTE)


### PR DESCRIPTION
<!--
    If this pull request fully addresses an issue, use:
    Fixes #xxxx

    If this pull request partially addresses an issue, use:
    Part of #xxxx

    If this pull request addresses multiple issues, put them in multiple lines:
    Fixes #xxxx
    Fixes #yyyy

    Format the title of the pull request with most relevant issue number as follows:
    [#xxxx] Title
-->
Fixes #1774.
Fixes #1778.

## Proposed commit message
<!--
    Propose a detailed commit message for this pull request within the triple backticks below.
    Wrap lines at 72 characters.

    Guide on how to write a good commit message:
    https://oss-generic.github.io/process/docs/FormatsAndConventions.html#commit-message
-->
```
The use of Instant.ofEpochMilli(Long.MIN_VALUE) as the arbitrary first
commit date now fails shallow cloning for
testSinceBeginningDateRangeWithShallowCloning system test.

In addition, using this arbitrary date in convertToGitDateRangeArgs
when converting timezone results in an overflow causing sinceDate to
be greater than untilDate. Thus, no commit results are retrieved,
leading to failing system tests.

Also, the arbitrary first commit date is in UTC. However, in the
convertToGitDateRangeArgs method, the zoneId used for the conversion
is from the config, which may be different. This leads to an erroneous
timezone conversion.

Finally, using --since d1 with --period results in an unintended date
range because the --period and the arbitrary commit date from 
--since d1 are used to calculate the until date as the actual 
earliest commit date is not immediately available.

Let's change Instant.ofEpochMilli() to use 0 so that the arbitrary date
is 1970-01-01 and the overflow of the sinceDate can be avoided.

At the same time, let's convert the arbitrary date to the correct
timezone within the ArgsParser class and add a component test for
parsing --since d1 to check that the correct timezone is used for each
RepoConfiguration before cloning any repos.

Finally, let's raise a warning when --since d1 is being used with 
--period.
```

## Other information
<!--
    Are there other relevant information, such as special testing instructions, 
    which will help the reviewer better understand the code?

    You may also include a brief description of why the problem occurred.
-->
Screenshot showing the overflow of the sinceDate when `Instant.ofEpochMilli(Long.MIN_VALUE)` is used:
![Screenshot (277)](https://user-images.githubusercontent.com/69678785/167245385-6dc7ae47-ef29-4ce8-9351-7001c3f52c52.png)


Notice how the sinceDate has `+` sign instead of `-` sign.

## Timezone Trivia
There also seems to be something strange with the timezone here:
![Screenshot (278)](https://user-images.githubusercontent.com/69678785/167244948-9a65b89e-5983-4712-b846-e0c6dc5321d1.png)

Although the code for this method has been changed, the timezone conversion logic in lines 60-61 is still preserved. The time appears to be converted to +07:30 instead of +08:00. However, tests still work correctly. This is likely following the [old SG timezone being used before 1 January 1982](https://en.wikipedia.org/wiki/Singapore_Standard_Time).
