### PR TITLE
Actions: remove Ubuntu 18.04 runner

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -15,7 +15,7 @@ jobs:
     name: ${{ matrix.os }} JDK 8
     strategy:
       matrix:
-        os: [ubuntu-18.04, ubuntu-20.04, ubuntu-22.04]
+        os: [ubuntu-20.04, ubuntu-22.04]
     runs-on: ${{ matrix.os }}
     env:
       NODE_VERSION: "lts/*"

--- a/docs/dg/devOpsGuide.md
+++ b/docs/dg/devOpsGuide.md
@@ -31,7 +31,7 @@ All three types of tests in the test suite are run in a single GitHub Actions wo
 1. Ubuntu JDK 8 (`ubuntu`): Runs both unit tests and system tests on JDK 1.8 running on supported Ubuntu versions. This job also produces a RepoSense report and the MarkBind documentation website for previewing.
 2. macOS JDK 8 (`macos`): Runs both unit tests and system tests on JDK 1.8 running on supported macOS versions.
 3. Windows JDK 8 (`windows`): Runs both unit tests and system tests on JDK 1.8 running on supported Windows versions.
-4. Cypress frontend tests (`cypress`): Runs only the frontend tests on JDK 1.8 running on Ubuntu 18.04 LTS.
+4. Cypress frontend tests (`cypress`): Runs only the frontend tests on JDK 1.8 running on Ubuntu 20.04 LTS.
 
 The list of supported OS versions are [available on the GitHub Docs website](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources). These jobs should be updated regularly whenever RepoSense supports newer versions of the Java Development Kit (JDK) as well as when new OS versions are made available (via the job OS matrix). Frontend tests are run separately to take advantage of parallel job execution.
 


### PR DESCRIPTION
<!--
    If this pull request fully addresses an issue, use:
    Fixes #xxxx

    If this pull request partially addresses an issue, use:
    Part of #xxxx

    If this pull request addresses multiple issues, put them in multiple lines:
    Fixes #xxxx
    Fixes #yyyy

    Format the title of the pull request with most relevant issue number as follows:
    [#xxxx] Title
-->


## Proposed commit message
<!--
    Propose a detailed commit message for this pull request within the triple backticks below.
    Wrap lines at 72 characters.

    Guide on how to write a good commit message:
    https://oss-generic.github.io/process/docs/FormatsAndConventions.html#commit-message
-->
```
The Ubuntu 18.04 runner is deprecated and will be fully removed on
2022-12-01, after which the jobs will fail.

Let's remove the Ubuntu 18.04 runner.

Reference: https://github.com/actions/runner-images/issues/6002
```

## Other information
<!--
    Are there other relevant information, such as special testing instructions, 
    which will help the reviewer better understand the code?

    You may also include a brief description of why the problem occurred.
-->

- The deprecation was [announced on 2 August 2022](https://github.com/actions/runner-images/issues/6002).
- The Ubuntu 22.04 image is now GA, so it has now been made a required check.
- The Ubuntu 18.04 image is now made an optional check.