### PR TITLE
[#2073] Refactor `RepoConfigCsvParser::processLine` method to avoid arrowhead style code

### DIFF
--- a/src/main/java/reposense/parser/RepoConfigCsvParser.java
+++ b/src/main/java/reposense/parser/RepoConfigCsvParser.java
@@ -145,9 +145,6 @@ public class RepoConfigCsvParser extends CsvParser<RepoConfiguration> {
                 isStandaloneConfigIgnored, isShallowCloningPerformed, isFindingPreviousAuthorsPerformed);
     }
 
-    private void process() {
-    }
-
     /**
      * Returns true if value from {@code record}, that matches any of the equivalent headers in
      * {@code equivalentHeaders}, is the same as the given {@code keyword}, else false.

--- a/src/main/java/reposense/parser/RepoConfigCsvParser.java
+++ b/src/main/java/reposense/parser/RepoConfigCsvParser.java
@@ -114,20 +114,19 @@ public class RepoConfigCsvParser extends CsvParser<RepoConfiguration> {
 
         // If file diff limit is specified
         if (fileSizeLimitStringList.size() > 0) {
+            String fileSizeLimitString = fileSizeLimitStringList.get(0).trim();
+            int parseValue;
+
             if (isFileSizeLimitIgnored) {
                 logger.warning("Ignoring file size limit column since file size limit is ignored");
                 isFileSizeLimitOverriding = false;
+            } else if (!StringsUtil.isNumeric(fileSizeLimitString)
+                    || (parseValue = Integer.parseInt(fileSizeLimitString)) <= 0) {
+                logger.warning(String.format("Values in \"%s\" column should be positive integers.",
+                        FILESIZE_LIMIT_HEADER[0]));
+                isFileSizeLimitOverriding = false;
             } else {
-                String fileSizeLimitString = fileSizeLimitStringList.get(0).trim();
-                int parseValue;
-                if (!StringsUtil.isNumeric(fileSizeLimitString)
-                        || (parseValue = Integer.parseInt(fileSizeLimitString)) <= 0) {
-                    logger.warning(String.format("Values in \"%s\" column should be positive integers.",
-                            FILESIZE_LIMIT_HEADER[0]));
-                    isFileSizeLimitOverriding = false;
-                } else {
-                    fileSizeLimit = parseValue;
-                }
+                fileSizeLimit = parseValue;
             }
         }
 
@@ -144,6 +143,9 @@ public class RepoConfigCsvParser extends CsvParser<RepoConfiguration> {
                 isIgnoreCommitListOverriding, ignoreCommitList, isIgnoredAuthorsListOverriding, ignoredAuthorsList,
                 isFileSizeLimitIgnored, isIgnoredFileAnalysisSkipped, isFileSizeLimitOverriding, fileSizeLimit,
                 isStandaloneConfigIgnored, isShallowCloningPerformed, isFindingPreviousAuthorsPerformed);
+    }
+
+    private void process() {
     }
 
     /**


### PR DESCRIPTION
<!--
    If this pull request fully addresses an issue, use:
    Fixes #xxxx

    If this pull request partially addresses an issue, use:
    Part of #xxxx

    If this pull request addresses multiple issues, put them in multiple lines:
    Fixes #xxxx
    Fixes #yyyy

    Format the title of the pull request with most relevant issue number as follows:
    [#xxxx] Title
-->
Fixes #2073 

### Proposed commit message
<!--
    Propose a detailed commit message for this pull request within the triple backticks below.
    Wrap lines at 72 characters.

    Guide on how to write a good commit message:
    https://oss-generic.github.io/process/docs/FormatsAndConventions.html#commit-message
-->
```
The current implementation of `RepoConfigCsvParser::processLine`
contains code that has 3 levels of indentation, making it 
difficult to read and maintain.

With the proposed changes, the level of deep nesting has 
been reduced to 2 levels, making the code more 
readable and maintainable.

Let's move to refactor and clean up the code to avoid 
arrowhead-style codes for better readability and 
maintainability.
```

### Other information
<!--
    Are there other relevant information, such as special testing instructions,
    which will help the reviewer better understand the code?

    You may also include a brief description of why the problem occurred.
-->

NA