### PR TITLE
Improve sort function desc efficiency

### DIFF
--- a/frontend/src/types/window.ts
+++ b/frontend/src/types/window.ts
@@ -52,7 +52,7 @@ declare global {
     removeHash: (key: string) => void;
     encodeHash: () => void;
     decodeHash: () => void;
-    comparator: <T> (fn: SortingFunction<T>, sortingOption?: string) => ComparatorFunction<T>;
+    comparator: <T> (fn: SortingFunction<T>, isDesc: boolean, sortingOption?: string) => ComparatorFunction<T>;
     filterUnsupported: (string: string) => string | undefined;
     getAuthorLink: (repoId: string, author: string) => string | undefined;
     getRepoLinkUnfiltered: (repoId: string) => string;

--- a/frontend/src/utils/api.ts
+++ b/frontend/src/utils/api.ts
@@ -84,7 +84,7 @@ window.decodeHash = function decodeHash() {
   window.hashParams = hashParams;
 };
 
-window.comparator = (fn, sortingOption = '') => function compare(a, b) {
+window.comparator = (fn, isDesc: boolean, sortingOption = '') => function compare(a, b): -1 | 0 | 1 {
   let a1;
   let b1;
   if (sortingOption) {
@@ -100,12 +100,13 @@ window.comparator = (fn, sortingOption = '') => function compare(a, b) {
   if (typeof b1 === 'string') {
     b1 = b1.toLowerCase();
   }
+
+  const descMultiplier = isDesc ? -1: 1;
+
   if (a1 === b1) {
     return 0;
-  } if (a1 < b1) {
-    return -1;
   }
-  return 1;
+  return (a1 < b1 ? -1 : 1) * descMultiplier as -1 | 0 | 1;
 };
 
 window.filterUnsupported = function filterUnsupported(string) {

--- a/frontend/src/utils/repo-sorter.ts
+++ b/frontend/src/utils/repo-sorter.ts
@@ -54,8 +54,8 @@ function groupByRepos(
   sortingControl: {
     sortingOption: string,
     sortingWithinOption: string,
-    isSortingDsc: string,
-    isSortingWithinDsc: string, },
+    isSortingDsc: boolean,
+    isSortingWithinDsc: boolean, },
 ): User[][] {
   const sortedRepos: User[][] = [];
   const {
@@ -65,20 +65,13 @@ function groupByRepos(
   const sortOption = sortingOption === 'groupTitle' ? 'searchPath' : sortingOption;
   repos.forEach((users) => {
     if (sortWithinOption === 'totalCommits') {
-      users.sort(window.comparator((ele) => ele.checkedFileTypeContribution ?? 0));
+      users.sort(window.comparator((ele) => ele.checkedFileTypeContribution ?? 0, isSortingWithinDsc));
     } else {
-      users.sort(window.comparator((ele) => getComparablePrimitive(ele, sortWithinOption)));
-    }
-
-    if (isSortingWithinDsc) {
-      users.reverse();
+      users.sort(window.comparator((ele) => getComparablePrimitive(ele, sortWithinOption), isSortingWithinDsc));
     }
     sortedRepos.push(users);
   });
-  sortedRepos.sort(window.comparator(sortingHelper, sortOption));
-  if (isSortingDsc) {
-    sortedRepos.reverse();
-  }
+  sortedRepos.sort(window.comparator(sortingHelper, isSortingDsc, sortOption));
   return sortedRepos;
 }
 
@@ -86,7 +79,7 @@ function groupByNone(
   repos: User[][],
   sortingControl: {
     sortingOption: string,
-    isSortingDsc: string, },
+    isSortingDsc: boolean, },
 ): User[] {
   const sortedRepos: User[] = [];
   const { sortingOption, isSortingDsc } = sortingControl;
@@ -104,10 +97,7 @@ function groupByNone(
       return repo.checkedFileTypeContribution ?? 0;
     }
     return getComparablePrimitive(repo, sortingOption);
-  }));
-  if (isSortingDsc) {
-    sortedRepos.reverse();
-  }
+  }, isSortingDsc));
 
   return sortedRepos;
 }
