### PR TITLE
[#1118] Change restriction for author names to disallow only empty names

### DIFF
--- a/src/main/java/reposense/authorship/analyzer/AnnotatorAnalyzer.java
+++ b/src/main/java/reposense/authorship/analyzer/AnnotatorAnalyzer.java
@@ -22,9 +22,6 @@ import reposense.model.AuthorConfiguration;
  */
 public class AnnotatorAnalyzer {
     private static final String AUTHOR_TAG = "@@author";
-    // GitHub username format
-    private static final String REGEX_AUTHOR_NAME_FORMAT = "^[a-zA-Z0-9](?:[a-zA-Z0-9]|-(?=[a-zA-Z0-9])){0,38}$";
-    private static final Pattern PATTERN_AUTHOR_NAME_FORMAT = Pattern.compile(REGEX_AUTHOR_NAME_FORMAT);
     private static final String REGEX_AUTHOR_TAG_FORMAT = "@@author(\\s+[^\\s]+)?";
 
     private static final String[][] COMMENT_FORMATS = {
@@ -106,8 +103,7 @@ public class AnnotatorAnalyzer {
                 .map(array -> array[1].trim().split(COMMENT_FORMATS[getCommentTypeIndex(line)][1]))
                 .filter(array -> array.length > 0)
                 .map(array -> array[0].trim())
-                // checks if the author name is valid
-                .filter(trimmedParameters -> PATTERN_AUTHOR_NAME_FORMAT.matcher(trimmedParameters).find());
+                .filter(trimmedParameters -> !trimmedParameters.isEmpty());
     }
 
     /**

--- a/src/test/java/reposense/authorship/AnnotatorAnalyzerTest.java
+++ b/src/test/java/reposense/authorship/AnnotatorAnalyzerTest.java
@@ -24,11 +24,15 @@ public class AnnotatorAnalyzerTest extends GitTestTemplate {
     private static final LocalDateTime SINCE_DATE = TestUtil.getSinceDate(2018, Month.FEBRUARY.getValue(), 8);
     private static final LocalDateTime UNTIL_DATE = TestUtil.getUntilDate(2021, Month.AUGUST.getValue(), 3);
     private static final String TIME_ZONE_ID_STRING = "Asia/Singapore";
+    private static final Author VALID_AUTHOR_IF_REGEX_CHECK_ABSENT_1 =
+            new Author("-invalidGitUsername_TreatedAsUnknownUser");
     private static final Author[] EXPECTED_LINE_AUTHORS_OVERRIDE_AUTHORSHIP_TEST = {
             FAKE_AUTHOR, FAKE_AUTHOR, FAKE_AUTHOR, FAKE_AUTHOR,
             MAIN_AUTHOR, MAIN_AUTHOR, MAIN_AUTHOR, MAIN_AUTHOR, MAIN_AUTHOR,
             FAKE_AUTHOR, FAKE_AUTHOR,
-            UNKNOWN_AUTHOR, UNKNOWN_AUTHOR, UNKNOWN_AUTHOR, UNKNOWN_AUTHOR, UNKNOWN_AUTHOR,
+            VALID_AUTHOR_IF_REGEX_CHECK_ABSENT_1, VALID_AUTHOR_IF_REGEX_CHECK_ABSENT_1,
+            VALID_AUTHOR_IF_REGEX_CHECK_ABSENT_1, VALID_AUTHOR_IF_REGEX_CHECK_ABSENT_1,
+            VALID_AUTHOR_IF_REGEX_CHECK_ABSENT_1,
             FAKE_AUTHOR, FAKE_AUTHOR, FAKE_AUTHOR,
             UNKNOWN_AUTHOR, UNKNOWN_AUTHOR, UNKNOWN_AUTHOR
     };
@@ -228,15 +232,15 @@ public class AnnotatorAnalyzerTest extends GitTestTemplate {
 
         line = "% @@author thisAuthorNameHasMoreThanThirtyNineLetters";
         Assertions.assertEquals(4, AnnotatorAnalyzer.getCommentTypeIndex(line));
-        Assertions.assertFalse(AnnotatorAnalyzer.extractAuthorName(line).isPresent());
+        Assertions.assertTrue(AnnotatorAnalyzer.extractAuthorName(line).isPresent());
 
-        line = "# @@author -invalidUsernameFormat";
+        line = "# @@author -validUsernameFormat";
         Assertions.assertEquals(2, AnnotatorAnalyzer.getCommentTypeIndex(line));
-        Assertions.assertFalse(AnnotatorAnalyzer.extractAuthorName(line).isPresent());
+        Assertions.assertTrue(AnnotatorAnalyzer.extractAuthorName(line).isPresent());
 
         line = "/*@@author fakeAuthor-->";
         Assertions.assertEquals(1, AnnotatorAnalyzer.getCommentTypeIndex(line));
-        Assertions.assertFalse(AnnotatorAnalyzer.extractAuthorName(line).isPresent());
+        Assertions.assertTrue(AnnotatorAnalyzer.extractAuthorName(line).isPresent()); // author name is "fakeAuthor-->"
     }
 
     @Test


### PR DESCRIPTION
Fixes #1118 

```
AnnotatorAnalyzer: Remove restriction for author name in @@author tags

RepoSense does restrictive checks for valid author names.

Following the discussion, it is recommended to remove such restrictive
checks so that names such as "--validName--" will be allowed.

Let's remove the regex pattern for checking author names and
update test cases accordingly so that all non-blank Strings are treated
as valid author names
```