### PR TITLE
Use email to identify Author instead of username

### DIFF
--- a/src/main/java/reposense/model/AuthorConfiguration.java
+++ b/src/main/java/reposense/model/AuthorConfiguration.java
@@ -304,12 +304,12 @@ public class AuthorConfiguration {
      * If no matching {@link Author} is found, {@link Author#UNKNOWN_AUTHOR} is returned.
      */
     public Author getAuthor(String name, String email) {
-        if (authorNamesToAuthorMap.containsKey(name.toLowerCase())) {
-            return authorNamesToAuthorMap.get(name.toLowerCase());
-        }
-
         if (authorEmailsToAuthorMap.containsKey(email)) {
             return authorEmailsToAuthorMap.get(email);
+        }
+
+        if (authorNamesToAuthorMap.containsKey(name.toLowerCase())) {
+            return authorNamesToAuthorMap.get(name.toLowerCase());
         }
 
         Matcher matcher = EMAIL_PLUS_OPERATOR_PATTERN.matcher(email);


### PR DESCRIPTION
Fixes #1897

```
Change the order of finding the Author from username->email to
email->username. This is to address the issue of mis-classifying
attributions due to multiple different users (with different emails)
using the same username.
```