### PR TITLE
Hotfix: revert highlight.js from version 11 to 10

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,7 +20,7 @@
     "@fortawesome/free-solid-svg-icons": "^6.0.0",
     "@fortawesome/vue-fontawesome": "^3.0.0-5",
     "core-js": "^3.6.5",
-    "highlight.js": "^11.5.0",
+    "highlight.js": "^10.5.0",
     "jszip": "^3.5.0",
     "minimatch": "^5.0.1",
     "muicss": "^0.10.3",


### PR DESCRIPTION
## Proposed commit message
<!--
    Propose a detailed commit message for this pull request within the triple backticks below.
    Wrap lines at 72 characters.

    Guide on how to write a good commit message:
    https://oss-generic.github.io/process/docs/FormatsAndConventions.html#commit-message
-->
```
After upgrading highlight.js to version 11, the formatting of code in
the code panel breaks.

Let's revert highlight.js back to version 10.
```

## Other information
<!--
    Are there other relevant information, such as special testing instructions, 
    which will help the reviewer better understand the code?

    You may also include a brief description of why the problem occurred.
-->

### Code panel with highlight.js version 10:

![Screenshot (5)](https://user-images.githubusercontent.com/69678785/183277006-a57e5e81-6b28-459f-bf2e-096e3b69c69b.png)

### Code panel with highlight.js version 11:

![Screenshot (6)](https://user-images.githubusercontent.com/69678785/183277011-bf51d284-bbb0-49e6-a122-8860d95123a4.png)

### Description

It appears that the following lines in `v-segment.vue` do not work with version 11:
https://github.com/reposense/RepoSense/blob/1caadd3cacb3aa293f563053aa18b05512062565/frontend/src/components/v-segment.vue#L15-L18

After reading through the [changelog for `highlight.js` version 11](https://highlightjs.readthedocs.io/en/latest/upgrade-11.html#changes-to-result-data), I noticed that the overall class for each segment will have `language-[language name]` appended to it, but I'm not sure how this affects the way the code is parsed.