### PR TITLE
[#1878] Updating `SystemTestUtil::assertJson` to compare Json objects instead of line-by-line analysis

### DIFF
--- a/src/systemtest/java/reposense/util/SystemTestUtil.java
+++ b/src/systemtest/java/reposense/util/SystemTestUtil.java
@@ -7,10 +7,9 @@ import java.nio.file.Path;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import com.google.gson.JsonArray;
-import com.google.gson.JsonElement;
 import org.junit.jupiter.api.Assertions;
 
+import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 

--- a/src/systemtest/java/reposense/util/SystemTestUtil.java
+++ b/src/systemtest/java/reposense/util/SystemTestUtil.java
@@ -7,6 +7,8 @@ import java.nio.file.Path;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
 import org.junit.jupiter.api.Assertions;
 
 import com.google.gson.JsonObject;
@@ -63,10 +65,16 @@ public class SystemTestUtil {
      */
     public static void assertJson(Path expectedJsonPath, Path actualJsonPath) {
         Assertions.assertTrue(Files.exists(actualJsonPath));
-        try {
-            Assertions.assertTrue(TestUtil.compareFileContents(expectedJsonPath, actualJsonPath));
-        } catch (Exception e) {
-            Assertions.fail(e.getMessage());
+
+        try (FileReader fileReaderExpected = new FileReader(expectedJsonPath.toFile());
+                FileReader fileReaderActual = new FileReader(actualJsonPath.toFile())) {
+
+            JsonElement jsonExpected = JsonParser.parseReader(fileReaderExpected);
+            JsonElement jsonActual = JsonParser.parseReader(fileReaderActual);
+
+            Assertions.assertEquals(jsonExpected, jsonActual);
+        } catch (IOException ex) {
+            Assertions.fail(ex.getMessage());
         }
     }
 }


### PR DESCRIPTION
<!--
    If this pull request fully addresses an issue, use:
    Fixes #xxxx

    If this pull request partially addresses an issue, use:
    Part of #xxxx

    If this pull request addresses multiple issues, put them in multiple lines:
    Fixes #xxxx
    Fixes #yyyy

    Format the title of the pull request with most relevant issue number as follows:
    [#xxxx] Title
-->
Fixes #1878

### Proposed commit message
<!--
    Propose a detailed commit message for this pull request within the triple backticks below.
    Wrap lines at 72 characters.

    Guide on how to write a good commit message:
    https://oss-generic.github.io/process/docs/FormatsAndConventions.html#commit-message
-->
```
`SystemTestUtil::assertJson` currently checks if two JSON files are
equal by comparing the file contents line by line rather than by
converting the files directly into JSON objects, which can then be
directly compared using the built-in `equals` methods for
`JsonElement`.

This process also does not automatically check if the file is indeed a
JSON file, and implicitly assumes that the input paths are paths to
JSON files. This may cause expected behaviours if a user accidentally
or intentionally includes a path to a non-JSON file within the method
calls.

Let's move to refactor the code, and utilise the built-in methods for
`JsonElement` objects to check for the equality of JSON objects.
```

### Other information
<!--
    Are there other relevant information, such as special testing instructions,
    which will help the reviewer better understand the code?

    You may also include a brief description of why the problem occurred.
-->

The original issue alludes to the use of `JsonObject` in the fixes, however, while trying to get the system test cases to run, it appears that this method is to be used on `JsonObject` and `JsonArray` as well. `JsonElement` was hence chosen as a suitable class that encapsulates the information of the parsed JSON objects, while allowing for equality of the JSON objects to be checked.