### PR TITLE
[#2134] Fix broken code highlighting in Code Panel

### DIFF
--- a/frontend/src/components/c-segment.vue
+++ b/frontend/src/components/c-segment.vue
@@ -71,6 +71,7 @@ export default defineComponent({
 
 <style lang="scss" scoped>
 @import '../styles/hightlight-js-style.css';
+@import '../styles/_colors.scss';
 
 .segment {
   border-left: .25rem solid mui-color('green');


### PR DESCRIPTION
Fixes #2134

### Proposed commit message
```
The code highlighting is not working as the colors are not being
recognized by the newly extracted c-segment.vue file. This is because
the defined colors were not imported into the file.  

Let us add the color styles import to restore code highlighting
functionality.  
```

### Other information
NIL
