### PR TITLE
Add functionality to take in mapping of Author name to git id

### DIFF
--- a/config/author-config.csv
+++ b/config/author-config.csv
@@ -1,12 +1,2 @@
 Repository's Location,Branch,Author's Git Host ID,Author's Emails,Author's Display Name,Author's Git Author Name,Ignore Glob List
-https://github.com/reposense/testrepo-Beta.git,master,nbriannl,,"Ashwin Mukadaan Singhania, Rathod",,
-https://github.com/reposense/testrepo-Beta.git,master,zacharytang,zacharytang.tc@gmail.com,Yagami Rukei Polland,,src/main**
-https://github.com/reposense/testrepo-Beta.git,master,April0616,,2805Tagoe,LAPTOP-7KFM2KSP\User;Fan Yuting,
-https://github.com/reposense/testrepo-Beta.git,master,CindyTsai1,,,YuHsuan,src/test**
-https://github.com/reposense/testrepo-Beta.git,add-config-json,nbriannl,,A.M.S.Rathod,,
-https://github.com/reposense/testrepo-Beta.git,add-config-json,zacharytang,zacharytang.tc@gmail.com,Yaga..Polland,,src/main**
-https://github.com/reposense/testrepo-Beta.git,add-config-json,April0616,,  ,LAPTOP-7KFM2KSP\User;Fan Yuting,
-https://github.com/reposense/testrepo-Beta.git,add-config-json,CindyTsai1,,Ravind s/o Ramesh,YuHsuan,src/test**
-https://bitbucket.org/skyblaise/testrepo-bitbucket.git,master,skyblaise,,Zhang Shi Chen,SHICHEN ZHANG;SkyBlaise,
-https://gitlab.com/reposense/testrepo-gitlab.git,main,zsc990124,,Zhang Shi Chen,SHICHEN ZHANG;SkyBlaise,
-https://tomluozhijie@git.code.sf.net/p/repo-sense-test-repo/code,master,luozhijie-tom,,Luo Zhijie,Luo Zhijie;Luo Zhijie,
+

--- a/config/author-name-to-gitid.csv
+++ b/config/author-name-to-gitid.csv
@@ -1,0 +1,3 @@
+Author Name,Git Id
+Eugene Peh, eugenepeh
+WANG CHAO, fzdy1914

--- a/config/group-config.csv
+++ b/config/group-config.csv
@@ -1,8 +1,2 @@
 Repository's Location,Group Name,Globs
-https://github.com/reposense/testrepo-Delta.git,code,**.java
-https://github.com/reposense/testrepo-Delta.git,tests,src/test**
-https://github.com/reposense/testrepo-Delta.git,docs,docs**;**.adoc;**.md
-https://github.com/reposense/RepoSense.git,frontend,frontend/**
-https://github.com/reposense/RepoSense.git,backend,**.java
-https://github.com/reposense/RepoSense.git,tests,src/test/**
-https://github.com/reposense/RepoSense.git,docs,docs**;**.md;**.adoc
+

--- a/config/repo-config.csv
+++ b/config/repo-config.csv
@@ -1,13 +1,2 @@
 Repository's Location,Branch,File formats,Ignore Glob List,Ignore standalone config,Ignore Commits List,Ignore Authors List,Shallow Cloning,Find Previous Authors
 https://github.com/reposense/testrepo-Alpha.git,master,,,,2fb6b9b2dd9fa40bf0f9815da2cb0ae8731436c7;c5a6dc774e22099cd9ddeb0faff1e75f9cf4f151;cd7f610e0becbdf331d5231887d8010a689f87c7;768015345e70f06add2a8b7d1f901dc07bf70582,,,
-https://github.com/reposense/testrepo-Beta.git,master,fxml,docs**,yes,,,,
-https://github.com/reposense/testrepo-Beta.git,add-config-json,fxml,docs**,yes,,,,
-https://github.com/reposense/testrepo-Delta.git,master,override:java;md,,,,,,
-https://github.com/reposense/testrepo-Delta.git,nonExistentBranch,,,,,,,
-https://github.com/reposense/testrepo-Delta.git,add-binary-file,,,,,,,
-https://github.com/reposense/RepoSense.git,master,,,,,,,
-https://github.com/reposense/testrepo-Empty.git,master,,,,,,,
-ftp://github.com/reposense/RepoSense.git,master,,,,,,,
-https://bitbucket.org/skyblaise/testrepo-bitbucket.git,master,,,,,,,
-https://gitlab.com/reposense/testrepo-gitlab.git,main,,,,,,,
-https://tomluozhijie@git.code.sf.net/p/repo-sense-test-repo/code,master,,,,,,,

--- a/src/main/java/reposense/RepoSense.java
+++ b/src/main/java/reposense/RepoSense.java
@@ -3,6 +3,7 @@ package reposense;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
@@ -14,7 +15,9 @@ import java.util.logging.Logger;
 import net.sourceforge.argparse4j.helper.HelpScreenException;
 import reposense.git.GitConfig;
 import reposense.git.GitVersion;
+import reposense.model.Author;
 import reposense.model.AuthorConfiguration;
+import reposense.model.AuthorNameToGitId;
 import reposense.model.CliArguments;
 import reposense.model.ConfigCliArguments;
 import reposense.model.GroupConfiguration;
