### PR TITLE
[#2027] Fix date range bug

### DIFF
--- a/frontend/src/components/c-summary-charts.vue
+++ b/frontend/src/components/c-summary-charts.vue
@@ -535,7 +535,9 @@ export default defineComponent({
 
       // skip if accidentally clicked on ramp chart
       if (this.drags.length === 2 && this.drags[1] - this.drags[0]) {
-        const tdiff = (new Date(this.filterUntilDate)).valueOf() - (new Date(this.filterSinceDate)).valueOf();
+        // additional day was added to include the date represented by filterUntilDate
+        const tdiff = (new Date(this.filterUntilDate)).valueOf() - (new Date(this.filterSinceDate)).valueOf()
+            + window.DAY_IN_MS;
         const idxs = this.drags.map((x) => (x * tdiff) / 100);
         const tsince = window.getDateStr(new Date(this.filterSinceDate).getTime() + idxs[0]);
         const tuntil = window.getDateStr(new Date(this.filterSinceDate).getTime() + idxs[1]);


### PR DESCRIPTION
<!--
    If this pull request fully addresses an issue, use:
    Fixes #xxxx

    If this pull request partially addresses an issue, use:
    Part of #xxxx

    If this pull request addresses multiple issues, put them in multiple lines:
    Fixes #xxxx
    Fixes #yyyy

    Format the title of the pull request with most relevant issue number as follows:
    [#xxxx] Title
-->
Fixes #2027 

### Proposed commit message
<!--
    Propose a detailed commit message for this pull request within the triple backticks below.
    Wrap lines at 72 characters.

    Guide on how to write a good commit message:
    https://oss-generic.github.io/process/docs/FormatsAndConventions.html#commit-message
-->
```
Currently, users are unable to select a zoom range that includes the until date.

This results in misleading data being presented to users.
```

### Other information
<!--
    Are there other relevant information, such as special testing instructions,
    which will help the reviewer better understand the code?

    You may also include a brief description of why the problem occurred.
-->
Upon further investigation, the bug is caused by inaccurate logic in the `openTabZoomSubrange` method in `c-summary-charts.vue`.

```
if (this.drags.length === 2 && this.drags[1] - this.drags[0]) {
        const tdiff = (new Date(this.filterUntilDate)).valueOf() - (new Date(this.filterSinceDate)).valueOf();
        const idxs = this.drags.map((x) => (x * tdiff) / 100);
        const tsince = window.getDateStr(new Date(this.filterSinceDate).getTime() + idxs[0]);
        const tuntil = window.getDateStr(new Date(this.filterSinceDate).getTime() + idxs[1]);
        this.drags = [];
        this.openTabZoom(user, tsince, tuntil, isMerged);
}
```
In line 2, the const `tdiff` is calculated as the time difference in ms between the `filterUntilDate` and the `filterSinceDate`. This is inaccurate as the after creation of each `Date` object using the arguments `this.filterUntilDate` and `this.filterSinceDate`, which results in `Date` objects with the correct date, but at 00:00 (GMT+0000). This results in the date represented by `this.filterUntilDate` not being accounted for when deciding which regions of the ramp chart would be considered a certain date. As such, by adding a day worth of time in ms to `tdiff`, we can adjust for this.

### Screenshot of GUI after fix:
![image](https://github.com/reposense/RepoSense/assets/95712150/10274666-1d2c-40a0-b78d-7ce6bc7746b5)