### PR TITLE
[#1943] Make ErrorSummary non-static by removing singleton design pattern 

### DIFF
--- a/docs/dg/learningBasics.md
+++ b/docs/dg/learningBasics.md
@@ -226,7 +226,7 @@ Here are some small tasks for you to gain some basic knowledge of the code relat
   Add this to the catch block of `spawnCloneProcess` and `waitForCloneProcess`, so that the message will be captured in `summary.json`.
 
   ```
-  ErrorSummary.getInstance().addErrorMessage(config.getDisplayName(), e.getMessage());
+  new ErrorSummary().addErrorMessage(config.getDisplayName(), e.getMessage());
   ```
   </panel>
 

--- a/src/main/java/reposense/model/RepoLocation.java
+++ b/src/main/java/reposense/model/RepoLocation.java
@@ -55,6 +55,8 @@ public class RepoLocation {
     private final transient String outputFolderRepoName;
     private final transient String outputFolderOrganization;
 
+    private final ErrorSummary errorSummary = new ErrorSummary();
+
     /**
      * Creates {@link RepoLocation} based on the {@code location}, which is represented by a {@code URL}
      * or {@link Path}.
@@ -110,6 +112,10 @@ public class RepoLocation {
         return domainName;
     }
 
+    public ErrorSummary getErrorSummary() {
+        return errorSummary;
+    }
+
     /**
      * Returns true if {@code repoArgument} is a valid local repository argument.
      * This implementation follows directly from the {@code git clone}
@@ -159,7 +165,7 @@ public class RepoLocation {
         Matcher localRepoMatcher = localRepoPattern.matcher(location);
 
         if (!localRepoMatcher.matches()) {
-            ErrorSummary.getInstance().addErrorMessage(location,
+            errorSummary.addErrorMessage(location,
                     String.format(MESSAGE_INVALID_LOCATION, location));
             throw new InvalidLocationException(String.format(MESSAGE_INVALID_LOCATION, location));
         }
@@ -185,14 +191,14 @@ public class RepoLocation {
             try {
                 new URI(location);
             } catch (URISyntaxException e) {
-                ErrorSummary.getInstance().addErrorMessage(location,
+                errorSummary.addErrorMessage(location,
                         String.format(MESSAGE_INVALID_REMOTE_URL, location));
                 throw new InvalidLocationException(String.format(MESSAGE_INVALID_REMOTE_URL, location));
             }
         }
         boolean isValidRemoteRepoUrl = remoteRepoMatcher.matches() || sshRepoMatcher.matches();
         if (!isValidRemoteRepoUrl) {
-            ErrorSummary.getInstance().addErrorMessage(location,
+            errorSummary.addErrorMessage(location,
                     String.format(MESSAGE_INVALID_REMOTE_URL, location));
             throw new InvalidLocationException(String.format(MESSAGE_INVALID_REMOTE_URL, location));
         }

--- a/src/main/java/reposense/report/ErrorSummary.java
+++ b/src/main/java/reposense/report/ErrorSummary.java
@@ -9,15 +9,7 @@ import java.util.Set;
  * Holds the data of set of repos that failed to analyze and the reasons for the failed operation.
  */
 public class ErrorSummary {
-    private static ErrorSummary instance = null;
-    private static Set<Map<String, String>> errorSet = new HashSet<>();
-
-    public static ErrorSummary getInstance() {
-        if (instance == null) {
-            instance = new ErrorSummary();
-        }
-        return instance;
-    }
+    private Set<Map<String, String>> errorSet = new HashSet<>();
 
     /**
      * Adds an error message for {@code repoName} with the reason {@code errorMessage} into a set of errors.

--- a/src/main/java/reposense/report/ReportGenerator.java
+++ b/src/main/java/reposense/report/ReportGenerator.java
@@ -92,6 +92,8 @@ public class ReportGenerator {
     private LocalDateTime earliestSinceDate = null;
     private ProgressTracker progressTracker = null;
 
+    private ErrorSummary errorSummary = new ErrorSummary();
+
     /**
      * Generates the authorship and commits JSON file for each repo in {@code configs} at {@code outputPath}, as
      * well as the summary JSON file of all the repos.
@@ -135,7 +137,7 @@ public class ReportGenerator {
         Optional<Path> summaryPath = FileUtil.writeJsonFile(
                 new SummaryJson(configs, reportConfig, generationDate,
                         reportSinceDate, untilDate, isSinceDateProvided,
-                        isUntilDateProvided, RepoSense.getVersion(), ErrorSummary.getInstance().getErrorSet(),
+                        isUntilDateProvided, RepoSense.getVersion(), errorSummary.getErrorSet(),
                         reportGenerationTimeProvider.get(), zoneId),
                 getSummaryResultPath(outputPath));
         summaryPath.ifPresent(reportFoldersAndFiles::add);
@@ -456,7 +458,7 @@ public class ReportGenerator {
         while (itr.hasNext()) {
             RepoConfiguration config = itr.next();
             if (failedConfigs.contains(config)) {
-                ErrorSummary.getInstance().addErrorMessage(config.getDisplayName(), errorMessage);
+                errorSummary.addErrorMessage(config.getDisplayName(), errorMessage);
                 itr.remove();
             }
         }

--- a/src/systemtest/java/reposense/ConfigSystemTest.java
+++ b/src/systemtest/java/reposense/ConfigSystemTest.java
@@ -18,7 +18,6 @@ import org.junit.jupiter.api.parallel.ExecutionMode;
 import reposense.git.GitVersion;
 import reposense.model.SupportedDomainUrlMap;
 import reposense.parser.SinceDateArgumentType;
-import reposense.report.ErrorSummary;
 import reposense.util.FileUtil;
 import reposense.util.InputBuilder;
 import reposense.util.SystemTestUtil;
@@ -39,7 +38,6 @@ public class ConfigSystemTest {
     public void setUp() throws Exception {
         SupportedDomainUrlMap.clearAccessedSet();
         FileUtil.deleteDirectory(OUTPUT_DIRECTORY);
-        ErrorSummary.getInstance().clearErrorSet();
     }
 
     @AfterEach

--- a/src/systemtest/java/reposense/LocalRepoSystemTest.java
+++ b/src/systemtest/java/reposense/LocalRepoSystemTest.java
@@ -18,7 +18,6 @@ import reposense.model.RepoConfiguration;
 import reposense.model.RepoLocation;
 import reposense.model.SupportedDomainUrlMap;
 import reposense.parser.SinceDateArgumentType;
-import reposense.report.ErrorSummary;
 import reposense.util.FileUtil;
 import reposense.util.InputBuilder;
 import reposense.util.SystemTestUtil;
@@ -49,7 +48,6 @@ public class LocalRepoSystemTest {
     public void setupLocalTest() throws Exception {
         SupportedDomainUrlMap.clearAccessedSet();
         FileUtil.deleteDirectory(OUTPUT_DIRECTORY);
-        ErrorSummary.getInstance().clearErrorSet();
     }
 
     @AfterEach

--- a/src/test/java/reposense/report/ErrorSummaryTest.java
+++ b/src/test/java/reposense/report/ErrorSummaryTest.java
@@ -12,43 +12,39 @@ public class ErrorSummaryTest {
         String invalidLocation1 = "ttp://github.com/reposense.RepoSense.git";
         String invalidLocation2 = "https://github.com/contains-illegal-chars/^\\/";
         String invalidLocation3 = "not-valid-protocol://abc.com/reposense/RepoSense.git";
-
-        ErrorSummary errorSummaryInstance = ErrorSummary.getInstance();
-        errorSummaryInstance.clearErrorSet();
-
         try {
-            new RepoLocation(invalidLocation1);
+            RepoLocation repoLocation = new RepoLocation(invalidLocation1);
+            Assertions.assertEquals(1, repoLocation.getErrorSummary().getErrorSet().size());
         } catch (InvalidLocationException e) {
             // not relevant to the test
         }
-        Assertions.assertEquals(1, errorSummaryInstance.getErrorSet().size());
 
         try {
-            new RepoLocation(invalidLocation1);
+            RepoLocation repoLocation = new RepoLocation(invalidLocation1);
+            Assertions.assertEquals(1, repoLocation.getErrorSummary().getErrorSet().size());
         } catch (InvalidLocationException e) {
             // not relevant to the test
         }
-        Assertions.assertEquals(1, errorSummaryInstance.getErrorSet().size());
 
         try {
-            new RepoLocation(invalidLocation2);
+            RepoLocation repoLocation = new RepoLocation(invalidLocation2);
+            Assertions.assertEquals(2, repoLocation.getErrorSummary().getErrorSet().size());
         } catch (InvalidLocationException e) {
             // not relevant to the test
         }
-        Assertions.assertEquals(2, errorSummaryInstance.getErrorSet().size());
 
         try {
-            new RepoLocation(invalidLocation1);
+            RepoLocation repoLocation = new RepoLocation(invalidLocation1);
+            Assertions.assertEquals(2, repoLocation.getErrorSummary().getErrorSet().size());
         } catch (InvalidLocationException e) {
             // not relevant to the test
         }
-        Assertions.assertEquals(2, errorSummaryInstance.getErrorSet().size());
 
         try {
-            new RepoLocation(invalidLocation3);
+            RepoLocation repoLocation = new RepoLocation(invalidLocation3);
+            Assertions.assertEquals(3, repoLocation.getErrorSummary().getErrorSet().size());
         } catch (InvalidLocationException e) {
             // not relevant to the test
         }
-        Assertions.assertEquals(3, errorSummaryInstance.getErrorSet().size());
     }
 }


### PR DESCRIPTION

Fixes #1943 

```
Currently, ErrorSummary implements the singleton design pattern.
However, ErrorSummary have to be made non-static if we 
want to parallelize/have concurrent runs of RepoSense.

Let's modify ErrorSummary to be non-static.
```

