### PR TITLE
[#1967] Use GitHub environmental files instead of set-output

### DIFF
--- a/.github/workflows/surge.yml
+++ b/.github/workflows/surge.yml
@@ -37,7 +37,7 @@ jobs:
 
     - name: Extract PR number
       id: pr-number
-      run: echo '::set-output name=ACTIONS_PR_NUMBER::'$(cat ./pr/NUMBER)
+      run: echo 'ACTIONS_PR_NUMBER=$(cat ./pr/NUMBER)' >> $GITHUB_OUTPUT
 
     - name: Download deployment status artifacts
       uses: dawidd6/action-download-artifact@v2

--- a/.github/workflows/surge.yml
+++ b/.github/workflows/surge.yml
@@ -37,7 +37,7 @@ jobs:
 
     - name: Extract PR number
       id: pr-number
-      run: echo 'ACTIONS_PR_NUMBER=$(cat ./pr/NUMBER)' >> $GITHUB_OUTPUT
+      run: echo 'ACTIONS_PR_NUMBER='$(cat ./pr/NUMBER) >> $GITHUB_OUTPUT
 
     - name: Download deployment status artifacts
       uses: dawidd6/action-download-artifact@v2


### PR DESCRIPTION
<!--
    If this pull request fully addresses an issue, use:
    Fixes #xxxx

    If this pull request partially addresses an issue, use:
    Part of #xxxx

    If this pull request addresses multiple issues, put them in multiple lines:
    Fixes #xxxx
    Fixes #yyyy

    Format the title of the pull request with most relevant issue number as follows:
    [#xxxx] Title
-->
Fixes #1967

### Proposed commit message
<!--
    Propose a detailed commit message for this pull request within the triple backticks below.
    Wrap lines at 72 characters.

    Guide on how to write a good commit message:
    https://oss-generic.github.io/process/docs/FormatsAndConventions.html#commit-message
-->
```
surge.yml currently uses set-output to extract and save the PR number
for use as part of the surge.sh preview domain. However, GitHub will be
deprecating set-output for security reasons.

Let's update surge.yml to use the new GITHUB_OUTPUT environment files
instead.
```

### Other information
<!--
    Are there other relevant information, such as special testing instructions,
    which will help the reviewer better understand the code?

    You may also include a brief description of why the problem occurred.
-->
The change were as per [GitHub's article](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/).

While our surge.sh preview is still currently down, the correctness of this PR can be checked against the link produced.
