### PR TITLE
Gradle: remove unneeded commons-text dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,6 @@ dependencies {
     implementation  group: 'net.sourceforge.argparse4j', name: 'argparse4j', version: '0.9.0'
     implementation  group: 'org.apache.ant', name: 'ant', version: '1.10.12'
     implementation  group: 'org.apache.commons', name: 'commons-csv', version: '1.9.0'
-    implementation  group: 'org.apache.commons', name: 'commons-text', version: '1.9'
     implementation  group: 'org.fusesource.jansi', name: 'jansi', version: '2.4.0'
 
     testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: jUnitVersion


### PR DESCRIPTION
<!--
    If this pull request fully addresses an issue, use:
    Fixes #xxxx

    If this pull request partially addresses an issue, use:
    Part of #xxxx

    If this pull request addresses multiple issues, put them in multiple lines:
    Fixes #xxxx
    Fixes #yyyy

    Format the title of the pull request with most relevant issue number as follows:
    [#xxxx] Title
-->

### Proposed commit message
<!--
    Propose a detailed commit message for this pull request within the triple backticks below.
    Wrap lines at 72 characters.

    Guide on how to write a good commit message:
    https://oss-generic.github.io/process/docs/FormatsAndConventions.html#commit-message
-->
```
The commons-text dependency has been flagged as vulnerable by OWASP
dependency check. This dependency does not appear to be used anywhere
in the source code.

Let's remove this dependency to reduce the vulnerabilities in the
project.
```

### Other information
<!--
    Are there other relevant information, such as special testing instructions, 
    which will help the reviewer better understand the code?

    You may also include a brief description of why the problem occurred.
-->

Attached is the relevant OWASP dependency check report
[RepoSense Dependency-Check Report.pdf](https://github.com/reposense/RepoSense/files/10830467/RepoSense.Dependency-Check.Report.pdf)
