### PR TITLE
[#2266] Fix Cypress tests that fail locally

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -197,7 +197,7 @@ def serveTestReportInBackground = tasks.register('serveTestReportInBackground', 
     workingDir = 'build/serveTestReport'
     main = mainClassName
     classpath = sourceSets.main.runtimeClasspath
-    args = ['--config', './exampleconfig', '--since', 'd1', '--view', '-A']
+    args = ['--config', './exampleconfig', '--since', 'd1', '--view', '-A', '-t', 'UTC']
     String versionJvmArgs = '-Dversion=' + getRepoSenseVersion()
     jvmArgs = [ versionJvmArgs ]
     waitForPort = 9000

--- a/frontend/cypress/tests/chartView/chartView_optimiseTimeline.cy.js
+++ b/frontend/cypress/tests/chartView/chartView_optimiseTimeline.cy.js
@@ -57,7 +57,6 @@ describe('optimise timeline', () => {
       .find('.summary-chart__ramp .date-indicators span')
       .last()
 
-      // 3/3 on GitHub CI, 3/4 on local
       .should('have.text', '2023-03-03');
   });
 


### PR DESCRIPTION
<!--
    If this pull request fully addresses an issue, use:
    Fixes #xxxx

    If this pull request partially addresses an issue, use:
    Part of #xxxx

    If this pull request addresses multiple issues, put them in multiple lines:
    Fixes #xxxx
    Fixes #yyyy

    Format the title of the pull request with most relevant issue number as follows:
    [#xxxx] Title
-->
Fixes #2266

### Proposed commit message
<!--
    Propose a detailed commit message for this pull request within the triple backticks below.
    Wrap lines at 72 characters.

    Guide on how to write a good commit message:
    https://oss-generic.github.io/process/docs/FormatsAndConventions.html#commit-message
-->
```
Set UTC timezone for test reports

Running Cypress tests locally uses system's default timezone
(UTC+8), causing 3 tests that check for dates to fail. These 3 tests
pass on GitHub Actions as the system's default timezone is UTC.

Let's standardize the timezone for all cypress tests to UTC.
```

### Other information
<!--
    Are there other relevant information, such as special testing instructions,
    which will help the reviewer better understand the code?

    You may also include a brief description of why the problem occurred.
-->
Run `./gradlew frontendTests` or `./gradlew cypress` locally to verify all tests are passing.

3 previously failing tests:
* chartView/chartView_mergeCommits.cy.js show merge commits in summary chart
* chartView/chartView_optimiseTimeline.cy.js start and end date indicators should exist
* chartView/chartView_optimiseTimeline.cy.js zoom panel range should work correctly when timeline is optimised