### PR TITLE
[#452] Add date range validation to sinceDate and untilDate

### DIFF
--- a/frontend/cypress/tests/codeView/codeView_filterGlob.js
+++ b/frontend/cypress/tests/codeView/codeView_filterGlob.js
@@ -1,0 +1,198 @@
+describe('filter glob', () => {
+  it('check filter glob radio button is clickable', () => {
+    // open the code panel
+    cy.get('.icon-button.fa-code')
+        .should('be.visible')
+        .first()
+        .click();
+
+    // click on filter glob radio button
+    cy.get('.radio-button--search')
+        .should('be.visible')
+        .click();
+
+    // filter by file type should be unchecked
+    cy.get('.radio-button--checkbox')
+        .should('not.be.checked');
+  });
+
+  it('check no filter glob input should show all file types by default', () => {
+    cy.get('.icon-button.fa-code')
+        .should('be.visible')
+        .first()
+        .click();
+
+    cy.get('.radio-button--search')
+        .should('be.visible')
+        .click();
+
+    // the contents of all the files should be visible
+    cy.get('#tab-authorship .files', { timeout: 90000 })
+        .should('be.visible');
+  });
+
+  it('check filter glob input should be in focus after click', () => {
+    cy.get('.icon-button.fa-code')
+        .should('be.visible')
+        .first()
+        .click();
+
+    cy.get('.radio-button--search')
+        .should('be.visible')
+        .click();
+
+    // click on input box
+    cy.get('#search')
+        .click()
+        .should('have.focus');
+  });
+
+  it('check filter glob input should have default empty value', () => {
+    cy.get('.icon-button.fa-code')
+        .should('be.visible')
+        .first()
+        .click();
+
+    cy.get('.radio-button--search')
+        .should('be.visible')
+        .click();
+
+    cy.get('#search')
+        .should('have.value', '');
+  });
+
+  it('check deleting previously searched input to filter empty input by enter should show all file types', () => {
+    cy.get('.icon-button.fa-code')
+        .should('be.visible')
+        .first()
+        .click();
+
+    cy.get('.radio-button--search')
+        .should('be.visible')
+        .click();
+
+    // enter some input
+    cy.get('#search')
+        .type('an input');
+
+    // submit some input
+    cy.get('#search')
+        .type('{enter}');
+
+    // delete previous input
+    cy.get('#search')
+        .clear();
+
+    // enter on empty input
+    cy.get('#search')
+        .type('{enter}');
+
+    cy.get('#tab-authorship .files', { timeout: 90000 })
+        .should('be.visible');
+  });
+
+  it('check deleting previously searched input to filter empty input by clicking should show all file types', () => {
+    cy.get('.icon-button.fa-code')
+        .should('be.visible')
+        .first()
+        .click();
+
+    cy.get('.radio-button--search')
+        .should('be.visible')
+        .click();
+
+    cy.get('#search')
+        .type('an input');
+
+    cy.get('#submit-button')
+        .click();
+
+    cy.get('#search')
+        .clear();
+
+    // click 'Filter' on empty input
+    cy.get('#submit-button')
+        .click();
+
+    cy.get('#tab-authorship .files', { timeout: 90000 })
+        .should('be.visible');
+  });
+
+  it('check request to filter invalid glob by enter should not show any files', () => {
+    cy.get('.icon-button.fa-code')
+        .should('be.visible')
+        .first()
+        .click();
+
+    cy.get('.radio-button--search')
+        .should('be.visible')
+        .click();
+
+    cy.get('#tab-authorship .files', { timeout: 90000 })
+        .should('be.visible');
+
+    cy.get('#search')
+        .type('invalid glob');
+
+    cy.get('#search')
+        .type('{enter}');
+
+    // no file should be shown
+    cy.get('#tab-authorship .files')
+        .should('not.be.visible');
+  });
+
+  it('check request to filter invalid glob by clicking should not show any files', () => {
+    cy.get('.icon-button.fa-code')
+        .should('be.visible')
+        .first()
+        .click();
+
+    cy.get('.radio-button--search')
+        .should('be.visible')
+        .click();
+
+    cy.get('#tab-authorship .files', { timeout: 90000 })
+        .should('be.visible');
+
+    cy.get('#search')
+        .type('invalid glob');
+
+    cy.get('#submit-button')
+        .click();
+
+    cy.get('#tab-authorship .files')
+        .should('not.be.visible');
+  });
+
+  it('check filter glob should only show files with that extension', () => {
+    cy.get('.icon-button.fa-code')
+        .should('be.visible')
+        .first()
+        .click();
+
+    cy.get('.radio-button--search')
+        .should('be.visible')
+        .click();
+
+    // try java
+    cy.get('#search')
+        .type('*java');
+
+    cy.get('#submit-button')
+        .click();
+
+    cy.get('#tab-authorship .files').then(($files) => {
+      // check if there is any file with .java extension
+      if ($files.hasClass('path')) {
+        // check each file for .java extension
+        cy.get('.title > .path > span')
+            .then(($spans) => {
+              $spans.toArray().forEach((span) => {
+                cy.wrap(span).contains('.java');
+              });
+            });
+      }
+    });
+  });
+});

--- a/src/main/java/reposense/util/TimeUtil.java
+++ b/src/main/java/reposense/util/TimeUtil.java
@@ -5,11 +5,13 @@ import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.time.format.ResolverStyle;
+import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import reposense.parser.ParseException;
 import reposense.parser.SinceDateArgumentType;
+import reposense.system.LogsManager;
 
 /**
  * Contains time related functionalities.
@@ -25,6 +27,15 @@ public class TimeUtil {
             "\"Since Date\" cannot be later than \"Until Date\".";
     private static final String MESSAGE_SINCE_DATE_LATER_THAN_TODAY_DATE =
             "\"Since Date\" must not be later than today's date.";
+
+    private static final String MESSAGE_SINCE_DATE_EARLIER_THAN_EARLIEST_VALID_DATE =
+            "\"Since Date\" of %s must not be earlier than %s, resetting it to earliest valid date";
+    private static final String MESSAGE_UNTIL_DATE_LATER_THAN_LATEST_VALID_DATE =
+            "\"Until Date\" of %s must not be later than %s, resetting it to latest valid date";
+    private static final String EARLIEST_VALID_DATE = "1970-01-01T00:00:00";
+    private static final String LATEST_VALID_DATE = "2099-12-31T23:59:59";
+
+    private static final Logger logger = LogsManager.getLogger(TimeUtil.class);
 
     /**
      * Sets the {@code startTime} to be the current time.
@@ -65,17 +76,36 @@ public class TimeUtil {
     }
 
     /**
-     * Returns a {@link LocalDateTime} that is set to midnight for the given {@code sinceDate}.
+     * Returns a valid {@link LocalDateTime} that is set to midnight for the given {@code sinceDate}.
      */
     public static LocalDateTime getSinceDate(LocalDateTime sinceDate) {
-        return sinceDate.withHour(0).withMinute(0).withSecond(0);
+        return getValidDate(sinceDate).withHour(0).withMinute(0).withSecond(0);
     }
 
     /**
-     * Returns a {@link LocalDateTime} that is set to 23:59:59 for the given {@code untilDate}.
+     * Returns a valid {@link LocalDateTime} that is set to 23:59:59 for the given {@code untilDate}.
      */
     public static LocalDateTime getUntilDate(LocalDateTime untilDate) {
-        return untilDate.withHour(23).withMinute(59).withSecond(59);
+        return getValidDate(untilDate).withHour(23).withMinute(59).withSecond(59);
+    }
+
+    /**
+     * Returns a valid {@link LocalDateTime} that is within {@value EARLIEST_VALID_DATE} and {@value LATEST_VALID_DATE}.
+     * Resets {@code date} passed the closest valid date if it exceeds the date range.
+     */
+    public static LocalDateTime getValidDate(LocalDateTime date) {
+        if (date.isBefore(LocalDateTime.parse(EARLIEST_VALID_DATE))) {
+            logger.warning(String.format(MESSAGE_SINCE_DATE_EARLIER_THAN_EARLIEST_VALID_DATE,
+                    date, EARLIEST_VALID_DATE));
+            return LocalDateTime.parse(EARLIEST_VALID_DATE);
+        }
+
+        if (date.isAfter(LocalDateTime.parse(LATEST_VALID_DATE))) {
+            logger.warning(String.format(MESSAGE_UNTIL_DATE_LATER_THAN_LATEST_VALID_DATE,
+                    date, LATEST_VALID_DATE));
+            return LocalDateTime.parse(LATEST_VALID_DATE);
+        }
+        return date;
     }
 
     /**
@@ -83,7 +113,7 @@ public class TimeUtil {
      * before report generation date otherwise.
      */
     public static LocalDateTime getDateMinusAMonth(LocalDateTime cliUntilDate) {
-        return getSinceDate(cliUntilDate.minusMonths(1));
+        return getSinceDate(cliUntilDate).minusMonths(1);
     }
 
     /**
@@ -91,14 +121,14 @@ public class TimeUtil {
      * before report generation date otherwise.
      */
     public static LocalDateTime getDateMinusNDays(LocalDateTime cliUntilDate, int numOfDays) {
-        return getSinceDate(cliUntilDate.minusDays(numOfDays));
+        return getSinceDate(cliUntilDate).minusDays(numOfDays);
     }
 
     /**
      * Returns a {@link LocalDateTime} that is {@code numOfDays} after {@code cliSinceDate} (if present).
      */
     public static LocalDateTime getDatePlusNDays(LocalDateTime cliSinceDate, int numOfDays) {
-        return getUntilDate(cliSinceDate.plusDays(numOfDays));
+        return getUntilDate(cliSinceDate).plusDays(numOfDays);
     }
 
     /**

--- a/src/main/java/reposense/util/TimeUtil.java
+++ b/src/main/java/reposense/util/TimeUtil.java
@@ -113,7 +113,7 @@ public class TimeUtil {
      * before report generation date otherwise.
      */
     public static LocalDateTime getDateMinusAMonth(LocalDateTime cliUntilDate) {
-        return getSinceDate(cliUntilDate).minusMonths(1);
+        return getSinceDate(cliUntilDate.minusMonths(1));
     }
 
     /**
@@ -121,14 +121,14 @@ public class TimeUtil {
      * before report generation date otherwise.
      */
     public static LocalDateTime getDateMinusNDays(LocalDateTime cliUntilDate, int numOfDays) {
-        return getSinceDate(cliUntilDate).minusDays(numOfDays);
+        return getSinceDate(cliUntilDate.minusDays(numOfDays));
     }
 
     /**
      * Returns a {@link LocalDateTime} that is {@code numOfDays} after {@code cliSinceDate} (if present).
      */
     public static LocalDateTime getDatePlusNDays(LocalDateTime cliSinceDate, int numOfDays) {
-        return getUntilDate(cliSinceDate).plusDays(numOfDays);
+        return getUntilDate(cliSinceDate.plusDays(numOfDays));
     }
 
     /**

--- a/src/main/java/reposense/util/TimeUtil.java
+++ b/src/main/java/reposense/util/TimeUtil.java
@@ -28,12 +28,14 @@ public class TimeUtil {
     private static final String MESSAGE_SINCE_DATE_LATER_THAN_TODAY_DATE =
             "\"Since Date\" must not be later than today's date.";
 
-    private static final String MESSAGE_SINCE_DATE_EARLIER_THAN_EARLIEST_VALID_DATE =
-            "\"Since Date\" of %s must not be earlier than %s, resetting it to earliest valid date";
-    private static final String MESSAGE_UNTIL_DATE_LATER_THAN_LATEST_VALID_DATE =
-            "\"Until Date\" of %s must not be later than %s, resetting it to latest valid date";
     private static final String EARLIEST_VALID_DATE = "1970-01-01T00:00:00";
     private static final String LATEST_VALID_DATE = "2099-12-31T23:59:59";
+    private static final String MESSAGE_SINCE_DATE_EARLIER_THAN_EARLIEST_VALID_DATE =
+            "Date of %s must not be earlier than "
+            + String.format("%s, resetting it to earliest valid date", EARLIEST_VALID_DATE);
+    private static final String MESSAGE_UNTIL_DATE_LATER_THAN_LATEST_VALID_DATE =
+            "Date of %s must not be later than "
+            + String.format("%s, resetting it to latest valid date", LATEST_VALID_DATE);
 
     private static final Logger logger = LogsManager.getLogger(TimeUtil.class);
 
@@ -95,14 +97,12 @@ public class TimeUtil {
      */
     public static LocalDateTime getValidDate(LocalDateTime date) {
         if (date.isBefore(LocalDateTime.parse(EARLIEST_VALID_DATE))) {
-            logger.warning(String.format(MESSAGE_SINCE_DATE_EARLIER_THAN_EARLIEST_VALID_DATE,
-                    date, EARLIEST_VALID_DATE));
+            logger.warning(String.format(MESSAGE_SINCE_DATE_EARLIER_THAN_EARLIEST_VALID_DATE, date));
             return LocalDateTime.parse(EARLIEST_VALID_DATE);
         }
 
         if (date.isAfter(LocalDateTime.parse(LATEST_VALID_DATE))) {
-            logger.warning(String.format(MESSAGE_UNTIL_DATE_LATER_THAN_LATEST_VALID_DATE,
-                    date, LATEST_VALID_DATE));
+            logger.warning(String.format(MESSAGE_UNTIL_DATE_LATER_THAN_LATEST_VALID_DATE, date));
             return LocalDateTime.parse(LATEST_VALID_DATE);
         }
         return date;

--- a/src/test/java/reposense/git/GitLogTest.java
+++ b/src/test/java/reposense/git/GitLogTest.java
@@ -13,6 +13,7 @@ import reposense.model.FileType;
 import reposense.model.RepoConfiguration;
 import reposense.template.GitTestTemplate;
 import reposense.util.TestUtil;
+import reposense.util.TimeUtil;
 
 public class GitLogTest extends GitTestTemplate {
     private RepoConfiguration config;
@@ -144,18 +145,33 @@ public class GitLogTest extends GitTestTemplate {
 
     @Test
     public void gitLog_sinceDateInFuture_noContent() {
-        LocalDateTime date = TestUtil.getSinceDate(2050, Month.JANUARY.getValue(), 1);
+        LocalDateTime date = TimeUtil.getSinceDate(
+                LocalDateTime.of(2050, Month.JANUARY,1, 0, 0));
         config.setSinceDate(date);
         String content = GitLog.get(config, getAlphaAllAliasAuthor());
+        Assertions.assertTrue(content.isEmpty());
+
+        date = TimeUtil.getSinceDate(
+                LocalDateTime.of(2100, Month.JANUARY,1, 0, 0));
+        config.setSinceDate(date);
+        content = GitLog.get(config, getAlphaAllAliasAuthor());
         Assertions.assertTrue(content.isEmpty());
     }
 
     @Test
     public void gitLog_untilDateBeforeAnyCommit_noContent() {
-        LocalDateTime date = TestUtil.getUntilDate(2010, Month.JANUARY.getValue(), 1);
+        LocalDateTime date = TimeUtil.getUntilDate(
+                LocalDateTime.of(2010, Month.JANUARY,1, 0, 0));
         config.setUntilDate(date);
         config.setSinceDate(null);
         String content = GitLog.get(config, getAlphaAllAliasAuthor());
+        Assertions.assertTrue(content.isEmpty());
+
+        date = TimeUtil.getUntilDate(
+                LocalDateTime.of(1970, Month.JANUARY,1, 0, 0));
+        config.setUntilDate(date);
+        config.setSinceDate(null);
+        content = GitLog.get(config, getAlphaAllAliasAuthor());
         Assertions.assertTrue(content.isEmpty());
     }
 

--- a/src/test/java/reposense/git/GitLogTest.java
+++ b/src/test/java/reposense/git/GitLogTest.java
@@ -146,13 +146,13 @@ public class GitLogTest extends GitTestTemplate {
     @Test
     public void gitLog_sinceDateInFuture_noContent() {
         LocalDateTime date = TimeUtil.getSinceDate(
-                LocalDateTime.of(2050, Month.JANUARY,1, 0, 0));
+                LocalDateTime.of(2050, Month.JANUARY, 1, 0, 0));
         config.setSinceDate(date);
         String content = GitLog.get(config, getAlphaAllAliasAuthor());
         Assertions.assertTrue(content.isEmpty());
 
         date = TimeUtil.getSinceDate(
-                LocalDateTime.of(2100, Month.JANUARY,1, 0, 0));
+                LocalDateTime.of(2100, Month.JANUARY, 1, 0, 0));
         config.setSinceDate(date);
         content = GitLog.get(config, getAlphaAllAliasAuthor());
         Assertions.assertTrue(content.isEmpty());
@@ -161,14 +161,14 @@ public class GitLogTest extends GitTestTemplate {
     @Test
     public void gitLog_untilDateBeforeAnyCommit_noContent() {
         LocalDateTime date = TimeUtil.getUntilDate(
-                LocalDateTime.of(2010, Month.JANUARY,1, 0, 0));
+                LocalDateTime.of(2010, Month.JANUARY, 1, 0, 0));
         config.setUntilDate(date);
         config.setSinceDate(null);
         String content = GitLog.get(config, getAlphaAllAliasAuthor());
         Assertions.assertTrue(content.isEmpty());
 
         date = TimeUtil.getUntilDate(
-                LocalDateTime.of(1970, Month.JANUARY,1, 0, 0));
+                LocalDateTime.of(1970, Month.JANUARY, 1, 0, 0));
         config.setUntilDate(date);
         config.setSinceDate(null);
         content = GitLog.get(config, getAlphaAllAliasAuthor());

--- a/src/test/java/reposense/git/GitLogTest.java
+++ b/src/test/java/reposense/git/GitLogTest.java
@@ -150,11 +150,14 @@ public class GitLogTest extends GitTestTemplate {
         config.setSinceDate(date);
         String content = GitLog.get(config, getAlphaAllAliasAuthor());
         Assertions.assertTrue(content.isEmpty());
+    }
 
-        date = TimeUtil.getSinceDate(
+    @Test
+    public void gitLog_invalidSinceDateInFuture_noContent() {
+        LocalDateTime date = TimeUtil.getSinceDate(
                 LocalDateTime.of(2100, Month.JANUARY, 1, 0, 0));
         config.setSinceDate(date);
-        content = GitLog.get(config, getAlphaAllAliasAuthor());
+        String content = GitLog.get(config, getAlphaAllAliasAuthor());
         Assertions.assertTrue(content.isEmpty());
     }
 
@@ -166,12 +169,15 @@ public class GitLogTest extends GitTestTemplate {
         config.setSinceDate(null);
         String content = GitLog.get(config, getAlphaAllAliasAuthor());
         Assertions.assertTrue(content.isEmpty());
+    }
 
-        date = TimeUtil.getUntilDate(
-                LocalDateTime.of(1970, Month.JANUARY, 1, 0, 0));
+    @Test
+    public void gitLog_invalidUntilDateBeforeAnyCommit_noContent() {
+        LocalDateTime date = TimeUtil.getUntilDate(
+                LocalDateTime.of(1969, Month.JANUARY, 1, 0, 0));
         config.setUntilDate(date);
         config.setSinceDate(null);
-        content = GitLog.get(config, getAlphaAllAliasAuthor());
+        String content = GitLog.get(config, getAlphaAllAliasAuthor());
         Assertions.assertTrue(content.isEmpty());
     }
 


### PR DESCRIPTION
Fixes #452

## Proposed commit message
<!--
    Propose a detailed commit message for this pull request within the triple backticks below.
    Wrap lines at 72 characters.

    Guide on how to write a good commit message:
    https://oss-generic.github.io/process/docs/FormatsAndConventions.html#commit-message
-->
```
Output from git log is unexpected when dates earlier than the epoch is
provided, or when the date is on or beyond 2100.

Let's modify the getSinceDate and getUntilDate methods in TimeUtil to
check if the date is valid first, and only operate on the valid date.
This helps to prevent the bug while having minimal impact on any of the
existing code utilizing the util.
```
