### PR TITLE
Actions: prevent bot from closing stale issues

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -7,14 +7,16 @@ on:
 
 jobs:
   stale:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
 
     steps:
     - uses: actions/stale@v5
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
-        days-before-stale: 30
-        days-before-close: 7
+        days-before-stale: -1
+        days-before-close: -1
+        days-before-pr-stale: 30
+        days-before-pr-close: 7
         exempt-pr-labels: 's.DoNotMerge'
         remove-stale-when-updated: true
         stale-pr-label: 'Stale'


### PR DESCRIPTION
## Proposed commit message
<!--
    Propose a detailed commit message for this pull request within the triple backticks below.
    Wrap lines at 72 characters.

    Guide on how to write a good commit message:
    https://oss-generic.github.io/process/docs/FormatsAndConventions.html#commit-message
-->
```
The actions/stale GitHub Actions was updated to v5, but the upstream
behavior of closing stale issues changed.

Let's prevent the bot from closing stale issues while keeping the
functionality of closing stale PRs intact.
```