### PR TITLE
[#1936] Migrate app.vue to TypeScript

### DIFF
--- a/frontend/src/app.vue
+++ b/frontend/src/app.vue
@@ -91,6 +91,13 @@ const loadingResourcesMessage = 'Loading resources...';
 
 const app = defineComponent({
   name: 'app',
+  components: {
+    LoadingOverlay,
+    cResizer,
+    cZoom,
+    cSummary,
+    cAuthorship,
+  },
   data() {
     return {
       repos: {} as { [key: string]: Repo },
@@ -105,6 +112,9 @@ const app = defineComponent({
       errorMessages: {},
     };
   },
+  computed: {
+    ...mapState(['loadingOverlayCount', 'loadingOverlayMessage', 'isTabActive']),
+  },
   watch: {
     '$store.state.tabZoomInfo': function () {
       if (this.$store.state.tabZoomInfo.isRefreshing) {
@@ -115,6 +125,14 @@ const app = defineComponent({
     '$store.state.tabAuthorshipInfo': function () {
       this.activateTab('authorship');
     },
+  },
+  created() {
+    try {
+      window.decodeHash();
+    } catch (error) {
+      this.userUpdated = false;
+    }
+    this.updateReportDir();
   },
   methods: {
     // model functions //
@@ -303,26 +321,6 @@ const app = defineComponent({
       }
       return REPOS[hashParams.tabRepo].location.location;
     },
-  },
-
-  computed: {
-    ...mapState(['loadingOverlayCount', 'loadingOverlayMessage', 'isTabActive']),
-  },
-
-  components: {
-    LoadingOverlay,
-    cResizer,
-    cZoom,
-    cSummary,
-    cAuthorship,
-  },
-  created() {
-    try {
-      window.decodeHash();
-    } catch (error) {
-      this.userUpdated = false;
-    }
-    this.updateReportDir();
   },
 });
 

--- a/frontend/src/store/store.ts
+++ b/frontend/src/store/store.ts
@@ -1,55 +1,62 @@
 import { createStore } from 'vuex';
+import { AuthorshipFile, CommitResult, DailyCommit } from '../types/types';
+import {
+  AuthorshipInfo,
+  StoreState,
+  SummaryDates,
+  ZoomInfo,
+} from '../types/vuex.d';
 
 export default createStore({
   state: {
-    tabAuthorshipInfo: {},
-    tabZoomInfo: {},
-    summaryDates: {},
+    tabAuthorshipInfo: {} as AuthorshipInfo,
+    tabZoomInfo: {} as ZoomInfo,
+    summaryDates: {} as SummaryDates,
     mergedGroups: [],
     fileTypeColors: {},
     loadingOverlayCount: 0,
     loadingOverlayMessage: '',
     isTabActive: true,
-  },
+  } as StoreState,
   mutations: {
-    updateTabZoomInfo(state, info) {
+    updateTabZoomInfo(state, info: ZoomInfo) {
       state.tabZoomInfo = info;
     },
-    updateTabAuthorshipInfo(state, info) {
+    updateTabAuthorshipInfo(state, info: AuthorshipInfo) {
       state.tabAuthorshipInfo = info;
     },
-    updateSummaryDates(state, info) {
+    updateSummaryDates(state, info: SummaryDates) {
       state.summaryDates = info;
     },
-    updateFileTypeColors(state, info) {
+    updateFileTypeColors(state, info: { [key: string]: string }) {
       state.fileTypeColors = info;
     },
-    updateMergedGroup(state, info) {
+    updateMergedGroup(state, info: string[]) {
       state.mergedGroups = info;
     },
-    incrementLoadingOverlayCount(state, increment) {
+    incrementLoadingOverlayCount(state, increment: number) {
       state.loadingOverlayCount += increment;
       if (state.loadingOverlayCount === 0) {
         state.loadingOverlayMessage = 'Loading. Please wait...';
       }
     },
-    updateLoadingOverlayMessage(state, message) {
+    updateLoadingOverlayMessage(state, message: string) {
       state.loadingOverlayMessage = message;
     },
-    updateTabState(state, isTabOpen) {
+    updateTabState(state, isTabOpen: boolean) {
       state.isTabActive = isTabOpen;
-      window.addHash('tabOpen', isTabOpen);
+      window.addHash('tabOpen', isTabOpen.toString());
       if (!isTabOpen) {
         window.removeHash('tabType');
       }
       window.encodeHash();
     },
-    toggleZoomCommitMessageBody(_, slice) {
+    toggleZoomCommitMessageBody(_, slice: CommitResult) {
       if (slice.isOpen !== undefined) {
         slice.isOpen = !slice.isOpen;
       }
     },
-    setAllZoomCommitMessageBody(_, { isOpen, commits }) {
+    setAllZoomCommitMessageBody(_, { isOpen, commits }: { isOpen: boolean; commits: DailyCommit[] }) {
       commits.forEach((commit) => {
         commit.commitResults.forEach((slice) => {
           if (slice.isOpen !== undefined) {
@@ -58,14 +65,14 @@ export default createStore({
         });
       });
     },
-    updateTabAuthorshipFiles(state, files) {
+    updateTabAuthorshipFiles(state, files: AuthorshipFile[]) {
       state.tabAuthorshipInfo.files.splice(0, state.tabAuthorshipInfo.files.length, ...files);
     },
-    toggleAuthorshipFileActiveProperty(_, file) {
+    toggleAuthorshipFileActiveProperty(_, file: AuthorshipFile) {
       file.active = !file.active;
       file.wasCodeLoaded = file.wasCodeLoaded || file.active;
     },
-    setAllAuthorshipFileActiveProperty(_, { isActive, files }) {
+    setAllAuthorshipFileActiveProperty(_, { isActive, files }: { isActive: boolean; files: AuthorshipFile[] }) {
       files.forEach((file) => {
         file.active = isActive;
         file.wasCodeLoaded = file.wasCodeLoaded || file.active;
@@ -75,7 +82,7 @@ export default createStore({
   actions: {
     // Actions are called with dispatch
 
-    async incrementLoadingOverlayCountForceReload({ commit }, increment) {
+    async incrementLoadingOverlayCountForceReload({ commit }, increment: number) {
       commit('incrementLoadingOverlayCount', increment);
       await new Promise(window.requestAnimationFrame);
       await new Promise(window.requestAnimationFrame);

--- a/frontend/src/types/types.ts
+++ b/frontend/src/types/types.ts
@@ -11,6 +11,7 @@ export interface CommitResult extends CommitResultRaw {
   repoId: string;
   insertions: number;
   deletions: number;
+  isOpen?: boolean;
 }
 
 // Similar to AuthorDailyContributions, but uses the updated CommitResult with the three new fields

--- a/frontend/src/types/types.ts
+++ b/frontend/src/types/types.ts
@@ -45,3 +45,23 @@ export interface Repo extends RepoRaw {
   files?: FileResult[];
   users?: User[];
 }
+
+interface AuthorshipFileSegment {
+  authored: boolean;
+  lineNumbers: number[];
+  lines: string[];
+}
+
+export interface AuthorshipFile {
+  active: boolean;
+  blankLineCount: number;
+  charCount: number;
+  fileSize: number | undefined; // not actually in schema - to verify relevancy when migrating c-authorship.vue
+  fileType: string;
+  isBinary: boolean;
+  isIgnored: boolean;
+  lineCount: number;
+  path: string;
+  segments: AuthorshipFileSegment[];
+  wasCodeLoaded: boolean;
+}

--- a/frontend/src/types/vuex.d.ts
+++ b/frontend/src/types/vuex.d.ts
@@ -1,0 +1,64 @@
+import { Store } from 'vuex';
+import { AuthorshipFile, User } from './types';
+
+interface AuthorshipInfo {
+  author: string;
+  checkedFileTypes?: string[];
+  files: AuthorshipFile[];
+  isMergeGroup: boolean;
+  isRefresh?: boolean;
+  location: string | undefined;
+  maxDate: string;
+  minDate: string;
+  name: string;
+  repo: string;
+}
+
+interface ZoomInfo {
+  isRefreshing?: boolean;
+  zAuthor: string;
+  zAvgCommitSize: number | string;
+  zFileTypeColors: { [key: string]: string };
+  zFilterGroup: string;
+  zFilterSearch: string;
+  zFromRamp: boolean;
+  zIsMerged: boolean;
+  zLocation: string | undefined;
+  zRepo: string;
+  zSince: string;
+  zTimeFrame: string;
+  zUntil: string;
+  zUser: User;
+}
+
+export interface SummaryDates {
+  since: string;
+  until: string;
+}
+
+export interface StoreState {
+  tabAuthorshipInfo: AuthorshipInfo;
+  tabZoomInfo: ZoomInfo;
+  summaryDates: SummaryDates;
+  mergedGroups: string[]
+  fileTypeColors: { [key: string]: string }
+  loadingOverlayCount: number
+  loadingOverlayMessage: string
+  isTabActive: boolean
+}
+
+declare module '@vue/runtime-core' {
+  interface State {
+    tabAuthorshipInfo: AuthorshipInfo;
+    tabZoomInfo: ZoomInfo;
+    summaryDates: SummaryDates;
+    mergedGroups: string[]
+    fileTypeColors: { [key: string]: string }
+    loadingOverlayCount: number
+    loadingOverlayMessage: string
+    isTabActive: boolean
+  }
+  interface ComponentCustomProperties {
+    $store: Store<State>;
+  }
+}

--- a/frontend/src/types/vuex.d.ts
+++ b/frontend/src/types/vuex.d.ts
@@ -31,12 +31,12 @@ interface ZoomInfo {
   zUser: User;
 }
 
-export interface SummaryDates {
+interface SummaryDates {
   since: string;
   until: string;
 }
 
-export interface StoreState {
+interface StoreState {
   tabAuthorshipInfo: AuthorshipInfo;
   tabZoomInfo: ZoomInfo;
   summaryDates: SummaryDates;

--- a/frontend/src/types/window.ts
+++ b/frontend/src/types/window.ts
@@ -68,5 +68,7 @@ declare global {
     isSinceDateProvided: boolean;
     isUntilDateProvided: boolean;
     DOMAIN_URL_MAP: DomainUrlMap;
+    // eslint-disable-next-line  @typescript-eslint/no-explicit-any
+    app: any;
   }
 }

--- a/frontend/src/types/zod/authorship-type.ts
+++ b/frontend/src/types/zod/authorship-type.ts
@@ -11,6 +11,8 @@ const fileResult = z.object({
   fileType: z.string(),
   lines: z.array(lineSchema),
   authorContributionMap: z.record(z.number()),
+  isBinary: z.boolean().optional(),
+  isIgnored: z.boolean().optional(),
 });
 
 // Contains the zod validation schema for the authorship.json file


### PR DESCRIPTION
<!--
    If this pull request fully addresses an issue, use:
    Fixes #xxxx

    If this pull request partially addresses an issue, use:
    Part of #xxxx

    If this pull request addresses multiple issues, put them in multiple lines:
    Fixes #xxxx
    Fixes #yyyy

    Format the title of the pull request with most relevant issue number as follows:
    [#xxxx] Title
-->
Part of #1936

### Proposed commit message
<!--
    Propose a detailed commit message for this pull request within the triple backticks below.
    Wrap lines at 72 characters.

    Guide on how to write a good commit message:
    https://oss-generic.github.io/process/docs/FormatsAndConventions.html#commit-message
-->
```
Currently, despite the addition of TypeScript support, the frontend is
still largely written in JavaScript. This results in a lack of type
safety and many complex objects being passed around as unknown types,
which may in turn lead to errors.

Let's migrate the root component, app.vue, to TypeScript. As this is
the entry point of the app, converting this file to TypeScript will
enable the conversion of other Vue components.
```

### Other information
<!--
    Are there other relevant information, such as special testing instructions,
    which will help the reviewer better understand the code?

    You may also include a brief description of why the problem occurred.
-->
The diff might look confusing because of the re-ordering of the options (apologies for missing this in #1867), please look at https://github.com/reposense/RepoSense/commit/4bfc3aae9212d7860d3af802d63e53b891dc7be9 to see the actual diff of the TypeScript conversion.

I had to use `any` to define the app property of `window.app` - not too sure if it's possible to type this.

Lastly, regarding the topic of combining/separating PRs, I was not too sure whether to separate this from #1937. Because of the nature of TypeScript migrations, the PRs would probably be mostly sequential (e.g. this PR relies on the previous PR for the `this.$store` to be typed), and hence also contains the changes of that PR. This might result in more work, such as requiring maintainers to merge a specific PR before another, as well as any changes to the preceding PR might have to be merged back into this one. I guess there's a tradeoff between the above and keeping the PR's to 'one small change'. Currently, I leaned towards separating them as each change is fairly substantial and they are two separate files. Would love to get any feedback/opinions on this.