### PR TITLE
[#1936] Migrate c-summary.vue to TypeScript

### DIFF
--- a/frontend/src/types/types.ts
+++ b/frontend/src/types/types.ts
@@ -27,7 +27,8 @@ export interface Commit extends DailyCommit {
   endDate?: string;
 }
 
-// User-defined type guard. https://www.typescriptlang.org/docs/handbook/advanced-types.html#user-defined-type-guards
+// This type predicate distinguishes between Commit and DailyCommit
+// https://www.typescriptlang.org/docs/handbook/2/narrowing.html#using-type-predicates
 export function isCommit(commit: Commit | DailyCommit): commit is Commit {
   return (commit as Commit).deletions !== undefined;
 }

--- a/frontend/src/types/types.ts
+++ b/frontend/src/types/types.ts
@@ -24,6 +24,12 @@ export interface DailyCommit {
 export interface Commit extends DailyCommit {
   deletions: number;
   insertions: number;
+  endDate?: string;
+}
+
+// User-defined type guard. https://www.typescriptlang.org/docs/handbook/advanced-types.html#user-defined-type-guards
+export function isCommit(commit: Commit | DailyCommit): commit is Commit {
+  return (commit as Commit).deletions !== undefined;
 }
 
 export interface User {

--- a/frontend/src/types/window.ts
+++ b/frontend/src/types/window.ts
@@ -46,7 +46,7 @@ declare global {
     getDateStr: (date: Date) => string;
     getHexToRGB: (color: string) => number[];
     getFontColor: (color: string) => string;
-    addHash: (newKey: string, newVal: string) => void;
+    addHash: (newKey: string, newVal: string | boolean) => void;
     removeHash: (key: string) => void;
     encodeHash: () => void;
     decodeHash: () => void;

--- a/frontend/src/types/window.ts
+++ b/frontend/src/types/window.ts
@@ -44,7 +44,7 @@ declare global {
     isMacintosh: boolean;
     REPORT_ZIP: JSZip | null;
     deactivateAllOverlays: () => void;
-    getDateStr: (date: Date) => string;
+    getDateStr: (date: number) => string;
     getHexToRGB: (color: string) => number[];
     getFontColor: (color: string) => string;
     addHash: (newKey: string, newVal: string | boolean) => void;

--- a/frontend/src/types/window.ts
+++ b/frontend/src/types/window.ts
@@ -13,7 +13,8 @@ interface ComparatorFunction<T> {
 }
 
 interface SortingFunction<T> {
-  (item: T, sortingOption?: string): T;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (item: T, sortingOption?: string): any;
 }
 
 interface Api {
@@ -50,7 +51,7 @@ declare global {
     removeHash: (key: string) => void;
     encodeHash: () => void;
     decodeHash: () => void;
-    comparator: <T> (fn: SortingFunction<T>, sortingOption: string) => ComparatorFunction<T>;
+    comparator: <T> (fn: SortingFunction<T>, sortingOption?: string) => ComparatorFunction<T>;
     filterUnsupported: (string: string) => string | undefined;
     getAuthorLink: (repoId: string, author: string) => string | undefined;
     getRepoLinkUnfiltered: (repoId: string) => string;

--- a/frontend/src/types/zod/commits-type.ts
+++ b/frontend/src/types/zod/commits-type.ts
@@ -35,3 +35,4 @@ export type Commits = z.infer<typeof commitsSchema>;
 export type CommitResultRaw = z.infer<typeof commitResult>;
 export type AuthorDailyContributions = z.infer<typeof authorDailyContributionsSchema>;
 export type AuthorFileTypeContributions = z.infer<typeof authorFileTypeContributionsSchema>;
+export type FileTypeAndContribution = z.infer<typeof fileTypesAndContributionSchema>;

--- a/frontend/src/utils/api.ts
+++ b/frontend/src/utils/api.ts
@@ -49,7 +49,7 @@ window.getFontColor = function getFontColor(color) {
 };
 
 window.addHash = function addHash(newKey, newVal) {
-  window.hashParams[newKey] = newVal;
+  window.hashParams[newKey] = newVal.toString();
 };
 
 window.removeHash = function removeHash(key) {

--- a/frontend/src/views/c-summary.vue
+++ b/frontend/src/views/c-summary.vue
@@ -127,28 +127,40 @@
   )
 </template>
 
-<script>
+<script lang='ts'>
 import { mapState } from 'vuex';
+import { PropType, defineComponent } from 'vue';
 
 import cSummaryCharts from '../components/c-summary-charts.vue';
 import getNonRepeatingColor from '../utils/ramp-colour-generator';
 import sortFiltered from '../utils/repo-sorter';
+import {
+  Commit,
+  DailyCommit,
+  Repo,
+  User,
+  isCommit,
+  CommitResult,
+} from '../types/types';
+import { ErrorMessage } from '../types/zod/summary-type';
+import { AuthorFileTypeContributions, FileTypeAndContribution } from '../types/zod/commits-type';
+import { ZoomInfo } from '../types/vuex.d';
 
 const getFontColor = window.getFontColor;
 const dateFormatRegex = /([12]\d{3}-(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01]))$/;
 
-export default {
+export default defineComponent({
   name: 'c-summary',
   components: {
     cSummaryCharts,
   },
   props: {
     repos: {
-      type: Array,
+      type: Array as PropType<Repo[]>,
       required: true,
     },
     errorMessages: {
-      type: Object,
+      type: Object as PropType<ErrorMessage>,
       default() {
         return {};
       },
@@ -156,9 +168,9 @@ export default {
   },
   data() {
     return {
-      checkedFileTypes: [],
-      fileTypes: [],
-      filtered: [],
+      checkedFileTypes: [] as string[],
+      fileTypes: [] as string[],
+      filtered: [] as User[][],
       filterSearch: '',
       filterGroupSelection: 'groupByRepos',
       sortGroupSelection: 'groupTitle', // UI for sorting groups
@@ -176,7 +188,7 @@ export default {
       filterHash: '',
       minDate: window.sinceDate,
       maxDate: window.untilDate,
-      fileTypeColors: {},
+      fileTypeColors: {} as { [key: string]: string },
       isSafariBrowser: /.*Version.*Safari.*/.test(navigator.userAgent),
       filterGroupSelectionWatcherFlag: false,
     };
@@ -186,7 +198,7 @@ export default {
       get() {
         return this.checkedFileTypes.length === this.fileTypes.length;
       },
-      set(value) {
+      set(value: boolean) {
         if (value) {
           this.checkedFileTypes = this.fileTypes.slice();
         } else {
@@ -200,7 +212,7 @@ export default {
       let totalLines = 0;
       let totalCount = 0;
       this.repos.forEach((repo) => {
-        repo.users.forEach((user) => {
+        repo.users?.forEach((user) => {
           if (user.checkedFileTypeContribution === undefined) {
             this.updateCheckedFileTypeContribution(user);
           }
@@ -221,9 +233,9 @@ export default {
         }
         return this.mergedGroups.length === this.filtered.length;
       },
-      set(value) {
+      set(value: boolean) {
         if (value) {
-          const mergedGroups = [];
+          const mergedGroups: string[] = [];
           this.filtered.forEach((group) => {
             mergedGroups.push(this.getGroupName(group));
           });
@@ -301,12 +313,14 @@ export default {
     }, 0);
   },
   methods: {
-    dismissTab(event) {
-      event.target.parentNode.style.display = 'none';
+    dismissTab(event: Event) {
+      if (event.target instanceof Element && event.target.parentNode instanceof HTMLElement) {
+        event.target.parentNode.style.display = 'none';
+      }
     },
 
     // view functions //
-    getReportIssueGitHubLink(stackTrace) {
+    getReportIssueGitHubLink(stackTrace: string) {
       return `${window.REPOSENSE_REPO_URL}/issues/new?title=${this.getReportIssueTitle()
       }&body=${this.getReportIssueMessage(stackTrace)}`;
     },
@@ -315,7 +329,7 @@ export default {
       return 'seer@comp.nus.edu.sg';
     },
 
-    getReportIssueEmailLink(stackTrace) {
+    getReportIssueEmailLink(stackTrace: string) {
       return `mailto:${this.getReportIssueEmailAddress()}?subject=${this.getReportIssueTitle()
       }&body=${this.getReportIssueMessage(stackTrace)}`;
     },
@@ -324,7 +338,7 @@ export default {
       return `${encodeURI('Unexpected error with RepoSense version ')}${window.repoSenseVersion}`;
     },
 
-    getReportIssueMessage(message) {
+    getReportIssueMessage(message: string) {
       return encodeURI(message);
     },
 
@@ -333,8 +347,9 @@ export default {
       this.filterSearch = '';
       this.getFiltered();
     },
-    updateFilterSearch(evt) {
-      this.filterSearch = evt.target.value;
+    updateFilterSearch(evt: Event) {
+      // Only called from an input onchange event, target guaranteed to be input element
+      this.filterSearch = (evt.target as HTMLInputElement).value;
       this.getFiltered();
     },
 
@@ -377,7 +392,7 @@ export default {
     },
 
     renderFilterHash() {
-      const convertBool = (txt) => (txt === 'true');
+      const convertBool = (txt: string) => (txt === 'true');
       const hash = Object.assign({}, window.hashParams);
 
       if (hash.search) { this.filterSearch = hash.search; }
@@ -414,11 +429,11 @@ export default {
       }
     },
 
-    getGroupName(group) {
+    getGroupName(group: User[]) {
       return window.getGroupName(group, this.filterGroupSelection);
     },
 
-    isMatchSearchedUser(filterSearch, user) {
+    isMatchSearchedUser(filterSearch: string, user: User) {
       return !filterSearch || filterSearch.toLowerCase()
         .split(' ')
         .filter(Boolean)
@@ -445,16 +460,16 @@ export default {
 
     getFilteredRepos() {
       // array of array, sorted by repo
-      const full = [];
+      const full: User[][] = [];
 
       // create deep clone of this.repos to not modify the original content of this.repos
       // when merging groups
-      const groups = this.hasMergedGroups() ? JSON.parse(JSON.stringify(this.repos)) : this.repos;
+      const groups = this.hasMergedGroups() ? JSON.parse(JSON.stringify(this.repos)) as Repo[] : this.repos;
       groups.forEach((repo) => {
-        const res = [];
+        const res: User[] = [];
 
         // filtering
-        repo.users.forEach((user) => {
+        repo.users?.forEach((user) => {
           if (this.isMatchSearchedUser(this.filterSearch, user)) {
             this.getUserCommits(user, this.filterSinceDate, this.filterUntilDate);
             if (this.filterTimeFrame === 'week') {
@@ -484,13 +499,13 @@ export default {
       this.filtered = sortFiltered(this.filtered, filterControl);
     },
 
-    updateMergedGroup(allGroupsMerged) {
+    updateMergedGroup(allGroupsMerged: boolean) {
       // merge group is not allowed when group by none
       // also reset merged groups
       if (this.filterGroupSelection === 'groupByNone' || !allGroupsMerged) {
         this.$store.commit('updateMergedGroup', []);
       } else {
-        const mergedGroups = [];
+        const mergedGroups: string[] = [];
         this.filtered.forEach((group) => {
           mergedGroups.push(this.getGroupName(group));
         });
@@ -506,16 +521,16 @@ export default {
       });
     },
 
-    mergeGroupByIndex(filtered, groupIndex) {
-      const dateToIndexMap = {};
-      const dailyIndexMap = {};
-      const mergedCommits = [];
-      const mergedDailyCommits = [];
-      const mergedFileTypeContribution = {};
+    mergeGroupByIndex(filtered: User[][], groupIndex: number) {
+      const dateToIndexMap: { [key: string]: number } = {};
+      const dailyIndexMap: { [key: string]: number } = {};
+      const mergedCommits: Commit[] = [];
+      const mergedDailyCommits: DailyCommit[] = [];
+      const mergedFileTypeContribution: AuthorFileTypeContributions = {};
       let mergedVariance = 0;
       let totalMergedCheckedFileTypeCommits = 0;
       filtered[groupIndex].forEach((user) => {
-        user.commits.forEach((commit) => {
+        user.commits?.forEach((commit) => {
           this.mergeCommits(commit, user, dateToIndexMap, mergedCommits);
         });
         user.dailyCommits.forEach((commit) => {
@@ -542,9 +557,14 @@ export default {
       return this.mergedGroups.length > 0;
     },
 
-    mergeCommits(commit, user, dateToIndexMap, merged) {
+    mergeCommits(
+      commit: Commit | DailyCommit,
+      user: User,
+      dateToIndexMap: { [key: string]: number },
+      merged: Commit[] | DailyCommit[],
+    ) {
       const {
-        commitResults, date, insertions, deletions,
+        commitResults, date,
       } = commit;
 
       // bind repoId to each commit
@@ -558,16 +578,18 @@ export default {
         commitResults.forEach((commitResult) => {
           commitWithSameDate.commitResults.push(commitResult);
         });
-
-        commitWithSameDate.insertions += insertions;
-        commitWithSameDate.deletions += deletions;
+        if (isCommit(commit) && isCommit(commitWithSameDate)) {
+          const { insertions, deletions } = commit;
+          commitWithSameDate.insertions += insertions;
+          commitWithSameDate.deletions += deletions;
+        }
       } else {
         dateToIndexMap[date] = Object.keys(dateToIndexMap).length;
         merged.push(JSON.parse(JSON.stringify(commit)));
       }
     },
 
-    mergeFileTypeContribution(user, merged) {
+    mergeFileTypeContribution(user: User, merged: AuthorFileTypeContributions) {
       Object.entries(user.fileTypeContribution).forEach((fileType) => {
         const key = fileType[0];
         const value = fileType[1];
@@ -583,11 +605,11 @@ export default {
       const selectedColors = ['#ffe119', '#4363d8', '#3cb44b', '#f58231', '#911eb4', '#46f0f0', '#f032e6',
         '#bcf60c', '#fabebe', '#008080', '#e6beff', '#9a6324', '#fffac8', '#800000', '#aaffc3', '#808000', '#ffd8b1',
         '#000075', '#808080'];
-      const fileTypeColors = {};
+      const fileTypeColors = {} as { [key: string]: string };
       let i = 0;
 
       this.repos.forEach((repo) => {
-        repo.users.forEach((user) => {
+        repo.users?.forEach((user) => {
           Object.keys(user.fileTypeContribution).forEach((fileType) => {
             if (!Object.prototype.hasOwnProperty.call(fileTypeColors, fileType)) {
               if (i < selectedColors.length) {
@@ -609,10 +631,13 @@ export default {
       this.$store.commit('updateFileTypeColors', this.fileTypeColors);
     },
 
-    splitCommitsWeek(user, sinceDate, untilDate) {
+    splitCommitsWeek(user: User, sinceDate: string, untilDate: string) {
       const { commits } = user;
+      if (commits === undefined) {
+        return;
+      }
 
-      const res = [];
+      const res: Commit[] = [];
 
       const nextMondayDate = this.dateRounding(sinceDate, 0); // round up for the next monday
 
@@ -629,7 +654,7 @@ export default {
       user.commits = res;
     },
 
-    pushCommitsWeek(sinceMs, untilMs, res, commits) {
+    pushCommitsWeek(sinceMs: number, untilMs: number, res: Commit[], commits: Commit[]) {
       const diff = Math.round(Math.abs((untilMs - sinceMs) / window.DAY_IN_MS));
       const weekInMS = window.DAY_IN_MS * 7;
 
@@ -638,7 +663,7 @@ export default {
         const endOfWeekMs = startOfWeekMs + weekInMS - window.DAY_IN_MS;
         const endOfWeekMsWithinUntilMs = endOfWeekMs <= untilMs ? endOfWeekMs : untilMs;
 
-        const week = {
+        const week: Commit = {
           insertions: 0,
           deletions: 0,
           date: window.getDateStr(startOfWeekMs),
@@ -653,20 +678,25 @@ export default {
       }
     },
 
-    addLineContributionWeek(endOfWeekMs, week, commits) {
+    addLineContributionWeek(endOfWeekMs: number, week: Commit, commits: Commit[]) {
       // commits are not contiguous, meaning there are gaps of days without
       // commits, so we are going to check each commit's date and make sure
       // it is within the duration of a week
       while (commits.length > 0
           && (new Date(commits[0].date)).getTime() <= endOfWeekMs) {
         const commit = commits.shift();
+        // shift() never returns undefined here because we check for commits.length > 0,
+        // but TypeScript is unable to infer this
+        if (commit === undefined) {
+          break;
+        }
         week.insertions += commit.insertions;
         week.deletions += commit.deletions;
         commit.commitResults.forEach((commitResult) => week.commitResults.push(commitResult));
       }
     },
 
-    getUserCommits(user, sinceDate, untilDate) {
+    getUserCommits(user: User, sinceDate: string, untilDate: string) {
       user.commits = [];
       const userFirst = user.dailyCommits[0];
       const userLast = user.dailyCommits[user.dailyCommits.length - 1];
@@ -686,7 +716,7 @@ export default {
       user.dailyCommits.forEach((commit) => {
         const { date } = commit;
         if (date >= sinceDate && date <= untilDate) {
-          const filteredCommit = JSON.parse(JSON.stringify(commit));
+          const filteredCommit: DailyCommit = JSON.parse(JSON.stringify(commit));
           this.filterCommitByCheckedFileTypes(filteredCommit);
 
           if (filteredCommit.commitResults.length > 0) {
@@ -695,7 +725,9 @@ export default {
                 commitResult.isOpen = true;
               }
             });
-            user.commits.push(filteredCommit);
+            // The typecast is safe here as we add the insertions and deletions fields
+            // in the filterCommitByCheckedFileTypes method above
+            user.commits?.push(filteredCommit as Commit);
           }
         }
       });
@@ -703,7 +735,7 @@ export default {
       return null;
     },
 
-    filterCommitByCheckedFileTypes(commit) {
+    filterCommitByCheckedFileTypes(commit: DailyCommit) {
       let commitResults = commit.commitResults.map((result) => {
         const filteredFileTypes = this.getFilteredFileTypes(result);
         this.updateCommitResultWithFileTypes(result, filteredFileTypes);
@@ -716,28 +748,32 @@ export default {
         );
       }
 
-      commit.insertions = commitResults.reduce((acc, result) => acc + result.insertions, 0);
-      commit.deletions = commitResults.reduce((acc, result) => acc + result.deletions, 0);
+      // Typecast from DailyCommit to Commit as we add insertions and deletions fields
+      (commit as Commit).insertions = commitResults.reduce((acc, result) => acc + result.insertions, 0);
+      (commit as Commit).deletions = commitResults.reduce((acc, result) => acc + result.deletions, 0);
       commit.commitResults = commitResults;
     },
 
-    getFilteredFileTypes(commitResult) {
+    getFilteredFileTypes(commitResult: CommitResult) {
       return Object.keys(commitResult.fileTypesAndContributionMap)
         .filter(this.isFileTypeChecked)
-        .reduce((obj, fileType) => {
+        .reduce((obj: { [key: string]: FileTypeAndContribution }, fileType) => {
           obj[fileType] = commitResult.fileTypesAndContributionMap[fileType];
           return obj;
         }, {});
     },
 
-    isFileTypeChecked(fileType) {
+    isFileTypeChecked(fileType: string) {
       if (this.filterBreakdown) {
         return this.checkedFileTypes.includes(fileType);
       }
       return true;
     },
 
-    updateCommitResultWithFileTypes(commitResult, filteredFileTypes) {
+    updateCommitResultWithFileTypes(
+      commitResult: CommitResult,
+      filteredFileTypes: { [key: string]: FileTypeAndContribution },
+    ) {
       commitResult.insertions = Object.values(filteredFileTypes)
         .reduce((acc, fileType) => acc + fileType.insertions, 0);
       commitResult.deletions = Object.values(filteredFileTypes)
@@ -761,43 +797,45 @@ export default {
       this.getFiltered();
     },
 
-    updateTmpFilterSinceDate(event) {
-      const since = event.target.value;
+    updateTmpFilterSinceDate(event: Event) {
+      // Only called from an input onchange event, target guaranteed to be input element
+      const since = (event.target as HTMLInputElement).value;
       this.hasModifiedSinceDate = true;
 
       if (!this.isSafariBrowser) {
         this.tmpFilterSinceDate = since;
-        event.target.value = this.filterSinceDate;
+        (event.target as HTMLInputElement).value = this.filterSinceDate;
         this.getFiltered();
       } else if (dateFormatRegex.test(since) && since >= this.minDate) {
         this.tmpFilterSinceDate = since;
-        event.currentTarget.style.removeProperty('border-bottom-color');
+        (event.currentTarget as HTMLInputElement).style.removeProperty('border-bottom-color');
         this.getFiltered();
       } else {
         // invalid since date detected
-        event.currentTarget.style.borderBottomColor = 'red';
+        (event.currentTarget as HTMLInputElement).style.borderBottomColor = 'red';
       }
     },
 
-    updateTmpFilterUntilDate(event) {
-      const until = event.target.value;
+    updateTmpFilterUntilDate(event: Event) {
+      // Only called from an input onchange event, target guaranteed to be input element
+      const until = (event.target as HTMLInputElement).value;
       this.hasModifiedUntilDate = true;
 
       if (!this.isSafariBrowser) {
         this.tmpFilterUntilDate = until;
-        event.target.value = this.filterUntilDate;
+        (event.target as HTMLInputElement).value = this.filterUntilDate;
         this.getFiltered();
       } else if (dateFormatRegex.test(until) && until <= this.maxDate) {
         this.tmpFilterUntilDate = until;
-        event.currentTarget.style.removeProperty('border-bottom-color');
+        (event.currentTarget as HTMLInputElement).style.removeProperty('border-bottom-color');
         this.getFiltered();
       } else {
         // invalid until date detected
-        event.currentTarget.style.borderBottomColor = 'red';
+        (event.currentTarget as HTMLInputElement).style.borderBottomColor = 'red';
       }
     },
 
-    updateCheckedFileTypeContribution(ele) {
+    updateCheckedFileTypeContribution(ele: User) {
       let validCommits = 0;
       Object.keys(ele.fileTypeContribution).forEach((fileType) => {
         if (!this.filterBreakdown) {
@@ -809,17 +847,17 @@ export default {
       ele.checkedFileTypeContribution = validCommits;
     },
 
-    restoreZoomFiltered(info) {
+    restoreZoomFiltered(info: ZoomInfo) {
       const {
         zSince, zUntil, zTimeFrame, zIsMerged, zFilterSearch,
       } = info;
-      const filtered = [];
+      const filtered: User[][] = [];
 
-      const groups = JSON.parse(JSON.stringify(this.repos));
+      const groups: Repo[] = JSON.parse(JSON.stringify(this.repos));
 
-      const res = [];
+      const res: User[] = [];
       groups.forEach((repo) => {
-        repo.users.forEach((user) => {
+        repo.users?.forEach((user) => {
           // only filter users that match with zoom user and previous searched user
           if (this.matchZoomUser(info, user) && this.isMatchSearchedUser(zFilterSearch, user)) {
             this.getUserCommits(user, zSince, zUntil);
@@ -844,7 +882,7 @@ export default {
       info.isRefreshing = false;
       this.$store.commit('updateTabZoomInfo', info);
     },
-    matchZoomUser(info, user) {
+    matchZoomUser(info: ZoomInfo, user: User) {
       const {
         zIsMerged, zFilterGroup, zRepo, zAuthor,
       } = info;
@@ -856,7 +894,7 @@ export default {
       return user.repoName === zRepo && user.name === zAuthor;
     },
 
-    dateRounding(datestr, roundDown) {
+    dateRounding(datestr: string, roundDown: number) {
       // rounding up to nearest monday
       const date = new Date(datestr);
       const day = date.getUTCDay();
@@ -872,7 +910,7 @@ export default {
 
     getFontColor,
   },
-};
+});
 </script>
 
 <!-- Add "scoped" attribute to limit CSS to this component only -->


### PR DESCRIPTION
<!--
    If this pull request fully addresses an issue, use:
    Fixes #xxxx

    If this pull request partially addresses an issue, use:
    Part of #xxxx

    If this pull request addresses multiple issues, put them in multiple lines:
    Fixes #xxxx
    Fixes #yyyy

    Format the title of the pull request with most relevant issue number as follows:
    [#xxxx] Title
-->
Part of #1936

### Proposed commit message
<!--
    Propose a detailed commit message for this pull request within the triple backticks below.
    Wrap lines at 72 characters.

    Guide on how to write a good commit message:
    https://oss-generic.github.io/process/docs/FormatsAndConventions.html#commit-message
-->
```
Currently, despite the addition of TypeScript support, the frontend is
still largely written in JavaScript. This results in a lack of type
safety and many complex objects being passed around as unknown types,
which may in turn lead to errors.

Let's migrate one of the main components, c-summary.vue, to TypeScript.
In addition to providing greater type safety, the migration of this
component will also allow the migration of its child components, such
as c-summary-charts.vue.
```

### Other information
<!--
    Are there other relevant information, such as special testing instructions,
    which will help the reviewer better understand the code?

    You may also include a brief description of why the problem occurred.
-->
### Forcing `hashParams` values to strings
One change that is included in this PR is [storing all the values of `window.hashParams` as strings](https://github.com/reposense/RepoSense/commit/5bd37bc45106edbed6a56c5ef0fd227e0af4b2d9) instead of strings or booleans.  This was done to prevent having to check/typecast between string/boolean constantly.

This should be safe because although the values of the hashParams object are sometimes set to booleans, they aren't ever referenced as booleans, and are decoded back as strings before being used.
- [In the root component `app.vue`](https://github.com/reposense/RepoSense/blob/master/frontend/src/app.vue#L313), on `created()`, the `window.decodeHash()` function is called, which [converts all `hashParams` values to strings](https://github.com/reposense/RepoSense/blob/master/frontend/src/utils/api.ts#L80).
- The rest of the codebase already treats the values of the `hashParams` values as strings:
  - https://github.com/reposense/RepoSense/blob/master/frontend/src/app.vue#L224
  - https://github.com/reposense/RepoSense/blob/master/frontend/src/app.vue#L240
  - https://github.com/reposense/RepoSense/blob/master/frontend/src/views/c-authorship.vue#L364
  - https://github.com/reposense/RepoSense/blob/master/frontend/src/views/c-zoom.vue#L324
### `any` type for comparator
When typing the `window.comparator` method, I mistakenly thought that the sorting function `fn` returned the same type - but this is not the case [e.g. takes in a Commit but returns a date string](https://github.com/reposense/RepoSense/blob/master/frontend/src/views/c-summary.vue#L530). I couldn't find anything like a comparable type for TypeScript, so I think we have to use any here. (Please correct me if I'm wrong!)
