### PR TITLE
Gradle: update Node 14 minor release version 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ OperatingSystem os = DefaultNativePlatform.currentOperatingSystem;
 
 mainClassName = 'reposense.RepoSense'
 
-node.nodeVersion = '14.19.0'
+node.nodeVersion = '14.20.0'
 
 sourceCompatibility = JavaVersion.VERSION_1_8
 targetCompatibility = JavaVersion.VERSION_1_8


### PR DESCRIPTION
## Proposed commit message
<!--
    Propose a detailed commit message for this pull request within the triple backticks below.
    Wrap lines at 72 characters.

    Guide on how to write a good commit message:
    https://oss-generic.github.io/process/docs/FormatsAndConventions.html#commit-message
-->
```
The current Node version for Gradle is 14.19.0. However, the latest
available version of Node 14 is 14.20.0.

Let's upgrade the Node 14 minor release version in build.gradle.
```

## Other information
<!--
    Are there other relevant information, such as special testing instructions, 
    which will help the reviewer better understand the code?

    You may also include a brief description of why the problem occurred.
-->
The most recent update to Node 14 is partly due to [vulnerabilities in the underlying OpenSSL]( https://mta.openssl.org/pipermail/openssl-announce/2022-July/000232.html).

Node `14.20.0` release notes: https://nodejs.org/en/blog/release/v14.20.0/

For `build.gradle`, using `14.x` is not allowed:
https://github.com/reposense/RepoSense/blob/507093628bc7a27ba65094a2b7b06a5bbb96423f/build.gradle#L19

unlike in `integration.yml`:
https://github.com/reposense/RepoSense/blob/507093628bc7a27ba65094a2b7b06a5bbb96423f/.github/workflows/integration.yml#L38-L41