### PR TITLE
[#1968] Incorrect dropdown box for config in UG: Customizing Report

### DIFF
--- a/docs/ug/cli.md
+++ b/docs/ug/cli.md
@@ -56,7 +56,7 @@ The section below provides explanations for each of the flags.
 
 * Cannot be used with `--repos`. The `--repos` flag will take precedence over this flag.
 * If both `--repos` and `--config` are not specified, RepoSense looks for config files in the `./config` directory.
-* Config files must follow [this](./#configFiles.html) format.
+* Config files must follow [this](../#configFiles.html) format.
 </box>
 </div>
 

--- a/docs/ug/cli.md
+++ b/docs/ug/cli.md
@@ -28,7 +28,7 @@ The section below provides explanations for each of the flags.
 
 ### `--assets`, `-a`
 
-<div id="section-config">
+<div id="section-assets">
 
 **`--assets ASSETS_DIRECTORY`**: Specifies where to place assets for report generation.
 * Parameter: `ASSETS_DIRECTORY` The directory containing the assets files. A `favicon.ico` file can be placed here to customize the favicon of the dashboard.

--- a/docs/ug/cli.md
+++ b/docs/ug/cli.md
@@ -56,7 +56,7 @@ The section below provides explanations for each of the flags.
 
 * Cannot be used with `--repos`. The `--repos` flag will take precedence over this flag.
 * If both `--repos` and `--config` are not specified, RepoSense looks for config files in the `./config` directory.
-* Config files must follow [this](#configFiles.html) format.
+* Config files must follow [this](./#configFiles.html) format.
 </box>
 </div>
 

--- a/docs/ug/cli.md
+++ b/docs/ug/cli.md
@@ -56,7 +56,7 @@ The section below provides explanations for each of the flags.
 
 * Cannot be used with `--repos`. The `--repos` flag will take precedence over this flag.
 * If both `--repos` and `--config` are not specified, RepoSense looks for config files in the `./config` directory.
-* Config files must follow [this](../#configFiles.html) format.
+* Config files must follow [this](./#configFiles.html) format.
 </box>
 </div>
 

--- a/docs/ug/cli.md
+++ b/docs/ug/cli.md
@@ -56,6 +56,7 @@ The section below provides explanations for each of the flags.
 
 * Cannot be used with `--repos`. The `--repos` flag will take precedence over this flag.
 * If both `--repos` and `--config` are not specified, RepoSense looks for config files in the `./config` directory.
+* Config files must follow [this](#configFiles.html) format.
 </box>
 </div>
 


### PR DESCRIPTION
Fixes #1968

```
There is a bug in the UG where the assets syntax is incorrectly
displayed under the config section instead of the correct config
syntax. This could potentially confuse users.

Let's fix the bug by displaying the correct config syntax, and add a
link to the page that explains the format of config files, for user
convenience.

```
https://docs-1950-pr-reposense-reposense.surge.sh/ug/customizingReports.html#customize-using-csv-config-files

