### PR TITLE
[#1880] Change hasAuthorConfigFile to become a local variable

### DIFF
--- a/src/main/java/reposense/RepoSense.java
+++ b/src/main/java/reposense/RepoSense.java
@@ -97,6 +97,12 @@ public class RepoSense {
                 GitConfig.setGlobalGitLfsConfig(GitConfig.SKIP_SMUDGE_CONFIG_SETTINGS);
             }
 
+            boolean isTestMode = cliArguments.isTestMode();
+            if (isTestMode) {
+                // Required by ConfigSystemTest to pass
+                RepoConfiguration.setHasAuthorConfigFileToRepoConfigs(configs, false);
+            }
+
             List<Path> reportFoldersAndFiles = ReportGenerator.generateReposReport(configs,
                     cliArguments.getOutputFilePath().toAbsolutePath().toString(),
                     cliArguments.getAssetsFilePath().toAbsolutePath().toString(), reportConfig,
@@ -142,6 +148,7 @@ public class RepoSense {
         try {
             authorConfigs = new AuthorConfigCsvParser(cliArguments.getAuthorConfigFilePath()).parse();
             RepoConfiguration.merge(repoConfigs, authorConfigs);
+            RepoConfiguration.setHasAuthorConfigFileToRepoConfigs(repoConfigs, true);
         } catch (FileNotFoundException fnfe) {
             // FileNotFoundException thrown as author-config.csv is not found.
             // Ignore exception as the file is optional.

--- a/src/main/java/reposense/RepoSense.java
+++ b/src/main/java/reposense/RepoSense.java
@@ -97,12 +97,6 @@ public class RepoSense {
                 GitConfig.setGlobalGitLfsConfig(GitConfig.SKIP_SMUDGE_CONFIG_SETTINGS);
             }
 
-            boolean isTestMode = cliArguments.isTestMode();
-            if (isTestMode) {
-                // Required by ConfigSystemTest to pass
-                AuthorConfiguration.setHasAuthorConfigFile(false);
-            }
-
             List<Path> reportFoldersAndFiles = ReportGenerator.generateReposReport(configs,
                     cliArguments.getOutputFilePath().toAbsolutePath().toString(),
                     cliArguments.getAssetsFilePath().toAbsolutePath().toString(), reportConfig,
@@ -148,7 +142,6 @@ public class RepoSense {
         try {
             authorConfigs = new AuthorConfigCsvParser(cliArguments.getAuthorConfigFilePath()).parse();
             RepoConfiguration.merge(repoConfigs, authorConfigs);
-            AuthorConfiguration.setHasAuthorConfigFile(true);
         } catch (FileNotFoundException fnfe) {
             // FileNotFoundException thrown as author-config.csv is not found.
             // Ignore exception as the file is optional.

--- a/src/main/java/reposense/authorship/analyzer/AnnotatorAnalyzer.java
+++ b/src/main/java/reposense/authorship/analyzer/AnnotatorAnalyzer.java
@@ -85,7 +85,7 @@ public class AnnotatorAnalyzer {
     private static Optional<Author> findAuthorInLine(String line, AuthorConfiguration authorConfig) {
         Optional<String> optionalName = extractAuthorName(line);
 
-        optionalName.filter(name -> !authorConfig.containsName(name) && !AuthorConfiguration.hasAuthorConfigFile())
+        optionalName.filter(name -> !authorConfig.containsName(name) && !authorConfig.hasAuthorConfigFile())
                 .ifPresent(name -> authorConfig.addAuthor(new Author(name)));
 
         return optionalName.map(name -> authorConfig.getAuthor(name, name));

--- a/src/main/java/reposense/model/AuthorConfiguration.java
+++ b/src/main/java/reposense/model/AuthorConfiguration.java
@@ -334,6 +334,6 @@ public class AuthorConfiguration {
     }
 
     public boolean hasAuthorConfigFile() {
-        return this.hasAuthorConfigFile;
+        return hasAuthorConfigFile;
     }
 }

--- a/src/main/java/reposense/model/AuthorConfiguration.java
+++ b/src/main/java/reposense/model/AuthorConfiguration.java
@@ -20,7 +20,7 @@ public class AuthorConfiguration {
     private static final Pattern EMAIL_PLUS_OPERATOR_PATTERN =
             Pattern.compile("^(?<prefix>.+)\\+(?<suffix>.*)(?<domain>@.+)$");
 
-    private static boolean hasAuthorConfigFile = DEFAULT_HAS_AUTHOR_CONFIG_FILE;
+    private boolean hasAuthorConfigFile = DEFAULT_HAS_AUTHOR_CONFIG_FILE;
 
     private RepoLocation location;
     private String branch;
@@ -329,11 +329,11 @@ public class AuthorConfiguration {
         return authorNamesToAuthorMap.containsKey(name.toLowerCase()) || authorEmailsToAuthorMap.containsKey(name);
     }
 
-    public static void setHasAuthorConfigFile(boolean hasAuthorConfigFile) {
-        AuthorConfiguration.hasAuthorConfigFile = hasAuthorConfigFile;
+    public void setHasAuthorConfigFile(boolean hasAuthorConfigFile) {
+        this.hasAuthorConfigFile = hasAuthorConfigFile;
     }
 
-    public static boolean hasAuthorConfigFile() {
-        return hasAuthorConfigFile;
+    public boolean hasAuthorConfigFile() {
+        return this.hasAuthorConfigFile;
     }
 }

--- a/src/main/java/reposense/model/RepoConfiguration.java
+++ b/src/main/java/reposense/model/RepoConfiguration.java
@@ -166,6 +166,7 @@ public class RepoConfiguration {
             if (authorConfig.getLocation().isEmpty()) {
                 for (RepoConfiguration repoConfig : repoConfigs) {
                     repoConfig.addAuthors(authorConfig.getAuthorList());
+                    repoConfig.setHasAuthorConfigFile(true);
                 }
                 continue;
             }
@@ -182,6 +183,7 @@ public class RepoConfiguration {
             if (authorConfig.isDefaultBranch()) {
                 locationMatchingRepoConfigs.forEach(matchingRepoConfig -> {
                     matchingRepoConfig.addAuthors(authorConfig.getAuthorList());
+                    matchingRepoConfig.setHasAuthorConfigFile(true);
                 });
                 continue;
             }
@@ -198,6 +200,7 @@ public class RepoConfiguration {
             }
 
             branchMatchingRepoConfig.addAuthors(authorConfig.getAuthorList());
+            branchMatchingRepoConfig.setHasAuthorConfigFile(true);
         }
     }
 
@@ -529,6 +532,10 @@ public class RepoConfiguration {
         authorConfig.setAuthorList(authorList);
         authorConfig.buildFromAuthorList();
         authorList.forEach(author -> AuthorConfiguration.propagateIgnoreGlobList(author, this.getIgnoreGlobList()));
+    }
+
+    public void setHasAuthorConfigFile(boolean hasAuthorConfigFile) {
+        authorConfig.setHasAuthorConfigFile(hasAuthorConfigFile);
     }
 
     public Map<String, Author> getAuthorNamesToAuthorMap() {

--- a/src/main/java/reposense/model/RepoConfiguration.java
+++ b/src/main/java/reposense/model/RepoConfiguration.java
@@ -159,9 +159,7 @@ public class RepoConfiguration {
 
     public static void setHasAuthorConfigFileToRepoConfigs(List<RepoConfiguration> configs,
                                                            boolean setHasAuthorConfigFile) {
-        for (RepoConfiguration config : configs) {
-            config.setHasAuthorConfigFile(setHasAuthorConfigFile);
-        }
+        configs.stream().forEach(config -> config.setHasAuthorConfigFile(setHasAuthorConfigFile));
     }
 
     /**

--- a/src/main/java/reposense/model/RepoConfiguration.java
+++ b/src/main/java/reposense/model/RepoConfiguration.java
@@ -157,6 +157,13 @@ public class RepoConfiguration {
         configs.stream().forEach(config -> config.setIsFindingPreviousAuthorsPerformed(false));
     }
 
+    public static void setHasAuthorConfigFileToRepoConfigs(List<RepoConfiguration> configs,
+                                                           boolean setHasAuthorConfigFile) {
+        for (RepoConfiguration config : configs) {
+            config.setHasAuthorConfigFile(setHasAuthorConfigFile);
+        }
+    }
+
     /**
      * Merges a {@link RepoConfiguration} from {@code repoConfigs} with an {@link AuthorConfiguration} from
      * {@code authorConfigs} if their {@link RepoLocation} and branch matches.
@@ -166,7 +173,6 @@ public class RepoConfiguration {
             if (authorConfig.getLocation().isEmpty()) {
                 for (RepoConfiguration repoConfig : repoConfigs) {
                     repoConfig.addAuthors(authorConfig.getAuthorList());
-                    repoConfig.setHasAuthorConfigFile(true);
                 }
                 continue;
             }
@@ -183,7 +189,6 @@ public class RepoConfiguration {
             if (authorConfig.isDefaultBranch()) {
                 locationMatchingRepoConfigs.forEach(matchingRepoConfig -> {
                     matchingRepoConfig.addAuthors(authorConfig.getAuthorList());
-                    matchingRepoConfig.setHasAuthorConfigFile(true);
                 });
                 continue;
             }
@@ -200,7 +205,6 @@ public class RepoConfiguration {
             }
 
             branchMatchingRepoConfig.addAuthors(authorConfig.getAuthorList());
-            branchMatchingRepoConfig.setHasAuthorConfigFile(true);
         }
     }
 

--- a/src/test/java/reposense/authorship/AnnotatorAnalyzerTest.java
+++ b/src/test/java/reposense/authorship/AnnotatorAnalyzerTest.java
@@ -54,13 +54,13 @@ public class AnnotatorAnalyzerTest extends GitTestTemplate {
         config.setUntilDate(UNTIL_DATE);
         config.setZoneId(TIME_ZONE_ID);
 
-        AuthorConfiguration.setHasAuthorConfigFile(AuthorConfiguration.DEFAULT_HAS_AUTHOR_CONFIG_FILE);
+        config.setHasAuthorConfigFile(AuthorConfiguration.DEFAULT_HAS_AUTHOR_CONFIG_FILE);
     }
 
     @AfterEach
     public void after() {
         super.after();
-        AuthorConfiguration.setHasAuthorConfigFile(AuthorConfiguration.DEFAULT_HAS_AUTHOR_CONFIG_FILE);
+        config.setHasAuthorConfigFile(AuthorConfiguration.DEFAULT_HAS_AUTHOR_CONFIG_FILE);
     }
 
     @Test
@@ -80,7 +80,7 @@ public class AnnotatorAnalyzerTest extends GitTestTemplate {
     @Test
     public void analyzeAnnotation_authorNameNotInConfigAndHaveAuthorConfigFile_disownCode() {
         config.setAuthorList(new ArrayList<>(Arrays.asList(FAKE_AUTHOR)));
-        AuthorConfiguration.setHasAuthorConfigFile(true);
+        config.setHasAuthorConfigFile(true);
         FileResult fileResult = getFileResult("annotationTest.java");
         assertFileAnalysisCorrectness(fileResult, Arrays.asList(EXPECTED_LINE_AUTHORS_DISOWN_CODE_TEST));
     }


### PR DESCRIPTION
<!--
    If this pull request fully addresses an issue, use:
    Fixes #xxxx

    If this pull request partially addresses an issue, use:
    Part of #xxxx

    If this pull request addresses multiple issues, put them in multiple lines:
    Fixes #xxxx
    Fixes #yyyy

    Format the title of the pull request with most relevant issue number as follows:
    [#xxxx] Title
-->
Fixes #1880 
Part of #1879
Part of #1873 

### Proposed commit message
<!--
    Propose a detailed commit message for this pull request within the triple backticks below.
    Wrap lines at 72 characters.

    Guide on how to write a good commit message:
    https://oss-generic.github.io/process/docs/FormatsAndConventions.html#commit-message
-->
```
AuthorConfiguration.hasAuthorConfigFile is currently a static variable 
that determines whether during the analysis of repo files, a new author
should be added and tracked. If an author config file is provided, an
unrecognized author is ignored, otherwise it is added and tracked.

This might cause parallel runs of test cases at the method level, 
especially system test cases, to have issues.

Let's make AuthorConfiguration.hasAuthorConfigFile a local variable to
the AuthorConfiguration found within each RepoConfiguration.
```

### Other information
<!--
    Are there other relevant information, such as special testing instructions, 
    which will help the reviewer better understand the code?

    You may also include a brief description of why the problem occurred.
-->
As mentioned by @chan-j-d, this issue is indeed related to #1879. This PR has to be merged in before the PR relevant to #1879. This is the case because in that PR, `AuthorConfiguration.hasAuthorConfigFile` is no longer set to false for all systemtest. LocalConfigSystemTest will fail as a result, as it does not have author-config.csv, however due to the global variable RepoSense believes it does.

This is also highly relevant to parallelizing of the ConfigSystemTest, as these static variables are shared across the threads used to run each test in ConfigSystemTest.
