### PR TITLE
[#2111] Fix failing zoomFeature cypress test

### DIFF
--- a/frontend/cypress/tests/chartView/chartView_zoomFeature.cy.js
+++ b/frontend/cypress/tests/chartView/chartView_zoomFeature.cy.js
@@ -251,6 +251,9 @@ describe('range changes in chartview should reflect in zoom', () => {
     cy.get('div.mui-textfield.search_box > input:visible')
       .should('be.visible')
       .type('jamessspanggg');
+    cy.get('input[name="until"]:visible')
+      .type('2023-12-31');
+
     cy.get('body').type(zoomKey, { release: false })
       .get('#summary-charts .summary-chart__ramp .ramp')
       .first()
@@ -277,6 +280,9 @@ describe('range changes in chartview should reflect in zoom', () => {
     cy.get('div.mui-textfield.search_box > input:visible')
       .should('be.visible')
       .type('jamessspanggg');
+    cy.get('input[name="until"]:visible')
+      .type('2023-12-31');
+
     cy.get('body').type(zoomKey, { release: false })
       .get('#summary-charts .summary-chart__ramp .ramp')
       .first()
@@ -303,6 +309,9 @@ describe('range changes in chartview should reflect in zoom', () => {
     cy.get('div.mui-textfield.search_box > input:visible')
       .should('be.visible')
       .type('jamessspanggg');
+    cy.get('input[name="until"]:visible')
+      .type('2023-12-31');
+
     cy.get('body').type(zoomKey, { release: false })
       .get('#summary-charts .summary-chart__ramp .ramp')
       .first()
@@ -329,6 +338,8 @@ describe('range changes in chartview should reflect in zoom', () => {
     cy.get('div.mui-textfield.search_box > input:visible')
       .should('be.visible')
       .type('jamessspanggg');
+    cy.get('input[name="until"]:visible')
+      .type('2023-12-31');
 
     cy.get('body').type(zoomKey, { release: false })
       .get('#summary-charts .summary-chart__ramp .ramp')


### PR DESCRIPTION
<!--
    If this pull request fully addresses an issue, use:
    Fixes #xxxx

    If this pull request partially addresses an issue, use:
    Part of #xxxx

    If this pull request addresses multiple issues, put them in multiple lines:
    Fixes #xxxx
    Fixes #yyyy

    Format the title of the pull request with most relevant issue number as follows:
    [#xxxx] Title
-->
Fixes #2111 
Fixes #2066 also

### Proposed commit message
<!--
    Propose a detailed commit message for this pull request within the triple backticks below.
    Wrap lines at 72 characters.

    Guide on how to write a good commit message:
    https://oss-generic.github.io/process/docs/FormatsAndConventions.html#commit-message
-->
```
Fix nondeterministically failing zoomFeature cypress test

The "range changes in chartview should reflect in zoom" test in
chartView_zoomFeature.cy.js fails because as time passes, the
coordinates in the ramp that correspond to the desired zoom area
change.

Let's add an "until" filter to the relevant cypress tests to stop this
from happening
```

### Other information
<!--
    Are there other relevant information, such as special testing instructions,
    which will help the reviewer better understand the code?

    You may also include a brief description of why the problem occurred.
-->
