### PR TITLE
[#2222] Fix Checkboxes Line Count

### DIFF
--- a/frontend/src/components/c-file-type-checkboxes.vue
+++ b/frontend/src/components/c-file-type-checkboxes.vue
@@ -101,7 +101,7 @@ export default defineComponent({
       blankLineCount: number,
     }): string {
       return `${label.fileType}\xA0\xA0`
-        + `${label.blankLineCount}\xA0\xA0`
+        + `${label.lineCount}\xA0\xA0`
         + `(${label.lineCount - label.blankLineCount})\xA0`;
     },
   },


### PR DESCRIPTION
<!--
    If this pull request fully addresses an issue, use:
    Fixes #xxxx

    If this pull request partially addresses an issue, use:
    Part of #xxxx

    If this pull request addresses multiple issues, put them in multiple lines:
    Fixes #xxxx
    Fixes #yyyy

    Format the title of the pull request with most relevant issue number as follows:
    [#xxxx] Title
-->
Fixes #2222

### Proposed commit message
<!--
    Propose a detailed commit message for this pull request within the triple backticks below.
    Wrap lines at 72 characters.

    Guide on how to write a good commit message:
    https://oss-generic.github.io/process/docs/FormatsAndConventions.html#commit-message
-->
```
Fix Checkboxes Line Count

In c-file-type-checkboxes, the method getLabel() should show fileType,
lineCount and effective line count, but it currently shows fileType,
blankLineCount and effective line count instead.

Let's fix the code to show the correct counts.
```

### Other information
<!--
    Are there other relevant information, such as special testing instructions,
    which will help the reviewer better understand the code?

    You may also include a brief description of why the problem occurred.
-->
