### PR TITLE
Fix missing PageNav in docs

### DIFF
--- a/docs/_markbind/layouts/body.md
+++ b/docs/_markbind/layouts/body.md
@@ -12,7 +12,7 @@
 <div id="content-wrapper" class="fixed-header-padding">
 {{ content }}
 </div>
-{% if pagnav %}
+{% if pagenav %}
 <nav id="page-nav" class="fixed-header-padding">
 <div class="nav-component slim-scroll">
 <page-nav />


### PR DESCRIPTION
Fixes a typo that caused the page navigation menu to not appear:

before:
![image](https://github.com/reposense/RepoSense/assets/1673303/083f0392-2f96-4d7f-9a1e-2b2f77a96693)

after:
![image](https://github.com/reposense/RepoSense/assets/1673303/23fe5a5d-06e2-4c73-9d81-a05cccec68ef)
