### PR TITLE
Remove Gradle wrapper version definition

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,10 +52,6 @@ sourceSets {
     }
 }
 
-wrapper {
-    gradleVersion = '7.6.1'
-}
-
 def installFrontend = tasks.register('installFrontend', com.liferay.gradle.plugins.node.tasks.ExecutePackageManagerTask) {
     workingDir 'frontend/'
     args = ['ci']


### PR DESCRIPTION
### Proposed commit message
<!--
    Propose a detailed commit message for this pull request within the triple backticks below.
    Wrap lines at 72 characters.

    Guide on how to write a good commit message:
    https://oss-generic.github.io/process/docs/FormatsAndConventions.html#commit-message
-->
```
The gradleVersion property of the wrapper fixes the Gradle version used
by the wrapper. This is confusing and difficult to maintain as Gradle
gets upgraded.

Let's remove the definition of the gradleVersion property in the
wrapper. This results in the current version of Gradle itself being used
for the wrapper too.
```

### Other information
<!--
    Are there other relevant information, such as special testing instructions,
    which will help the reviewer better understand the code?

    You may also include a brief description of why the problem occurred.
-->
I noticed that I missed out on updating the wrapper version when doing [previous upgrades of Gradle versions](https://github.com/reposense/RepoSense/pull/1919#pullrequestreview-1328993999).

Looking at the Gradle docs, it turns out that the `gradleVersion` property is for defining [what version of Gradle the wrapper itself is using](https://docs.gradle.org/7.6/dsl/org.gradle.api.tasks.wrapper.Wrapper.html#org.gradle.api.tasks.wrapper.Wrapper:gradleVersion). By default, it will match the version that Gradle itself uses. Hence, the removal of the definition.