### PR TITLE
[#1881] Check if author config file exists instead of detecting it via an exception

### DIFF
--- a/src/main/java/reposense/model/ConfigRunConfiguration.java
+++ b/src/main/java/reposense/model/ConfigRunConfiguration.java
@@ -1,7 +1,8 @@
 package reposense.model;
 
-import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -40,27 +41,29 @@ public class ConfigRunConfiguration implements RunConfiguration {
         List<AuthorConfiguration> authorConfigs;
         List<GroupConfiguration> groupConfigs;
 
-        try {
-            authorConfigs = new AuthorConfigCsvParser(cliArguments.getAuthorConfigFilePath()).parse();
-            RepoConfiguration.merge(repoConfigs, authorConfigs);
-            RepoConfiguration.setHasAuthorConfigFileToRepoConfigs(repoConfigs, true);
-        } catch (FileNotFoundException fnfe) {
-            // FileNotFoundException thrown as author-config.csv is not found.
-            // Ignore exception as the file is optional.
-        } catch (IOException | InvalidCsvException e) {
-            // for all IO and invalid csv exceptions, log the error and continue
-            logger.log(Level.WARNING, e.getMessage(), e);
+        Path authorConfigFilePath = cliArguments.getAuthorConfigFilePath();
+        Path groupConfigFilePath = cliArguments.getGroupConfigFilePath();
+
+
+        if (authorConfigFilePath != null && Files.exists(authorConfigFilePath)) {
+            try {
+                authorConfigs = new AuthorConfigCsvParser(cliArguments.getAuthorConfigFilePath()).parse();
+                RepoConfiguration.merge(repoConfigs, authorConfigs);
+                RepoConfiguration.setHasAuthorConfigFileToRepoConfigs(repoConfigs, true);
+            } catch (IOException | InvalidCsvException e) {
+                // for all IO and invalid csv exceptions, log the error and continue
+                logger.log(Level.WARNING, e.getMessage(), e);
+            }
         }
 
-        try {
-            groupConfigs = new GroupConfigCsvParser(cliArguments.getGroupConfigFilePath()).parse();
-            RepoConfiguration.setGroupConfigsToRepos(repoConfigs, groupConfigs);
-        } catch (FileNotFoundException fnfe) {
-            // FileNotFoundException thrown as groups-config.csv is not found.
-            // Ignore exception as the file is optional.
-        } catch (IOException | InvalidCsvException e) {
-            // for all other IO and invalid csv exceptions, log the error and continue
-            logger.log(Level.WARNING, e.getMessage(), e);
+        if (groupConfigFilePath != null && Files.exists(groupConfigFilePath)) {
+            try {
+                groupConfigs = new GroupConfigCsvParser(cliArguments.getGroupConfigFilePath()).parse();
+                RepoConfiguration.setGroupConfigsToRepos(repoConfigs, groupConfigs);
+            } catch (IOException | InvalidCsvException e) {
+                // for all IO and invalid csv exceptions, log the error and continue
+                logger.log(Level.WARNING, e.getMessage(), e);
+            }
         }
 
         return repoConfigs;


### PR DESCRIPTION
Fixes #1881

```
Currently, for both detection of author config and group config, it relies 
on running the code normally as if the file is always present and 
catching the FileNotFoundException to determine 
if the file is not present.

Let's refactor the code to detect if the file does not exist using 
an `if` block instead of catching it in the try-catch 
block
```
