### PR TITLE
Make ErrorSummary non-static

### DIFF
--- a/src/main/java/reposense/RepoSense.java
+++ b/src/main/java/reposense/RepoSense.java
@@ -31,6 +31,7 @@ import reposense.parser.InvalidHeaderException;
 import reposense.parser.InvalidLocationException;
 import reposense.parser.ParseException;
 import reposense.parser.RepoConfigCsvParser;
+import reposense.report.ErrorSummary;
 import reposense.report.ReportGenerator;
 import reposense.system.LogsManager;
 import reposense.system.ReportServer;
@@ -58,16 +59,17 @@ public class RepoSense {
             CliArguments cliArguments = ArgsParser.parse(args);
             List<RepoConfiguration> configs = null;
             ReportConfiguration reportConfig = new ReportConfiguration();
+            ErrorSummary errorSummary = new ErrorSummary();
 
             if (cliArguments instanceof ViewCliArguments) {
                 ReportServer.startServer(SERVER_PORT_NUMBER, ((
                         ViewCliArguments) cliArguments).getReportDirectoryPath().toAbsolutePath());
                 return;
             } else if (cliArguments instanceof ConfigCliArguments) {
-                configs = getRepoConfigurations((ConfigCliArguments) cliArguments);
+                configs = getRepoConfigurations((ConfigCliArguments) cliArguments, errorSummary);
                 reportConfig = ((ConfigCliArguments) cliArguments).getReportConfiguration();
             } else if (cliArguments instanceof LocationsCliArguments) {
-                configs = getRepoConfigurations((LocationsCliArguments) cliArguments);
+                configs = getRepoConfigurations((LocationsCliArguments) cliArguments, errorSummary);
             } else {
                 throw new AssertionError("CliArguments's subclass type is unhandled.");
             }
@@ -97,7 +99,7 @@ public class RepoSense {
                 GitConfig.setGlobalGitLfsConfig(GitConfig.SKIP_SMUDGE_CONFIG_SETTINGS);
             }
 
-            ReportGenerator reportGenerator = new ReportGenerator();
+            ReportGenerator reportGenerator = new ReportGenerator(errorSummary);
             List<Path> reportFoldersAndFiles = reportGenerator.generateReposReport(configs,
                     cliArguments.getOutputFilePath().toAbsolutePath().toString(),
                     cliArguments.getAssetsFilePath().toAbsolutePath().toString(), reportConfig,
@@ -134,14 +136,16 @@ public class RepoSense {
      * @throws InvalidCsvException if user-supplied repo-config csv is malformed.
      * @throws InvalidHeaderException if user-supplied csv file has header that cannot be parsed.
      */
-    public static List<RepoConfiguration> getRepoConfigurations(ConfigCliArguments cliArguments)
+    public static List<RepoConfiguration> getRepoConfigurations(
+            ConfigCliArguments cliArguments, ErrorSummary errorSummary)
             throws IOException, InvalidCsvException, InvalidHeaderException {
-        List<RepoConfiguration> repoConfigs = new RepoConfigCsvParser(cliArguments.getRepoConfigFilePath()).parse();
+        List<RepoConfiguration> repoConfigs = new RepoConfigCsvParser(
+                cliArguments.getRepoConfigFilePath(), errorSummary).parse();
         List<AuthorConfiguration> authorConfigs;
         List<GroupConfiguration> groupConfigs;
 
         try {
-            authorConfigs = new AuthorConfigCsvParser(cliArguments.getAuthorConfigFilePath()).parse();
+            authorConfigs = new AuthorConfigCsvParser(cliArguments.getAuthorConfigFilePath(), errorSummary).parse();
             RepoConfiguration.merge(repoConfigs, authorConfigs);
             RepoConfiguration.setHasAuthorConfigFileToRepoConfigs(repoConfigs, true);
         } catch (FileNotFoundException fnfe) {
@@ -153,7 +157,7 @@ public class RepoSense {
         }
 
         try {
-            groupConfigs = new GroupConfigCsvParser(cliArguments.getGroupConfigFilePath()).parse();
+            groupConfigs = new GroupConfigCsvParser(cliArguments.getGroupConfigFilePath(), errorSummary).parse();
             RepoConfiguration.setGroupConfigsToRepos(repoConfigs, groupConfigs);
         } catch (FileNotFoundException fnfe) {
             // FileNotFoundException thrown as groups-config.csv is not found.
@@ -171,13 +175,15 @@ public class RepoSense {
      *
      * @throws ParseException if all repo locations are invalid.
      */
-    public static List<RepoConfiguration> getRepoConfigurations(LocationsCliArguments cliArguments)
+    public static List<RepoConfiguration> getRepoConfigurations(
+            LocationsCliArguments cliArguments, ErrorSummary errorSummary)
             throws ParseException {
         List<RepoConfiguration> configs = new ArrayList<>();
         for (String locationString : cliArguments.getLocations()) {
             try {
                 configs.add(new RepoConfiguration(new RepoLocation(locationString)));
             } catch (InvalidLocationException ile) {
+                errorSummary.addErrorMessage(locationString, ile.getMessage());
                 logger.log(Level.WARNING, ile.getMessage(), ile);
             }
         }

--- a/src/main/java/reposense/model/RepoLocation.java
+++ b/src/main/java/reposense/model/RepoLocation.java
@@ -13,7 +13,6 @@ import java.util.regex.Pattern;
 
 import reposense.git.GitRemote;
 import reposense.parser.InvalidLocationException;
-import reposense.report.ErrorSummary;
 import reposense.util.StringsUtil;
 import reposense.util.SystemUtil;
 
@@ -159,8 +158,6 @@ public class RepoLocation {
         Matcher localRepoMatcher = localRepoPattern.matcher(location);
 
         if (!localRepoMatcher.matches()) {
-            ErrorSummary.getInstance().addErrorMessage(location,
-                    String.format(MESSAGE_INVALID_LOCATION, location));
             throw new InvalidLocationException(String.format(MESSAGE_INVALID_LOCATION, location));
         }
 
@@ -185,15 +182,11 @@ public class RepoLocation {
             try {
                 new URI(location);
             } catch (URISyntaxException e) {
-                ErrorSummary.getInstance().addErrorMessage(location,
-                        String.format(MESSAGE_INVALID_REMOTE_URL, location));
                 throw new InvalidLocationException(String.format(MESSAGE_INVALID_REMOTE_URL, location));
             }
         }
         boolean isValidRemoteRepoUrl = remoteRepoMatcher.matches() || sshRepoMatcher.matches();
         if (!isValidRemoteRepoUrl) {
-            ErrorSummary.getInstance().addErrorMessage(location,
-                    String.format(MESSAGE_INVALID_REMOTE_URL, location));
             throw new InvalidLocationException(String.format(MESSAGE_INVALID_REMOTE_URL, location));
         }
 

--- a/src/main/java/reposense/parser/CsvParser.java
+++ b/src/main/java/reposense/parser/CsvParser.java
@@ -24,6 +24,7 @@ import java.util.stream.Stream;
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVRecord;
 
+import reposense.report.ErrorSummary;
 import reposense.system.LogsManager;
 
 /**
@@ -51,6 +52,7 @@ public abstract class CsvParser<T> {
     private static final String MESSAGE_ZERO_VALID_CONFIGS = "No valid configurations in the %s.";
     private static final String MESSAGE_UNKNOWN_COLUMN = "Unknown column(s) found: %s (%s)";
 
+    protected ErrorSummary errorSummary;
     private Path csvFilePath;
     private Map<String, Integer> headerMap = new HashMap<>();
     private int numOfLinesBeforeFirstRecord = 0;
@@ -60,13 +62,14 @@ public abstract class CsvParser<T> {
      *
      * @throws FileNotFoundException if the csv file cannot be found in the provided {@code csvFilePath}.
      */
-    public CsvParser(Path csvFilePath) throws FileNotFoundException {
+    public CsvParser(Path csvFilePath, ErrorSummary errorSummary) throws FileNotFoundException {
         if (csvFilePath == null || !Files.exists(csvFilePath)) {
             throw new FileNotFoundException("Csv file does not exist at the given path.\n"
                     + "Use '-help' to list all the available subcommands and some concept guides.");
         }
 
         this.csvFilePath = csvFilePath;
+        this.errorSummary = errorSummary;
     }
 
     /**

--- a/src/main/java/reposense/parser/RepoConfigCsvParser.java
+++ b/src/main/java/reposense/parser/RepoConfigCsvParser.java
@@ -10,6 +10,7 @@ import reposense.model.CommitHash;
 import reposense.model.FileType;
 import reposense.model.RepoConfiguration;
 import reposense.model.RepoLocation;
+import reposense.report.ErrorSummary;
 import reposense.util.FileUtil;
 import reposense.util.StringsUtil;
 
@@ -40,8 +41,8 @@ public class RepoConfigCsvParser extends CsvParser<RepoConfiguration> {
     private static final String[] FIND_PREVIOUS_AUTHORS_CONFIG_HEADER = {"Find Previous Authors"};
     private static final String[] FILESIZE_LIMIT_HEADER = {"File Size Limit"};
 
-    public RepoConfigCsvParser(Path csvFilePath) throws FileNotFoundException {
-        super(csvFilePath);
+    public RepoConfigCsvParser(Path csvFilePath, ErrorSummary errorSummary) throws FileNotFoundException {
+        super(csvFilePath, errorSummary);
     }
 
     /**

--- a/src/main/java/reposense/report/ErrorSummary.java
+++ b/src/main/java/reposense/report/ErrorSummary.java
@@ -10,7 +10,7 @@ import java.util.Set;
  */
 public class ErrorSummary {
     private static ErrorSummary instance = null;
-    private static Set<Map<String, String>> errorSet = new HashSet<>();
+    private Set<Map<String, String>> errorSet = new HashSet<>();
 
     public static ErrorSummary getInstance() {
         if (instance == null) {
@@ -34,12 +34,5 @@ public class ErrorSummary {
      */
     public Set<Map<String, String>> getErrorSet() {
         return errorSet;
-    }
-
-    /**
-     * Clears all previously stored set of errors in {@link ErrorSummary#errorSet}.
-     */
-    public void clearErrorSet() {
-        errorSet.clear();
     }
 }

--- a/src/main/java/reposense/report/ReportGenerator.java
+++ b/src/main/java/reposense/report/ReportGenerator.java
@@ -91,6 +91,11 @@ public class ReportGenerator {
 
     private LocalDateTime earliestSinceDate = null;
     private ProgressTracker progressTracker = null;
+    private ErrorSummary errorSummary;
+
+    public ReportGenerator(ErrorSummary errorSummary) {
+        this.errorSummary = errorSummary;
+    }
 
     /**
      * Generates the authorship and commits JSON file for each repo in {@code configs} at {@code outputPath}, as
@@ -135,7 +140,7 @@ public class ReportGenerator {
         Optional<Path> summaryPath = FileUtil.writeJsonFile(
                 new SummaryJson(configs, reportConfig, generationDate,
                         reportSinceDate, untilDate, isSinceDateProvided,
-                        isUntilDateProvided, RepoSense.getVersion(), ErrorSummary.getInstance().getErrorSet(),
+                        isUntilDateProvided, RepoSense.getVersion(), errorSummary.getErrorSet(),
                         reportGenerationTimeProvider.get(), zoneId),
                 getSummaryResultPath(outputPath));
         summaryPath.ifPresent(reportFoldersAndFiles::add);
@@ -456,7 +461,7 @@ public class ReportGenerator {
         while (itr.hasNext()) {
             RepoConfiguration config = itr.next();
             if (failedConfigs.contains(config)) {
-                ErrorSummary.getInstance().addErrorMessage(config.getDisplayName(), errorMessage);
+                errorSummary.addErrorMessage(config.getDisplayName(), errorMessage);
                 itr.remove();
             }
         }

--- a/src/systemtest/java/reposense/ConfigSystemTest.java
+++ b/src/systemtest/java/reposense/ConfigSystemTest.java
@@ -18,7 +18,6 @@ import org.junit.jupiter.api.parallel.ExecutionMode;
 import reposense.git.GitVersion;
 import reposense.model.SupportedDomainUrlMap;
 import reposense.parser.SinceDateArgumentType;
-import reposense.report.ErrorSummary;
 import reposense.util.FileUtil;
 import reposense.util.InputBuilder;
 import reposense.util.SystemTestUtil;
@@ -39,7 +38,6 @@ public class ConfigSystemTest {
     public void setUp() throws Exception {
         SupportedDomainUrlMap.clearAccessedSet();
         FileUtil.deleteDirectory(OUTPUT_DIRECTORY);
-        ErrorSummary.getInstance().clearErrorSet();
     }
 
     @AfterEach

--- a/src/systemtest/java/reposense/LocalRepoSystemTest.java
+++ b/src/systemtest/java/reposense/LocalRepoSystemTest.java
@@ -49,7 +49,6 @@ public class LocalRepoSystemTest {
     public void setupLocalTest() throws Exception {
         SupportedDomainUrlMap.clearAccessedSet();
         FileUtil.deleteDirectory(OUTPUT_DIRECTORY);
-        ErrorSummary.getInstance().clearErrorSet();
     }
 
     @AfterEach

--- a/src/systemtest/java/reposense/LocalRepoSystemTest.java
+++ b/src/systemtest/java/reposense/LocalRepoSystemTest.java
@@ -18,7 +18,6 @@ import reposense.model.RepoConfiguration;
 import reposense.model.RepoLocation;
 import reposense.model.SupportedDomainUrlMap;
 import reposense.parser.SinceDateArgumentType;
-import reposense.report.ErrorSummary;
 import reposense.util.FileUtil;
 import reposense.util.InputBuilder;
 import reposense.util.SystemTestUtil;

--- a/src/test/java/reposense/model/RepoConfigurationTest.java
+++ b/src/test/java/reposense/model/RepoConfigurationTest.java
@@ -19,6 +19,7 @@ import reposense.parser.ArgsParser;
 import reposense.parser.AuthorConfigCsvParser;
 import reposense.parser.GroupConfigCsvParser;
 import reposense.parser.RepoConfigCsvParser;
+import reposense.report.ErrorSummary;
 import reposense.report.ReportGenerator;
 import reposense.util.InputBuilder;
 import reposense.util.TestRepoCloner;
@@ -45,18 +46,18 @@ public class RepoConfigurationTest {
             "RepoConfigurationTest/repoconfig_ignoreFileSizeLimit_test");
     private static final Path IGNORE_FILESIZE_LIMIT_OVERRIDE_CSV_TEST_CONFIG_FILES =
             loadResource(RepoConfigurationTest.class,
-            "RepoConfigurationTest/repoconfig_ignoreFileSizeLimitOverrideCsv_test");
+                    "RepoConfigurationTest/repoconfig_ignoreFileSizeLimitOverrideCsv_test");
     private static final Path SHALLOW_CLONING_TEST_CONFIG_FILES =
             loadResource(RepoConfigurationTest.class, "RepoConfigurationTest/repoconfig_shallowCloning_test");
     private static final Path SHALLOW_CLONING_FLAG_OVERRIDE_TEST_CONFIG_FILES =
             loadResource(RepoConfigurationTest.class,
-            "RepoConfigurationTest/repoconfig_shallowCloningOverrideCsv_test");
+                    "RepoConfigurationTest/repoconfig_shallowCloningOverrideCsv_test");
     private static final Path FIND_PREVIOUS_AUTHORS_TEST_CONFIG_FILES =
             loadResource(RepoConfigurationTest.class,
-            "RepoConfigurationTest/repoconfig_findPreviousAuthors_test");
+                    "RepoConfigurationTest/repoconfig_findPreviousAuthors_test");
     private static final Path FIND_PREVIOUS_AUTHORS_FLAG_OVERRIDE_TEST_CONFIG_FILES =
             loadResource(RepoConfigurationTest.class,
-            "RepoConfigurationTest/repoconfig_findPreviousAuthorsOverrideCsv_test");
+                    "RepoConfigurationTest/repoconfig_findPreviousAuthorsOverrideCsv_test");
 
     private static final String TEST_REPO_BETA = "https://github.com/reposense/testrepo-Beta.git";
     private static final String TEST_REPO_DELTA = "https://github.com/reposense/testrepo-Delta.git";
@@ -91,7 +92,9 @@ public class RepoConfigurationTest {
     private static final List<String> CLI_FORMATS = Arrays.asList("css", "html");
 
     private static RepoConfiguration repoDeltaStandaloneConfig;
-    private ReportGenerator reportGenerator = new ReportGenerator();
+    private ErrorSummary errorSummary = new ErrorSummary();
+    private ReportGenerator reportGenerator = new ReportGenerator(errorSummary);
+
 
     @BeforeAll
     public static void setUp() throws Exception {
@@ -161,9 +164,11 @@ public class RepoConfigurationTest {
         CliArguments cliArguments = ArgsParser.parse(translateCommandline(input));
 
         List<RepoConfiguration> actualConfigs =
-                new RepoConfigCsvParser(((ConfigCliArguments) cliArguments).getRepoConfigFilePath()).parse();
+                new RepoConfigCsvParser(((ConfigCliArguments) cliArguments).getRepoConfigFilePath(),
+                        errorSummary).parse();
         List<AuthorConfiguration> authorConfigs =
-                new AuthorConfigCsvParser(((ConfigCliArguments) cliArguments).getAuthorConfigFilePath()).parse();
+                new AuthorConfigCsvParser(((ConfigCliArguments) cliArguments).getAuthorConfigFilePath(),
+                        errorSummary).parse();
         RepoConfiguration.merge(actualConfigs, authorConfigs);
 
         RepoConfiguration actualConfig = actualConfigs.get(0);
@@ -185,7 +190,8 @@ public class RepoConfigurationTest {
                 .addIgnoreStandaloneConfig()
                 .build();
         CliArguments cliArguments = ArgsParser.parse(translateCommandline(input));
-        List<RepoConfiguration> actualConfigs = RepoSense.getRepoConfigurations((LocationsCliArguments) cliArguments);
+        List<RepoConfiguration> actualConfigs = RepoSense.getRepoConfigurations((LocationsCliArguments) cliArguments,
+                errorSummary);
         RepoConfiguration.setFormatsToRepoConfigs(actualConfigs, cliArguments.getFormats());
         RepoConfiguration.setStandaloneConfigIgnoredToRepoConfigs(actualConfigs,
                 cliArguments.isStandaloneConfigIgnored());
@@ -212,7 +218,8 @@ public class RepoConfigurationTest {
                 .build();
         CliArguments cliArguments = ArgsParser.parse(translateCommandline(input));
         List<RepoConfiguration> actualConfigs =
-                new RepoConfigCsvParser(((ConfigCliArguments) cliArguments).getRepoConfigFilePath()).parse();
+                new RepoConfigCsvParser(((ConfigCliArguments) cliArguments).getRepoConfigFilePath(),
+                        errorSummary).parse();
         RepoConfiguration.setStandaloneConfigIgnoredToRepoConfigs(actualConfigs,
                 cliArguments.isStandaloneConfigIgnored());
 
@@ -241,7 +248,8 @@ public class RepoConfigurationTest {
         CliArguments cliArguments = ArgsParser.parse(translateCommandline(input));
 
         List<RepoConfiguration> actualConfigs =
-                new RepoConfigCsvParser(((ConfigCliArguments) cliArguments).getRepoConfigFilePath()).parse();
+                new RepoConfigCsvParser(((ConfigCliArguments) cliArguments).getRepoConfigFilePath(),
+                        errorSummary).parse();
         RepoConfiguration.setStandaloneConfigIgnoredToRepoConfigs(actualConfigs, true);
 
         RepoConfiguration actualConfig = actualConfigs.get(0);
@@ -268,7 +276,8 @@ public class RepoConfigurationTest {
                 .build();
         CliArguments cliArguments = ArgsParser.parse(translateCommandline(input));
         List<RepoConfiguration> actualConfigs =
-                new RepoConfigCsvParser(((ConfigCliArguments) cliArguments).getRepoConfigFilePath()).parse();
+                new RepoConfigCsvParser(((ConfigCliArguments) cliArguments).getRepoConfigFilePath(),
+                        errorSummary).parse();
         RepoConfiguration.setStandaloneConfigIgnoredToRepoConfigs(actualConfigs, true);
         RepoConfiguration.setFileSizeLimitIgnoredToRepoConfigs(actualConfigs,
                 cliArguments.isFileSizeLimitIgnored());
@@ -293,7 +302,8 @@ public class RepoConfigurationTest {
         String input = new InputBuilder().addConfig(IGNORE_STANDALONE_FLAG_OVERRIDE_CSV_TEST).build();
         CliArguments cliArguments = ArgsParser.parse(translateCommandline(input));
         List<RepoConfiguration> actualConfigs =
-                new RepoConfigCsvParser(((ConfigCliArguments) cliArguments).getRepoConfigFilePath()).parse();
+                new RepoConfigCsvParser(((ConfigCliArguments) cliArguments).getRepoConfigFilePath(),
+                        errorSummary).parse();
         RepoConfiguration.setStandaloneConfigIgnoredToRepoConfigs(actualConfigs,
                 cliArguments.isStandaloneConfigIgnored());
 
@@ -316,7 +326,8 @@ public class RepoConfigurationTest {
         CliArguments cliArguments = ArgsParser.parse(translateCommandline(input));
 
         List<RepoConfiguration> actualConfigs =
-                new RepoConfigCsvParser(((ConfigCliArguments) cliArguments).getRepoConfigFilePath()).parse();
+                new RepoConfigCsvParser(((ConfigCliArguments) cliArguments).getRepoConfigFilePath(),
+                        errorSummary).parse();
 
         RepoConfiguration actualConfig = actualConfigs.get(0);
         TestRepoCloner.cloneAndBranch(actualConfig);
@@ -340,7 +351,8 @@ public class RepoConfigurationTest {
         CliArguments cliArguments = ArgsParser.parse(translateCommandline(input));
 
         List<RepoConfiguration> actualConfigs =
-                new RepoConfigCsvParser(((ConfigCliArguments) cliArguments).getRepoConfigFilePath()).parse();
+                new RepoConfigCsvParser(((ConfigCliArguments) cliArguments).getRepoConfigFilePath(),
+                        errorSummary).parse();
         RepoConfiguration.setStandaloneConfigIgnoredToRepoConfigs(actualConfigs, true);
 
         RepoConfiguration actualConfig = actualConfigs.get(0);
@@ -363,7 +375,8 @@ public class RepoConfigurationTest {
                 .addShallowCloning()
                 .build();
         CliArguments cliArguments = ArgsParser.parse(translateCommandline(input));
-        List<RepoConfiguration> actualConfigs = RepoSense.getRepoConfigurations((LocationsCliArguments) cliArguments);
+        List<RepoConfiguration> actualConfigs = RepoSense.getRepoConfigurations((LocationsCliArguments) cliArguments,
+                errorSummary);
         RepoConfiguration.setFormatsToRepoConfigs(actualConfigs, cliArguments.getFormats());
         RepoConfiguration.setStandaloneConfigIgnoredToRepoConfigs(actualConfigs, true);
         RepoConfiguration.setIsShallowCloningPerformedToRepoConfigs(actualConfigs,
@@ -393,7 +406,8 @@ public class RepoConfigurationTest {
                 .build();
         CliArguments cliArguments = ArgsParser.parse(translateCommandline(input));
         List<RepoConfiguration> actualConfigs =
-                new RepoConfigCsvParser(((ConfigCliArguments) cliArguments).getRepoConfigFilePath()).parse();
+                new RepoConfigCsvParser(((ConfigCliArguments) cliArguments).getRepoConfigFilePath(),
+                        errorSummary).parse();
         RepoConfiguration.setStandaloneConfigIgnoredToRepoConfigs(actualConfigs, true);
         RepoConfiguration.setIsShallowCloningPerformedToRepoConfigs(actualConfigs,
                 cliArguments.isShallowCloningPerformed());
@@ -422,7 +436,8 @@ public class RepoConfigurationTest {
         String input = new InputBuilder().addConfig(SHALLOW_CLONING_FLAG_OVERRIDE_TEST_CONFIG_FILES).build();
         CliArguments cliArguments = ArgsParser.parse(translateCommandline(input));
         List<RepoConfiguration> actualConfigs =
-                new RepoConfigCsvParser(((ConfigCliArguments) cliArguments).getRepoConfigFilePath()).parse();
+                new RepoConfigCsvParser(((ConfigCliArguments) cliArguments).getRepoConfigFilePath(),
+                        errorSummary).parse();
         RepoConfiguration.setStandaloneConfigIgnoredToRepoConfigs(actualConfigs, true);
         RepoConfiguration.setIsShallowCloningPerformedToRepoConfigs(actualConfigs,
                 cliArguments.isShallowCloningPerformed());
@@ -452,7 +467,8 @@ public class RepoConfigurationTest {
         CliArguments cliArguments = ArgsParser.parse(translateCommandline(input));
 
         List<RepoConfiguration> actualConfigs =
-                new RepoConfigCsvParser(((ConfigCliArguments) cliArguments).getRepoConfigFilePath()).parse();
+                new RepoConfigCsvParser(((ConfigCliArguments) cliArguments).getRepoConfigFilePath(),
+                        errorSummary).parse();
         RepoConfiguration.setStandaloneConfigIgnoredToRepoConfigs(actualConfigs, true);
 
         RepoConfiguration actualConfig = actualConfigs.get(0);
@@ -475,7 +491,8 @@ public class RepoConfigurationTest {
                 .addFindPreviousAuthors()
                 .build();
         CliArguments cliArguments = ArgsParser.parse(translateCommandline(input));
-        List<RepoConfiguration> actualConfigs = RepoSense.getRepoConfigurations((LocationsCliArguments) cliArguments);
+        List<RepoConfiguration> actualConfigs = RepoSense.getRepoConfigurations((LocationsCliArguments) cliArguments,
+                errorSummary);
         RepoConfiguration.setFormatsToRepoConfigs(actualConfigs, cliArguments.getFormats());
         RepoConfiguration.setStandaloneConfigIgnoredToRepoConfigs(actualConfigs, true);
         RepoConfiguration.setIsFindingPreviousAuthorsPerformedToRepoConfigs(actualConfigs,
@@ -505,7 +522,8 @@ public class RepoConfigurationTest {
                 .build();
         CliArguments cliArguments = ArgsParser.parse(translateCommandline(input));
         List<RepoConfiguration> actualConfigs =
-                new RepoConfigCsvParser(((ConfigCliArguments) cliArguments).getRepoConfigFilePath()).parse();
+                new RepoConfigCsvParser(((ConfigCliArguments) cliArguments).getRepoConfigFilePath(),
+                        errorSummary).parse();
         RepoConfiguration.setStandaloneConfigIgnoredToRepoConfigs(actualConfigs, true);
         RepoConfiguration.setIsFindingPreviousAuthorsPerformedToRepoConfigs(actualConfigs,
                 cliArguments.isFindingPreviousAuthorsPerformed());
@@ -534,7 +552,8 @@ public class RepoConfigurationTest {
         String input = new InputBuilder().addConfig(FIND_PREVIOUS_AUTHORS_FLAG_OVERRIDE_TEST_CONFIG_FILES).build();
         CliArguments cliArguments = ArgsParser.parse(translateCommandline(input));
         List<RepoConfiguration> actualConfigs =
-                new RepoConfigCsvParser(((ConfigCliArguments) cliArguments).getRepoConfigFilePath()).parse();
+                new RepoConfigCsvParser(((ConfigCliArguments) cliArguments).getRepoConfigFilePath(),
+                        errorSummary).parse();
         RepoConfiguration.setStandaloneConfigIgnoredToRepoConfigs(actualConfigs, true);
         RepoConfiguration.setIsFindingPreviousAuthorsPerformedToRepoConfigs(actualConfigs,
                 cliArguments.isFindingPreviousAuthorsPerformed());
@@ -563,7 +582,8 @@ public class RepoConfigurationTest {
         String input = new InputBuilder().addConfig(FIND_PREVIOUS_AUTHORS_FLAG_OVERRIDE_TEST_CONFIG_FILES).build();
         CliArguments cliArguments = ArgsParser.parse(translateCommandline(input));
         List<RepoConfiguration> actualConfigs =
-                new RepoConfigCsvParser(((ConfigCliArguments) cliArguments).getRepoConfigFilePath()).parse();
+                new RepoConfigCsvParser(((ConfigCliArguments) cliArguments).getRepoConfigFilePath(),
+                        errorSummary).parse();
         RepoConfiguration.setStandaloneConfigIgnoredToRepoConfigs(actualConfigs, true);
         RepoConfiguration.setIsFindingPreviousAuthorsPerformedToRepoConfigs(actualConfigs,
                 cliArguments.isFindingPreviousAuthorsPerformed());
@@ -590,7 +610,8 @@ public class RepoConfigurationTest {
         CliArguments cliArguments = ArgsParser.parse(translateCommandline(input));
 
         List<RepoConfiguration> actualConfigs =
-                new RepoConfigCsvParser(((ConfigCliArguments) cliArguments).getRepoConfigFilePath()).parse();
+                new RepoConfigCsvParser(((ConfigCliArguments) cliArguments).getRepoConfigFilePath(),
+                        errorSummary).parse();
         RepoConfiguration.setFormatsToRepoConfigs(actualConfigs, cliArguments.getFormats());
 
         Assertions.assertEquals(1, actualConfigs.size());
@@ -606,7 +627,8 @@ public class RepoConfigurationTest {
         CliArguments cliArguments = ArgsParser.parse(translateCommandline(input));
 
         List<RepoConfiguration> actualConfigs =
-                new RepoConfigCsvParser(((ConfigCliArguments) cliArguments).getRepoConfigFilePath()).parse();
+                new RepoConfigCsvParser(((ConfigCliArguments) cliArguments).getRepoConfigFilePath(),
+                        errorSummary).parse();
         RepoConfiguration.setFormatsToRepoConfigs(actualConfigs, cliArguments.getFormats());
 
         Assertions.assertEquals(1, actualConfigs.size());
@@ -621,9 +643,11 @@ public class RepoConfigurationTest {
         CliArguments cliArguments = ArgsParser.parse(translateCommandline(input));
 
         List<RepoConfiguration> actualConfigs =
-                new RepoConfigCsvParser(((ConfigCliArguments) cliArguments).getRepoConfigFilePath()).parse();
+                new RepoConfigCsvParser(((ConfigCliArguments) cliArguments).getRepoConfigFilePath(),
+                        errorSummary).parse();
         List<GroupConfiguration> groupConfigs =
-                new GroupConfigCsvParser(((ConfigCliArguments) cliArguments).getGroupConfigFilePath()).parse();
+                new GroupConfigCsvParser(((ConfigCliArguments) cliArguments).getGroupConfigFilePath(),
+                        errorSummary).parse();
 
         RepoConfiguration.setGroupConfigsToRepos(actualConfigs, groupConfigs);
 
@@ -638,7 +662,8 @@ public class RepoConfigurationTest {
         CliArguments cliArguments = ArgsParser.parse(translateCommandline(input));
 
         List<RepoConfiguration> actualConfigs =
-                new RepoConfigCsvParser(((ConfigCliArguments) cliArguments).getRepoConfigFilePath()).parse();
+                new RepoConfigCsvParser(((ConfigCliArguments) cliArguments).getRepoConfigFilePath(),
+                        errorSummary).parse();
         RepoConfiguration.setFormatsToRepoConfigs(actualConfigs, cliArguments.getFormats());
 
         Assertions.assertEquals(1, actualConfigs.size());
@@ -697,7 +722,8 @@ public class RepoConfigurationTest {
         CliArguments cliArguments = ArgsParser.parse(translateCommandline(input));
 
         List<RepoConfiguration> actualConfigs =
-                new RepoConfigCsvParser(((ConfigCliArguments) cliArguments).getRepoConfigFilePath()).parse();
+                new RepoConfigCsvParser(((ConfigCliArguments) cliArguments).getRepoConfigFilePath(),
+                        errorSummary).parse();
 
         RepoConfiguration actualConfig = actualConfigs.get(0);
         TestRepoCloner.cloneAndBranch(actualConfig);
@@ -752,9 +778,11 @@ public class RepoConfigurationTest {
         CliArguments cliArguments = ArgsParser.parse(translateCommandline(input));
 
         List<RepoConfiguration> actualConfigs =
-                new RepoConfigCsvParser(((ConfigCliArguments) cliArguments).getRepoConfigFilePath()).parse();
+                new RepoConfigCsvParser(((ConfigCliArguments) cliArguments).getRepoConfigFilePath(),
+                        errorSummary).parse();
         List<AuthorConfiguration> authorConfigs =
-                new AuthorConfigCsvParser(((ConfigCliArguments) cliArguments).getAuthorConfigFilePath()).parse();
+                new AuthorConfigCsvParser(((ConfigCliArguments) cliArguments).getAuthorConfigFilePath(),
+                        errorSummary).parse();
         RepoConfiguration.merge(actualConfigs, authorConfigs);
 
         RepoConfiguration actualConfig = actualConfigs.get(0);

--- a/src/test/java/reposense/parser/ArgsParserTest.java
+++ b/src/test/java/reposense/parser/ArgsParserTest.java
@@ -28,6 +28,7 @@ import reposense.model.FileTypeTest;
 import reposense.model.LocationsCliArguments;
 import reposense.model.RepoConfiguration;
 import reposense.model.ViewCliArguments;
+import reposense.report.ErrorSummary;
 import reposense.util.FileUtil;
 import reposense.util.InputBuilder;
 import reposense.util.TestUtil;
@@ -57,6 +58,8 @@ public class ArgsParserTest {
 
     private static final String DEFAULT_TIME_ZONE_STRING = "Asia/Singapore";
     private static final ZoneId DEFAULT_TIME_ZONE_ID = TestUtil.getZoneId(DEFAULT_TIME_ZONE_STRING);
+
+    private ErrorSummary errorSummary = new ErrorSummary();
 
     @BeforeEach
     public void before() {
@@ -485,7 +488,8 @@ public class ArgsParserTest {
         String input = new InputBuilder().addRepos(TEST_REPO_REPOSENSE, TEST_REPO_DELTA).build();
         CliArguments cliArguments = ArgsParser.parse(translateCommandline(input));
         Assertions.assertTrue(cliArguments instanceof LocationsCliArguments);
-        List<RepoConfiguration> repoConfigs = RepoSense.getRepoConfigurations((LocationsCliArguments) cliArguments);
+        List<RepoConfiguration> repoConfigs = RepoSense.getRepoConfigurations((LocationsCliArguments) cliArguments,
+                errorSummary);
         Assertions.assertEquals(2, repoConfigs.size());
     }
 
@@ -540,13 +544,13 @@ public class ArgsParserTest {
         CliArguments configCliArguments = ArgsParser.parse(translateCommandline(input));
         Assertions.assertTrue(configCliArguments instanceof ConfigCliArguments);
         List<RepoConfiguration> actualRepoConfigs =
-                RepoSense.getRepoConfigurations((ConfigCliArguments) configCliArguments);
+                RepoSense.getRepoConfigurations((ConfigCliArguments) configCliArguments, errorSummary);
 
         input = new InputBuilder().addRepos(TEST_REPO_BETA, TEST_REPO_CHARLIE, TEST_REPO_DELTA).build();
         CliArguments locationCliArguments = ArgsParser.parse(translateCommandline(input));
         Assertions.assertTrue(locationCliArguments instanceof LocationsCliArguments);
         List<RepoConfiguration> expectedRepoConfigs =
-                RepoSense.getRepoConfigurations((LocationsCliArguments) locationCliArguments);
+                RepoSense.getRepoConfigurations((LocationsCliArguments) locationCliArguments, errorSummary);
 
         Assertions.assertEquals(actualRepoConfigs, expectedRepoConfigs);
     }

--- a/src/test/java/reposense/parser/AuthorConfigParserTest.java
+++ b/src/test/java/reposense/parser/AuthorConfigParserTest.java
@@ -72,15 +72,15 @@ public class AuthorConfigParserTest {
             Arrays.asList("Borex T\"ony Tong");
     private static final Map<Author, List<String>> AUTHOR_ALIAS_COMMAS_AND_DOUBLE_QUOTES_MAP =
             Stream.of(new SimpleEntry<>(FIRST_COMMAS_AND_DOUBLEQUOTES_AUTHOR, FIRST_COMMAS_AND_DOUBLEQUOTES_ALIAS),
-                            new SimpleEntry<>(SECOND_COMMAS_AND_DOUBLEQUOTES_AUTHOR, SECOND_COMMAS_AND_DOUBLEQUOTES_ALIAS),
-                            new SimpleEntry<>(THIRD_COMMAS_AND_DOUBLEQUOTES_AUTHOR, THIRD_COMMAS_AND_DOUBLEQUOTES_ALIAS))
+                      new SimpleEntry<>(SECOND_COMMAS_AND_DOUBLEQUOTES_AUTHOR, SECOND_COMMAS_AND_DOUBLEQUOTES_ALIAS),
+                      new SimpleEntry<>(THIRD_COMMAS_AND_DOUBLEQUOTES_AUTHOR, THIRD_COMMAS_AND_DOUBLEQUOTES_ALIAS))
                     .collect(Collectors.toMap(entry -> entry.getKey(), entry -> entry.getValue()));
     private static final Map<Author, String> AUTHOR_DISPLAY_NAME_COMMAS_AND_DOUBLE_QUOTES_MAP =
-            Stream.of(new SimpleEntry<>(FIRST_COMMAS_AND_DOUBLEQUOTES_AUTHOR,
-                                    FIRST_COMMAS_AND_DOUBLEQUOTES_DISPLAY_NAME),
-                            new SimpleEntry<>(SECOND_COMMAS_AND_DOUBLEQUOTES_AUTHOR,
-                                    SECOND_COMMAS_AND_DOUBLEQUOTES_DISPLAY_NAME),
-                            new SimpleEntry<>(THIRD_COMMAS_AND_DOUBLEQUOTES_AUTHOR, THIRD_COMMAS_AND_DOUBLEQUOTES_DISPLAY_NAME))
+            Stream.of(
+                    new SimpleEntry<>(FIRST_COMMAS_AND_DOUBLEQUOTES_AUTHOR, FIRST_COMMAS_AND_DOUBLEQUOTES_DISPLAY_NAME),
+                    new SimpleEntry<>(
+                            SECOND_COMMAS_AND_DOUBLEQUOTES_AUTHOR, SECOND_COMMAS_AND_DOUBLEQUOTES_DISPLAY_NAME),
+                    new SimpleEntry<>(THIRD_COMMAS_AND_DOUBLEQUOTES_AUTHOR, THIRD_COMMAS_AND_DOUBLEQUOTES_DISPLAY_NAME))
                     .collect(Collectors.toMap(entry -> entry.getKey(), entry -> entry.getValue()));
 
     private static final List<String> FIRST_AUTHOR_EMAIL_LIST =

--- a/src/test/java/reposense/parser/AuthorConfigParserTest.java
+++ b/src/test/java/reposense/parser/AuthorConfigParserTest.java
@@ -17,6 +17,7 @@ import org.junit.jupiter.api.Test;
 import reposense.model.Author;
 import reposense.model.AuthorConfiguration;
 import reposense.model.RepoLocation;
+import reposense.report.ErrorSummary;
 
 public class AuthorConfigParserTest {
     private static final Path AUTHOR_CONFIG_EMPTY_LOCATION_FILE = loadResource(AuthorConfigParserTest.class,
@@ -71,24 +72,26 @@ public class AuthorConfigParserTest {
             Arrays.asList("Borex T\"ony Tong");
     private static final Map<Author, List<String>> AUTHOR_ALIAS_COMMAS_AND_DOUBLE_QUOTES_MAP =
             Stream.of(new SimpleEntry<>(FIRST_COMMAS_AND_DOUBLEQUOTES_AUTHOR, FIRST_COMMAS_AND_DOUBLEQUOTES_ALIAS),
-                    new SimpleEntry<>(SECOND_COMMAS_AND_DOUBLEQUOTES_AUTHOR, SECOND_COMMAS_AND_DOUBLEQUOTES_ALIAS),
-                    new SimpleEntry<>(THIRD_COMMAS_AND_DOUBLEQUOTES_AUTHOR, THIRD_COMMAS_AND_DOUBLEQUOTES_ALIAS))
+                            new SimpleEntry<>(SECOND_COMMAS_AND_DOUBLEQUOTES_AUTHOR, SECOND_COMMAS_AND_DOUBLEQUOTES_ALIAS),
+                            new SimpleEntry<>(THIRD_COMMAS_AND_DOUBLEQUOTES_AUTHOR, THIRD_COMMAS_AND_DOUBLEQUOTES_ALIAS))
                     .collect(Collectors.toMap(entry -> entry.getKey(), entry -> entry.getValue()));
     private static final Map<Author, String> AUTHOR_DISPLAY_NAME_COMMAS_AND_DOUBLE_QUOTES_MAP =
             Stream.of(new SimpleEntry<>(FIRST_COMMAS_AND_DOUBLEQUOTES_AUTHOR,
-                            FIRST_COMMAS_AND_DOUBLEQUOTES_DISPLAY_NAME),
-                    new SimpleEntry<>(SECOND_COMMAS_AND_DOUBLEQUOTES_AUTHOR,
-                            SECOND_COMMAS_AND_DOUBLEQUOTES_DISPLAY_NAME),
-                    new SimpleEntry<>(THIRD_COMMAS_AND_DOUBLEQUOTES_AUTHOR, THIRD_COMMAS_AND_DOUBLEQUOTES_DISPLAY_NAME))
+                                    FIRST_COMMAS_AND_DOUBLEQUOTES_DISPLAY_NAME),
+                            new SimpleEntry<>(SECOND_COMMAS_AND_DOUBLEQUOTES_AUTHOR,
+                                    SECOND_COMMAS_AND_DOUBLEQUOTES_DISPLAY_NAME),
+                            new SimpleEntry<>(THIRD_COMMAS_AND_DOUBLEQUOTES_AUTHOR, THIRD_COMMAS_AND_DOUBLEQUOTES_DISPLAY_NAME))
                     .collect(Collectors.toMap(entry -> entry.getKey(), entry -> entry.getValue()));
 
     private static final List<String> FIRST_AUTHOR_EMAIL_LIST =
             Arrays.asList("nbr@example.com", "nbriannl@test.net", "nbriannl@users.noreply.github.com");
 
+    private ErrorSummary errorSummary = new ErrorSummary();
+
     @Test
     public void authorConfig_noSpecialCharacter_success() throws Exception {
         AuthorConfigCsvParser authorConfigCsvParser =
-                new AuthorConfigCsvParser(AUTHOR_CONFIG_NO_SPECIAL_CHARACTER_FILE);
+                new AuthorConfigCsvParser(AUTHOR_CONFIG_NO_SPECIAL_CHARACTER_FILE, errorSummary);
         List<AuthorConfiguration> configs = authorConfigCsvParser.parse();
 
         Assertions.assertEquals(1, configs.size());
@@ -105,7 +108,8 @@ public class AuthorConfigParserTest {
     public void authorConfig_emptyLocation_success() throws Exception {
         AuthorConfiguration expectedConfig = new AuthorConfiguration(new RepoLocation(""));
 
-        AuthorConfigCsvParser authorConfigCsvParser = new AuthorConfigCsvParser(AUTHOR_CONFIG_EMPTY_LOCATION_FILE);
+        AuthorConfigCsvParser authorConfigCsvParser = new AuthorConfigCsvParser(AUTHOR_CONFIG_EMPTY_LOCATION_FILE,
+                errorSummary);
         List<AuthorConfiguration> authorConfigs = authorConfigCsvParser.parse();
         AuthorConfiguration authorConfig = authorConfigs.get(0);
 
@@ -117,13 +121,15 @@ public class AuthorConfigParserTest {
 
     @Test
     public void authorConfig_emptyConfig_throwsInvalidCsvException() throws Exception {
-        AuthorConfigCsvParser authorConfigCsvParser = new AuthorConfigCsvParser(AUTHOR_CONFIG_EMPTY_CONFIG_FILE);
+        AuthorConfigCsvParser authorConfigCsvParser = new AuthorConfigCsvParser(AUTHOR_CONFIG_EMPTY_CONFIG_FILE,
+                errorSummary);
         Assertions.assertThrows(InvalidCsvException.class, () -> authorConfigCsvParser.parse());
     }
 
     @Test
     public void authorConfig_specialCharacter_success() throws Exception {
-        AuthorConfigCsvParser authorConfigCsvParser = new AuthorConfigCsvParser(AUTHOR_CONFIG_SPECIAL_CHARACTER_FILE);
+        AuthorConfigCsvParser authorConfigCsvParser = new AuthorConfigCsvParser(AUTHOR_CONFIG_SPECIAL_CHARACTER_FILE,
+                errorSummary);
         List<AuthorConfiguration> configs = authorConfigCsvParser.parse();
 
         Assertions.assertEquals(1, configs.size());
@@ -138,7 +144,8 @@ public class AuthorConfigParserTest {
 
     @Test
     public void authorConfig_multipleEmails_success() throws Exception {
-        AuthorConfigCsvParser authorConfigCsvParser = new AuthorConfigCsvParser(AUTHOR_CONFIG_MULTIPLE_EMAILS_FILE);
+        AuthorConfigCsvParser authorConfigCsvParser = new AuthorConfigCsvParser(AUTHOR_CONFIG_MULTIPLE_EMAILS_FILE,
+                errorSummary);
         List<AuthorConfiguration> configs = authorConfigCsvParser.parse();
 
         Assertions.assertEquals(1, configs.size());
@@ -153,7 +160,7 @@ public class AuthorConfigParserTest {
     @Test
     public void authorConfig_differentColumnOrder_success() throws Exception {
         AuthorConfigCsvParser authorConfigCsvParser =
-                new AuthorConfigCsvParser(AUTHOR_CONFIG_DIFFERENT_COLUMN_ORDER);
+                new AuthorConfigCsvParser(AUTHOR_CONFIG_DIFFERENT_COLUMN_ORDER, errorSummary);
         List<AuthorConfiguration> configs = authorConfigCsvParser.parse();
 
         Assertions.assertEquals(1, configs.size());
@@ -168,7 +175,8 @@ public class AuthorConfigParserTest {
 
     @Test
     public void authorConfig_missingOptionalHeader_success() throws Exception {
-        AuthorConfigCsvParser authorConfigCsvParser = new AuthorConfigCsvParser(AUTHOR_CONFIG_MISSING_OPTIONAL_HEADER);
+        AuthorConfigCsvParser authorConfigCsvParser = new AuthorConfigCsvParser(AUTHOR_CONFIG_MISSING_OPTIONAL_HEADER,
+                errorSummary);
         List<AuthorConfiguration> configs = authorConfigCsvParser.parse();
 
         Assertions.assertEquals(1, configs.size());
@@ -182,10 +190,10 @@ public class AuthorConfigParserTest {
     public void authorConfig_newGitHostIdHeader_success() throws Exception {
         AuthorConfigCsvParser authorConfigCsvParser;
 
-        authorConfigCsvParser = new AuthorConfigCsvParser(AUTHOR_CONFIG_GIT_HOST_ID_HEADER);
+        authorConfigCsvParser = new AuthorConfigCsvParser(AUTHOR_CONFIG_GIT_HOST_ID_HEADER, errorSummary);
         List<AuthorConfiguration> configsWithGitHostIdHeader = authorConfigCsvParser.parse();
 
-        authorConfigCsvParser = new AuthorConfigCsvParser(AUTHOR_CONFIG_GITHUB_ID_HEADER);
+        authorConfigCsvParser = new AuthorConfigCsvParser(AUTHOR_CONFIG_GITHUB_ID_HEADER, errorSummary);
         List<AuthorConfiguration> configsWithGitHubIdHeader = authorConfigCsvParser.parse();
 
         Assertions.assertEquals(configsWithGitHubIdHeader, configsWithGitHostIdHeader);
@@ -193,20 +201,22 @@ public class AuthorConfigParserTest {
 
     @Test
     public void authorConfig_missingMandatoryHeader_throwsInvalidCsvException() throws Exception {
-        AuthorConfigCsvParser authorConfigCsvParser = new AuthorConfigCsvParser(AUTHOR_CONFIG_MISSING_MANDATORY_HEADER);
+        AuthorConfigCsvParser authorConfigCsvParser = new AuthorConfigCsvParser(AUTHOR_CONFIG_MISSING_MANDATORY_HEADER,
+                errorSummary);
         Assertions.assertThrows(InvalidCsvException.class, () -> authorConfigCsvParser.parse());
     }
 
     @Test
     public void authorConfig_unknownHeaders_throwsInvalidHeaderException() throws Exception {
-        AuthorConfigCsvParser authorConfigCsvParser = new AuthorConfigCsvParser(AUTHOR_CONFIG_UNKNOWN_HEADER);
+        AuthorConfigCsvParser authorConfigCsvParser = new AuthorConfigCsvParser(AUTHOR_CONFIG_UNKNOWN_HEADER,
+                errorSummary);
         Assertions.assertThrows(InvalidHeaderException.class, () -> authorConfigCsvParser.parse());
     }
 
     @Test
     public void parse_multipleColumnsWithCommasAndDoubleQuotes_success() throws Exception {
         AuthorConfigCsvParser authorConfigCsvParser =
-                new AuthorConfigCsvParser(AUTHOR_CONFIG_COMMAS_AND_DOUBLEQUOTES_FILE);
+                new AuthorConfigCsvParser(AUTHOR_CONFIG_COMMAS_AND_DOUBLEQUOTES_FILE, errorSummary);
         List<AuthorConfiguration> configs = authorConfigCsvParser.parse();
 
         Assertions.assertEquals(1, configs.size());

--- a/src/test/java/reposense/parser/GroupConfigParserTest.java
+++ b/src/test/java/reposense/parser/GroupConfigParserTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.Test;
 
 import reposense.model.FileType;
 import reposense.model.GroupConfiguration;
+import reposense.report.ErrorSummary;
 
 public class GroupConfigParserTest {
     private static final Path GROUP_CONFIG_MULTI_LOCATION_FILE = loadResource(GroupConfigParserTest.class,
@@ -36,10 +37,12 @@ public class GroupConfigParserTest {
     private static final List<FileType> TEST_REPO_DELTA_GROUPS = Arrays.asList(
             new FileType("Main", Collections.singletonList("src/main/**")),
             new FileType("Test", Arrays.asList("src/test/**", "src/systest/**")));
+    private ErrorSummary errorSummary = new ErrorSummary();
 
     @Test
     public void groupConfig_emptyLocation_success() throws Exception {
-        GroupConfigCsvParser groupConfigCsvParser = new GroupConfigCsvParser(GROUP_CONFIG_EMPTY_LOCATION_FILE);
+        GroupConfigCsvParser groupConfigCsvParser = new GroupConfigCsvParser(GROUP_CONFIG_EMPTY_LOCATION_FILE,
+                errorSummary);
         List<GroupConfiguration> groupConfigs = groupConfigCsvParser.parse();
 
         Assertions.assertEquals(2, groupConfigs.size());
@@ -53,7 +56,8 @@ public class GroupConfigParserTest {
 
     @Test
     public void groupConfig_multipleLocations_success() throws Exception {
-        GroupConfigCsvParser groupConfigCsvParser = new GroupConfigCsvParser(GROUP_CONFIG_MULTI_LOCATION_FILE);
+        GroupConfigCsvParser groupConfigCsvParser = new GroupConfigCsvParser(GROUP_CONFIG_MULTI_LOCATION_FILE,
+                errorSummary);
         List<GroupConfiguration> groupConfigs = groupConfigCsvParser.parse();
 
         Assertions.assertEquals(2, groupConfigs.size());
@@ -69,7 +73,8 @@ public class GroupConfigParserTest {
 
     @Test
     public void groupConfig_differentColumnOrder_success() throws Exception {
-        GroupConfigCsvParser groupConfigCsvParser = new GroupConfigCsvParser(GROUP_CONFIG_DIFFERENT_COLUMN_ORDER_FILE);
+        GroupConfigCsvParser groupConfigCsvParser = new GroupConfigCsvParser(GROUP_CONFIG_DIFFERENT_COLUMN_ORDER_FILE,
+                errorSummary);
         List<GroupConfiguration> groupConfigs = groupConfigCsvParser.parse();
 
         Assertions.assertEquals(2, groupConfigs.size());
@@ -85,7 +90,8 @@ public class GroupConfigParserTest {
 
     @Test
     public void groupConfig_missingOptionalHeader_success() throws Exception {
-        GroupConfigCsvParser groupConfigCsvParser = new GroupConfigCsvParser(GROUP_CONFIG_MISSING_OPTIONAL_HEADER_FILE);
+        GroupConfigCsvParser groupConfigCsvParser = new GroupConfigCsvParser(GROUP_CONFIG_MISSING_OPTIONAL_HEADER_FILE,
+                errorSummary);
         List<GroupConfiguration> groupConfigs = groupConfigCsvParser.parse();
 
         Assertions.assertEquals(1, groupConfigs.size());
@@ -96,14 +102,14 @@ public class GroupConfigParserTest {
     @Test
     public void groupConfig_missingMandatoryHeader_throwsInvalidCsvException() throws Exception {
         GroupConfigCsvParser groupConfigCsvParser = new GroupConfigCsvParser(
-                GROUP_CONFIG_MISSING_MANDATORY_HEADER_FILE);
+                GROUP_CONFIG_MISSING_MANDATORY_HEADER_FILE, errorSummary);
         Assertions.assertThrows(InvalidCsvException.class, () -> groupConfigCsvParser.parse());
     }
 
     @Test
     public void groupConfig_unknownHeader_throwsInvalidHeaderException() throws Exception {
         GroupConfigCsvParser groupConfigCsvParser = new GroupConfigCsvParser(
-                GROUP_CONFIG_UNKNOWN_HEADER_FILE);
+                GROUP_CONFIG_UNKNOWN_HEADER_FILE, errorSummary);
         Assertions.assertThrows(InvalidHeaderException.class, () -> groupConfigCsvParser.parse());
     }
 }

--- a/src/test/java/reposense/parser/RepoConfigParserTest.java
+++ b/src/test/java/reposense/parser/RepoConfigParserTest.java
@@ -20,6 +20,7 @@ import reposense.model.ConfigCliArguments;
 import reposense.model.FileType;
 import reposense.model.RepoConfiguration;
 import reposense.model.RepoLocation;
+import reposense.report.ErrorSummary;
 import reposense.util.InputBuilder;
 import reposense.util.TestUtil;
 
@@ -35,13 +36,13 @@ public class RepoConfigParserTest {
             "RepoConfigParserTest/require_trailing_whitespaces/repoconfig_redundantLines_test.csv");
     private static final Path REPO_CONFIG_UNRECOGNIZED_VALUES_FOR_YES_KEYWORD_HEADERS_FILE =
             loadResource(RepoConfigParserTest.class,
-            "RepoConfigParserTest/repoconfig_unrecognizedValuesForYesKeywordHeaders_test.csv");
+                    "RepoConfigParserTest/repoconfig_unrecognizedValuesForYesKeywordHeaders_test.csv");
     private static final Path REPO_CONFIG_DUPLICATE_HEADERS_CASE_SENSITIVE_FILE =
             loadResource(RepoConfigParserTest.class,
-            "RepoConfigParserTest/repoconfig_duplicateHeadersCaseSensitive_test.csv");
+                    "RepoConfigParserTest/repoconfig_duplicateHeadersCaseSensitive_test.csv");
     private static final Path REPO_CONFIG_DUPLICATE_HEADERS_CASE_INSENSITIVE_FILE =
             loadResource(RepoConfigParserTest.class,
-            "RepoConfigParserTest/repoconfig_duplicateHeadersCaseInsensitive_test.csv");
+                    "RepoConfigParserTest/repoconfig_duplicateHeadersCaseInsensitive_test.csv");
     private static final Path REPO_CONFIG_DIFFERENT_COLUMN_ORDER_FILE = loadResource(RepoConfigParserTest.class,
             "RepoConfigParserTest/repoconfig_differentColumnOrder_test.csv");
     private static final Path REPO_CONFIG_OPTIONAL_HEADER_MISSING_FILE = loadResource(RepoConfigParserTest.class,
@@ -85,10 +86,13 @@ public class RepoConfigParserTest {
     private static final List<String> REPO_LEVEL_GLOB_LIST = Arrays.asList("collated**");
     private static final List<String> FIRST_AUTHOR_GLOB_LIST = Arrays.asList("**.java", "collated**");
     private static final List<String> SECOND_AUTHOR_GLOB_LIST = Arrays.asList("**.doc", "collated**");
+    private ErrorSummary errorSummary = new ErrorSummary();
+
 
     @Test
     public void repoConfig_noSpecialCharacter_success() throws Exception {
-        RepoConfigCsvParser repoConfigCsvParser = new RepoConfigCsvParser(REPO_CONFIG_NO_SPECIAL_CHARACTER_FILE);
+        RepoConfigCsvParser repoConfigCsvParser = new RepoConfigCsvParser(REPO_CONFIG_NO_SPECIAL_CHARACTER_FILE,
+                errorSummary);
         List<RepoConfiguration> configs = repoConfigCsvParser.parse();
 
         Assertions.assertEquals(1, configs.size());
@@ -145,9 +149,11 @@ public class RepoConfigParserTest {
         CliArguments cliArguments = ArgsParser.parse(translateCommandline(input));
 
         List<RepoConfiguration> actualConfigs =
-                new RepoConfigCsvParser(((ConfigCliArguments) cliArguments).getRepoConfigFilePath()).parse();
+                new RepoConfigCsvParser(((ConfigCliArguments) cliArguments).getRepoConfigFilePath(),
+                        errorSummary).parse();
         List<AuthorConfiguration> authorConfigs =
-                new AuthorConfigCsvParser(((ConfigCliArguments) cliArguments).getAuthorConfigFilePath()).parse();
+                new AuthorConfigCsvParser(((ConfigCliArguments) cliArguments).getAuthorConfigFilePath(),
+                        errorSummary).parse();
         RepoConfiguration.merge(actualConfigs, authorConfigs);
 
         Assertions.assertEquals(2, actualConfigs.size());
@@ -192,9 +198,11 @@ public class RepoConfigParserTest {
         CliArguments cliArguments = ArgsParser.parse(translateCommandline(input));
 
         List<RepoConfiguration> actualConfigs =
-                new RepoConfigCsvParser(((ConfigCliArguments) cliArguments).getRepoConfigFilePath()).parse();
+                new RepoConfigCsvParser(((ConfigCliArguments) cliArguments).getRepoConfigFilePath(),
+                        errorSummary).parse();
         List<AuthorConfiguration> authorConfigs =
-                new AuthorConfigCsvParser(((ConfigCliArguments) cliArguments).getAuthorConfigFilePath()).parse();
+                new AuthorConfigCsvParser(((ConfigCliArguments) cliArguments).getAuthorConfigFilePath(),
+                        errorSummary).parse();
         RepoConfiguration.merge(actualConfigs, authorConfigs);
 
         Assertions.assertEquals(2, actualConfigs.size());
@@ -213,9 +221,11 @@ public class RepoConfigParserTest {
         CliArguments cliArguments = ArgsParser.parse(translateCommandline(input));
 
         List<RepoConfiguration> actualConfigs =
-                new RepoConfigCsvParser(((ConfigCliArguments) cliArguments).getRepoConfigFilePath()).parse();
+                new RepoConfigCsvParser(((ConfigCliArguments) cliArguments).getRepoConfigFilePath(),
+                        errorSummary).parse();
         List<AuthorConfiguration> authorConfigs =
-                new AuthorConfigCsvParser(((ConfigCliArguments) cliArguments).getAuthorConfigFilePath()).parse();
+                new AuthorConfigCsvParser(((ConfigCliArguments) cliArguments).getAuthorConfigFilePath(),
+                        errorSummary).parse();
         RepoConfiguration.merge(actualConfigs, authorConfigs);
 
         Assertions.assertEquals(1, actualConfigs.size());
@@ -225,7 +235,8 @@ public class RepoConfigParserTest {
 
     @Test
     public void repoConfig_overrideKeyword_success() throws Exception {
-        RepoConfigCsvParser repoConfigCsvParser = new RepoConfigCsvParser(REPO_CONFIG_OVERRIDE_KEYWORD_FILE);
+        RepoConfigCsvParser repoConfigCsvParser = new RepoConfigCsvParser(REPO_CONFIG_OVERRIDE_KEYWORD_FILE,
+                errorSummary);
         List<RepoConfiguration> configs = repoConfigCsvParser.parse();
         RepoConfiguration config = configs.get(0);
 
@@ -246,7 +257,8 @@ public class RepoConfigParserTest {
 
     @Test
     public void repoConfig_redundantLines_success() throws Exception {
-        RepoConfigCsvParser repoConfigCsvParser = new RepoConfigCsvParser(REPO_CONFIG_REDUNDANT_LINES_FILE);
+        RepoConfigCsvParser repoConfigCsvParser = new RepoConfigCsvParser(REPO_CONFIG_REDUNDANT_LINES_FILE,
+                errorSummary);
         List<RepoConfiguration> configs = repoConfigCsvParser.parse();
 
         Assertions.assertEquals(3, configs.size());
@@ -265,7 +277,8 @@ public class RepoConfigParserTest {
 
     @Test
     public void repoConfig_differentColumnOrder_success() throws Exception {
-        RepoConfigCsvParser repoConfigCsvParser = new RepoConfigCsvParser(REPO_CONFIG_DIFFERENT_COLUMN_ORDER_FILE);
+        RepoConfigCsvParser repoConfigCsvParser = new RepoConfigCsvParser(REPO_CONFIG_DIFFERENT_COLUMN_ORDER_FILE,
+                errorSummary);
         List<RepoConfiguration> configs = repoConfigCsvParser.parse();
 
         Assertions.assertEquals(1, configs.size());
@@ -289,7 +302,8 @@ public class RepoConfigParserTest {
 
     @Test
     public void repoConfig_missingOptionalHeader_success() throws Exception {
-        RepoConfigCsvParser repoConfigCsvParser = new RepoConfigCsvParser(REPO_CONFIG_OPTIONAL_HEADER_MISSING_FILE);
+        RepoConfigCsvParser repoConfigCsvParser = new RepoConfigCsvParser(REPO_CONFIG_OPTIONAL_HEADER_MISSING_FILE,
+                errorSummary);
         List<RepoConfiguration> configs = repoConfigCsvParser.parse();
 
         Assertions.assertEquals(1, configs.size());
@@ -313,7 +327,8 @@ public class RepoConfigParserTest {
     @Test
     public void repoConfig_withUnrecognizedValuesForYesKeywordHeaders_valuesIgnored() throws Exception {
         RepoConfigCsvParser repoConfigCsvParser =
-                new RepoConfigCsvParser(REPO_CONFIG_UNRECOGNIZED_VALUES_FOR_YES_KEYWORD_HEADERS_FILE);
+                new RepoConfigCsvParser(REPO_CONFIG_UNRECOGNIZED_VALUES_FOR_YES_KEYWORD_HEADERS_FILE,
+                        errorSummary);
         List<RepoConfiguration> configs = repoConfigCsvParser.parse();
 
         Assertions.assertFalse(configs.get(0).isStandaloneConfigIgnored());
@@ -326,7 +341,7 @@ public class RepoConfigParserTest {
     @Test
     public void repoConfig_invalidFileSizeLimit_valueIgnored() throws Exception {
         RepoConfigCsvParser repoConfigCsvParser =
-                new RepoConfigCsvParser(REPO_CONFIG_INVALID_FILE_SIZE_LIMIT);
+                new RepoConfigCsvParser(REPO_CONFIG_INVALID_FILE_SIZE_LIMIT, errorSummary);
         List<RepoConfiguration> configs = repoConfigCsvParser.parse();
 
         Assertions.assertEquals(configs.get(0).getFileSizeLimit(), DEFAULT_FILE_SIZE_LIMIT);
@@ -336,7 +351,7 @@ public class RepoConfigParserTest {
     @Test
     public void repoConfig_ignoreFileSizeLimit_ignoreFileSizeColumns() throws Exception {
         RepoConfigCsvParser repoConfigCsvParser =
-                new RepoConfigCsvParser(REPO_CONFIG_IGNORE_FILE_SIZE_LIMIT);
+                new RepoConfigCsvParser(REPO_CONFIG_IGNORE_FILE_SIZE_LIMIT, errorSummary);
         List<RepoConfiguration> configs = repoConfigCsvParser.parse();
 
         Assertions.assertTrue(configs.get(0).isFileSizeLimitIgnored());
@@ -346,34 +361,36 @@ public class RepoConfigParserTest {
 
     @Test
     public void repoConfig_mandatoryHeaderMissing_throwsInvalidCsvException() throws Exception {
-        RepoConfigCsvParser repoConfigCsvParser = new RepoConfigCsvParser(REPO_CONFIG_MANDATORY_HEADER_MISSING_FILE);
+        RepoConfigCsvParser repoConfigCsvParser = new RepoConfigCsvParser(REPO_CONFIG_MANDATORY_HEADER_MISSING_FILE,
+                errorSummary);
         Assertions.assertThrows(InvalidCsvException.class, () -> repoConfigCsvParser.parse());
     }
 
     @Test
     public void repoConfig_zeroValidRecords_throwsInvalidCsvException() throws Exception {
-        RepoConfigCsvParser repoConfigCsvParser = new RepoConfigCsvParser(REPO_CONFIG_ZERO_VALID_RECORDS);
+        RepoConfigCsvParser repoConfigCsvParser = new RepoConfigCsvParser(REPO_CONFIG_ZERO_VALID_RECORDS,
+                errorSummary);
         Assertions.assertThrows(InvalidCsvException.class, () -> repoConfigCsvParser.parse());
     }
 
     @Test
     public void repoConfig_duplicateHeadersCaseSensitive_throwsInvalidCsvException() throws Exception {
         RepoConfigCsvParser repoConfigCsvParser =
-                new RepoConfigCsvParser(REPO_CONFIG_DUPLICATE_HEADERS_CASE_SENSITIVE_FILE);
+                new RepoConfigCsvParser(REPO_CONFIG_DUPLICATE_HEADERS_CASE_SENSITIVE_FILE, errorSummary);
         Assertions.assertThrows(InvalidCsvException.class, () -> repoConfigCsvParser.parse());
     }
 
     @Test
     public void repoConfig_duplicateHeadersCaseInsensitive_throwsInvalidCsvException() throws Exception {
         RepoConfigCsvParser repoConfigCsvParser =
-                new RepoConfigCsvParser(REPO_CONFIG_DUPLICATE_HEADERS_CASE_INSENSITIVE_FILE);
+                new RepoConfigCsvParser(REPO_CONFIG_DUPLICATE_HEADERS_CASE_INSENSITIVE_FILE, errorSummary);
         Assertions.assertThrows(InvalidCsvException.class, () -> repoConfigCsvParser.parse());
     }
 
     @Test
     public void repoConfig_unknownHeaders_throwsInvalidHeaderException() throws Exception {
         RepoConfigCsvParser repoConfigCsvParser =
-                new RepoConfigCsvParser(REPO_CONFIG_UNKNOWN_HEADER_FILE);
+                new RepoConfigCsvParser(REPO_CONFIG_UNKNOWN_HEADER_FILE, errorSummary);
         Assertions.assertThrows(InvalidHeaderException.class, () -> repoConfigCsvParser.parse());
     }
 }

--- a/src/test/java/reposense/report/ErrorSummaryTest.java
+++ b/src/test/java/reposense/report/ErrorSummaryTest.java
@@ -13,42 +13,41 @@ public class ErrorSummaryTest {
         String invalidLocation2 = "https://github.com/contains-illegal-chars/^\\/";
         String invalidLocation3 = "not-valid-protocol://abc.com/reposense/RepoSense.git";
 
-        ErrorSummary errorSummaryInstance = ErrorSummary.getInstance();
-        errorSummaryInstance.clearErrorSet();
+        ErrorSummary errorSummary = new ErrorSummary();
 
         try {
             new RepoLocation(invalidLocation1);
-        } catch (InvalidLocationException e) {
-            // not relevant to the test
+        } catch (InvalidLocationException ile) {
+            errorSummary.addErrorMessage(invalidLocation1, ile.getMessage());
         }
-        Assertions.assertEquals(1, errorSummaryInstance.getErrorSet().size());
+        Assertions.assertEquals(1, errorSummary.getErrorSet().size());
 
         try {
             new RepoLocation(invalidLocation1);
-        } catch (InvalidLocationException e) {
-            // not relevant to the test
+        } catch (InvalidLocationException ile) {
+            errorSummary.addErrorMessage(invalidLocation1, ile.getMessage());
         }
-        Assertions.assertEquals(1, errorSummaryInstance.getErrorSet().size());
+        Assertions.assertEquals(1, errorSummary.getErrorSet().size());
 
         try {
             new RepoLocation(invalidLocation2);
-        } catch (InvalidLocationException e) {
-            // not relevant to the test
+        } catch (InvalidLocationException ile) {
+            errorSummary.addErrorMessage(invalidLocation2, ile.getMessage());
         }
-        Assertions.assertEquals(2, errorSummaryInstance.getErrorSet().size());
+        Assertions.assertEquals(2, errorSummary.getErrorSet().size());
 
         try {
             new RepoLocation(invalidLocation1);
-        } catch (InvalidLocationException e) {
-            // not relevant to the test
+        } catch (InvalidLocationException ile) {
+            errorSummary.addErrorMessage(invalidLocation1, ile.getMessage());
         }
-        Assertions.assertEquals(2, errorSummaryInstance.getErrorSet().size());
+        Assertions.assertEquals(2, errorSummary.getErrorSet().size());
 
         try {
             new RepoLocation(invalidLocation3);
-        } catch (InvalidLocationException e) {
-            // not relevant to the test
+        } catch (InvalidLocationException ile) {
+            errorSummary.addErrorMessage(invalidLocation3, ile.getMessage());
         }
-        Assertions.assertEquals(3, errorSummaryInstance.getErrorSet().size());
+        Assertions.assertEquals(3, errorSummary.getErrorSet().size());
     }
 }


### PR DESCRIPTION
<!--
    If this pull request fully addresses an issue, use:
    Fixes #xxxx

    If this pull request partially addresses an issue, use:
    Part of #xxxx

    If this pull request addresses multiple issues, put them in multiple lines:
    Fixes #xxxx
    Fixes #yyyy

    Format the title of the pull request with most relevant issue number as follows:
    [#xxxx] Title
-->
Fixes #1943 

### Proposed commit message
<!--
    Propose a detailed commit message for this pull request within the triple backticks below.
    Wrap lines at 72 characters.

    Guide on how to write a good commit message:
    https://oss-generic.github.io/process/docs/FormatsAndConventions.html#commit-message
-->
```
Currently, ErrorSummary implements the singleton design pattern (and 
has done so since the beginning).

ErrorSummary have to be made non-static if we want to parallelize/have
concurrent runs of RepoSense. For example, for systemtest, there exist 
a @BeforeEach method that clears the static error set. This made it 
such that only sequential runs of the tests result in the correct 
output.

Let's make ErrorSummary non-static.
```

### Other information
<!--
    Are there other relevant information, such as special testing instructions,
    which will help the reviewer better understand the code?

    You may also include a brief description of why the problem occurred.
-->
Currently, error messages are added into the `ErrorSummary` via the constructor of `RepoLocation`, as the checking and validating of repo locations is done there. Given that error messages were present as early as that, I elected for Reposense::main have a local `ErrorSummary` that would be passed into methods that invokes the constructor of `RepoLocation`.

`RepoLocation` will no longer add error messages to `ErrorSummary` through a static method, as that would involve passing `ErrorSummary` as a parameter to `RepoLocation`. Instead, methods that handle the `InvalidLocationException` will perform the adding of the error message. This is found in the subclasses of `CsvParser` for runs of RepoSense with configs, and the relevant `RepoSense::getRepoConfigurations` for `--repo` LocationCli based runs.
