### PR TITLE
[#1674] Convert zoneId String to ZoneId Object

### DIFF
--- a/src/main/java/reposense/RepoSense.java
+++ b/src/main/java/reposense/RepoSense.java
@@ -73,7 +73,7 @@ public class RepoSense {
 
             RepoConfiguration.setFormatsToRepoConfigs(configs, cliArguments.getFormats());
             RepoConfiguration.setDatesToRepoConfigs(configs, cliArguments.getSinceDate(), cliArguments.getUntilDate());
-            RepoConfiguration.setZoneIdToRepoConfigs(configs, cliArguments.getZoneId().toString());
+            RepoConfiguration.setZoneIdToRepoConfigs(configs, cliArguments.getZoneId());
             RepoConfiguration.setStandaloneConfigIgnoredToRepoConfigs(configs,
                     cliArguments.isStandaloneConfigIgnored());
             RepoConfiguration.setFileSizeLimitIgnoredToRepoConfigs(configs,

--- a/src/main/java/reposense/authorship/FileInfoAnalyzer.java
+++ b/src/main/java/reposense/authorship/FileInfoAnalyzer.java
@@ -5,7 +5,6 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Instant;
 import java.time.LocalDateTime;
-import java.time.ZoneId;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -162,7 +161,7 @@ public class FileInfoAnalyzer {
                     .substring(AUTHOR_EMAIL_OFFSET).replaceAll("<|>", "");
             Long commitDateInMs = Long.parseLong(blameResultLines[lineCount + 3].substring(AUTHOR_TIME_OFFSET)) * 1000;
             LocalDateTime commitDate = LocalDateTime.ofInstant(Instant.ofEpochMilli(commitDateInMs),
-                    ZoneId.of(config.getZoneId()));
+                    config.getZoneId());
             Author author = config.getAuthor(authorName, authorEmail);
 
             if (!fileInfo.isFileLineTracked(lineCount / 5) || author.isIgnoringFile(filePath)

--- a/src/main/java/reposense/authorship/FileInfoExtractor.java
+++ b/src/main/java/reposense/authorship/FileInfoExtractor.java
@@ -7,7 +7,6 @@ import java.nio.file.Files;
 import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashSet;
@@ -69,12 +68,12 @@ public class FileInfoExtractor {
         // git blame file analyze output
         try {
             GitCheckout.checkoutDate(config.getRepoRoot(), config.getBranch(), config.getUntilDate(),
-                    ZoneId.of(config.getZoneId()));
+                    config.getZoneId());
         } catch (CommitNotFoundException cnfe) {
             return fileInfos;
         }
         String lastCommitHash = GitRevList.getCommitHashUntilDate(
-                config.getRepoRoot(), config.getBranch(), config.getSinceDate(), ZoneId.of(config.getZoneId()));
+                config.getRepoRoot(), config.getBranch(), config.getSinceDate(), config.getZoneId());
 
         fileInfos = (lastCommitHash.isEmpty())
                 ? getAllFileInfo(config, false)

--- a/src/main/java/reposense/commits/CommitInfoAnalyzer.java
+++ b/src/main/java/reposense/commits/CommitInfoAnalyzer.java
@@ -3,7 +3,6 @@ package reposense.commits;
 import static reposense.util.StringsUtil.removeQuote;
 
 import java.time.LocalDateTime;
-import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
@@ -95,7 +94,7 @@ public class CommitInfoAnalyzer {
         }
 
         // Commit date may be in a timezone different from the one given in the config.
-        LocalDateTime adjustedDate = date.withZoneSameInstant(ZoneId.of(config.getZoneId())).toLocalDateTime();
+        LocalDateTime adjustedDate = date.withZoneSameInstant(config.getZoneId()).toLocalDateTime();
 
         String messageTitle = (elements.length > MESSAGE_TITLE_INDEX) ? elements[MESSAGE_TITLE_INDEX] : "";
         String messageBody = (elements.length > MESSAGE_BODY_INDEX)

--- a/src/main/java/reposense/git/GitLog.java
+++ b/src/main/java/reposense/git/GitLog.java
@@ -5,7 +5,6 @@ import static reposense.util.StringsUtil.addQuotesForFilePath;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.time.ZoneId;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -32,8 +31,7 @@ public class GitLog {
         Path rootPath = Paths.get(config.getRepoRoot());
 
         String command = "git log --no-merges -i ";
-        command += GitUtil.convertToGitDateRangeArgs(config.getSinceDate(), config.getUntilDate(),
-                ZoneId.of(config.getZoneId()));
+        command += GitUtil.convertToGitDateRangeArgs(config.getSinceDate(), config.getUntilDate(), config.getZoneId());
         command += " --pretty=format:" + PRETTY_FORMAT_STRING + " --shortstat";
         command += GitUtil.convertToFilterAuthorArgs(author);
         command += GitUtil.convertToGitFormatsArgs(config.getFileTypeManager().getFormats());
@@ -50,8 +48,7 @@ public class GitLog {
         Path rootPath = Paths.get(config.getRepoRoot());
 
         String command = "git log --no-merges -i ";
-        command += GitUtil.convertToGitDateRangeArgs(config.getSinceDate(), config.getUntilDate(),
-                ZoneId.of(config.getZoneId()));
+        command += GitUtil.convertToGitDateRangeArgs(config.getSinceDate(), config.getUntilDate(), config.getZoneId());
         command += " --pretty=format:" + PRETTY_FORMAT_STRING + " --numstat --shortstat";
         command += GitUtil.convertToFilterAuthorArgs(author);
         command += GitUtil.convertToGitFormatsArgs(config.getFileTypeManager().getFormats());
@@ -68,8 +65,7 @@ public class GitLog {
         Path rootPath = Paths.get(config.getRepoRoot());
 
         String command = "git log --pretty=format:\"%an\t%ae\" ";
-        command += GitUtil.convertToGitDateRangeArgs(config.getSinceDate(), config.getUntilDate(),
-                ZoneId.of(config.getZoneId()));
+        command += GitUtil.convertToGitDateRangeArgs(config.getSinceDate(), config.getUntilDate(), config.getZoneId());
         command += " " + addQuotesForFilePath(filePath);
 
         String result = runCommand(rootPath, command);

--- a/src/main/java/reposense/git/GitShortlog.java
+++ b/src/main/java/reposense/git/GitShortlog.java
@@ -26,7 +26,7 @@ public class GitShortlog {
      */
     public static List<Author> getAuthors(RepoConfiguration config) {
         String summary = getShortlogSummary(
-                config.getRepoRoot(), config.getSinceDate(), config.getUntilDate(), ZoneId.of(config.getZoneId()));
+                config.getRepoRoot(), config.getSinceDate(), config.getUntilDate(), config.getZoneId());
 
         if (summary.isEmpty()) {
             return Collections.emptyList();

--- a/src/main/java/reposense/model/RepoConfiguration.java
+++ b/src/main/java/reposense/model/RepoConfiguration.java
@@ -563,6 +563,10 @@ public class RepoConfiguration {
         this.zoneId = zoneId;
     }
 
+    public void setZoneId(String zoneId) {
+        this.zoneId = ZoneId.of(zoneId);
+    }
+
     public void setAuthorDisplayName(Author author, String displayName) {
         authorConfig.setAuthorDisplayName(author, displayName);
     }

--- a/src/main/java/reposense/model/RepoConfiguration.java
+++ b/src/main/java/reposense/model/RepoConfiguration.java
@@ -563,10 +563,6 @@ public class RepoConfiguration {
         this.zoneId = zoneId;
     }
 
-    public void setZoneId(String zoneId) {
-        this.zoneId = ZoneId.of(zoneId);
-    }
-
     public void setAuthorDisplayName(Author author, String displayName) {
         authorConfig.setAuthorDisplayName(author, displayName);
     }

--- a/src/main/java/reposense/model/RepoConfiguration.java
+++ b/src/main/java/reposense/model/RepoConfiguration.java
@@ -2,6 +2,7 @@ package reposense.model;
 
 import java.io.File;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -26,7 +27,7 @@ public class RepoConfiguration {
     private String branch;
     private String displayName;
     private String outputFolderName;
-    private transient String zoneId;
+    private transient ZoneId zoneId;
     private transient LocalDateTime sinceDate;
     private transient LocalDateTime untilDate;
     private transient String repoFolderName;
@@ -102,7 +103,7 @@ public class RepoConfiguration {
         }
     }
 
-    public static void setZoneIdToRepoConfigs(List<RepoConfiguration> configs, String zoneId) {
+    public static void setZoneIdToRepoConfigs(List<RepoConfiguration> configs, ZoneId zoneId) {
         for (RepoConfiguration config : configs) {
             config.setZoneId(zoneId);
         }
@@ -554,11 +555,11 @@ public class RepoConfiguration {
         this.untilDate = untilDate;
     }
 
-    public String getZoneId() {
+    public ZoneId getZoneId() {
         return zoneId;
     }
 
-    public void setZoneId(String zoneId) {
+    public void setZoneId(ZoneId zoneId) {
         this.zoneId = zoneId;
     }
 

--- a/src/main/java/reposense/report/ReportGenerator.java
+++ b/src/main/java/reposense/report/ReportGenerator.java
@@ -167,7 +167,7 @@ public class ReportGenerator {
                 new SummaryJson(configs, reportConfig, generationDate,
                         reportSinceDate, untilDate, isSinceDateProvided,
                         isUntilDateProvided, RepoSense.getVersion(), ErrorSummary.getInstance().getErrorSet(),
-                        reportGenerationTimeProvider.get(), zoneId),
+                        reportGenerationTimeProvider.get(), zoneId.toString()),
                 getSummaryResultPath(outputPath));
         summaryPath.ifPresent(reportFoldersAndFiles::add);
 

--- a/src/main/java/reposense/report/ReportGenerator.java
+++ b/src/main/java/reposense/report/ReportGenerator.java
@@ -167,7 +167,7 @@ public class ReportGenerator {
                 new SummaryJson(configs, reportConfig, generationDate,
                         reportSinceDate, untilDate, isSinceDateProvided,
                         isUntilDateProvided, RepoSense.getVersion(), ErrorSummary.getInstance().getErrorSet(),
-                        reportGenerationTimeProvider.get(), zoneId.toString()),
+                        reportGenerationTimeProvider.get(), zoneId),
                 getSummaryResultPath(outputPath));
         summaryPath.ifPresent(reportFoldersAndFiles::add);
 

--- a/src/main/java/reposense/report/SummaryJson.java
+++ b/src/main/java/reposense/report/SummaryJson.java
@@ -1,7 +1,6 @@
 package reposense.report;
 
 import java.time.LocalDateTime;
-import java.time.ZoneId;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -31,7 +30,7 @@ public class SummaryJson {
 
     public SummaryJson(List<RepoConfiguration> repos, ReportConfiguration reportConfig, String reportGeneratedTime,
             LocalDateTime sinceDate, LocalDateTime untilDate, boolean isSinceDateProvided, boolean isUntilDateProvided,
-            String repoSenseVersion, Set<Map<String, String>> errorSet, String reportGenerationTime, ZoneId zoneId) {
+            String repoSenseVersion, Set<Map<String, String>> errorSet, String reportGenerationTime, String zoneId) {
         this.repos = repos;
         this.reportGeneratedTime = reportGeneratedTime;
         this.reportGenerationTime = reportGenerationTime;
@@ -42,7 +41,7 @@ public class SummaryJson {
         this.isUntilDateProvided = isUntilDateProvided;
         this.repoSenseVersion = repoSenseVersion;
         this.errorSet = errorSet;
-        this.zoneId = zoneId.toString();
+        this.zoneId = zoneId;
         this.supportedDomainUrlMap = SupportedDomainUrlMap.getDefaultDomainUrlMap();
     }
 }

--- a/src/main/java/reposense/report/SummaryJson.java
+++ b/src/main/java/reposense/report/SummaryJson.java
@@ -1,6 +1,7 @@
 package reposense.report;
 
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -30,7 +31,7 @@ public class SummaryJson {
 
     public SummaryJson(List<RepoConfiguration> repos, ReportConfiguration reportConfig, String reportGeneratedTime,
             LocalDateTime sinceDate, LocalDateTime untilDate, boolean isSinceDateProvided, boolean isUntilDateProvided,
-            String repoSenseVersion, Set<Map<String, String>> errorSet, String reportGenerationTime, String zoneId) {
+            String repoSenseVersion, Set<Map<String, String>> errorSet, String reportGenerationTime, ZoneId zoneId) {
         this.repos = repos;
         this.reportGeneratedTime = reportGeneratedTime;
         this.reportGenerationTime = reportGenerationTime;
@@ -41,7 +42,7 @@ public class SummaryJson {
         this.isUntilDateProvided = isUntilDateProvided;
         this.repoSenseVersion = repoSenseVersion;
         this.errorSet = errorSet;
-        this.zoneId = zoneId;
+        this.zoneId = zoneId.toString();
         this.supportedDomainUrlMap = SupportedDomainUrlMap.getDefaultDomainUrlMap();
     }
 }

--- a/src/main/java/reposense/report/SummaryJson.java
+++ b/src/main/java/reposense/report/SummaryJson.java
@@ -1,6 +1,7 @@
 package reposense.report;
 
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -18,7 +19,7 @@ public class SummaryJson {
     private final String repoSenseVersion;
     private final String reportGeneratedTime;
     private final String reportGenerationTime;
-    private final String zoneId;
+    private final ZoneId zoneId;
     private final String reportTitle;
     private final List<RepoConfiguration> repos;
     private final Set<Map<String, String>> errorSet;
@@ -30,7 +31,7 @@ public class SummaryJson {
 
     public SummaryJson(List<RepoConfiguration> repos, ReportConfiguration reportConfig, String reportGeneratedTime,
             LocalDateTime sinceDate, LocalDateTime untilDate, boolean isSinceDateProvided, boolean isUntilDateProvided,
-            String repoSenseVersion, Set<Map<String, String>> errorSet, String reportGenerationTime, String zoneId) {
+            String repoSenseVersion, Set<Map<String, String>> errorSet, String reportGenerationTime, ZoneId zoneId) {
         this.repos = repos;
         this.reportGeneratedTime = reportGeneratedTime;
         this.reportGenerationTime = reportGenerationTime;

--- a/src/main/java/reposense/util/FileUtil.java
+++ b/src/main/java/reposense/util/FileUtil.java
@@ -14,6 +14,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import java.util.List;
@@ -105,9 +106,13 @@ public class FileUtil {
                 .registerTypeAdapter(LocalDateTime.class, (JsonSerializer<LocalDateTime>) (date, typeOfSrc, context)
                         -> new JsonPrimitive(date.format(DateTimeFormatter.ofPattern(GITHUB_API_DATE_FORMAT))))
                 .registerTypeAdapter(FileType.class, new FileType.FileTypeSerializer())
+                .registerTypeAdapter(ZoneId.class, (JsonSerializer<ZoneId>) (zoneId, typeOfSrc, context)
+                        -> new JsonPrimitive(zoneId.toString()))
                 .create();
+
         // Gson serializer from:
         // https://stackoverflow.com/questions/39192945/serialize-java-8-localdate-as-yyyy-mm-dd-with-gson
+
         String result = gson.toJson(object);
 
         try (PrintWriter out = new PrintWriter(path)) {

--- a/src/systemtest/java/reposense/ConfigSystemTest.java
+++ b/src/systemtest/java/reposense/ConfigSystemTest.java
@@ -197,7 +197,7 @@ public class ConfigSystemTest {
         RepoConfiguration.setFormatsToRepoConfigs(repoConfigs, cliArguments.getFormats());
         RepoConfiguration.setDatesToRepoConfigs(
                 repoConfigs, cliArguments.getSinceDate(), cliArguments.getUntilDate());
-        RepoConfiguration.setZoneIdToRepoConfigs(repoConfigs, cliArguments.getZoneId().toString());
+        RepoConfiguration.setZoneIdToRepoConfigs(repoConfigs, cliArguments.getZoneId());
         RepoConfiguration.setIsLastModifiedDateIncludedToRepoConfigs(repoConfigs, shouldIncludeModifiedDateInLines);
         RepoConfiguration.setIsFindingPreviousAuthorsPerformedToRepoConfigs(repoConfigs,
                 cliArguments.isFindingPreviousAuthorsPerformed());

--- a/src/test/java/reposense/authorship/AnnotatorAnalyzerTest.java
+++ b/src/test/java/reposense/authorship/AnnotatorAnalyzerTest.java
@@ -23,7 +23,6 @@ import reposense.util.TestUtil;
 public class AnnotatorAnalyzerTest extends GitTestTemplate {
     private static final LocalDateTime SINCE_DATE = TestUtil.getSinceDate(2018, Month.FEBRUARY.getValue(), 8);
     private static final LocalDateTime UNTIL_DATE = TestUtil.getUntilDate(2021, Month.AUGUST.getValue(), 3);
-    private static final String TIME_ZONE_ID_STRING = "Asia/Singapore";
     private static final Author[] EXPECTED_LINE_AUTHORS_OVERRIDE_AUTHORSHIP_TEST = {
             FAKE_AUTHOR, FAKE_AUTHOR, FAKE_AUTHOR, FAKE_AUTHOR,
             MAIN_AUTHOR, MAIN_AUTHOR, MAIN_AUTHOR, MAIN_AUTHOR, MAIN_AUTHOR,
@@ -47,7 +46,7 @@ public class AnnotatorAnalyzerTest extends GitTestTemplate {
         super.before();
         config.setSinceDate(SINCE_DATE);
         config.setUntilDate(UNTIL_DATE);
-        config.setZoneId(TIME_ZONE_ID_STRING);
+        config.setZoneId(TIME_ZONE_ID);
         AuthorConfiguration.setHasAuthorConfigFile(AuthorConfiguration.DEFAULT_HAS_AUTHOR_CONFIG_FILE);
     }
 

--- a/src/test/java/reposense/authorship/FileAnalyzerTest.java
+++ b/src/test/java/reposense/authorship/FileAnalyzerTest.java
@@ -2,7 +2,6 @@ package reposense.authorship;
 
 import java.time.LocalDateTime;
 import java.time.Month;
-import java.time.ZoneId;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -61,8 +60,6 @@ public class FileAnalyzerTest extends GitTestTemplate {
     private static final LocalDateTime ANALYZE_FILES_EMPTY_EMAIL_COMMIT_UNTIL_DATE =
             TestUtil.getUntilDate(2022, Month.FEBRUARY.getValue(), 14);
 
-    private static final String TIME_ZONE_ID_STRING = "Asia/Singapore";
-
     private static final Author[] EXPECTED_LINE_AUTHORS_BLAME_TEST = {
             MAIN_AUTHOR, MAIN_AUTHOR, FAKE_AUTHOR, MAIN_AUTHOR
     };
@@ -76,7 +73,7 @@ public class FileAnalyzerTest extends GitTestTemplate {
     @BeforeEach
     public void before() throws Exception {
         super.before();
-        config.setZoneId(TIME_ZONE_ID_STRING);
+        config.setZoneId(TIME_ZONE_ID);
     }
 
     @Test
@@ -114,8 +111,7 @@ public class FileAnalyzerTest extends GitTestTemplate {
 
     @Test
     public void blameTestDateRange() throws Exception {
-        GitCheckout.checkoutDate(config.getRepoRoot(), config.getBranch(), BLAME_TEST_UNTIL_DATE,
-                ZoneId.of(config.getZoneId()));
+        GitCheckout.checkoutDate(config.getRepoRoot(), config.getBranch(), BLAME_TEST_UNTIL_DATE, config.getZoneId());
         config.setSinceDate(BLAME_TEST_SINCE_DATE);
         config.setUntilDate(BLAME_TEST_UNTIL_DATE);
 
@@ -133,7 +129,7 @@ public class FileAnalyzerTest extends GitTestTemplate {
 
         GitCheckout.checkout(config.getRepoRoot(), TEST_REPO_BLAME_WITH_PREVIOUS_AUTHORS_BRANCH);
         GitCheckout.checkoutDate(config.getRepoRoot(), config.getBranch(), PREVIOUS_AUTHOR_BLAME_TEST_UNTIL_DATE,
-                ZoneId.of(config.getZoneId()));
+                config.getZoneId());
 
         createTestIgnoreRevsFile(AUTHOR_TO_IGNORE_BLAME_COMMIT_LIST_07082021);
         FileResult fileResult = getFileResult("blameTest.java");
@@ -144,8 +140,7 @@ public class FileAnalyzerTest extends GitTestTemplate {
 
     @Test
     public void movedFileBlameTestDateRange() throws Exception {
-        GitCheckout.checkoutDate(config.getRepoRoot(), config.getBranch(), MOVED_FILE_UNTIL_DATE,
-                ZoneId.of(config.getZoneId()));
+        GitCheckout.checkoutDate(config.getRepoRoot(), config.getBranch(), MOVED_FILE_UNTIL_DATE, config.getZoneId());
         config.setSinceDate(MOVED_FILE_SINCE_DATE);
         config.setUntilDate(MOVED_FILE_UNTIL_DATE);
 

--- a/src/test/java/reposense/commits/CommitInfoAnalyzerTest.java
+++ b/src/test/java/reposense/commits/CommitInfoAnalyzerTest.java
@@ -234,7 +234,7 @@ public class CommitInfoAnalyzerTest extends GitTestTemplate {
         secondFileTypeAndContributionMap.put(FILETYPE_JAVA, new ContributionPair(0, 1));
 
         ZoneId originalZoneId = config.getZoneId();
-        config.setZoneId("UTC-0530");
+        config.setZoneId(ZoneId.of("UTC-0530"));
         config.setSinceDate(LocalDateTime.of(2019, Month.JUNE, 18, 0, 0));
         config.setUntilDate(LocalDateTime.of(2019, Month.JUNE, 19, 0, 0));
 
@@ -310,7 +310,7 @@ public class CommitInfoAnalyzerTest extends GitTestTemplate {
         config.setBranch("879-CommitInfoAnalyzerTest-analyzeCommits_commitsWithMultipleTags_success");
         config.setAuthorList(Collections.singletonList(author));
 
-        config.setZoneId("UTC+10");
+        config.setZoneId(ZoneId.of("UTC+10"));
         config.setSinceDate(LocalDateTime.of(2019, Month.DECEMBER, 21, 0, 0));
         config.setUntilDate(LocalDateTime.of(2019, Month.DECEMBER, 22, 0, 0));
 
@@ -362,7 +362,7 @@ public class CommitInfoAnalyzerTest extends GitTestTemplate {
 
         // Equivalent to 2020-01-27 23:20:51 in UTC+9 time.
         ZoneId originalZoneId = config.getZoneId();
-        config.setZoneId("UTC+9");
+        config.setZoneId(ZoneId.of("UTC+9"));
         config.setSinceDate(LocalDateTime.of(2020, Month.JANUARY, 27, 0, 0));
         config.setUntilDate(LocalDateTime.of(2020, Month.JANUARY, 28, 0, 0));
 

--- a/src/test/java/reposense/commits/CommitInfoAnalyzerTest.java
+++ b/src/test/java/reposense/commits/CommitInfoAnalyzerTest.java
@@ -233,8 +233,8 @@ public class CommitInfoAnalyzerTest extends GitTestTemplate {
         Map<FileType, ContributionPair> secondFileTypeAndContributionMap = new HashMap<>();
         secondFileTypeAndContributionMap.put(FILETYPE_JAVA, new ContributionPair(0, 1));
 
-        String originalZoneId = config.getZoneId();
-        config.setZoneId("UTC-0530");
+        ZoneId originalZoneId = config.getZoneId();
+        config.setZoneId(ZoneId.of("UTC-0530"));
         config.setSinceDate(LocalDateTime.of(2019, Month.JUNE, 18, 0, 0));
         config.setUntilDate(LocalDateTime.of(2019, Month.JUNE, 19, 0, 0));
 
@@ -305,12 +305,12 @@ public class CommitInfoAnalyzerTest extends GitTestTemplate {
         Map<FileType, ContributionPair> secondFileTypeAndContributionMap = new HashMap<>();
         secondFileTypeAndContributionMap.put(FILETYPE_MD, new ContributionPair(1, 0));
 
-        String originalZoneId = config.getZoneId();
+        ZoneId originalZoneId = config.getZoneId();
 
         config.setBranch("879-CommitInfoAnalyzerTest-analyzeCommits_commitsWithMultipleTags_success");
         config.setAuthorList(Collections.singletonList(author));
 
-        config.setZoneId("UTC+10");
+        config.setZoneId(ZoneId.of("UTC+10"));
         config.setSinceDate(LocalDateTime.of(2019, Month.DECEMBER, 21, 0, 0));
         config.setUntilDate(LocalDateTime.of(2019, Month.DECEMBER, 22, 0, 0));
 
@@ -361,8 +361,8 @@ public class CommitInfoAnalyzerTest extends GitTestTemplate {
         List<CommitResult> expectedCommitResults = new ArrayList<>();
 
         // Equivalent to 2020-01-27 23:20:51 in UTC+9 time.
-        String originalZoneId = config.getZoneId();
-        config.setZoneId("UTC+9");
+        ZoneId originalZoneId = config.getZoneId();
+        config.setZoneId(ZoneId.of("UTC+9"));
         config.setSinceDate(LocalDateTime.of(2020, Month.JANUARY, 27, 0, 0));
         config.setUntilDate(LocalDateTime.of(2020, Month.JANUARY, 28, 0, 0));
 
@@ -436,8 +436,8 @@ public class CommitInfoAnalyzerTest extends GitTestTemplate {
     /**
      * Returns a {@link LocalDateTime} from a string {@code gitStrictIsoDate}.
      */
-    private LocalDateTime parseGitStrictIsoDate(String gitStrictIsoDate) throws Exception {
+    private LocalDateTime parseGitStrictIsoDate(String gitStrictIsoDate) {
         return ZonedDateTime.parse(gitStrictIsoDate, CommitInfoAnalyzer.GIT_STRICT_ISO_DATE_FORMAT)
-                .withZoneSameInstant(ZoneId.of(config.getZoneId())).toLocalDateTime();
+                .withZoneSameInstant(config.getZoneId()).toLocalDateTime();
     }
 }

--- a/src/test/java/reposense/commits/CommitInfoAnalyzerTest.java
+++ b/src/test/java/reposense/commits/CommitInfoAnalyzerTest.java
@@ -234,7 +234,7 @@ public class CommitInfoAnalyzerTest extends GitTestTemplate {
         secondFileTypeAndContributionMap.put(FILETYPE_JAVA, new ContributionPair(0, 1));
 
         ZoneId originalZoneId = config.getZoneId();
-        config.setZoneId(ZoneId.of("UTC-0530"));
+        config.setZoneId("UTC-0530");
         config.setSinceDate(LocalDateTime.of(2019, Month.JUNE, 18, 0, 0));
         config.setUntilDate(LocalDateTime.of(2019, Month.JUNE, 19, 0, 0));
 
@@ -310,7 +310,7 @@ public class CommitInfoAnalyzerTest extends GitTestTemplate {
         config.setBranch("879-CommitInfoAnalyzerTest-analyzeCommits_commitsWithMultipleTags_success");
         config.setAuthorList(Collections.singletonList(author));
 
-        config.setZoneId(ZoneId.of("UTC+10"));
+        config.setZoneId("UTC+10");
         config.setSinceDate(LocalDateTime.of(2019, Month.DECEMBER, 21, 0, 0));
         config.setUntilDate(LocalDateTime.of(2019, Month.DECEMBER, 22, 0, 0));
 
@@ -362,7 +362,7 @@ public class CommitInfoAnalyzerTest extends GitTestTemplate {
 
         // Equivalent to 2020-01-27 23:20:51 in UTC+9 time.
         ZoneId originalZoneId = config.getZoneId();
-        config.setZoneId(ZoneId.of("UTC+9"));
+        config.setZoneId("UTC+9");
         config.setSinceDate(LocalDateTime.of(2020, Month.JANUARY, 27, 0, 0));
         config.setUntilDate(LocalDateTime.of(2020, Month.JANUARY, 28, 0, 0));
 

--- a/src/test/java/reposense/git/GitCheckoutTest.java
+++ b/src/test/java/reposense/git/GitCheckoutTest.java
@@ -5,7 +5,6 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.LocalDateTime;
 import java.time.Month;
-import java.time.ZoneId;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -13,7 +12,6 @@ import org.junit.jupiter.api.Test;
 import reposense.git.exception.CommitNotFoundException;
 import reposense.template.GitTestTemplate;
 import reposense.util.TestUtil;
-
 
 public class GitCheckoutTest extends GitTestTemplate {
 
@@ -48,7 +46,7 @@ public class GitCheckoutTest extends GitTestTemplate {
         Assertions.assertTrue(Files.exists(newFile));
 
         LocalDateTime untilDate = TestUtil.getUntilDate(2018, Month.FEBRUARY.getValue(), 6);
-        GitCheckout.checkoutDate(config.getRepoRoot(), config.getBranch(), untilDate, ZoneId.of(config.getZoneId()));
+        GitCheckout.checkoutDate(config.getRepoRoot(), config.getBranch(), untilDate, config.getZoneId());
         Assertions.assertFalse(Files.exists(newFile));
     }
 
@@ -56,6 +54,6 @@ public class GitCheckoutTest extends GitTestTemplate {
     public void checkoutToDate_invalidDate_throwsEmptyCommitException() {
         LocalDateTime untilDate = TestUtil.getUntilDate(2015, Month.FEBRUARY.getValue(), 6);
         Assertions.assertThrows(CommitNotFoundException.class, () -> GitCheckout.checkoutDate(config.getRepoRoot(),
-                config.getBranch(), untilDate, ZoneId.of(config.getZoneId())));
+                config.getBranch(), untilDate, config.getZoneId()));
     }
 }

--- a/src/test/java/reposense/git/GitRevListTest.java
+++ b/src/test/java/reposense/git/GitRevListTest.java
@@ -2,7 +2,6 @@ package reposense.git;
 
 import java.time.LocalDateTime;
 import java.time.Month;
-import java.time.ZoneId;
 import java.util.List;
 
 import org.junit.jupiter.api.Assertions;
@@ -17,7 +16,7 @@ public class GitRevListTest extends GitTestTemplate {
     public void getCommitHashUntilDate_beforeInitialCommitDate_emptyResult() {
         LocalDateTime date = TestUtil.getUntilDate(2018, Month.FEBRUARY.getValue(), 4);
         String commitHash = GitRevList.getCommitHashUntilDate(config.getRepoRoot(), config.getBranch(), date,
-                ZoneId.of(config.getZoneId()));
+                config.getZoneId());
         Assertions.assertTrue(commitHash.isEmpty());
     }
 
@@ -25,7 +24,7 @@ public class GitRevListTest extends GitTestTemplate {
     public void getCommitHashUntilDate_afterLatestCommitDate_success() {
         LocalDateTime date = TestUtil.getUntilDate(2018, Month.MAY.getValue(), 10);
         String commitHash = GitRevList.getCommitHashUntilDate(config.getRepoRoot(), config.getBranch(), date,
-                ZoneId.of(config.getZoneId()));
+                config.getZoneId());
 
         // result from git has a newline at the end
         Assertions.assertEquals(EUGENE_AUTHOR_README_FILE_COMMIT_07052018 + "\n", commitHash);
@@ -35,7 +34,7 @@ public class GitRevListTest extends GitTestTemplate {
     public void getCommitHashUntilDate_februaryNineDate_success() {
         LocalDateTime date = TestUtil.getUntilDate(2018, Month.FEBRUARY.getValue(), 8);
         String commitHash = GitRevList.getCommitHashUntilDate(config.getRepoRoot(), config.getBranch(), date,
-                ZoneId.of(config.getZoneId()));
+                config.getZoneId());
 
         // result from git has a newline at the end
         Assertions.assertEquals(FAKE_AUTHOR_BLAME_TEST_FILE_COMMIT_08022018 + "\n", commitHash);
@@ -51,7 +50,7 @@ public class GitRevListTest extends GitTestTemplate {
     public void getCommitHashBeforeDate_invalidBranch_throwsRunTimeException() {
         LocalDateTime date = TestUtil.getUntilDate(2018, Month.FEBRUARY.getValue(), 9);
         Assertions.assertThrows(RuntimeException.class, () -> GitRevList.getCommitHashUntilDate(config.getRepoRoot(),
-                "invalidBranch", date, ZoneId.of(config.getZoneId())));
+                "invalidBranch", date, config.getZoneId()));
     }
 
     @Test

--- a/src/test/java/reposense/template/GitTestTemplate.java
+++ b/src/test/java/reposense/template/GitTestTemplate.java
@@ -3,6 +3,7 @@ package reposense.template;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.File;
+import java.time.ZoneId;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Iterator;
@@ -88,7 +89,7 @@ public class GitTestTemplate {
             new CommitHash(AUTHOR_TO_IGNORE_BLAME_TEST_FILE_COMMIT_07082021_STRING)
     );
     protected static final String NONEXISTENT_COMMIT_HASH = "nonExistentCommitHash";
-    protected static final String TIME_ZONE_ID_STRING = "Asia/Singapore";
+    protected static final ZoneId TIME_ZONE_ID = ZoneId.of("Asia/Singapore");
 
     protected static final Author MAIN_AUTHOR = new Author(MAIN_AUTHOR_NAME);
     protected static final Author FAKE_AUTHOR = new Author(FAKE_AUTHOR_NAME);
@@ -100,14 +101,14 @@ public class GitTestTemplate {
         config = new RepoConfiguration(new RepoLocation(TEST_REPO_GIT_LOCATION), "master");
         config.setAuthorList(Collections.singletonList(getAlphaAllAliasAuthor()));
         config.setFormats(FileTypeTest.DEFAULT_TEST_FORMATS);
-        config.setZoneId(TIME_ZONE_ID_STRING);
+        config.setZoneId(TIME_ZONE_ID);
         config.setIsLastModifiedDateIncluded(false);
     }
 
     @BeforeAll
     public static void beforeClass() throws Exception {
         config = new RepoConfiguration(new RepoLocation(TEST_REPO_GIT_LOCATION), "master");
-        config.setZoneId(TIME_ZONE_ID_STRING);
+        config.setZoneId(TIME_ZONE_ID);
         TestRepoCloner.cloneAndBranch(config);
     }
 


### PR DESCRIPTION
<!--
    If this pull request fully addresses an issue, use:
    Fixes #xxxx

    If this pull request partially addresses an issue, use:
    Part of #xxxx

    If this pull request addresses multiple issues, put them in multiple lines:
    Fixes #xxxx
    Fixes #yyyy

    Format the title of the pull request with most relevant issue number as follows:
    [#xxxx] Title
-->
Fixes #1674

## Proposed commit message
<!--
    Propose a detailed commit message for this pull request within the triple backticks below.
    Wrap lines at 72 characters.

    Guide on how to write a good commit message:
    https://oss-generic.github.io/process/docs/FormatsAndConventions.html#commit-message
-->
```
zoneId is stored as ZoneId object in CliArguments.java. It is converted 
into String when stored in RepoConfiguration.java. Subsequently, it is 
then converted back to ZoneId when required in FileInfoAnalyzer.java or 
other places.

Such repeated conversion is redundant.

Let's standardize and save zoneId as ZoneId Object across all files.
```

## Other information
<!--
    Are there other relevant information, such as special testing instructions, 
    which will help the reviewer better understand the code?

    You may also include a brief description of why the problem occurred.
-->
1. `zoneId` in `SummaryJson.java` remains as `String` as changing to `ZoneId` will break `systemtest`. Instead, the constructor will now accept a `ZoneId` input which will subsequent be converted and stored as `String`.
