### PR TITLE
[#2082] Fix typo in command in Setting Up page

### DIFF
--- a/docs/dg/settingUp.md
+++ b/docs/dg/settingUp.md
@@ -15,7 +15,7 @@
 
   <box type="info" seamless>
 
-  Type `java -version`, `npm -v` and `git --version` respectively on your OS terminal and ensure that you have the correct version of each prerequisite installed.
+  Type `java -version`, `node -v` and `git --version` respectively on your OS terminal and ensure that you have the correct version of each prerequisite installed.
   </box>
 
 <!-- ==================================================================================================== -->


### PR DESCRIPTION
Fixes #2082 

```
Replace the command `npm -v` with `node -v`.
This displays the node version instead of the npm version.
```