### PR TITLE
[#1853] Change git log author regex type

### DIFF
--- a/src/main/java/reposense/git/GitLog.java
+++ b/src/main/java/reposense/git/GitLog.java
@@ -30,7 +30,7 @@ public class GitLog {
     public static String get(RepoConfiguration config, Author author) {
         Path rootPath = Paths.get(config.getRepoRoot());
 
-        String command = "git log --no-merges -i ";
+        String command = "git log --no-merges -i --extended-regexp ";
         command += GitUtil.convertToGitDateRangeArgs(config.getSinceDate(), config.getUntilDate(), config.getZoneId());
         command += " --pretty=format:" + PRETTY_FORMAT_STRING + " --shortstat";
         command += GitUtil.convertToFilterAuthorArgs(author);
@@ -47,7 +47,7 @@ public class GitLog {
     public static String getWithFiles(RepoConfiguration config, Author author) {
         Path rootPath = Paths.get(config.getRepoRoot());
 
-        String command = "git log --no-merges -i ";
+        String command = "git log --no-merges -i --extended-regexp ";
         command += GitUtil.convertToGitDateRangeArgs(config.getSinceDate(), config.getUntilDate(), config.getZoneId());
         command += " --pretty=format:" + PRETTY_FORMAT_STRING + " --numstat --shortstat";
         command += GitUtil.convertToFilterAuthorArgs(author);

--- a/src/main/java/reposense/git/GitUtil.java
+++ b/src/main/java/reposense/git/GitUtil.java
@@ -58,6 +58,7 @@ class GitUtil {
 
     /**
      * Returns the {@code String} command to specify the {@code author} to analyze for `git log` command.
+     * The regex type used is extended regex, which corresponds to the `--extended-regexp` flag in `git log`.
      */
     static String convertToFilterAuthorArgs(Author author) {
         StringBuilder filterAuthorArgsBuilder = new StringBuilder(" --author=\"");

--- a/src/main/java/reposense/git/GitUtil.java
+++ b/src/main/java/reposense/git/GitUtil.java
@@ -33,9 +33,9 @@ class GitUtil {
     private static final String AUTHOR_NAME_PATTERN = "^%s <.*>$";
 
     // ignore check against author name
-    private static final String AUTHOR_EMAIL_PATTERN = "^.* <\\(.*+\\)\\?%s>$";
+    private static final String AUTHOR_EMAIL_PATTERN = "^.* <(.*\\+)?%s>$";
 
-    private static final String OR_OPERATOR_PATTERN = "\\|";
+    private static final String OR_OPERATOR_PATTERN = "|";
 
     /**
      * Returns the {@code String} command to specify the date range of commits to analyze for `git` commands.
@@ -60,7 +60,7 @@ class GitUtil {
      * Returns the {@code String} command to specify the {@code author} to analyze for `git log` command.
      */
     static String convertToFilterAuthorArgs(Author author) {
-        StringBuilder filterAuthorArgsBuilder = new StringBuilder(" --author=\"");
+        StringBuilder filterAuthorArgsBuilder = new StringBuilder(" --extended-regexp --author=\"");
 
         // git author names and emails may contain regex meta-characters, so we need to escape those
         author.getAuthorAliases().stream()

--- a/src/main/java/reposense/git/GitUtil.java
+++ b/src/main/java/reposense/git/GitUtil.java
@@ -60,7 +60,7 @@ class GitUtil {
      * Returns the {@code String} command to specify the {@code author} to analyze for `git log` command.
      */
     static String convertToFilterAuthorArgs(Author author) {
-        StringBuilder filterAuthorArgsBuilder = new StringBuilder(" --extended-regexp --author=\"");
+        StringBuilder filterAuthorArgsBuilder = new StringBuilder(" --author=\"");
 
         // git author names and emails may contain regex meta-characters, so we need to escape those
         author.getAuthorAliases().stream()


### PR DESCRIPTION
<!--
    If this pull request fully addresses an issue, use:
    Fixes #xxxx

    If this pull request partially addresses an issue, use:
    Part of #xxxx

    If this pull request addresses multiple issues, put them in multiple lines:
    Fixes #xxxx
    Fixes #yyyy

    Format the title of the pull request with most relevant issue number as follows:
    [#xxxx] Title
-->
Fixes #1853

## Proposed commit message
<!--
    Propose a detailed commit message for this pull request within the triple backticks below.
    Wrap lines at 72 characters.

    Guide on how to write a good commit message:
    https://oss-generic.github.io/process/docs/FormatsAndConventions.html#commit-message
-->
```
In Git 2.39, there was a change to the regex library used for MacOS.
This may have caused the git log command with the --author=<pattern>
option, which interprets <pattern> as basic regex, to return nothing on
MacOS.

Let's switch the pattern to extended regex to restore the broken
functionality.
```

## Description of probable cause of MacOS CI problem.
<!--
    Are there other relevant information, such as special testing instructions, 
    which will help the reviewer better understand the code?

    You may also include a brief description of why the problem occurred.
-->
One [pull request on Git](https://github.com/git/git/pull/1319) changed the regex library used on MacOS to the native MacOS regex library, from the original Git regex library. This change was part of [Git release 2.39](https://github.com/git/git/blob/v2.39.0/Documentation/RelNotes/2.39.0.txt).

As a result, the way basic regex patterns was interpreted in MacOS `git log` may have changed. This could result in the `git log` command not giving back any results when the `--author` option was used.

I suspect that this was what caused our MacOS CI in #1853 to fail since the MacOS CI uses Git 2.39. Given that the regex library used for Windows and Linux was not changed, this may have been the reason why the failure was exclusive to MacOS CI.

## Special Credit
I would like to thank @zhoukerrr for helping to diagnose and solve the issue. Personally, I do not have a Mac at home so trying to identify the root cause of the problem was inefficient for me as I would have to push any debugging code onto my remote fork and observe the MacOS CI.

@zhoukerrr helped to manually run the `git log` command and identify that the `--author` option was causing `git log` on Git 2.39 MacOS to fail. 

I would also like to thank @dcshzj for identifying Git 2.39 as the version which causes MacOS CI to fail.

## A primer on basic vs extended regex
Below was the site used to compare basic and extended regex:
* https://www.gnu.org/software/sed/manual/html_node/BRE-vs-ERE.html