@@ -117,8 +107,8 @@ function groupByAuthors(
   sortingControl: {
     sortingOption: string,
     sortingWithinOption: string,
-    isSortingDsc: string,
-    isSortingWithinDsc: string, },
+    isSortingDsc: boolean,
+    isSortingWithinDsc: boolean, },
 ): User[][] {
   const authorMap: { [userName: string]: User[] } = {};
   const filtered: User[][] = [];
@@ -138,20 +128,16 @@ function groupByAuthors(
   });
   Object.keys(authorMap).forEach((author) => {
     if (sortWithinOption === 'totalCommits') {
-      authorMap[author].sort(window.comparator((repo) => repo.checkedFileTypeContribution ?? 0));
+      authorMap[author].sort(window.comparator((repo) => repo.checkedFileTypeContribution ?? 0, isSortingWithinDsc));
     } else {
-      authorMap[author].sort(window.comparator((repo) => getComparablePrimitive(repo, sortingWithinOption)));
-    }
-    if (isSortingWithinDsc) {
-      authorMap[author].reverse();
+      authorMap[author].sort(window.comparator((repo) =>
+          getComparablePrimitive(repo, sortingWithinOption), isSortingWithinDsc)
+      );
     }
     filtered.push(authorMap[author]);
   });
 
-  filtered.sort(window.comparator(sortingHelper, sortOption));
-  if (isSortingDsc) {
-    filtered.reverse();
-  }
+  filtered.sort(window.comparator(sortingHelper, isSortingDsc, sortOption));
   return filtered;
 }
 
@@ -161,8 +147,8 @@ function sortFiltered(
     filterGroupSelection: FilterGroupSelection,
     sortingOption: string,
     sortingWithinOption: string,
-    isSortingDsc: string,
-    isSortingWithinDsc: string, },
+    isSortingDsc: boolean,
+    isSortingWithinDsc: boolean, },
 ): User[][] {
   const { filterGroupSelection } = filterControl;
   let full = [];

--- a/frontend/src/views/c-summary.vue
+++ b/frontend/src/views/c-summary.vue
@@ -203,9 +203,9 @@ export default defineComponent({
     sortGroupSelection: SortGroupSelection,
     sortWithinGroupSelection: SortWithinGroupSelection,
     sortingOption: string,
-    isSortingDsc: string,
+    isSortingDsc: boolean,
     sortingWithinOption: string,
-    isSortingWithinDsc: string,
+    isSortingWithinDsc: boolean,
     filterTimeFrame: FilterTimeFrame,
     filterBreakdown: boolean,
     tmpFilterSinceDate: string,
@@ -234,9 +234,9 @@ export default defineComponent({
       sortGroupSelection: SortGroupSelection.GroupTitleDsc, // UI for sorting groups
       sortWithinGroupSelection: SortWithinGroupSelection.Title, // UI for sorting within groups
       sortingOption: '',
-      isSortingDsc: '',
+      isSortingDsc: false,
       sortingWithinOption: '',
-      isSortingWithinDsc: '',
+      isSortingWithinDsc: false,
       filterTimeFrame: FilterTimeFrame.Commit,
       filterBreakdown: false,
       tmpFilterSinceDate: '',
@@ -897,8 +897,13 @@ export default defineComponent({
     },
 
     getOptionWithOrder(): void {
-      [this.sortingOption, this.isSortingDsc] = this.sortGroupSelection.split(' ');
-      [this.sortingWithinOption, this.isSortingWithinDsc] = this.sortWithinGroupSelection.split(' ');
+      const [sortingOption, isSortingDsc] = this.sortGroupSelection.split(' ');
+      this.sortingOption = sortingOption;
+      this.isSortingDsc = isSortingDsc === 'dsc';
+
+      const [sortingWithinOption, isSortingWithinDsc] = this.sortWithinGroupSelection.split(' ');
+      this.sortingWithinOption = sortingWithinOption;
+      this.isSortingWithinDsc = isSortingWithinDsc === 'dsc';
     },
 
     // updating filters programically //


### PR DESCRIPTION
Fixes #2332 


```
Frontend Sort Function Enhancement

Improve frontend sort function efficiency for descending order by
refactoring to use boolean, and modify the sort comparator to take in 1
additional argument `isDesc` instead of calling `.reverse()` after
doing an ascending sort.
```