### PR TITLE
[#1904] Add ESLint support for TypeScript imports

### DIFF
--- a/frontend/.eslintrc.json
+++ b/frontend/.eslintrc.json
@@ -5,7 +5,8 @@
   "extends": [
     "airbnb-base",
     "plugin:vue/recommended",
-    "@vue/typescript"
+    "@vue/typescript",
+    "plugin:import/typescript"
   ],
   "rules": {
     "vue/component-definition-name-casing": [
@@ -47,7 +48,14 @@
     ],
     "prefer-object-spread": 0,
     "function-call-argument-newline": 0,
-    "vue/no-computed-properties-in-data": 0
+    "vue/no-computed-properties-in-data": 0,
+    "import/extensions": [
+      "error",
+      {
+        "js": "never",
+        "ts": "never"
+      }
+    ]
   },
   "parserOptions": {
     "parser": "@typescript-eslint/parser"

--- a/frontend/src/components/c-ramp.vue
+++ b/frontend/src/components/c-ramp.vue
@@ -34,8 +34,8 @@
 </template>
 
 <script>
-import brokenLinkDisabler from '../mixin/brokenLinkMixin.ts';
-import User from '../utils/user.ts';
+import brokenLinkDisabler from '../mixin/brokenLinkMixin';
+import User from '../utils/user';
 
 export default {
   name: 'c-ramp',

--- a/frontend/src/components/c-segment.vue
+++ b/frontend/src/components/c-segment.vue
@@ -25,7 +25,7 @@
 </template>
 
 <script>
-import Segment from '../utils/segment.ts';
+import Segment from '../utils/segment';
 
 export default {
   name: 'c-segment',

--- a/frontend/src/components/c-summary-charts.vue
+++ b/frontend/src/components/c-summary-charts.vue
@@ -184,7 +184,7 @@
 <script>
 import { mapState } from 'vuex';
 
-import brokenLinkDisabler from '../mixin/brokenLinkMixin.ts';
+import brokenLinkDisabler from '../mixin/brokenLinkMixin';
 import cRamp from './c-ramp.vue';
 
 export default {

--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -1,4 +1,4 @@
-import User from './user.ts';
+import User from './user';
 
 // utility functions //
 window.$ = (id) => document.getElementById(id);

--- a/frontend/src/views/c-authorship.vue
+++ b/frontend/src/views/c-authorship.vue
@@ -166,9 +166,9 @@
 <script>
 import { mapState } from 'vuex';
 import minimatch from 'minimatch';
-import brokenLinkDisabler from '../mixin/brokenLinkMixin.ts';
+import brokenLinkDisabler from '../mixin/brokenLinkMixin';
 import cSegmentCollection from '../components/c-segment-collection.vue';
-import Segment from '../utils/segment.ts';
+import Segment from '../utils/segment';
 
 const getFontColor = window.getFontColor;
 

--- a/frontend/src/views/c-zoom.vue
+++ b/frontend/src/views/c-zoom.vue
@@ -134,9 +134,9 @@
 <script>
 import { mapState } from 'vuex';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
-import brokenLinkDisabler from '../mixin/brokenLinkMixin.ts';
+import brokenLinkDisabler from '../mixin/brokenLinkMixin';
 import cRamp from '../components/c-ramp.vue';
-import User from '../utils/user.ts';
+import User from '../utils/user';
 
 const getFontColor = window.getFontColor;
 


### PR DESCRIPTION
<!--
    If this pull request fully addresses an issue, use:
    Fixes #xxxx

    If this pull request partially addresses an issue, use:
    Part of #xxxx

    If this pull request addresses multiple issues, put them in multiple lines:
    Fixes #xxxx
    Fixes #yyyy

    Format the title of the pull request with most relevant issue number as follows:
    [#xxxx] Title
-->
Fixes #1904 

### Proposed commit message
<!--
    Propose a detailed commit message for this pull request within the triple backticks below.
    Wrap lines at 72 characters.

    Guide on how to write a good commit message:
    https://oss-generic.github.io/process/docs/FormatsAndConventions.html#commit-message
-->
```
ESLint is currently not configured to properly support TypeScript
imports. This results in an error when importing local TypeScript files
with the file extension omitted, which is the default way to import
TypeScript files.

Let's configure ESLint to support TypeScript imports and enforce the
omission of file extensions for .ts and .js files. This will allow us to
pass the lint check while using the default import method, and enforce
consistency throughout the codebase.
```

### Other information
<!--
    Are there other relevant information, such as special testing instructions, 
    which will help the reviewer better understand the code?

    You may also include a brief description of why the problem occurred.
-->

### Changes to `.eslintrc.json`
Adding `plugin:import/typescript` allows ESLint to properly resolve TypeScript imports that don't include the `.ts` file extension, which solves the "Unable to resolve path to module '../..'" error.

```
   "import/extensions": [
      "error",
      {
        "js": "never",
        "ts": "never"
      }
    ]
```
The above lines configure the `import/extensions` rule to make sure imports should never end with `.js` or `.ts`. If the rule is broken, it will be considered an `error` by ESLint. This solves the "Missing file extension for '../..'" error.

### Others
The other changes are removing the `.ts` extensions from existing imports.
