### PR TITLE
[#2213] Fix hr element not appearing in report

### DIFF
--- a/frontend/src/styles/style.scss
+++ b/frontend/src/styles/style.scss
@@ -22,6 +22,7 @@ a.broken-link {
 }
 
 hr {
+  // This is needed because normalize.css sets the height to 0px.
   height: 1px;
 }
 

--- a/frontend/src/styles/style.scss
+++ b/frontend/src/styles/style.scss
@@ -21,6 +21,10 @@ a.broken-link {
   text-decoration: none;
 }
 
+hr {
+  height: 1px;
+}
+
 [v-cloak] {
   display: none;
 }


### PR DESCRIPTION
<!--
    If this pull request fully addresses an issue, use:
    Fixes #xxxx

    If this pull request partially addresses an issue, use:
    Part of #xxxx

    If this pull request addresses multiple issues, put them in multiple lines:
    Fixes #xxxx
    Fixes #yyyy

    Format the title of the pull request with most relevant issue number as follows:
    [#xxxx] Title
-->
Fixes #2213 

### Proposed commit message
<!--
    Propose a detailed commit message for this pull request within the triple backticks below.
    Wrap lines at 72 characters.

    Guide on how to write a good commit message:
    https://oss-generic.github.io/process/docs/FormatsAndConventions.html#commit-message
-->
```
Fix the <hr> element not appearing in report.

The <hr> element in title.md and blurbs.md is not appearing in the
report because the normalise.css defaults the <hr> element style.

Let's override the <hr> element style in style.scss so that it will
appear in the report.
```
