### PR TITLE
[#1945] Enforce stricter formatting rules for TypeScript files

### DIFF
--- a/docs/dg/styleGuides.md
+++ b/docs/dg/styleGuides.md
@@ -124,8 +124,9 @@ public LocalDateTime parseDate(String dateString) throws NullPointerException, P
 }
 ```
 ## TypeScript specific formatting
+
 For TypeScript specific code, such as within an `interface` or type annotations, we also stipulate the following standards:
-- Use semicolons as delimiters for TypeScript interfaces and types.
+* Use semicolons as delimiters for TypeScript interfaces and types.
 
 Negative Examples:
 ```typescript
@@ -149,7 +150,7 @@ interface Foo {
     greet(): string;
 }
 ```
-- For type annotations, use a space after but not before.
+* For type annotations, use a space after but not before.
 
 Negative Examples:
 ```typescript
@@ -183,4 +184,3 @@ class Foo {
     name: string;
 }
 ```
-

--- a/docs/dg/styleGuides.md
+++ b/docs/dg/styleGuides.md
@@ -16,6 +16,7 @@ Our coding standards are mostly based on those at [se-education.org/guides](http
 * [**Markdown/MarkBind** coding standard](https://se-education.org/guides/conventions/markdown.html)
 * [**Java** coding standard](https://se-education.org/guides/conventions/java/index.html)
 * [**JavaScript** coding standard](https://se-education.org/guides/conventions/javascript.html)
+* **TypeScript**: In addition to the JavaScript coding standard, follow the [**recommended ESLint rules**](https://typescript-eslint.io/rules/) and the formatting rules [described below](#typescript-specific-formatting).
 * **Vue Components**: Follow the [**Vue style guide**](https://vuejs.org/style-guide/), up to the **Recommended** section.
 * **Documentation**: Follow the [**Google developer documentation style guide**](https://developers.google.com/style).
 
@@ -122,5 +123,64 @@ public LocalDateTime parseDate(String dateString) throws NullPointerException, P
     // Code here
 }
 ```
+## TypeScript specific formatting
+For TypeScript specific code, such as within an `interface` or type annotations, we also stipulate the following standards:
+- Use semicolons as delimiters for TypeScript interfaces and types.
 
+Negative Examples:
+```typescript
+// missing semicolon delimiter
+interface Foo {
+    name: string
+    greet(): string
+}
+
+// using incorrect delimiter
+interface Foo {
+    name: string,
+    greet(): string,
+}
+```
+Positive Example:
+```typescript
+// semicolon delimiter
+interface Foo {
+    name: string;
+    greet(): string;
+}
+```
+- For type annotations, use a space after but not before.
+
+Negative Examples:
+```typescript
+let foo:string = "bar";
+let foo :string = "bar";
+let foo : string = "bar";
+
+function foo():string {}
+function foo() :string {}
+function foo() : string {}
+
+class Foo {
+    name:string;
+}
+
+class Foo {
+    name :string;
+}
+
+class Foo {
+    name : string;
+}
+```
+Positive Examples:
+```typescript
+let foo: string = "bar";
+
+function foo(): string {}
+
+class Foo {
+    name: string;
+}
+```
 

--- a/frontend/.eslintrc.json
+++ b/frontend/.eslintrc.json
@@ -76,7 +76,8 @@
             ],
             "SwitchCase": 0
           }
-        ]
+        ],
+        "@typescript-eslint/member-delimiter-style": "error"
       }
     }
   ]

--- a/frontend/.eslintrc.json
+++ b/frontend/.eslintrc.json
@@ -77,7 +77,8 @@
             "SwitchCase": 0
           }
         ],
-        "@typescript-eslint/member-delimiter-style": "error"
+        "@typescript-eslint/member-delimiter-style": "error",
+        "@typescript-eslint/type-annotation-spacing": "error"
       }
     }
   ]

--- a/frontend/src/types/window.ts
+++ b/frontend/src/types/window.ts
@@ -19,10 +19,10 @@ interface SortingFunction<T> {
 interface Api {
   loadJSON: (fname: string) => Promise<unknown>;
   loadSummary: () => Promise<{
-    creationDate: string,
-    reportGenerationTime: string,
-    errorMessages: { [key: string]: ErrorMessage },
-    names: string[],
+    creationDate: string;
+    reportGenerationTime: string;
+    errorMessages: { [key: string]: ErrorMessage };
+    names: string[];
   } | null>;
   loadCommits: (repoName: string) => Promise<User[]>;
   loadAuthorship: (repoName: string) => Promise<AuthorshipSchema>;

--- a/frontend/src/utils/user.ts
+++ b/frontend/src/utils/user.ts
@@ -2,7 +2,7 @@ import { Commit, DailyCommit, User as UserType } from '../types/types';
 import { AuthorFileTypeContributions } from '../types/zod/commits-type';
 
 export default class User implements UserType {
-  checkedFileTypeContribution : number;
+  checkedFileTypeContribution: number;
 
   commits: Commit[];
 


### PR DESCRIPTION
<!--
    If this pull request fully addresses an issue, use:
    Fixes #xxxx

    If this pull request partially addresses an issue, use:
    Part of #xxxx

    If this pull request addresses multiple issues, put them in multiple lines:
    Fixes #xxxx
    Fixes #yyyy

    Format the title of the pull request with most relevant issue number as follows:
    [#xxxx] Title
-->
Fixes #1945 

### Proposed commit message
<!--
    Propose a detailed commit message for this pull request within the triple backticks below.
    Wrap lines at 72 characters.

    Guide on how to write a good commit message:
    https://oss-generic.github.io/process/docs/FormatsAndConventions.html#commit-message
-->
```
Currently, our ESLint ruleset does not enforce certain formatting rules
for TypeScript code, such as delimiters in TypeScript interfaces and
spacing in type annotations.

Let's update the ESLint ruleset to check for proper delimiters and
spacing in type annotations. This will enforce consistency throughout
the codebase and improve code readability.
```

### Other information
<!--
    Are there other relevant information, such as special testing instructions,
    which will help the reviewer better understand the code?

    You may also include a brief description of why the problem occurred.
-->
Most of the information is in #1945. The first rule enforces semicolons as delimiters in TypeScript interfaces, and the second rule enforces the following format for type annotations: `foo: string` over `foo : string` or `foo :string`.