### PR TITLE
[#2190] Add ESLint rule to enforce commas between types

### DIFF
--- a/frontend/.eslintrc.json
+++ b/frontend/.eslintrc.json
@@ -82,7 +82,23 @@
             ]
           }
         ],
-        "@stylistic/member-delimiter-style": "error",
+        "@stylistic/member-delimiter-style": [
+          "error",
+          {
+            "overrides": {
+              "typeLiteral": {
+                "singleline": {
+                  "delimiter": "comma",
+                  "requireLast": false
+                },
+                "multiline": {
+                  "delimiter": "comma",
+                  "requireLast": true
+                }
+              }
+            }
+          }
+        ],
         "@stylistic/type-annotation-spacing": "error",
         "@typescript-eslint/array-type": [
           "error",

--- a/frontend/src/store/store.ts
+++ b/frontend/src/store/store.ts
@@ -61,7 +61,7 @@ export default createStore<StoreState>({
         slice.isOpen = !slice.isOpen;
       }
     },
-    setAllZoomCommitMessageBody(_, { isOpen, commits }: { isOpen: boolean; commits: DailyCommit[] }) {
+    setAllZoomCommitMessageBody(_, { isOpen, commits }: { isOpen: boolean, commits: DailyCommit[] }) {
       commits.forEach((commit) => {
         commit.commitResults.forEach((slice) => {
           if (slice.isOpen !== undefined) {
@@ -77,7 +77,7 @@ export default createStore<StoreState>({
       file.active = !file.active;
       file.wasCodeLoaded = file.wasCodeLoaded || file.active;
     },
-    setAllAuthorshipFileActiveProperty(_, { isActive, files }: { isActive: boolean; files: AuthorshipFile[] }) {
+    setAllAuthorshipFileActiveProperty(_, { isActive, files }: { isActive: boolean, files: AuthorshipFile[] }) {
       files.forEach((file) => {
         file.active = isActive;
         file.wasCodeLoaded = file.wasCodeLoaded || file.active;

--- a/frontend/src/types/window.ts
+++ b/frontend/src/types/window.ts
@@ -20,11 +20,11 @@ interface SortingFunction<T> {
 interface Api {
   loadJSON: (fname: string) => Promise<unknown>;
   loadSummary: () => Promise<{
-    creationDate: string;
-    reportGenerationTime: string;
-    errorMessages: { [key: string]: ErrorMessage };
-    names: string[];
-    blurbMap: { [key: string]: string };
+    creationDate: string,
+    reportGenerationTime: string,
+    errorMessages: { [key: string]: ErrorMessage },
+    names: string[],
+    blurbMap: { [key: string]: string },
   } | null>;
   loadCommits: (repoName: string) => Promise<User[]>;
   loadAuthorship: (repoName: string) => Promise<AuthorshipSchema>;

--- a/frontend/src/utils/repo-sorter.ts
+++ b/frontend/src/utils/repo-sorter.ts
@@ -52,10 +52,10 @@ function sortingHelper(element: User[], sortingOption?: string): string | number
 function groupByRepos(
   repos: User[][],
   sortingControl: {
-    sortingOption: string;
-    sortingWithinOption: string;
-    isSortingDsc: string;
-    isSortingWithinDsc: string; },
+    sortingOption: string,
+    sortingWithinOption: string,
+    isSortingDsc: string,
+    isSortingWithinDsc: string, },
 ): User[][] {
   const sortedRepos: User[][] = [];
   const {
@@ -85,8 +85,8 @@ function groupByRepos(
 function groupByNone(
   repos: User[][],
   sortingControl: {
-    sortingOption: string;
-    isSortingDsc: string; },
+    sortingOption: string,
+    isSortingDsc: string, },
 ): User[] {
   const sortedRepos: User[] = [];
   const { sortingOption, isSortingDsc } = sortingControl;
@@ -115,10 +115,10 @@ function groupByNone(
 function groupByAuthors(
   repos: User[][],
   sortingControl: {
-    sortingOption: string;
-    sortingWithinOption: string;
-    isSortingDsc: string;
-    isSortingWithinDsc: string; },
+    sortingOption: string,
+    sortingWithinOption: string,
+    isSortingDsc: string,
+    isSortingWithinDsc: string, },
 ): User[][] {
   const authorMap: { [userName: string]: User[] } = {};
   const filtered: User[][] = [];
@@ -158,11 +158,11 @@ function groupByAuthors(
 function sortFiltered(
   filtered: User[][],
   filterControl: {
-    filterGroupSelection: FilterGroupSelection;
-    sortingOption: string;
-    sortingWithinOption: string;
-    isSortingDsc: string;
-    isSortingWithinDsc: string; },
+    filterGroupSelection: FilterGroupSelection,
+    sortingOption: string,
+    sortingWithinOption: string,
+    isSortingDsc: string,
+    isSortingWithinDsc: string, },
 ): User[][] {
   const { filterGroupSelection } = filterControl;
   let full = [];


### PR DESCRIPTION
Fixes #2190


```
Add ESLint rule to enforce commas between types

This PR overrides the default behavior of requiring semicolon
separators for both interface and type in ESLint, to require semicolon
separator for interface and comma separator for type
```