### PR TITLE
Checkstyle: add MissingJavadocType check and update comments

### DIFF
--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -402,6 +402,9 @@
       <property name="tokens" value="METHOD_DEF, ANNOTATION_FIELD_DEF"/>
     </module>
 
+    <!-- Checks that every public class, enumeration and interface has a header comment. -->
+    <module name="MissingJavadocType"/>
+
     <!-- Checks that all Javadoc comments have a description. -->
     <!-- Javadoc with only block tags will fail this check. -->
     <module name="JavadocStyle">

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -4,8 +4,9 @@
     "https://checkstyle.org/dtds/configuration_1_3.dtd">
 
 <!--
-    This configuration file enforces rules for a modified version of the module's code standard at
-    https://oss-generic.github.io/process/codingstandards/coding-standards-java.html
+    This configuration file enforces rules for the coding standard at
+    https://se-education.org/guides/conventions/java/index.html as well as additional standards at
+    https://reposense.org/RepoSense/dg/styleGuides.html
 -->
 
 <module name="Checker">

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -358,7 +358,7 @@
     <!-- Checks that all Javadoc comments start from the second line. -->
     <module name="JavadocContentLocationCheck" />
 
-    <!-- Checks the format's Javadoc for every method (excluding getters, setters and constructors). -->
+    <!-- Checks the Javadoc's format for every method (excluding getters, setters and constructors). -->
     <module name="JavadocMethod">
       <property name="allowMissingParamTags" value="true"/>
       <property name="allowMissingReturnTag" value="true"/>
@@ -371,7 +371,7 @@
     <!-- Checks that each line in Javadoc has whitespace after leading asterisk. -->
     <module name="JavadocMissingWhitespaceAfterAsterisk"/>
 
-    <!-- Checks that every class, enumeration and interface have a header comment. -->
+    <!-- Checks the Javadoc's format for every class, enumeration and interface. -->
     <module name="JavadocType">
       <property name="allowMissingParamTags" value="true"/>
     </module>


### PR DESCRIPTION
<!--
    If this pull request fully addresses an issue, use:
    Fixes #xxxx

    If this pull request partially addresses an issue, use:
    Part of #xxxx

    If this pull request addresses multiple issues, put them in multiple lines:
    Fixes #xxxx
    Fixes #yyyy

    Format the title of the pull request with most relevant issue number as follows:
    [#xxxx] Title
-->
Part of #1769 

## Proposed commit message
<!--
    Propose a detailed commit message for this pull request within the triple backticks below.
    Wrap lines at 72 characters.

    Guide on how to write a good commit message:
    https://oss-generic.github.io/process/docs/FormatsAndConventions.html#commit-message
-->
```
The oss-generic link for the coding standard is obsolete. At the same
time, the description vaguely refers to a module. The checkstyle file 
also references our own standards, which should be mentioned explicitly.

The JavadocType check actually checks that the Javadoc for classes,
enums and interfaces are of the correct format. The MissingJavadocType
check should be used instead to check that the public classes, enums and
interfaces have Javadoc.

Finally, the phrase "format's Javadoc" for the comment on the
JavadocMethod check does not make sense.

Let's change the coding standard link to the one used by SE-EDU, remove
the reference to the module and add the link to our style guide.

Let's also update the comments for the checks and add the
MissingJavadocType check.
```
