### PR TITLE
[#2262] Update type adapter adding methods for gson builder

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, ubuntu-22.04, macos-13, macos-14, macos-15, windows-2019, windows-2022]
+        os: [ubuntu-22.04, ubuntu-24.04, macos-13, macos-14, macos-15, windows-2019, windows-2022]
     runs-on: ${{ matrix.os }}
     env:
       HOMEBREW_NO_AUTO_UPDATE: 1 # Prevent time-consuming brew update
@@ -78,7 +78,7 @@ jobs:
       run: ./gradlew clean checkstyleAll test systemTest coverage
 
     - name: Run code coverage
-      if: ${{ success() && ( matrix.os == 'ubuntu-20.04' || matrix.os == 'macos-15' || matrix.os == 'windows-2022' ) }}
+      if: ${{ success() && ( matrix.os == 'ubuntu-24.04' || matrix.os == 'macos-15' || matrix.os == 'windows-2022' ) }}
       uses: codecov/codecov-action@v3
       with:
         directory: ${{ github.workspace }}/build/reports/jacoco/coverage
@@ -86,7 +86,7 @@ jobs:
         fail_ci_if_error: false
 
     - name: Build preview website (pull request)
-      if: ${{ success() && github.event_name == 'pull_request' && matrix.os == 'ubuntu-20.04' }}
+      if: ${{ success() && github.event_name == 'pull_request' && matrix.os == 'ubuntu-24.04' }}
       run: |
         git fetch --all && git config --global user.email "-" && git config --global user.name "-" && ./gradlew run -Dargs="--since d1"
         sudo apt-get -y install graphviz
@@ -94,14 +94,14 @@ jobs:
         (cd docs && markbind build)
 
     - name: Save PR number and HEAD commit (pull request)
-      if: ${{ success() && github.event_name == 'pull_request' && matrix.os == 'ubuntu-20.04' }}
+      if: ${{ success() && github.event_name == 'pull_request' && matrix.os == 'ubuntu-24.04' }}
       run: |
         mkdir -p ./pr
         echo ${{ github.event.number }} > ./pr/NUMBER
         echo ${{ github.event.pull_request.head.sha }} > ./pr/SHA
 
     - name: Upload artifacts (pull request)
-      if: ${{ success() && github.event_name == 'pull_request' && matrix.os == 'ubuntu-20.04' }}
+      if: ${{ success() && github.event_name == 'pull_request' && matrix.os == 'ubuntu-24.04' }}
       uses: actions/upload-artifact@v3
       with:
         name: reposense-deployment

