### PR TITLE
[#1856] Fix concurrency issue with LOGGER_LIST

### DIFF
--- a/src/main/java/reposense/system/LogsManager.java
+++ b/src/main/java/reposense/system/LogsManager.java
@@ -132,7 +132,7 @@ public class LogsManager {
      * Sets the log folder location using {@code location} and adds file handler with this location to all the loggers
      * created.
      */
-    public static synchronized void setLogFolderLocation(Path location) {
+    public static void setLogFolderLocation(Path location) {
         logFolderLocation = location;
 
         synchronized (LOGGER_LIST) {

--- a/src/main/java/reposense/system/LogsManager.java
+++ b/src/main/java/reposense/system/LogsManager.java
@@ -36,7 +36,6 @@ public class LogsManager {
 
     public static Logger getLogger(String name) {
         Logger logger = Logger.getLogger(name);
-        LOGGER_LIST.add(logger);
         logger.setUseParentHandlers(false);
 
         removeHandlers(logger);
@@ -44,6 +43,10 @@ public class LogsManager {
 
         if (logFolderLocation != null) {
             addFileHandler(logger);
+        }
+
+        synchronized (LOGGER_LIST) {
+            LOGGER_LIST.add(logger);
         }
 
         return logger;
@@ -131,6 +134,9 @@ public class LogsManager {
      */
     public static synchronized void setLogFolderLocation(Path location) {
         logFolderLocation = location;
-        LOGGER_LIST.stream().forEach(logger -> addFileHandler(logger));
+
+        synchronized (LOGGER_LIST) {
+            LOGGER_LIST.stream().forEach(logger -> addFileHandler(logger));
+        }
     }
 }


### PR DESCRIPTION
<!--
    If this pull request fully addresses an issue, use:
    Fixes #xxxx

    If this pull request partially addresses an issue, use:
    Part of #xxxx

    If this pull request addresses multiple issues, put them in multiple lines:
    Fixes #xxxx
    Fixes #yyyy

    Format the title of the pull request with most relevant issue number as follows:
    [#xxxx] Title
-->
Fixes #1856 

### Proposed commit message
<!--

-->
```
A JavaConcurrentModificationException would occasionally be thrown when
LOGGER_LIST is modified while being streamed. 

Let's add synchronization and fix the concurrency issue.
```

### Other information
<!--
    Are there other relevant information, such as special testing instructions, 
    which will help the reviewer better understand the code?

    You may also include a brief description of why the problem occurred.
-->
The `setLogFolderLocation` is used in the `ArgsParser::parse` method which is occasionally indirectly called in some tests. `setLogFolderLocation` calls `stream()` on the `LOGGER_LIST` variable. While this happens, there is a small chance that while running tests in parallel, a new `logger` is added to the list which causes the `JavaConcurrentModificationException`. 

It is extremely rare and I managed to get the error on my own machine only once after about 50 runs but I did manage to look at the stack trace and this seems to be the main cause. 