@@ -25,6 +28,7 @@ import reposense.model.ReportConfiguration;
 import reposense.model.ViewCliArguments;
 import reposense.parser.ArgsParser;
 import reposense.parser.AuthorConfigCsvParser;
+import reposense.parser.AuthorNameToGitIdCsvParser;
 import reposense.parser.GroupConfigCsvParser;
 import reposense.parser.InvalidCsvException;
 import reposense.parser.InvalidHeaderException;
@@ -58,6 +62,10 @@ public class RepoSense {
             CliArguments cliArguments = ArgsParser.parse(args);
             List<RepoConfiguration> configs = null;
             ReportConfiguration reportConfig = new ReportConfiguration();
+
+            //TODO: Change this to a better location
+            Path path = Paths.get("config/author-name-to-gitid.csv");
+            updateAuthorNameToGitIdMap(path);
 
             if (cliArguments instanceof ViewCliArguments) {
                 ReportServer.startServer(SERVER_PORT_NUMBER, ((
@@ -202,5 +210,12 @@ public class RepoSense {
         }
 
         return version;
+    }
+
+    //TODO: get this path via cliArguments
+    public static void updateAuthorNameToGitIdMap(Path configFilePath)
+            throws IOException, InvalidCsvException, InvalidHeaderException {
+        List<AuthorNameToGitId> authorNameToGitIds = new AuthorNameToGitIdCsvParser(configFilePath).parse();
+        Author.updateAuthorNameToGitIdMap(authorNameToGitIds);
     }
 }

--- a/src/main/java/reposense/model/AuthorNameToGitId.java
+++ b/src/main/java/reposense/model/AuthorNameToGitId.java
@@ -1,0 +1,19 @@
+package reposense.model;
+
+public class AuthorNameToGitId {
+    private String authorName;
+    private String gitId;
+
+    public AuthorNameToGitId(String authorName, String gitId) {
+        this.authorName = authorName;
+        this.gitId = gitId;
+    }
+
+    public String getAuthorName() {
+        return authorName;
+    }
+
+    public String getGitId() {
+        return gitId;
+    }
+}

--- a/src/main/java/reposense/parser/AuthorNameToGitIdCsvParser.java
+++ b/src/main/java/reposense/parser/AuthorNameToGitIdCsvParser.java
@@ -1,0 +1,38 @@
+package reposense.parser;
+
+import org.apache.commons.csv.CSVRecord;
+import reposense.model.AuthorNameToGitId;
+
+import java.io.FileNotFoundException;
+import java.nio.file.Path;
+import java.util.List;
+
+public class AuthorNameToGitIdCsvParser extends CsvParser<AuthorNameToGitId>{
+    private static final String AUTHOR_NAME_HEADER[] = {"Author Name"};
+    private static final String GIT_ID_HEADER[] = {"Git Id"};
+
+    public AuthorNameToGitIdCsvParser(Path csvFilePath) throws FileNotFoundException {
+        super(csvFilePath);
+    }
+
+    @Override
+    protected String[][] mandatoryHeaders() {
+        return new String[][]{
+                AUTHOR_NAME_HEADER, GIT_ID_HEADER
+        };
+    }
+
+    @Override
+    protected String[][] optionalHeaders() {
+        return new String[0][];
+    }
+
+
+    @Override
+    protected void processLine(List<AuthorNameToGitId> results, final CSVRecord record) {
+        String authorName = get(record, AUTHOR_NAME_HEADER);
+        String gitId = get(record, GIT_ID_HEADER);
+        AuthorNameToGitId authorNameToGitId = new AuthorNameToGitId(authorName, gitId);
+        results.add(authorNameToGitId);
+    }
+}

--- a/src/main/java/reposense/util/FileUtil.java
+++ b/src/main/java/reposense/util/FileUtil.java
@@ -109,6 +109,7 @@ public class FileUtil {
                 .registerTypeAdapter(FileType.class, new FileType.FileTypeSerializer())
                 .registerTypeAdapter(ZoneId.class, (JsonSerializer<ZoneId>) (zoneId, typeOfSrc, context)
                         -> new JsonPrimitive(zoneId.toString()))
+                .setPrettyPrinting()
                 .create();
 
         // Gson serializer from:


### PR DESCRIPTION
<!--
    If this pull request partially addresses an issue, use:
    Part of #xxxx
-->
Part of #1484

## Proposed commit message
<!--
    Propose a detailed commit message for this pull request within the triple backticks below.
    Wrap lines at 72 characters.

    Guide on how to write a good commit message:
    https://oss-generic.github.io/process/docs/FormatsAndConventions.html#commit-message
-->
```
Corrects git id associated with the authors in the report

The git id of the authors are incorrect in the generated report in certain cases

This can lead to broken links on the report, reducing the user experience

Let's correct the associated git id for the authors
```

## Other information
<!--
    Are there other relevant information, such as special testing instructions, 
    which will help the reviewer better understand the code?

    You may also include a brief description of why the problem occurred.
-->

This is a proof of concept using the config file solution as mentioned in [this comment](https://github.com/reposense/RepoSense/issues/1484#issuecomment-1353696437). 

Before the fix:
The two authors in red boxes have incorrect github id
![image](https://user-images.githubusercontent.com/38873431/207980948-8cd1ba14-de9c-4702-8a87-44f61771e546.png)

After the fix:
The two authors now have the correct github id
![image](https://user-images.githubusercontent.com/38873431/207981199-6e3dac0a-2654-42bc-98b9-30498ad1189b.png)

