### PR TITLE
[#1793] TimeUtil: update DATE_FORMAT_REGEX

### DIFF
--- a/src/main/java/reposense/util/TimeUtil.java
+++ b/src/main/java/reposense/util/TimeUtil.java
@@ -17,7 +17,7 @@ import reposense.parser.SinceDateArgumentType;
 public class TimeUtil {
     private static Long startTime;
     private static final String DATE_FORMAT_REGEX =
-            "^((0[1-9]|[12][0-9]|3[01])\\/(0[1-9]|1[012])\\/(19|2[0-9])[0-9]{2})";
+            "^((0?[1-9]|[12][0-9]|3[01])\\/(0?[1-9]|1[012])\\/(19|2[0-9])[0-9]{2})";
 
     // "uuuu" is used for year since "yyyy" does not work with ResolverStyle.STRICT
     private static final DateTimeFormatter CLI_ARGS_DATE_FORMAT = DateTimeFormatter.ofPattern("d/M/uuuu HH:mm:ss");

--- a/src/test/java/reposense/util/TimeUtilTest.java
+++ b/src/test/java/reposense/util/TimeUtilTest.java
@@ -40,9 +40,9 @@ public class TimeUtilTest {
 
     @Test
     public void extractDate_validSingleDigitDateAndString_success() {
-        String originalDateAndTime = "1/1/2022 addedstring";
+        String originalDateAndString = "1/1/2022addedstring";
         String expectedDate = "1/1/2022";
-        String actualDate = TimeUtil.extractDate(originalDateAndTime);
+        String actualDate = TimeUtil.extractDate(originalDateAndString);
         Assertions.assertEquals(expectedDate, actualDate);
     }
 

--- a/src/test/java/reposense/util/TimeUtilTest.java
+++ b/src/test/java/reposense/util/TimeUtilTest.java
@@ -24,6 +24,29 @@ public class TimeUtilTest {
     }
 
     @Test
+    public void extractDate_validSingleDigitDate_success() {
+        String expectedDate = "1/1/2022";
+        String actualDate = TimeUtil.extractDate(expectedDate);
+        Assertions.assertEquals(expectedDate, actualDate);
+    }
+
+    @Test
+    public void extractDate_validSingleDigitDateAndTime_success() {
+        String originalDateAndTime = "1/1/2022 12:34:56";
+        String expectedDate = "1/1/2022";
+        String actualDate = TimeUtil.extractDate(originalDateAndTime);
+        Assertions.assertEquals(expectedDate, actualDate);
+    }
+
+    @Test
+    public void extractDate_validSingleDigitDateAndString_success() {
+        String originalDateAndTime = "1/1/2022 addedstring";
+        String expectedDate = "1/1/2022";
+        String actualDate = TimeUtil.extractDate(originalDateAndTime);
+        Assertions.assertEquals(expectedDate, actualDate);
+    }
+
+    @Test
     public void parseDate_validDateAndTime_success() throws Exception {
         String originalDateAndTime = "20/05/2020 00:00:00";
         LocalDateTime expectedDate = TestUtil.getSinceDate(2020, Month.MAY.getValue(), 20);


### PR DESCRIPTION
<!--
    If this pull request fully addresses an issue, use:
    Fixes #xxxx

    If this pull request partially addresses an issue, use:
    Part of #xxxx

    If this pull request addresses multiple issues, put them in multiple lines:
    Fixes #xxxx
    Fixes #yyyy

    Format the title of the pull request with most relevant issue number as follows:
    [#xxxx] Title
-->
Fixes #1793

## Proposed commit message
<!--
    Propose a detailed commit message for this pull request within the triple backticks below.
    Wrap lines at 72 characters.

    Guide on how to write a good commit message:
    https://oss-generic.github.io/process/docs/FormatsAndConventions.html#commit-message
-->
```
The expected date input is 'dd/mm/yyyy' or 'd/m/yyyy'. With 
extractDate(), inputs like 'dd/mm/yyyyaddedstring' is also accepted.

The same behavior is expected with single-digit date input. However, 
extractDate() cannot process inputs such as '1/1/2022addedstring'.

Let's fix this by updating DATE_FORMAT_REGEX.
```
