### PR TITLE
Align right panel with welcome title

### DIFF
--- a/frontend/src/styles/panels.scss
+++ b/frontend/src/styles/panels.scss
@@ -2,7 +2,7 @@
 @import 'z-indices';
 
 .panel-padding {
-  padding: 0 0 2rem 2.2rem;
+  padding: 0 1.5rem 2rem 2.2rem;
 }
 
 #app-wrapper {

--- a/frontend/src/styles/panels.scss
+++ b/frontend/src/styles/panels.scss
@@ -2,7 +2,7 @@
 @import 'z-indices';
 
 .panel-padding {
-  padding: 2rem 1.5rem 2rem 2.2rem;
+  padding: 0 0 2rem 2.2rem;
 }
 
 #app-wrapper {

--- a/frontend/src/views/c-authorship.vue
+++ b/frontend/src/views/c-authorship.vue
@@ -1,14 +1,14 @@
 <template lang="pug">
 #authorship
-  <br></br>
-  .panel-title
-    span Code Panel
-  .toolbar--multiline
-    a(
-      v-if="activeFilesCount < selectedFiles.length",
-      v-on:click="toggleAllFileActiveProperty(true)"
-    ) show all file details
-    a(v-if="activeFilesCount > 0", v-on:click="toggleAllFileActiveProperty(false)") hide all file details
+  h2
+    .panel-title
+        span Code Panel
+    .toolbar--multiline
+      a(
+        v-if="activeFilesCount < selectedFiles.length",
+        v-on:click="toggleAllFileActiveProperty(true)"
+      ) show all file details
+      a(v-if="activeFilesCount > 0", v-on:click="toggleAllFileActiveProperty(false)") hide all file details
   .panel-heading
     a.group-name(
       v-bind:href="info.location", target="_blank",

--- a/frontend/src/views/c-authorship.vue
+++ b/frontend/src/views/c-authorship.vue
@@ -2,7 +2,7 @@
 #authorship
   h2
     .panel-title
-        span Code Panel
+      span Code Panel
     .toolbar--multiline
       a(
         v-if="activeFilesCount < selectedFiles.length",

--- a/frontend/src/views/c-authorship.vue
+++ b/frontend/src/views/c-authorship.vue
@@ -1,7 +1,6 @@
 <template lang="pug">
 #authorship
-  <br>
-  </br>
+  <br></br>
   .panel-title
     span Code Panel
   .toolbar--multiline

--- a/frontend/src/views/c-authorship.vue
+++ b/frontend/src/views/c-authorship.vue
@@ -1,5 +1,7 @@
 <template lang="pug">
 #authorship
+  <br>
+  </br>
   .panel-title
     span Code Panel
   .toolbar--multiline

--- a/frontend/src/views/c-zoom.vue
+++ b/frontend/src/views/c-zoom.vue
@@ -1,17 +1,17 @@
 <template lang="pug">
 #zoom(v-if="filteredUser")
-  <br></br>
-  .panel-title
-    span Commits Panel
-  .toolbar--multiline(v-if="filteredUser.commits.length && totalCommitMessageBodyCount")
-    a(
-      v-if="expandedCommitMessagesCount < totalCommitMessageBodyCount",
-      v-on:click="toggleAllCommitMessagesBody(true); toggleDiffstatView(true);"
-    ) show all commit details
-    a(
-      v-if="expandedCommitMessagesCount > 0",
-      v-on:click="toggleAllCommitMessagesBody(false); toggleDiffstatView(false);"
-    ) hide all commit details
+  h2
+    .panel-title
+      span Commits Panel
+    .toolbar--multiline(v-if="filteredUser.commits.length && totalCommitMessageBodyCount")
+      a(
+        v-if="expandedCommitMessagesCount < totalCommitMessageBodyCount",
+        v-on:click="toggleAllCommitMessagesBody(true); toggleDiffstatView(true);"
+      ) show all commit details
+      a(
+        v-if="expandedCommitMessagesCount > 0",
+        v-on:click="toggleAllCommitMessagesBody(false); toggleDiffstatView(false);"
+      ) hide all commit details
   .panel-heading
     .group-name
       span(

--- a/frontend/src/views/c-zoom.vue
+++ b/frontend/src/views/c-zoom.vue
@@ -1,7 +1,6 @@
 <template lang="pug">
 #zoom(v-if="filteredUser")
-  <br>
-  </br>
+  <br></br>
   .panel-title
     span Commits Panel
   .toolbar--multiline(v-if="filteredUser.commits.length && totalCommitMessageBodyCount")

--- a/frontend/src/views/c-zoom.vue
+++ b/frontend/src/views/c-zoom.vue
@@ -1,5 +1,7 @@
 <template lang="pug">
 #zoom(v-if="filteredUser")
+  <br>
+  </br>
   .panel-title
     span Commits Panel
   .toolbar--multiline(v-if="filteredUser.commits.length && totalCommitMessageBodyCount")


### PR DESCRIPTION
Resolves #2127

### Proposed commit message

```
Align panel titles

The title text on the left panel is not flushed to the top because it
is a header.

There are several types of title texts on the right panel. Initially,
some were headers and others were not. There was padding to ensure that
those which were not headers were not flushed to the top.  However, this
meant that those headers were lower than expected and not aligned. 

To align the texts, let us remove the padding for the right panel and
set the first element on the right panel as a header. 
```
### Other information

Before:

![Before](https://github.com/reposense/RepoSense/assets/110604064/20007f75-aae0-471e-bb82-e75e5153fae5)

After:

![After](https://github.com/reposense/RepoSense/assets/110604064/93ce15aa-7105-419d-b923-93b13b5c903e)

