### PR TITLE
Fix some minor cosmetic issues in docs

### DIFF
--- a/docs/_markbind/variables.json
+++ b/docs/_markbind/variables.json
@@ -1,3 +1,0 @@
-{
-    "jsonVariableExample": "Your variables can be defined here as well"
-}

--- a/docs/_markbind/variables.md
+++ b/docs/_markbind/variables.md
@@ -1,42 +1,42 @@
-<span id="icon_announcement"><md>:fas-bell:</md></span>
-<span id="icon_book"><md>:fas-book:</md></span>
-<span id="icon_calendar"><md>:fas-calendar-alt:</md></span>
-<span id="icon_dislike"><md>:fas-thumbs-down:</md></span>
-<span id="icon_example"><md>:fas-cube:</md></span>
-<span id="icon_embedding"><md>:glyphicon-log-in:</md></span>
-<span id="icon_exercise"><md>:fas-dumbbell:</md></span>
-<span id="icon_extra"><span class='badge rounded-pill bg-secondary'><md>:fas-plus: extra</md></span></span>
-<span id="icon_info"><md>:fas-info-circle:</md></span>
-<span id="icon_like"><md>:fas-thumbs-up:</md></span>
-<span id="icon_linux"><md>:fab-linux:</md></span>
-<span id="icon_level_basic"><md><span class="badge rounded-pill bg-danger">:far-star:</span></md></span>
-<span id="icon_level_intermediate"><md><span class="badge rounded-pill bg-warning text-white">:far-star::far-star:</span></md></span>
-<span id="icon_level_advanced"><md><span class="badge rounded-pill bg-success">:far-star::far-star::far-star:</span></md></span>
-<span id="icon_important_big_red"><font color="red"><big>:glyphicon-exclamation-sign:</big></font></span>
-<span id="icon_important"><md>:glyphicon-exclamation-sign:</md></span>
-<span id="icon_new_window"><md>:glyphicon-new-window:</md></span>
-<span id="icon_outcome"><md>:fas-trophy:</md></span>
-<span id="icon_output"><md>:fas-arrow-down:</md></span>
-<span id="icon_output_right"><md>:fas-arrow-right:</md></span>
-<span id="icon_print"><md>:glyphicon-print:</md></span>
-<span id="icon_prereq"><md>:glyphicon-education:</md></span>
-<span id="icon_preview"><md>:glyphicon-eye-open:</md></span>
-<span id="icon_pro_tip"><span class="badge rounded-pill bg-warning">:fas-lightbulb: PRO TIP</span></span>
-<span id="icon_Q"><md>:glyphicon-question-sign:</md></span>
-<span id="icon_Q_A">{{ icon_Q | safe }}:glyphicon-ok-sign:</span>
-<span id="icon_resource"><md>:fas-paperclip:</md></span>
-<span id="icon_terminal"><smal><span class="badge bg-secondary">&gt;_</span></smal></span>
-<span id="icon_text"><md>:far-file-alt:</md></span>
-<span id="icon_tick"><md>:fas-check:</md></span>
-<span id="icon_tip"><span class="badge rounded-pill bg-warning">:fas-lightbulb:</span></span>
-<span id="icon_tick_green"><span style="color:green">{{ icon_tick | safe }}</span></span>
-<span id="icon_todo"><md>:glyphicon-check:</md></span>
-<span id="icon_slides"><md>:far-images:</md></span>
-<span id="icon_video"><md>:glyphicon-facetime-video:</md></span>
-<span id="icon_windows"><md>:fab-windows:</md></span>
-<span id="icon_x"><md>:fas-times:</md></span>
-<span id="icon_x_red"><span style="color:red">{{ icon_x | safe }}</span></span>
-<span id="bad"><font color="red"><md>**{{ icon_dislike | safe }} Bad**</md></font></span>
-<span id="good"><font color="green"><md>**{{ icon_like | safe }} Good**</md></font></span>
+<variable name="icon_announcement"><md>:fas-bell:</md></variable>
+<variable name="icon_book"><md>:fas-book:</md></variable>
+<variable name="icon_calendar"><md>:fas-calendar-alt:</md></variable>
+<variable name="icon_dislike"><md>:fas-thumbs-down:</md></variable>
+<variable name="icon_example"><md>:fas-cube:</md></variable>
+<variable name="icon_embedding"><md>:glyphicon-log-in:</md></variable>
+<variable name="icon_exercise"><md>:fas-dumbbell:</md></variable>
+<variable name="icon_extra"><span class='badge rounded-pill bg-secondary'><md>:fas-plus: extra</md></span></variable>
+<variable name="icon_info"><md>:fas-info-circle:</md></variable>
+<variable name="icon_like"><md>:fas-thumbs-up:</md></variable>
+<variable name="icon_linux"><md>:fab-linux:</md></variable>
+<variable name="icon_level_basic"><md><span class="badge rounded-pill bg-danger">:far-star:</span></md></variable>
+<variable name="icon_level_intermediate"><md><span class="badge rounded-pill bg-wg text-white">:far-star::far-star:</span></md></variable>
+<variable name="icon_level_advanced"><md><span class="badge rounded-pill bg-success">:far-star::far-star::far-star:</span></md></variable>
+<variable name="icon_important_big_red"><font color="red"><big>:glyphicon-exclamation-sign:</big></font></variable>
+<variable name="icon_important"><md>:glyphicon-exclamation-sign:</md></variable>
+<variable name="icon_new_window"><md>:glyphicon-new-window:</md></variable>
+<variable name="icon_outcome"><md>:fas-trophy:</md></variable>
+<variable name="icon_output"><md>:fas-arrow-down:</md></variable>
+<variable name="icon_output_right"><md>:fas-arrow-right:</md></variable>
+<variable name="icon_print"><md>:glyphicon-print:</md></variable>
+<variable name="icon_prereq"><md>:glyphicon-education:</md></variable>
+<variable name="icon_preview"><md>:glyphicon-eye-open:</md></variable>
+<variable name="icon_pro_tip"><span class="badge rounded-pill bg-warning">:fas-lightbulb: PRO TIP</span></variable>
+<variable name="icon_Q"><md>:glyphicon-question-sign:</md></variable>
+<variable name="icon_Q_A">{{ icon_Q | safe }}:glyphicon-ok-sign:</variable>
+<variable name="icon_resource"><md>:fas-paperclip:</md></variable>
+<variable name="icon_terminal"><smal><span class="badge bg-secondary">&gt;_</span></smal></variable>
+<variable name="icon_text"><md>:far-file-alt:</md></variable>
+<variable name="icon_tick"><md>:fas-check:</md></variable>
+<variable name="icon_tip"><span class="badge rounded-pill bg-warning">:fas-lightbulb:</span></variable>
+<variable name="icon_tick_green"><span style="color:green">{{ icon_tick | safe }}</span></variable>
+<variable name="icon_todo"><md>:glyphicon-check:</md></variable>
+<variable name="icon_slides"><md>:far-images:</md></variable>
+<variable name="icon_video"><md>:glyphicon-facetime-video:</md></variable>
+<variable name="icon_windows"><md>:fab-windows:</md></variable>
+<variable name="icon_x"><md>:fas-times:</md></variable>
+<variable name="icon_x_red"><span style="color:red">{{ icon_x | safe }}</span></variable>
+<variable name="bad"><font color="red"><md>**{{ icon_dislike | safe }} Bad**</md></font></variable>
+<variable name="good"><font color="green"><md>**{{ icon_like | safe }} Good**</md></font></variable>
 
 <variable from="variables.json" />

