### PR TITLE
[#1936] Migrate c-segment.vue to typescript

### DIFF
--- a/frontend/src/components/c-segment.vue
+++ b/frontend/src/components/c-segment.vue
@@ -31,11 +31,13 @@
     )
 </template>
 
-<script>
+<script lang='ts'>
+import { defineComponent } from 'vue';
 import { mapState } from 'vuex';
 import Segment from '../utils/segment';
+import { StoreState } from '../types/vuex.d';
 
-export default {
+export default defineComponent({
   name: 'c-segment',
   props: {
     segment: {
@@ -49,14 +51,14 @@ export default {
   },
   data() {
     return {
-      isOpen: this.segment.knownAuthor || this.segment.lines.length < 5,
-      canOpen: !this.segment.knownAuthor && this.segment.lines.length > 4,
-      transparencyValue: '30',
+      isOpen: (this.segment.knownAuthor === null) || this.segment.lines.length < 5 as boolean,
+      canOpen: (this.segment.knownAuthor !== null) && this.segment.lines.length > 4 as boolean,
+      transparencyValue: '30' as string,
     };
   },
   computed: {
     ...mapState({
-      authorColors: ['tabAuthorColors'],
+      authorColors: (state: unknown) => (state as StoreState).tabAuthorColors,
     }),
   },
   methods: {
@@ -64,7 +66,7 @@ export default {
       this.isOpen = !this.isOpen;
     },
   },
-};
+});
 </script>
 
 <style lang="css">

--- a/frontend/src/components/c-segment.vue
+++ b/frontend/src/components/c-segment.vue
@@ -51,8 +51,8 @@ export default defineComponent({
   },
   data() {
     return {
-      isOpen: (this.segment.knownAuthor === null) || this.segment.lines.length < 5 as boolean,
-      canOpen: (this.segment.knownAuthor !== null) && this.segment.lines.length > 4 as boolean,
+      isOpen: (this.segment.knownAuthor !== null) || this.segment.lines.length < 5 as boolean,
+      canOpen: (this.segment.knownAuthor === null) && this.segment.lines.length > 4 as boolean,
       transparencyValue: '30' as string,
     };
   },


### PR DESCRIPTION
<!--
    If this pull request fully addresses an issue, use:
    Fixes #xxxx

    If this pull request partially addresses an issue, use:
    Part of #xxxx

    If this pull request addresses multiple issues, put them in multiple lines:
    Fixes #xxxx
    Fixes #yyyy

    Format the title of the pull request with most relevant issue number as follows:
    [#xxxx] Title
-->
Part of #1936 

### Proposed commit message
<!--
    Propose a detailed commit message for this pull request within the triple backticks below.
    Wrap lines at 72 characters.

    Guide on how to write a good commit message:
    https://oss-generic.github.io/process/docs/FormatsAndConventions.html#commit-message
-->
```
Currently, there is still some JavaScript code which remains 
unmigrated. This allows for type unsafe code to be written, 
potentially resulting in unintended behavior.

Let's migrate the rest of the JavaScript code to TypeScript 
code to facilitate future changes to the code.
```

### Other information
<!--
    Are there other relevant information, such as special testing instructions,
    which will help the reviewer better understand the code?

    You may also include a brief description of why the problem occurred.
-->
### Changes made
* Converted JavaScript code in `c-segment.vue` to TypeScript.
* Modified potentially dangerous code (see below).

### Dangerous code
The following code makes use of the behavior of the `||` operator where the result will be the first operand given that the first operand is not `false` or `null` or any value that is represented by the value `0`. In this case, `this.segment.knownAuthor` has been declared to be `string` or `null` in `segment.ts`. The consequence of this would be that the result, given that the first operand is a `string` that is not the empty string, `''`, would be the `string` itself. Due to common naming conventions, one would expect `isOpen` to be of type `boolean`, however, in actuality, it would be a `string`, hence the potentially dangerous behavior which currently works as intended, but may not in the future with more features relating to `segment` being added. 

The same can be said for `canOpen`, however, it is not as dangerous due to the `&&` operator taking into consideration both operands and returning a `boolean` value only. But in order to prevent future misunderstandings where someone mistakenly assumes that `this.segment.knownAuthor` is a `boolean` value from its use in the `canOpen` data field, I have opted to disambiguate this.
```
data() {
    return {
      isOpen: this.segment.knownAuthor || this.segment.lines.length < 5,
      canOpen: this.segment.knownAuthor && this.segment.lines.length > 4,
      transparencyValue: '30' as string,
    };
},
```