### PR TITLE
[#1989] Reduce scope of try-catch block in ArgsParser::parse

### DIFF
--- a/src/main/java/reposense/parser/ArgsParser.java
+++ b/src/main/java/reposense/parser/ArgsParser.java
@@ -258,76 +258,78 @@ public class ArgsParser {
      * @throws ParseException if the given string arguments fails to parse to a {@link CliArguments} object.
      */
     public static CliArguments parse(String[] args) throws HelpScreenException, ParseException {
+        ArgumentParser parser = getArgumentParser();
+        Namespace results;
+
         try {
-            ArgumentParser parser = getArgumentParser();
-            Namespace results = parser.parseArgs(args);
-
-            Path configFolderPath = results.get(CONFIG_FLAGS[0]);
-            Path reportFolderPath = results.get(VIEW_FLAGS[0]);
-            Path outputFolderPath = results.get(OUTPUT_FLAGS[0]);
-            ZoneId zoneId = results.get(TIMEZONE_FLAGS[0]);
-            Path assetsFolderPath = results.get(ASSETS_FLAGS[0]);
-            List<String> locations = results.get(REPO_FLAGS[0]);
-            List<FileType> formats = FileType.convertFormatStringsToFileTypes(results.get(FORMAT_FLAGS[0]));
-            boolean isStandaloneConfigIgnored = results.get(IGNORE_CONFIG_FLAGS[0]);
-            boolean isFileSizeLimitIgnored = results.get(IGNORE_SIZELIMIT_FLAGS[0]);
-            boolean shouldIncludeLastModifiedDate = results.get(LAST_MODIFIED_DATE_FLAGS[0]);
-            boolean shouldPerformShallowCloning = results.get(SHALLOW_CLONING_FLAGS[0]);
-            boolean shouldFindPreviousAuthors = results.get(FIND_PREVIOUS_AUTHORS_FLAGS[0]);
-            boolean isTestMode = results.get(TEST_MODE_FLAG[0]);
-            int numCloningThreads = results.get(CLONING_THREADS_FLAG[0]);
-            int numAnalysisThreads = results.get(ANALYSIS_THREADS_FLAG[0]);
-
-            CliArguments.Builder cliArgumentsBuilder = new CliArguments.Builder()
-                    .configFolderPath(configFolderPath)
-                    .reportDirectoryPath(reportFolderPath)
-                    .outputFilePath(outputFolderPath)
-                    .zoneId(zoneId)
-                    .assetsFilePath(assetsFolderPath)
-                    .locations(locations)
-                    .formats(formats)
-                    .isStandaloneConfigIgnored(isStandaloneConfigIgnored)
-                    .isFileSizeLimitIgnored(isFileSizeLimitIgnored)
-                    .isLastModifiedDateIncluded(shouldIncludeLastModifiedDate)
-                    .isShallowCloningPerformed(shouldPerformShallowCloning)
-                    .isFindingPreviousAuthorsPerformed(shouldFindPreviousAuthors)
-                    .numCloningThreads(numCloningThreads)
-                    .numAnalysisThreads(numAnalysisThreads)
-                    .isTestMode(isTestMode);
-
-            LogsManager.setLogFolderLocation(outputFolderPath);
-
-            if (locations == null && configFolderPath.equals(DEFAULT_CONFIG_PATH)) {
-                logger.info(MESSAGE_USING_DEFAULT_CONFIG_PATH);
-            }
-
-            addReportConfigToBuilder(cliArgumentsBuilder, results);
-            addAnalysisDatesToBuilder(cliArgumentsBuilder, results);
-
-            boolean isViewModeOnly = reportFolderPath != null
-                    && !reportFolderPath.equals(EMPTY_PATH)
-                    && configFolderPath.equals(DEFAULT_CONFIG_PATH)
-                    && locations == null;
-            cliArgumentsBuilder.isViewModeOnly(isViewModeOnly);
-
-            boolean isAutomaticallyLaunching = reportFolderPath != null;
-            if (isAutomaticallyLaunching && !reportFolderPath.equals(EMPTY_PATH) && !isViewModeOnly) {
-                logger.info(String.format("Ignoring argument '%s' for --view.", reportFolderPath.toString()));
-            }
-            cliArgumentsBuilder.isAutomaticallyLaunching(isAutomaticallyLaunching);
-
-
-            boolean shouldPerformFreshCloning = isTestMode
-                    ? results.get(FRESH_CLONING_FLAG[0])
-                    : DEFAULT_SHOULD_FRESH_CLONE;
-            cliArgumentsBuilder.isFreshClonePerformed(shouldPerformFreshCloning);
-
-            return cliArgumentsBuilder.build();
+            results = parser.parseArgs(args);
         } catch (HelpScreenException hse) {
             throw hse;
         } catch (ArgumentParserException ape) {
             throw new ParseException(getArgumentParser().formatUsage() + ape.getMessage() + "\n");
         }
+
+        Path configFolderPath = results.get(CONFIG_FLAGS[0]);
+        Path reportFolderPath = results.get(VIEW_FLAGS[0]);
+        Path outputFolderPath = results.get(OUTPUT_FLAGS[0]);
+        ZoneId zoneId = results.get(TIMEZONE_FLAGS[0]);
+        Path assetsFolderPath = results.get(ASSETS_FLAGS[0]);
+        List<String> locations = results.get(REPO_FLAGS[0]);
+        List<FileType> formats = FileType.convertFormatStringsToFileTypes(results.get(FORMAT_FLAGS[0]));
+        boolean isStandaloneConfigIgnored = results.get(IGNORE_CONFIG_FLAGS[0]);
+        boolean isFileSizeLimitIgnored = results.get(IGNORE_SIZELIMIT_FLAGS[0]);
+        boolean shouldIncludeLastModifiedDate = results.get(LAST_MODIFIED_DATE_FLAGS[0]);
+        boolean shouldPerformShallowCloning = results.get(SHALLOW_CLONING_FLAGS[0]);
+        boolean shouldFindPreviousAuthors = results.get(FIND_PREVIOUS_AUTHORS_FLAGS[0]);
+        boolean isTestMode = results.get(TEST_MODE_FLAG[0]);
+        int numCloningThreads = results.get(CLONING_THREADS_FLAG[0]);
+        int numAnalysisThreads = results.get(ANALYSIS_THREADS_FLAG[0]);
+
+        CliArguments.Builder cliArgumentsBuilder = new CliArguments.Builder()
+                .configFolderPath(configFolderPath)
+                .reportDirectoryPath(reportFolderPath)
+                .outputFilePath(outputFolderPath)
+                .zoneId(zoneId)
+                .assetsFilePath(assetsFolderPath)
+                .locations(locations)
+                .formats(formats)
+                .isStandaloneConfigIgnored(isStandaloneConfigIgnored)
+                .isFileSizeLimitIgnored(isFileSizeLimitIgnored)
+                .isLastModifiedDateIncluded(shouldIncludeLastModifiedDate)
+                .isShallowCloningPerformed(shouldPerformShallowCloning)
+                .isFindingPreviousAuthorsPerformed(shouldFindPreviousAuthors)
+                .numCloningThreads(numCloningThreads)
+                .numAnalysisThreads(numAnalysisThreads)
+                .isTestMode(isTestMode);
+
+        LogsManager.setLogFolderLocation(outputFolderPath);
+
+        if (locations == null && configFolderPath.equals(DEFAULT_CONFIG_PATH)) {
+            logger.info(MESSAGE_USING_DEFAULT_CONFIG_PATH);
+        }
+
+        addReportConfigToBuilder(cliArgumentsBuilder, results);
+        addAnalysisDatesToBuilder(cliArgumentsBuilder, results);
+
+        boolean isViewModeOnly = reportFolderPath != null
+                && !reportFolderPath.equals(EMPTY_PATH)
+                && configFolderPath.equals(DEFAULT_CONFIG_PATH)
+                && locations == null;
+        cliArgumentsBuilder.isViewModeOnly(isViewModeOnly);
+
+        boolean isAutomaticallyLaunching = reportFolderPath != null;
+        if (isAutomaticallyLaunching && !reportFolderPath.equals(EMPTY_PATH) && !isViewModeOnly) {
+            logger.info(String.format("Ignoring argument '%s' for --view.", reportFolderPath.toString()));
+        }
+        cliArgumentsBuilder.isAutomaticallyLaunching(isAutomaticallyLaunching);
+
+
+        boolean shouldPerformFreshCloning = isTestMode
+                ? results.get(FRESH_CLONING_FLAG[0])
+                : DEFAULT_SHOULD_FRESH_CLONE;
+        cliArgumentsBuilder.isFreshClonePerformed(shouldPerformFreshCloning);
+
+        return cliArgumentsBuilder.build();
     }
 
     /**

--- a/src/test/java/reposense/parser/ArgsParserTest.java
+++ b/src/test/java/reposense/parser/ArgsParserTest.java
@@ -11,7 +11,6 @@ import java.nio.file.Paths;
 import java.time.LocalDateTime;
 import java.time.Month;
 import java.time.ZoneId;
-import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import java.util.List;
 
@@ -603,18 +602,6 @@ public class ArgsParserTest {
     public void sinceDate_laterThanUntilDate_throwsParseException() {
         String input = DEFAULT_INPUT_BUILDER.addSinceDate("01/12/2017")
                 .addUntilDate("30/11/2017")
-                .build();
-        Assertions.assertThrows(ParseException.class, () -> ArgsParser.parse(translateCommandline(input)));
-    }
-
-    @Test
-    public void sinceDate_laterThanCurrentDate_throwsParseException() {
-        LocalDateTime tomorrowDateTime = LocalDateTime.now()
-                .plusDays(1L);
-        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("dd/MM/yyyy");
-        String tomorrow = tomorrowDateTime.format(formatter);
-
-        String input = DEFAULT_INPUT_BUILDER.addSinceDate(tomorrow)
                 .build();
         Assertions.assertThrows(ParseException.class, () -> ArgsParser.parse(translateCommandline(input)));
     }

--- a/src/test/java/reposense/parser/ArgsParserTest.java
+++ b/src/test/java/reposense/parser/ArgsParserTest.java
@@ -11,6 +11,7 @@ import java.nio.file.Paths;
 import java.time.LocalDateTime;
 import java.time.Month;
 import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import java.util.List;
 
@@ -602,6 +603,18 @@ public class ArgsParserTest {
     public void sinceDate_laterThanUntilDate_throwsParseException() {
         String input = DEFAULT_INPUT_BUILDER.addSinceDate("01/12/2017")
                 .addUntilDate("30/11/2017")
+                .build();
+        Assertions.assertThrows(ParseException.class, () -> ArgsParser.parse(translateCommandline(input)));
+    }
+
+    @Test
+    public void sinceDate_laterThanCurrentDate_throwsParseException() {
+        LocalDateTime tomorrowDateTime = LocalDateTime.now()
+                .plusDays(1L);
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("dd/MM/yyyy");
+        String tomorrow = tomorrowDateTime.format(formatter);
+
+        String input = DEFAULT_INPUT_BUILDER.addSinceDate(tomorrow)
                 .build();
         Assertions.assertThrows(ParseException.class, () -> ArgsParser.parse(translateCommandline(input)));
     }


### PR DESCRIPTION
<!--
    If this pull request fully addresses an issue, use:
    Fixes #xxxx

    If this pull request partially addresses an issue, use:
    Part of #xxxx

    If this pull request addresses multiple issues, put them in multiple lines:
    Fixes #xxxx
    Fixes #yyyy

    Format the title of the pull request with most relevant issue number as follows:
    [#xxxx] Title
-->
Fixes #1989

### Proposed commit message
<!--
    Propose a detailed commit message for this pull request within the triple backticks below.
    Wrap lines at 72 characters.

    Guide on how to write a good commit message:
    https://oss-generic.github.io/process/docs/FormatsAndConventions.html#commit-message
-->
```
Reduce scope of try-catch block tin ArgsParser::parse

The old scope of the try block in ArgsParser::parse 
is too permissive, making it less apparent which 
methods throw the associated exceptions.

Let's reduce the scope of the try block in 
ArgsParser::parse.
```

### Other information
<!--
    Are there other relevant information, such as special testing instructions,
    which will help the reviewer better understand the code?

    You may also include a brief description of why the problem occurred.
-->
NA