--- a/docs/_markbind/variables.md
+++ b/docs/_markbind/variables.md
@@ -38,5 +38,3 @@
 <variable name="icon_x_red"><span style="color:red">{{ icon_x | safe }}</span></variable>
 <variable name="bad"><font color="red"><md>**{{ icon_dislike | safe }} Bad**</md></font></variable>
 <variable name="good"><font color="green"><md>**{{ icon_like | safe }} Good**</md></font></variable>
-
-<variable from="variables.json" />

--- a/docs/dg/architecture.md
+++ b/docs/dg/architecture.md
@@ -39,7 +39,7 @@
  * [`GitShortlog`](https://github.com/reposense/RepoSense/blob/master/src/main/java/reposense/git/GitShortlog.java): Wrapper class for `git shortlog` functionality. Obtains the list of authors who have contributed to the target repo.
  * [`GitShow`](https://github.com/reposense/RepoSense/blob/master/src/main/java/reposense/git/GitShow.java): Wrapper class for `git show` functionality. Gets the date of the commit with the commit hash.
  * [`GitUtil`](https://github.com/reposense/RepoSense/blob/master/src/main/java/reposense/git/GitUtil.java): Contains helper functions used by the other Git classes above.
- * [`GitVersion`](https://github.com/reposense/RepoSense/blob/master/src/main/java/reposense/git/GitVersion.java): Wrapper class for `git --version` functionality. Obtains the current git version of the environment that RepoSense is being run on.
+ * [`GitVersion`](https://github.com/reposense/RepoSense/blob/master/src/main/java/reposense/git/GitVersion.java): Wrapper class for `git --version` functionality. Obtains the current Git version of the environment that RepoSense is being run on.
 
 <box type="info" seamless>
 

--- a/docs/dg/report.md
+++ b/docs/dg/report.md
@@ -50,7 +50,7 @@ The tabbed interface is responsible for loading various modules such as authorsh
 
 - **summary.json** - a list of all the repositories and their respective details
 - **projName/commits.json** - contains information of the users' commits information (e.g., line deletion, insertion, etc.), grouped by date
-- **projName/authorship.json** - contains information from git blame, detailing the author of each line for all the processed files
+- **projName/authorship.json** - contains information from `git blame`, detailing the author of each line for all the processed files
 
 <!-- ==================================================================================================== -->
 

--- a/docs/dg/settingUp.md
+++ b/docs/dg/settingUp.md
@@ -11,7 +11,7 @@
 **Prerequisites:**
 * **JDK `11.0.21+9`** up to **`17`** ([download :fas-download:](https://www.oracle.com/technetwork/java/javase/downloads/index.html)).
 * **Node.js** **`18`** up to the latest minor version of **`19`** ([download :fas-download:](https://www.npmjs.com/get-npm)).
-* **git `2.23`** or later ([download :fas-download:](https://git-scm.com/downloads)).
+* **Git `2.23`** or later ([download :fas-download:](https://git-scm.com/downloads)).
 
   <box type="info" seamless>
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,7 +11,7 @@
   <h1 class="display-3">RepoSense</h1>
   <div class="lead">
 
-Visualize programmer activities across git repositories...
+Visualize programmer activities across Git repositories...
 <br><br>
 <img src="images/reposenseOverview.png" width="909" alt="RepoSense overview"/>
 <br><br>

--- a/docs/ug/cli.md
+++ b/docs/ug/cli.md
@@ -215,7 +215,7 @@ credit is given.
 ### `--repo`, `--repos`, `-r`
 
 **`--repo REPO_LOCATION`**: Specifies which repositories to analyze.
-* Parameter: `REPO_LOCATION` A list of URLs or the disk location of the git repositories to analyze, separated by spaces.
+* Parameter: `REPO_LOCATION` A list of URLs or the disk location of the Git repositories to analyze, separated by spaces.
 * Alias: `-r`
 * Examples:
   * `--repos https://github.com/reposense/RepoSense.git`

--- a/docs/ug/configFiles.md
+++ b/docs/ug/configFiles.md
@@ -33,7 +33,7 @@ Given below are the details of the various config files used by RepoSense.
 
 | Column Name | Explanation |
 |-------------|-------------|
-| Repository's Location {{ mandatory }} | The `Remote Repo URL` or `Disk Path` to the git repository e.g., `https://github.com/foo/bar.git` or `C:\Users\user\Desktop\GitHub\foo\bar` |
+| Repository's Location {{ mandatory }} | The `Remote Repo URL` or `Disk Path` to the Git repository e.g., `https://github.com/foo/bar.git` or `C:\Users\user\Desktop\GitHub\foo\bar` |
 | Branch | The branch to analyze in the target repository e.g., `master`. Default: the default branch of the repo |
 | File formats<sup>*+</sup> | The file extensions to analyze. Binary file formats, such as `png` and `jpg`, will be automatically labelled as the file type `binary` in the generated report. Default: all file formats |
 | Find Previous Authors | Enter **`yes`** to utilize Git blame's ignore revisions functionality, RepoSense will attempt to blame the line changes caused by commits in the ignore commit list to the previous authors who altered those lines (if available). |
@@ -75,7 +75,7 @@ Optionally, you can use an `author-config.csv` (which should be in the same dire
 | Author's Git Host ID<sup>#</sup> {{ mandatory }} | Username of the target author's profile on GitHub, GitLab or Bitbucket, e.g.`JohnDoe`.                                                                                                           |
 | Author's Emails<sup>*</sup>                      | Associated emails of the author. For GitHub users, this can be found in your [GitHub settings](https://github.com/settings/emails).                                                              |
 | Author's Display Name                            | The name to display for the author. Default: author's username.                                                                                                                                  |
-| Author's Git Author Name<sup>*</sup>             | The meaning of _Git Author Name_ is explained in [_A note about git author name_](#a-note-about-git-author-name).                                                                                |
+| Author's Git Author Name<sup>*</sup>             | The meaning of _Git Author Name_ is explained in [_A note about Git author name_](#a-note-about-git-author-name).                                                                                |
 | Ignore Glob List<sup>*</sup>                     | Files to ignore for this author, in addition to files ignored by the patterns specified in `repo-config.csv`. The path glob syntax is the same as that of Ignore Glob List in `repo-config.csv`. |
 
 <sup>* **Multi-value column**: multiple values can be entered in this column using a semicolon `;` as the separator.</sup>
@@ -122,7 +122,7 @@ You can optionally use `report-config.json` to customize report generation by pr
 
 Repo owners can provide the following additional information to RepoSense using a config file that we call the **_standalone config file_**:
 * which files/authors/commits to analyze/omit
-* which git and git host usernames belong to which authors
+* which Git and Git host usernames belong to which authors
 * the display of an author
 
 To use this feature, add a `_reposense/config.json` to the root of your repo using the format in the example below ([another example](https://github.com/reposense/RepoSense/blob/master/_reposense/config.json)) and **commit it** (reason: RepoSense can see committed code only):
@@ -160,9 +160,9 @@ Note: all fields are optional unless specified otherwise.
 **Fields to provide _author-level_ info**:<br>
 Note: `authors` field should contain _all_ authors that should be captured in the analysis.
 * `gitId`: Username of the author. {{ mandatory }} field.
-* `emails`: Associated git emails of the author. For GitHub, this can be found in your [GitHub settings](https://github.com/settings/emails).
+* `emails`: Associated Git emails of the author. For GitHub, this can be found in your [GitHub settings](https://github.com/settings/emails).
 * `displayName`: Name to display on the report for this author.
-* `authorNames`: Git Author Name(s) used in the author's commits. By default, RepoSense assumes an author would use their remote Git Host username as the Git username too. The meaning of _Git Author Name_ is explained in [_A note about git author name_](#a-note-about-git-author-name).
+* `authorNames`: Git Author Name(s) used in the author's commits. By default, RepoSense assumes an author would use their remote Git Host username as the Git username too. The meaning of _Git Author Name_ is explained in [_A note about Git author name_](#a-note-about-git-author-name).
 * `ignoreGlobList`: _Additional_ (i.e. on top of the repo-level `ignoreGlobList`) folders/files to ignore for a specific author. The path glob syntax is specified by the [_glob format_](https://docs.oracle.com/javase/tutorial/essential/io/fileOps.html#glob). In the example above, the actual `ignoreGlobList` for `alice` would be `["about-us/**", "**index.html", "**.css"]`.
 
 To verify your standalone configuration is as intended, add the `_reposense/config.json` to your local copy of repo and run RepoSense against it as follows:<br>
@@ -170,7 +170,7 @@ To verify your standalone configuration is as intended, add the `_reposense/conf
 * Example: `java -jar RepoSense.jar --repo c:/myRepose/foo/bar`<br>
 After that, view the report to see if the configuration you specified in the config file is being reflected correctly in the report.
 
-## A note about git author name
+## A note about Git author name
 
 `Git Author Name` refers to the customizable author's display name set in the local `.gitconfig` file. For example, in the Git Log's display:
 ``` {.no-line-numbers}
@@ -189,15 +189,15 @@ Date:   Fri Feb 9 19:13:13 2018 +0800
  ...
 ```
 `ActualGitHostId` and `ConfiguredAuthorName` are both `Git Author Name` of the same author.<br>
-To find the author name that you are currently using for your current git repository, run the following command within your git repository:
+To find the author name that you are currently using for your current Git repository, run the following command within your Git repository:
 ``` shell {.no-line-numbers}
 git config user.name
 ```
-To set the author name to the value you want (e.g., to set it to your GitHub username) for your current git repository, you can use the following command ([more info](https://www.git-tower.com/learn/git/faq/change-author-name-email)):
+To set the author name to the value you want (e.g., to set it to your GitHub username) for your current Git repository, you can use the following command ([more info](https://www.git-tower.com/learn/git/faq/change-author-name-email)):
 ``` shell {.no-line-numbers}
 git config user.name "YOUR_AUTHOR_NAME”
 ```
-To set the author name to use a default value you want for future git repositories, you can use the following command:
+To set the author name to use a default value you want for future Git repositories, you can use the following command:
 ``` shell {.no-line-numbers}
 git config --global user.name "YOUR_AUTHOR_NAME”
 ```

--- a/docs/ug/customizingReports.md
+++ b/docs/ug/customizingReports.md
@@ -31,7 +31,7 @@ The report can be customized using several ways, as explained below.
 
 <box type="tip" seamless>
 
-**Managing config files collaboratively**: If you use RepoSense to monitor a large number of programmers, it may be more practical to get the programmers to submit PRs to update the config files as necessary (<tooltip content="a coder realizes some of her code is missing from the report because she used multiple git usernames, and wants to add the additional usernames to the config file">example use case</tooltip>).
+**Managing config files collaboratively**: If you use RepoSense to monitor a large number of programmers, it may be more practical to get the programmers to submit PRs to update the config files as necessary (<tooltip content="a coder realizes some of her code is missing from the report because she used multiple Git usernames, and wants to add the additional usernames to the config file">example use case</tooltip>).
 
 To ensure that their PRs are correct, you can use [Netlify _deploy previews_](https://www.netlify.com/blog/2016/07/20/introducing-deploy-previews-in-netlify/) to preview how the report would look like after the PR has been merged. More details are in the panels below.
 
@@ -58,7 +58,7 @@ In both instances, it is **necessary to commit any changes** for them to be dete
 
 </box>
 
-3\. Add a git `.mailmap` file at the top-level of the repository, specifying mapped authors/commiters and/or e-mail addresses as per [gitmailmap documentation](https://git-scm.com/docs/gitmailmap). Any mappings specified here will be applied by git before all other RepoSense configurations. Configuration via `.mailmap` is particularly useful if you want the mapping to apply for all git commands as well instead of just for RepoSense.
+3\. Add a Git `.mailmap` file at the top-level of the repository, specifying mapped authors/commiters and/or e-mail addresses as per [gitmailmap documentation](https://git-scm.com/docs/gitmailmap). Any mappings specified here will be applied by Git before all other RepoSense configurations. Configuration via `.mailmap` is particularly useful if you want the mapping to apply for all Git commands as well instead of just for RepoSense.
 
 <!-- ------------------------------------------------------------------------------------------------------ -->
 

--- a/docs/ug/faq.md
+++ b/docs/ug/faq.md
@@ -9,8 +9,8 @@
 <!-- ------------------------------------------------------------------------------------------------------ -->
 
 ### Q: Does RepoSense work on private repositories?
-**A:** *RepoSense* will first clone the git repository to be analyzed; thus, if you do not have access to the repository, we cannot run the analysis.<br>
-To enable *RepoSense* to work on private repositories, ensure that you have enabled access to your private repository in your git terminal first before running the analysis.
+**A:** *RepoSense* will first clone the Git repository to be analyzed; thus, if you do not have access to the repository, we cannot run the analysis.<br>
+To enable *RepoSense* to work on private repositories, ensure that you have enabled access to your private repository in your Git terminal first before running the analysis.
 
 <!-- ------------------------------------------------------------------------------------------------------ -->
 

--- a/docs/ug/generatingReports.md
+++ b/docs/ug/generatingReports.md
@@ -20,7 +20,7 @@ Let's look at different ways to generate RepoSense reports.
 
 <box type="info" seamless>
 
-RepoSense is built to analyze any type of git repo, remote or local. It works best when analyzing remote repositories hosted on GitHub, GitLab or BitBucket.
+RepoSense is built to analyze any type of Git repo, remote or local. It works best when analyzing remote repositories hosted on GitHub, GitLab or BitBucket.
 For other types of repositories, external links are disabled.
 </box>
 
@@ -30,7 +30,7 @@ For other types of repositories, external links are disabled.
 
 1. **Ensure you have the prerequisites**:
    * **Java 11** or later ([download :fas-download:](https://www.java.com/en/)).
-   * **git `2.23`** or later on the command line. ([download :fas-download:](https://git-scm.com/downloads)).<br> run `git --version` in your OS terminal to confirm the version.
+   * **Git `2.23`** or later on the command line. ([download :fas-download:](https://git-scm.com/downloads)).<br> run `git --version` in your OS terminal to confirm the version.
 
 1. **Download the latest JAR file** from our [releases](https://github.com/reposense/RepoSense/releases/latest).
 

--- a/docs/ug/usingAuthorTags.md
+++ b/docs/ug/usingAuthorTags.md
@@ -12,7 +12,7 @@
 `@@author` tags is a rather invasive but sometimes necessary way to provide more information to RepoSense, by annotating the code being analyzed.
 </div>
 
-If you want to override the code authorship deduced by RepoSense (which is based on Git blame/log data), you can use `@@author` tags to specify certain code segments that should be credited to a certain author irrespective of git history. An example scenario where this is useful is when a method was originally written by one author but a second author did some minor refactoring to it; in this case, RepoSense might attribute the code to the second author while you may want to attribute the code to the first author.
+If you want to override the code authorship deduced by RepoSense (which is based on Git blame/log data), you can use `@@author` tags to specify certain code segments that should be credited to a certain author irrespective of Git history. An example scenario where this is useful is when a method was originally written by one author but a second author did some minor refactoring to it; in this case, RepoSense might attribute the code to the second author while you may want to attribute the code to the first author.
 
 There are 2 types of `@@author` tags:
 - Start Tags (format: `@@author AUTHOR_GIT_AUTHOR_NAME`): A start tag indicates the start of a code segment written by the author identified by the `AUTHOR_GIT_AUTHOR_NAME`.

--- a/docs/ug/usingReports.md
+++ b/docs/ug/usingReports.md
@@ -94,7 +94,7 @@ The `Tool Bar` at the top of the Chart panel provides a set of configuration opt
   * Multiple keywords/terms can be used, separated by spaces.
   * Entries that contain _any_ (not necessarily _all_) of the search terms will be displayed.
   * The keywords used to filter the author and repository are case-insensitive.
-  * Starting a search with `tag:` will filter author and repository by git tags. Similar search rules as above (like separating multiple tag names by space) apply.
+  * Starting a search with `tag:` will filter author and repository by Git tags. Similar search rules as above (like separating multiple tag names by space) apply.
 * `Group by`: grouping criteria for the rows of results.
   * `None`: results will not be grouped in any particular way.
   * `Repo/Branch`: results will be grouped by repositories and its' associating branches.

--- a/docs/ug/usingReports.md
+++ b/docs/ug/usingReports.md
@@ -18,7 +18,7 @@ Let's look at how to view, interpret, and interact with a RepoSense report.
 As a report consists of web pages, it can be viewed using a Web Browser. Here are the ways to view the report in different situations.
 
 * **Situation 1: The report has been hosted on a website**
-  * Simply go to the URL of the report ([example](https://nus-cs2113-ay1920s2.github.io/tp-dashboard)) in your browser.
+  * Simply go to the URL of the report ([example](https://nus-cs2113-ay2324s2.github.io/tp-dashboard)) in your browser.
 * **Situation 2: You generated the report in your computer earlier**
   * Run RepoSense with the `--view` option:<br>
     Format: `java -jar RepoSense.jar --view REPORT_FOLDER`<br>
@@ -129,7 +129,7 @@ Notes:<br>
 
 <box type="tip" seamless>
 
-**RepoSense support _intelligent_ bookmarks**: Note how the browser URL changes as you modify settings in the report. If you send that URL to someone else, that person will be able to use that URL to view the report in the same _view configuration_ you had when you copied the URL. For example, [this URL](https://nus-cs2113-ay1920s2.github.io/tp-dashboard/) and [this URL](https://nus-cs2113-ay1920s2.github.io/tp-dashboard/#search=&sort=groupTitle&sortWithin=title&since=2020-03-01&timeframe=day&mergegroup=true&groupSelect=groupByRepos&breakdown=true) give two different views of the same report.
+**RepoSense support _intelligent_ bookmarks**: Note how the browser URL changes as you modify settings in the report. If you send that URL to someone else, that person will be able to use that URL to view the report in the same _view configuration_ you had when you copied the URL. For example, [this URL](https://nus-cs2113-ay2324s2.github.io/tp-dashboard/) and [this URL](https://nus-cs2113-ay2324s2.github.io/tp-dashboard/?search=&sort=groupTitle%20dsc&sortWithin=title&since=2024-02-23&until=2024-04-26&timeframe=commit&mergegroup=&groupSelect=groupByRepos&breakdown=true&tabOpen=false&checkedFileTypes=docs~functional-code~test-code~other) give two different views of the same report.
 </box>
 
 <!-- ==================================================================================================== -->


### PR DESCRIPTION
Fixes for some minor cosmetic issues I noticed while reading the UG.

You can do a rebase merge for this, as each commit is a separate fix.

```
Fix some minor cosmetic issues in docs

The documentation site for RepoSense uses the legacy <span> syntax for
defining variables. The example dashboards are also outdated. Moreover, the
word 'Git' has been capitalised wrongly in the docs.

Let's update variables.md to use the proper <variable> syntax instead
of the legacy <span> syntax for defining variables. Also, let's remove
the variables.json file as it is not used. Let's update links of example
dashboards to point to a later version which uses a more recent version of
RepoSense. Lastly, let's fix the 'Git' typos across the docs. 
```