### PR TITLE
Change header style for GitHub Issue and PR Templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -8,24 +8,24 @@ labels: "c.Bug"
   Before opening a new issue, please search existing issues:  https://github.com/reposense/RepoSense/issues
 -->
 
-## Tell us about your environment
+### Tell us about your environment
 
 * **RepoSense Version:**
 * **OS and Version:**
 * **Web Browser and Version (if applicable):**
 
 
-## Please include the steps to reproduce the bug.
+### Please include the steps to reproduce the bug.
 
 1.
 1.
 
 
-## What was expected to happen?
+### What was expected to happen?
 
 
-## What actually happened? Please include a screenshot of the output.
+### What actually happened? Please include a screenshot of the output.
 
 
-## If possible, include the URL to your RepoSense report or log files (if any).
+### If possible, include the URL to your RepoSense report or log files (if any).
 

--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -8,24 +8,24 @@ labels: "c.Bug"
   Before opening a new issue, please search existing issues:  https://github.com/reposense/RepoSense/issues
 -->
 
-**Tell us about your environment**
+## Tell us about your environment
 
 * **RepoSense Version:**
 * **OS and Version:**
 * **Web Browser and Version (if applicable):**
 
 
-**Please include the steps to reproduce the bug.**
+## Please include the steps to reproduce the bug.
 
 1.
 1.
 
 
-**What was expected to happen?**
+## What was expected to happen?
 
 
-**What actually happened? Please include a screenshot of the output.**
+## What actually happened? Please include a screenshot of the output.
 
 
-**If possible, include the URL to your RepoSense report or log files (if any).**
+## If possible, include the URL to your RepoSense report or log files (if any).
 

--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -8,14 +8,14 @@ labels: "a-Docs"
   Before opening a new issue, please search existing issues:  https://github.com/reposense/RepoSense/issues
 -->
 
-## What problem(s) did you run into that caused you to request additional documentation? What, if any, existing documentation relates to this proposal?
+### What problem(s) did you run into that caused you to request additional documentation? What, if any, existing documentation relates to this proposal?
 <!--
     Mention the part of the documentation you're referring to
     and how it relates to your request.
 -->
 
 
-## What would you like added or modified in the documentation?
+### What would you like added or modified in the documentation?
 <!--
     Summarize the suggested addition to or
     modification of existing documentation.

--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -8,14 +8,14 @@ labels: "a-Docs"
   Before opening a new issue, please search existing issues:  https://github.com/reposense/RepoSense/issues
 -->
 
-**What problem(s) did you run into that caused you to request additional documentation? What, if any, existing documentation relates to this proposal?**
+## What problem(s) did you run into that caused you to request additional documentation? What, if any, existing documentation relates to this proposal?
 <!--
     Mention the part of the documentation you're referring to
     and how it relates to your request.
 -->
 
 
-**What would you like added or modified in the documentation?**
+## What would you like added or modified in the documentation?
 <!--
     Summarize the suggested addition to or
     modification of existing documentation.

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -8,13 +8,13 @@ labels: "c.Feature"
   Before opening a new issue, please search existing issues:  https://github.com/reposense/RepoSense/issues
 -->
 
-**What feature(s) would you like to see in RepoSense?**
+## What feature(s) would you like to see in RepoSense
 <!--
   Provide a clear and concise description of the feature.
 -->
 
 
-**Is the feature request related to a problem?**
+## Is the feature request related to a problem?
 
 <!--
   Provide a clear and concise description of what the problem is.
@@ -22,7 +22,7 @@ labels: "c.Feature"
 -->
 
 
-**If possible, describe the solution**
+## If possible, describe the solution
 
 <!--
   Here would be a good place to talk about the solution or the
@@ -30,14 +30,14 @@ labels: "c.Feature"
 -->
 
 
-**If applicable, describe alternatives you've considered**
+## If applicable, describe alternatives you've considered
 
 <!--
   Let us know about other solutions you've tried or researched.
 -->
 
 
-**Additional context**
+## Additional context
 
 <!--
   Is there anything else that can be added about the proposal?

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -8,13 +8,13 @@ labels: "c.Feature"
   Before opening a new issue, please search existing issues:  https://github.com/reposense/RepoSense/issues
 -->
 
-## What feature(s) would you like to see in RepoSense
+### What feature(s) would you like to see in RepoSense
 <!--
   Provide a clear and concise description of the feature.
 -->
 
 
-## Is the feature request related to a problem?
+### Is the feature request related to a problem?
 
 <!--
   Provide a clear and concise description of what the problem is.
@@ -22,7 +22,7 @@ labels: "c.Feature"
 -->
 
 
-## If possible, describe the solution
+### If possible, describe the solution
 
 <!--
   Here would be a good place to talk about the solution or the
@@ -30,14 +30,14 @@ labels: "c.Feature"
 -->
 
 
-## If applicable, describe alternatives you've considered
+### If applicable, describe alternatives you've considered
 
 <!--
   Let us know about other solutions you've tried or researched.
 -->
 
 
-## Additional context
+### Additional context
 
 <!--
   Is there anything else that can be added about the proposal?

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,7 +14,7 @@
 -->
 Fixes #xxxx
 
-## Proposed commit message
+### Proposed commit message
 <!--
     Propose a detailed commit message for this pull request within the triple backticks below.
     Wrap lines at 72 characters.
@@ -28,7 +28,7 @@ Brief description of current behaviour and reason(s) for the change.
 Call-to-action statement describing what you are doing in this PR.
 ```
 
-## Other information
+### Other information
 <!--
     Are there other relevant information, such as special testing instructions, 
     which will help the reviewer better understand the code?


### PR DESCRIPTION
<!--
    If this pull request fully addresses an issue, use:
    Fixes #xxxx

    If this pull request partially addresses an issue, use:
    Part of #xxxx

    If this pull request addresses multiple issues, put them in multiple lines:
    Fixes #xxxx
    Fixes #yyyy

    Format the title of the pull request with most relevant issue number as follows:
    [#xxxx] Title
-->

## Proposed commit message
<!--
    Propose a detailed commit message for this pull request within the triple backticks below.
    Wrap lines at 72 characters.

    Guide on how to write a good commit message:
    https://oss-generic.github.io/process/docs/FormatsAndConventions.html#commit-message
-->
```
The current header style of bolding for issue templates is difficult to 
notice compared to the body text. The level 2 header for pull request
template is too large.

Let's update both to use level 3 headings.
```

## For PRs:

#1896 provides a preview of what level 3 headers would look like.

