### PR TITLE
[#2119] Implement Proper Deep Cloning for `RepoConfiguration` and `CliArguments`

### DIFF
--- a/src/main/java/reposense/model/Author.java
+++ b/src/main/java/reposense/model/Author.java
@@ -10,7 +10,7 @@ import java.util.regex.Pattern;
 /**
  * Represents a Git Author.
  */
-public class Author {
+public class Author implements Cloneable {
     public static final String NAME_NO_AUTHOR_WITH_COMMITS_FOUND =
             "NO AUTHOR WITH COMMITS FOUND WITHIN THIS PERIOD OF TIME";
     private static final String UNKNOWN_AUTHOR_GIT_ID = "-";
@@ -207,6 +207,15 @@ public class Author {
         if (!emails.contains(standardGitLabEmail)) {
             emails.add(standardGitLabEmail);
         }
+    }
+
+    @Override
+    public Author clone() throws CloneNotSupportedException {
+        Author clone = (Author) super.clone();
+        clone.emails = new ArrayList<>(this.emails);
+        clone.authorAliases = new ArrayList<>(this.authorAliases);
+        clone.ignoreGlobList = new ArrayList<>(this.ignoreGlobList);
+        return clone;
     }
 }
 

--- a/src/main/java/reposense/model/AuthorConfiguration.java
+++ b/src/main/java/reposense/model/AuthorConfiguration.java
@@ -13,7 +13,7 @@ import reposense.system.LogsManager;
 /**
  * Represents author configuration information from CSV config file for a single repository.
  */
-public class AuthorConfiguration {
+public class AuthorConfiguration implements Cloneable {
     public static final String DEFAULT_BRANCH = "HEAD";
     public static final boolean DEFAULT_HAS_AUTHOR_CONFIG_FILE = false;
     private static final Logger logger = LogsManager.getLogger(AuthorConfiguration.class);
@@ -335,5 +335,35 @@ public class AuthorConfiguration {
 
     public boolean hasAuthorConfigFile() {
         return hasAuthorConfigFile;
+    }
+
+    /**
+     * Creates an identical deep copy of this {@code AuthorConfiguration} object.
+     *
+     * @return Deep copy of this {@code AuthorConfiguration} object.
+     * @throws CloneNotSupportedException if the cloning operation fails.
+     */
+    @Override
+    public AuthorConfiguration clone() throws CloneNotSupportedException {
+        AuthorConfiguration clone = (AuthorConfiguration) super.clone();
+        clone.location = this.location.clone();
+        clone.authorList = new ArrayList<>(this.authorList);
+        clone.authorNamesToAuthorMap = new HashMap<>();
+        clone.authorEmailsToAuthorMap = new HashMap<>();
+        clone.authorDisplayNameMap = new HashMap<>();
+
+        for (Map.Entry<String, Author> entry : this.authorNamesToAuthorMap.entrySet()) {
+            clone.authorNamesToAuthorMap.put(entry.getKey(), entry.getValue().clone());
+        }
+
+        for (Map.Entry<String, Author> entry : this.authorEmailsToAuthorMap.entrySet()) {
+            clone.authorEmailsToAuthorMap.put(entry.getKey(), entry.getValue().clone());
+        }
+
+        for (Map.Entry<Author, String> entry : this.authorDisplayNameMap.entrySet()) {
+            clone.authorDisplayNameMap.put(entry.getKey().clone(), entry.getValue());
+        }
+
+        return clone;
     }
 }

--- a/src/main/java/reposense/model/CommitHash.java
+++ b/src/main/java/reposense/model/CommitHash.java
@@ -10,7 +10,7 @@ import reposense.git.GitRevList;
 /**
  * Represents a git commit hash in {@code RepoConfiguration}.
  */
-public class CommitHash {
+public class CommitHash implements Cloneable {
     private static final String COMMIT_HASH_REGEX = "^[0-9a-f]+$";
     private static final String COMMIT_RANGED_HASH_REGEX = "^[0-9a-f]+\\.\\.[0-9a-f]+$";
     private static final String INVALID_COMMIT_HASH_MESSAGE =
@@ -108,6 +108,17 @@ public class CommitHash {
         if (!commitHash.matches(COMMIT_HASH_REGEX) && !commitHash.matches(COMMIT_RANGED_HASH_REGEX)) {
             throw new IllegalArgumentException(String.format(INVALID_COMMIT_HASH_MESSAGE, commitHash));
         }
+    }
+
+    /**
+     * Creates a deep copy of this {@code CommitHash} object.
+     *
+     * @return Deep copy of this {@code CommitHash} object.
+     * @throws CloneNotSupportedException if the cloning operation fails.
+     */
+    @Override
+    public CommitHash clone() throws CloneNotSupportedException {
+        return (CommitHash) super.clone();
     }
 }
 

--- a/src/main/java/reposense/model/FileType.java
+++ b/src/main/java/reposense/model/FileType.java
@@ -4,6 +4,7 @@ import java.lang.reflect.Type;
 import java.nio.file.FileSystems;
 import java.nio.file.PathMatcher;
 import java.nio.file.Paths;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.regex.Pattern;
@@ -17,7 +18,7 @@ import com.google.gson.JsonSerializer;
 /**
  * Represents a file type for use in {@link FileTypeManager}.
  */
-public class FileType {
+public class FileType implements Cloneable {
     private static final Pattern FILE_FORMAT_VALIDATION_PATTERN = Pattern.compile("^\\w+$");
     private static final String MESSAGE_ILLEGAL_FILE_FORMAT = "The provided file format, %s, contains illegal "
             + "characters.";
@@ -108,6 +109,22 @@ public class FileType {
         }
         FileType otherFileType = (FileType) other;
         return this.label.equals(otherFileType.label) && this.paths.equals(otherFileType.paths);
+    }
+
+    /**
+     * Clones this instance of {@code FileType}.
+     *
+     * @return New instance of {@code FileType} that is semantically similar to this instance
+     *     of {@code FileType}.
+     * @throws CloneNotSupportedException if there are any objects that cannot be cloned.
+     */
+    @Override
+    public FileType clone() throws CloneNotSupportedException {
+        // it suffices to do a shallow clone since strings are immutable
+        FileType clone = (FileType) super.clone();
+        clone.paths = new ArrayList<>(this.paths);
+
+        return clone;
     }
 
     /**

--- a/src/main/java/reposense/model/FileTypeManager.java
+++ b/src/main/java/reposense/model/FileTypeManager.java
@@ -8,7 +8,7 @@ import java.util.List;
  * Holds a list of whitelisted formats and user-specified custom
  * groupings.
  */
-public class FileTypeManager {
+public class FileTypeManager implements Cloneable {
     private static final String DEFAULT_GROUP = "other";
     private static final FileType DEFAULT_GROUP_TYPE = new FileType(DEFAULT_GROUP, Collections.singletonList("**"));
 
@@ -125,5 +125,16 @@ public class FileTypeManager {
 
         FileTypeManager otherFileType = (FileTypeManager) other;
         return this.groups.equals(otherFileType.groups) && this.formats.equals(otherFileType.formats);
+    }
+
+    @Override
+    public FileTypeManager clone() throws CloneNotSupportedException {
+        FileTypeManager clone = (FileTypeManager) super.clone();
+
+        // do a shallow copy since strings are immutable
+        clone.formats = new ArrayList<>(this.formats);
+        clone.groups = new ArrayList<>(this.groups);
+
+        return clone;
     }
 }

--- a/src/main/java/reposense/model/RepoConfiguration.java
+++ b/src/main/java/reposense/model/RepoConfiguration.java
@@ -20,7 +20,7 @@ import reposense.util.FileUtil;
 /**
  * Represents configuration information from CSV config file for a single repository.
  */
-public class RepoConfiguration {
+public class RepoConfiguration implements Cloneable {
     public static final String DEFAULT_BRANCH = "HEAD";
     public static final String DEFAULT_EXTRA_OUTPUT_FOLDER_NAME = "";
     public static final long DEFAULT_FILE_SIZE_LIMIT = 500000;
@@ -59,6 +59,29 @@ public class RepoConfiguration {
      * to construct new {@code RepoConfiguration} instances.
      */
     private RepoConfiguration() {}
+
+    /**
+     * Creates a deep copy of this {@code RepoConfiguration} object.
+     *
+     * @return Deep copy of this {@code RepoConfiguration} object.
+     * @throws CloneNotSupportedException if the cloning operation fails.
+     */
+    @Override
+    public RepoConfiguration clone() throws CloneNotSupportedException {
+        RepoConfiguration clone = (RepoConfiguration) super.clone();
+        clone.location = this.location == null ? clone.location : this.location.clone();
+        clone.fileTypeManager = this.fileTypeManager == null ? clone.fileTypeManager : this.fileTypeManager.clone();
+        clone.ignoreGlobList = new ArrayList<>(this.ignoreGlobList);
+        clone.ignoredAuthorsList = new ArrayList<>(this.ignoredAuthorsList);
+        clone.authorConfig = this.authorConfig == null ? clone.authorConfig : this.authorConfig.clone();
+        clone.ignoreCommitList = new ArrayList<>();
+
+        for (CommitHash hash : this.ignoreCommitList) {
+            clone.ignoreCommitList.add(hash.clone());
+        }
+
+        return clone;
+    }
 
     /**
      * Builds the necessary configurations for RepoConfiguration.
@@ -426,13 +449,11 @@ public class RepoConfiguration {
             this.processNames();
 
             // save a reference to the current built object
-            RepoConfiguration toReturn = this.repoConfiguration;
-
-            // reset the internal reference to avoid aliasing
-            this.repoConfiguration = new RepoConfiguration();
-
-            // return the reference to the built RepoConfiguration object
-            return toReturn;
+            try {
+                return this.repoConfiguration.clone();
+            } catch (CloneNotSupportedException ex) {
+                throw new ConfigurationBuildException();
+            }
         }
 
         /**

--- a/src/main/java/reposense/model/RepoLocation.java
+++ b/src/main/java/reposense/model/RepoLocation.java
@@ -20,7 +20,7 @@ import reposense.util.SystemUtil;
 /**
  * Represents a repository location.
  */
-public class RepoLocation {
+public class RepoLocation implements Cloneable {
     protected static final String UNSUPPORTED_DOMAIN_NAME = "NOT_RECOGNIZED";
 
     private static final String MESSAGE_INVALID_LOCATION = "%s is an invalid location.";
@@ -268,5 +268,19 @@ public class RepoLocation {
     @Override
     public int hashCode() {
         return location.hashCode();
+    }
+
+    /**
+     * Clones this {@code RepoLocation} instance.
+     *
+     * @return A new instance of {@code RepoLocation} that is sematically identical to this
+     *     {@code RepoLocation} instance.
+     * @throws CloneNotSupportedException if there is a problem when cloning this
+     *     {@code RepoLocation} object.
+     */
+    @Override
+    public RepoLocation clone() throws CloneNotSupportedException {
+        // regular shallow clone will suffice since strings are immutable
+        return (RepoLocation) super.clone();
     }
 }

--- a/src/main/java/reposense/model/ReportConfiguration.java
+++ b/src/main/java/reposense/model/ReportConfiguration.java
@@ -3,11 +3,16 @@ package reposense.model;
 /**
  * Represents configuration information from JSON config file for generated report.
  */
-public class ReportConfiguration {
+public class ReportConfiguration implements Cloneable {
     private static final String DEFAULT_TITLE = "RepoSense Report";
     private String title;
 
     public String getTitle() {
         return (title == null) ? DEFAULT_TITLE : title;
+    }
+
+    @Override
+    public ReportConfiguration clone() throws CloneNotSupportedException {
+        return (ReportConfiguration) super.clone();
     }
 }

--- a/src/test/java/reposense/model/AuthorTest.java
+++ b/src/test/java/reposense/model/AuthorTest.java
@@ -108,4 +108,10 @@ public class AuthorTest {
         Assertions.assertThrows(IllegalArgumentException.class, () -> author.importIgnoreGlobList(
                 Arrays.asList(ignoreGlobs)));
     }
+
+    @Test
+    public void author_cloneAuthor_success() throws Exception {
+        Author author = new Author("Try");
+        Assertions.assertNotSame(author.clone(), author.clone());
+    }
 }

--- a/src/test/java/reposense/model/CommitHashTest.java
+++ b/src/test/java/reposense/model/CommitHashTest.java
@@ -23,4 +23,10 @@ public class CommitHashTest {
         Assertions.assertThrows(IllegalArgumentException.class, () -> CommitHash.validateCommits(
                 Arrays.asList("!d0ac2ee20f04dce8df0591caed460gffacb65a4")));
     }
+
+    @Test
+    public void commitHash_cloneCommitHash_success() throws Exception {
+        CommitHash hash = new CommitHash("8d0ac2ee20f04dce8df0591caed460bffacb65a4");
+        Assertions.assertNotSame(hash.clone(), hash.clone());
+    }
 }

--- a/src/test/java/reposense/model/FileTypeManagerTest.java
+++ b/src/test/java/reposense/model/FileTypeManagerTest.java
@@ -49,4 +49,11 @@ public class FileTypeManagerTest {
         fileTypeManager.setFormats(FileTypeTest.DEFAULT_TEST_FORMATS);
         Assertions.assertFalse(fileTypeManager.isInsideWhitelistedFormats("test.cpp"));
     }
+
+    @Test
+    public void fileTypeManager_cloneFileTypeManager_success() throws Exception {
+        Assertions.assertNotSame(
+                this.fileTypeManager.clone(), this.fileTypeManager.clone()
+        );
+    }
 }

--- a/src/test/java/reposense/model/FileTypeTest.java
+++ b/src/test/java/reposense/model/FileTypeTest.java
@@ -60,4 +60,10 @@ public class FileTypeTest {
         FileType fileType = new FileType("test", Collections.singletonList("**/test/*"));
         Assertions.assertFalse(fileType.isFileGlobMatching("test/main.java"));
     }
+
+    @Test
+    public void fileType_cloneFileType_success() throws Exception {
+        FileType fileType = new FileType("test", Collections.singletonList("**/test/*"));
+        Assertions.assertNotSame(fileType.clone(), fileType.clone());
+    }
 }

--- a/src/test/java/reposense/model/RepoConfigurationTest.java
+++ b/src/test/java/reposense/model/RepoConfigurationTest.java
@@ -960,4 +960,14 @@ public class RepoConfigurationTest {
     public void repoBuilder_buildWithInvalid_failure() {
         Assertions.assertThrows(ConfigurationBuildException.class, () -> new RepoConfiguration.Builder().build());
     }
+
+    @Test
+    public void repoBuilder_cloneRepoConfiguration_success() throws Exception {
+        RepoConfiguration.Builder actualConfig = new RepoConfiguration.Builder()
+                .isLastModifiedDateIncluded(true)
+                .location(new RepoLocation(TEST_REPO_MINIMAL_STANDALONE_CONFIG))
+                .branch("master");
+
+        Assertions.assertNotSame(actualConfig.build(), actualConfig.build());
+    }
 }

--- a/src/test/java/reposense/model/RepoLocationTest.java
+++ b/src/test/java/reposense/model/RepoLocationTest.java
@@ -190,6 +190,12 @@ public class RepoLocationTest {
         AssertUtil.assertThrows(InvalidLocationException.class, () -> getDomainNameFromDomain("github."));
     }
 
+    @Test
+    public void repoLocation_cloneRepoLocation_success() throws Exception {
+        RepoLocation location = new RepoLocation(LOCAL_REPO_VALID_WITH_DOT_GIT_TWO);
+        Assertions.assertNotSame(location.clone(), location.clone());
+    }
+
     /**
      * Compares the information of {@code rawLocation} parsed by the RepoLocation model with {@code expectedRepoName}
      * and {@code expectedOrganization}.


### PR DESCRIPTION
<!--
    If this pull request fully addresses an issue, use:
    Fixes #xxxx

    If this pull request partially addresses an issue, use:
    Part of #xxxx

    If this pull request addresses multiple issues, put them in multiple lines:
    Fixes #xxxx
    Fixes #yyyy

    Format the title of the pull request with most relevant issue number as follows:
    [#xxxx] Title
-->
Fixes #2119 

### Proposed commit message
<!--
    Propose a detailed commit message for this pull request within the triple backticks below.
    Wrap lines at 72 characters.

    Guide on how to write a good commit message:
    https://oss-generic.github.io/process/docs/FormatsAndConventions.html#commit-message
-->
```
The current implementation of `RepoConfiguration` and `CliArguments` do
not permit Builder reuse. When a Builder `build` an instance of
`RepoConfiguration` or `CliArguments`, the stored instance of
`RepoConfiguration` or `CliArguments` within the Builder objects is
dereferenced and reset to the base instance of `RepoConfiguration` or
`CliArguments`.

This might result in unnecessary repetition of code to create duplicate
instances of `RepoConfiguration` or `CliArguments`, if needed.

Let's move to implement a cloning method in both `RepoConfiguration`
and `CliArguments`, to reduce code duplication.
```

### Other information
<!--
    Are there other relevant information, such as special testing instructions,
    which will help the reviewer better understand the code?

    You may also include a brief description of why the problem occurred.
-->

This issue is currently being discussed, and this PR serves as a proof of concept for implementing `clone` for `RepoConfiguration` and `CliArguments`.