--- a/docs/dg/learningBasics.md
+++ b/docs/dg/learningBasics.md
@@ -151,11 +151,9 @@ Here are some small tasks for you to gain some basic knowledge of the code relat
 
   ```java
   GsonBuilder gsonBuilder = new GsonBuilder()
-          .registerTypeAdapter(LocalDateTime.class, (JsonSerializer<LocalDateTime>) (date, typeOfSrc, context)
-                        -> new JsonPrimitive(date.format(DateTimeFormatter.ofPattern(GITHUB_API_DATE_FORMAT))))
+          .registerTypeHierarchyAdapter(LocalDateTime.class, new DateSerializer())
           .registerTypeAdapter(FileType.class, new FileType.FileTypeSerializer())
-          .registerTypeAdapter(ZoneId.class, (JsonSerializer<ZoneId>) (zoneId, typeOfSrc, context)
-                        -> new JsonPrimitive(zoneId.toString()));
+          .registerTypeHierarchyAdapter(ZoneId.class, new ZoneSerializer())
   Gson gson;
   if (isPrettyPrintingUsed) {
       gson = gsonBuilder.setPrettyPrinting().create();

--- a/src/main/java/reposense/util/FileUtil.java
+++ b/src/main/java/reposense/util/FileUtil.java
@@ -48,9 +48,11 @@ public class FileUtil {
 
     private static final Logger logger = LogsManager.getLogger(FileUtil.class);
     private static final ByteBuffer buffer = ByteBuffer.allocate(1 << 11); // 2KB
+
     private static final String BARE_REPO_SUFFIX = "_bare";
     private static final String PARTIAL_REPO_SUFFIX = "_partial";
     private static final String SHALLOW_PARTIAL_REPO_SUFFIX = "_shallow_partial";
+
     private static final String MESSAGE_INVALID_FILE_PATH = "\"%s\" is an invalid file path. Skipping this directory.";
     private static final String MESSAGE_FAIL_TO_ZIP_FILES =
             "Exception occurred while attempting to zip the report files.";

--- a/src/main/java/reposense/util/FileUtil.java
+++ b/src/main/java/reposense/util/FileUtil.java
@@ -42,18 +42,15 @@ import reposense.util.adapters.ZoneSerializer;
  */
 public class FileUtil {
     public static final String REPOS_ADDRESS = "repos";
-    public static final String GITHUB_API_DATE_FORMAT = "yyyy-MM-dd";
+
     // zip file which contains all the specified file types
     public static final String ZIP_FILE = "archive.zip";
 
     private static final Logger logger = LogsManager.getLogger(FileUtil.class);
-
     private static final ByteBuffer buffer = ByteBuffer.allocate(1 << 11); // 2KB
-
     private static final String BARE_REPO_SUFFIX = "_bare";
     private static final String PARTIAL_REPO_SUFFIX = "_partial";
     private static final String SHALLOW_PARTIAL_REPO_SUFFIX = "_shallow_partial";
-
     private static final String MESSAGE_INVALID_FILE_PATH = "\"%s\" is an invalid file path. Skipping this directory.";
     private static final String MESSAGE_FAIL_TO_ZIP_FILES =
             "Exception occurred while attempting to zip the report files.";

--- a/src/main/java/reposense/util/FileUtil.java
+++ b/src/main/java/reposense/util/FileUtil.java
@@ -42,12 +42,12 @@ import reposense.util.adapters.ZoneSerializer;
  */
 public class FileUtil {
     public static final String REPOS_ADDRESS = "repos";
-
+    public static final String GITHUB_API_DATE_FORMAT = "yyyy-MM-dd";
     // zip file which contains all the specified file types
     public static final String ZIP_FILE = "archive.zip";
 
     private static final Logger logger = LogsManager.getLogger(FileUtil.class);
-    public static final String GITHUB_API_DATE_FORMAT = "yyyy-MM-dd";
+
     private static final ByteBuffer buffer = ByteBuffer.allocate(1 << 11); // 2KB
 
     private static final String BARE_REPO_SUFFIX = "_bare";

--- a/src/main/java/reposense/util/FileUtil.java
+++ b/src/main/java/reposense/util/FileUtil.java
@@ -16,7 +16,6 @@ import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
-import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
@@ -29,14 +28,14 @@ import java.util.zip.ZipOutputStream;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
-import com.google.gson.JsonPrimitive;
-import com.google.gson.JsonSerializer;
 
 import reposense.model.CommitHash;
 import reposense.model.FileType;
 import reposense.model.RepoConfiguration;
 import reposense.system.CommandRunner;
 import reposense.system.LogsManager;
+import reposense.util.adapters.DateSerializer;
+import reposense.util.adapters.ZoneSerializer;
 
 /**
  * Contains file processing related functionalities.
@@ -48,7 +47,7 @@ public class FileUtil {
     public static final String ZIP_FILE = "archive.zip";
 
     private static final Logger logger = LogsManager.getLogger(FileUtil.class);
-    private static final String GITHUB_API_DATE_FORMAT = "yyyy-MM-dd";
+    public static final String GITHUB_API_DATE_FORMAT = "yyyy-MM-dd";
     private static final ByteBuffer buffer = ByteBuffer.allocate(1 << 11); // 2KB
 
     private static final String BARE_REPO_SUFFIX = "_bare";
@@ -104,11 +103,9 @@ public class FileUtil {
      */
     public static Optional<Path> writeJsonFile(Object object, String path) {
         Gson gson = new GsonBuilder()
-                .registerTypeAdapter(LocalDateTime.class, (JsonSerializer<LocalDateTime>) (date, typeOfSrc, context)
-                        -> new JsonPrimitive(date.format(DateTimeFormatter.ofPattern(GITHUB_API_DATE_FORMAT))))
+                .registerTypeHierarchyAdapter(LocalDateTime.class, new DateSerializer())
                 .registerTypeAdapter(FileType.class, new FileType.FileTypeSerializer())
-                .registerTypeAdapter(ZoneId.class, (JsonSerializer<ZoneId>) (zoneId, typeOfSrc, context)
-                        -> new JsonPrimitive(zoneId.toString()))
+                .registerTypeHierarchyAdapter(ZoneId.class, new ZoneSerializer())
                 .create();
 
         // Gson serializer from:

--- a/src/main/java/reposense/util/adapters/DateSerializer.java
+++ b/src/main/java/reposense/util/adapters/DateSerializer.java
@@ -1,0 +1,19 @@
+package reposense.util.adapters;
+
+import static reposense.util.FileUtil.GITHUB_API_DATE_FORMAT;
+
+import java.lang.reflect.Type;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonPrimitive;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
+
+public class DateSerializer implements JsonSerializer<LocalDateTime> {
+    @Override
+    public JsonElement serialize(LocalDateTime date, Type typeofDate, JsonSerializationContext ctx) {
+        return new JsonPrimitive(date.format(DateTimeFormatter.ofPattern(GITHUB_API_DATE_FORMAT)));
+    }
+}

--- a/src/main/java/reposense/util/adapters/DateSerializer.java
+++ b/src/main/java/reposense/util/adapters/DateSerializer.java
@@ -11,6 +11,9 @@ import com.google.gson.JsonPrimitive;
 import com.google.gson.JsonSerializationContext;
 import com.google.gson.JsonSerializer;
 
+/**
+ * Overrides the custom gson serializer for LocalDateTine type object.
+ */
 public class DateSerializer implements JsonSerializer<LocalDateTime> {
     @Override
     public JsonElement serialize(LocalDateTime date, Type typeofDate, JsonSerializationContext ctx) {

--- a/src/main/java/reposense/util/adapters/DateSerializer.java
+++ b/src/main/java/reposense/util/adapters/DateSerializer.java
@@ -1,7 +1,5 @@
 package reposense.util.adapters;
 
-import static reposense.util.FileUtil.GITHUB_API_DATE_FORMAT;
-
 import java.lang.reflect.Type;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
@@ -15,6 +13,7 @@ import com.google.gson.JsonSerializer;
  * Overrides the custom gson serializer for LocalDateTine type object.
  */
 public class DateSerializer implements JsonSerializer<LocalDateTime> {
+    private static final String GITHUB_API_DATE_FORMAT = "yyyy-MM-dd";
     @Override
     public JsonElement serialize(LocalDateTime date, Type typeofDate, JsonSerializationContext ctx) {
         return new JsonPrimitive(date.format(DateTimeFormatter.ofPattern(GITHUB_API_DATE_FORMAT)));

--- a/src/main/java/reposense/util/adapters/ZoneSerializer.java
+++ b/src/main/java/reposense/util/adapters/ZoneSerializer.java
@@ -1,0 +1,16 @@
+package reposense.util.adapters;
+
+import java.lang.reflect.Type;
+import java.time.ZoneId;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonPrimitive;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
+
+public class ZoneSerializer implements JsonSerializer<ZoneId> {
+    @Override
+    public JsonElement serialize(ZoneId z, Type t, JsonSerializationContext ctx) {
+        return new JsonPrimitive(z.toString());
+    }
+}

--- a/src/main/java/reposense/util/adapters/ZoneSerializer.java
+++ b/src/main/java/reposense/util/adapters/ZoneSerializer.java
@@ -8,6 +8,9 @@ import com.google.gson.JsonPrimitive;
 import com.google.gson.JsonSerializationContext;
 import com.google.gson.JsonSerializer;
 
+/**
+ * Overrides the custom gson serializer for ZoneId type object.
+ */
 public class ZoneSerializer implements JsonSerializer<ZoneId> {
     @Override
     public JsonElement serialize(ZoneId z, Type t, JsonSerializationContext ctx) {


### PR DESCRIPTION
<!--
    If this pull request fully addresses an issue, use:
    Fixes #xxxx

    If this pull request partially addresses an issue, use:
    Part of #xxxx

    If this pull request addresses multiple issues, put them in multiple lines:
    Fixes #xxxx
    Fixes #yyyy

    Format the title of the pull request with most relevant issue number as follows:
    [#xxxx] Title
-->
Fixes #2262 

### Proposed commit message
<!--
    Propose a detailed commit message for this pull request within the triple backticks below.
    Wrap lines at 72 characters.

    Guide on how to write a good commit message:
    https://oss-generic.github.io/process/docs/FormatsAndConventions.html#commit-message
-->

```
Update GSON type adapter adding methods

The registration of custom adapters for ZoneID and LocalDateTime causes
The JsonIOException to pop up when trying to run the jar file in java
17.

Let's use the registerTypeHierarchyAdapter method to add the custom
adapters instead.
```

### Other information
<!--
    Are there other relevant information, such as special testing instructions,
    which will help the reviewer better understand the code?

    You may also include a brief description of why the problem occurred.
-->
Here are some reference resources I found online:
- https://stackoverflow.com/questions/74924830/why-is-gson-looking-for-java-time-zoneregion-when-serializing-java-time-zoneid
- https://www.javadoc.io/doc/com.google.code.gson/gson/2.6.2/com/google/gson/GsonBuilder.html#registerTypeHierarchyAdapter-java.lang.Class-java.lang.Object