### PR TITLE
[#452] RepoConfiguration: Restrict sinceDate and untilDate

### DIFF
--- a/src/main/java/reposense/model/RepoConfiguration.java
+++ b/src/main/java/reposense/model/RepoConfiguration.java
@@ -2,6 +2,7 @@ package reposense.model;
 
 import java.io.File;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -13,6 +14,7 @@ import reposense.git.GitBranch;
 import reposense.git.exception.GitBranchException;
 import reposense.system.LogsManager;
 import reposense.util.FileUtil;
+import reposense.util.TimeUtil;
 
 /**
  * Represents configuration information from CSV config file for a single repository.
@@ -539,7 +541,7 @@ public class RepoConfiguration {
     }
 
     public LocalDateTime getSinceDate() {
-        return sinceDate;
+        return TimeUtil.getOrDefaultValidTime(sinceDate, ZoneId.of(zoneId));
     }
 
     public void setSinceDate(LocalDateTime sinceDate) {
@@ -547,7 +549,7 @@ public class RepoConfiguration {
     }
 
     public LocalDateTime getUntilDate() {
-        return untilDate;
+        return TimeUtil.getOrDefaultValidTime(untilDate, ZoneId.of(zoneId));
     }
 
     public void setUntilDate(LocalDateTime untilDate) {

--- a/src/main/java/reposense/parser/ArgsParser.java
+++ b/src/main/java/reposense/parser/ArgsParser.java
@@ -330,7 +330,9 @@ public class ArgsParser {
             LogsManager.setLogFolderLocation(outputFolderPath);
 
             TimeUtil.verifySinceDateIsValid(sinceDate, currentDate);
-            TimeUtil.verifyDatesRangeIsCorrect(sinceDate, untilDate);
+            LocalDateTime validSinceDate = TimeUtil.getOrDefaultValidTime(sinceDate, zoneId);
+            LocalDateTime validUntilDate = TimeUtil.getOrDefaultValidTime(untilDate, zoneId);
+            TimeUtil.verifyDatesRangeIsCorrect(validSinceDate, validUntilDate);
 
             if (reportFolderPath != null && !reportFolderPath.equals(EMPTY_PATH)
                     && configFolderPath.equals(DEFAULT_CONFIG_PATH) && locations == null) {
@@ -344,18 +346,18 @@ public class ArgsParser {
             }
 
             if (locations != null) {
-                return new LocationsCliArguments(locations, outputFolderPath, assetsFolderPath, sinceDate, untilDate,
-                        isSinceDateProvided, isUntilDateProvided, numCloningThreads, numAnalysisThreads, formats,
-                        shouldIncludeLastModifiedDate, shouldPerformShallowCloning, isAutomaticallyLaunching,
+                return new LocationsCliArguments(locations, outputFolderPath, assetsFolderPath, validSinceDate,
+                        validUntilDate, isSinceDateProvided, isUntilDateProvided, numCloningThreads, numAnalysisThreads,
+                        formats, shouldIncludeLastModifiedDate, shouldPerformShallowCloning, isAutomaticallyLaunching,
                         isStandaloneConfigIgnored, isFileSizeLimitIgnored, zoneId, shouldFindPreviousAuthors);
             }
 
             if (configFolderPath.equals(EMPTY_PATH)) {
                 logger.info(MESSAGE_USING_DEFAULT_CONFIG_PATH);
             }
-            return new ConfigCliArguments(configFolderPath, outputFolderPath, assetsFolderPath, sinceDate, untilDate,
-                    isSinceDateProvided, isUntilDateProvided, numCloningThreads, numAnalysisThreads, formats,
-                    shouldIncludeLastModifiedDate, shouldPerformShallowCloning, isAutomaticallyLaunching,
+            return new ConfigCliArguments(configFolderPath, outputFolderPath, assetsFolderPath, validSinceDate,
+                    validUntilDate, isSinceDateProvided, isUntilDateProvided, numCloningThreads, numAnalysisThreads,
+                    formats, shouldIncludeLastModifiedDate, shouldPerformShallowCloning, isAutomaticallyLaunching,
                     isStandaloneConfigIgnored, isFileSizeLimitIgnored, zoneId, reportConfig, shouldFindPreviousAuthors);
         } catch (HelpScreenException hse) {
             throw hse;

--- a/src/test/java/reposense/git/GitLogTest.java
+++ b/src/test/java/reposense/git/GitLogTest.java
@@ -2,13 +2,20 @@ package reposense.git;
 
 import java.time.LocalDateTime;
 import java.time.Month;
+import java.time.format.DateTimeFormatter;
 import java.util.Collections;
+import java.util.List;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import net.sourceforge.argparse4j.helper.HelpScreenException;
 import reposense.model.Author;
+import reposense.model.CliArguments;
+import reposense.model.ConfigCliArguments;
 import reposense.model.FileType;
+import reposense.parser.ArgsParser;
+import reposense.parser.ParseException;
 import reposense.template.GitTestTemplate;
 import reposense.util.TestUtil;
 
@@ -139,6 +146,12 @@ public class GitLogTest extends GitTestTemplate {
         config.setSinceDate(date);
         String content = GitLog.get(config, getAlphaAllAliasAuthor());
         Assertions.assertTrue(content.isEmpty());
+
+        date = TestUtil.getSinceDate(2200, Month.JANUARY.getValue(), 1);
+        config.setUntilDate(null);
+        config.setSinceDate(date);
+        content = GitLog.get(config, getAlphaAllAliasAuthor());
+        Assertions.assertTrue(content.isEmpty());
     }
 
     @Test
@@ -147,6 +160,12 @@ public class GitLogTest extends GitTestTemplate {
         config.setUntilDate(date);
         config.setSinceDate(null);
         String content = GitLog.get(config, getAlphaAllAliasAuthor());
+        Assertions.assertTrue(content.isEmpty());
+
+        date = TestUtil.getUntilDate(1950, Month.JANUARY.getValue(), 1);
+        config.setUntilDate(date);
+        config.setSinceDate(null);
+        content = GitLog.get(config, getAlphaAllAliasAuthor());
         Assertions.assertTrue(content.isEmpty());
     }
 


### PR DESCRIPTION
Fixes #452 

```
The flags sinceDate and untilDate are not checked to ensure they are
between 1970/01/01 00:00:00UTC and 2099/12/31 23:59:59UTC (inclusive)

Git is unable to handle timestamps before the Unix epoch and after 2099.
This had caused GitLogTest unit tests to fail unexpected, for example showing
logs of all commits when untilDate is set to 1950. Upon investigation, this
problem applies across git commands, and not only for git log.

Therefore, sinceDate and untilDate should always range between 1970UTC
and 2099UTC for git commands to function expectedly.

Let's create a new method in TimeUtils to get a validated time. If the
input time does not lie in the range, we'll log a warning and then reset
the date to the latest or earliest permitted time. This function will
be used when first parsing CLI arguments, and also in the getSinceDate()
and getUntilDate() in RepoConfiguration to ensure the validity of the two
dates everywhere.
```