### PR TITLE
[#2332] Frontend Sort Function Bugfix and Enhancement

### DIFF
--- a/frontend/cypress/tests/chartView/chartView_showTags.cy.js
+++ b/frontend/cypress/tests/chartView/chartView_showTags.cy.js
@@ -81,17 +81,17 @@ describe('show tags', () => {
       .first()
       .find('.summary-chart__title--tags')
       .find('a')
-      .should('have.length', 0);
+      .should('have.length', 4);
 
     cy.get('.summary-chart')
       .eq(1)
       .find('.summary-chart__title--tags')
       .find('a')
-      .should('have.length.gt', 0);
+      .should('have.length', 0);
 
     cy.get('.icon-button.fa-list-ul')
       .should('exist')
-      .eq(1)
+      .eq(0)
       .click();
 
     const correctTags = [];
@@ -101,7 +101,7 @@ describe('show tags', () => {
       .each(($tag) => correctTags.push($tag.text().trim()))
       .then(() => {
         cy.get('.summary-chart')
-          .eq(1)
+          .eq(0)
           .find('.summary-chart__title--tags')
           .find('.tag')
           .each(($tag) => {
@@ -109,7 +109,7 @@ describe('show tags', () => {
           });
 
         cy.get('.summary-chart')
-          .eq(1)
+          .eq(0)
           .find('.summary-chart__title--tags')
           .find('.tag')
           .should('have.length', correctTags.length);

--- a/frontend/src/types/window.ts
+++ b/frontend/src/types/window.ts
@@ -52,7 +52,7 @@ declare global {
     removeHash: (key: string) => void;
     encodeHash: () => void;
     decodeHash: () => void;
-    comparator: <T> (fn: SortingFunction<T>, sortingOption?: string) => ComparatorFunction<T>;
+    comparator: <T> (fn: SortingFunction<T>, isDesc?: boolean, sortingOption?: string) => ComparatorFunction<T>;
     filterUnsupported: (string: string) => string | undefined;
     getAuthorLink: (repoId: string, author: string) => string | undefined;
     getRepoLinkUnfiltered: (repoId: string) => string;

--- a/frontend/src/utils/api.ts
+++ b/frontend/src/utils/api.ts
@@ -104,9 +104,9 @@ window.comparator = (fn, isDesc = false, sortingOption = '') => function compare
   const descMultiplier = isDesc ? -1: 1;
 
   if (a1 === b1) {
-    return  0;
+    return 0;
   }
-  return (a1 < b1 ? -1 : 1) * descMultiplier as -1 | 0 | 1;
+  return (a1 < b1 ? -1 : 1) * descMultiplier as -1 | 1;
 };
 
 window.filterUnsupported = function filterUnsupported(string) {

--- a/frontend/src/utils/api.ts
+++ b/frontend/src/utils/api.ts
@@ -84,7 +84,7 @@ window.decodeHash = function decodeHash() {
   window.hashParams = hashParams;
 };
 
-window.comparator = (fn, sortingOption = '') => function compare(a, b) {
+window.comparator = (fn, isDesc = false, sortingOption = '') => function compare(a, b): -1 | 0 | 1 {
   let a1;
   let b1;
   if (sortingOption) {
@@ -100,12 +100,13 @@ window.comparator = (fn, sortingOption = '') => function compare(a, b) {
   if (typeof b1 === 'string') {
     b1 = b1.toLowerCase();
   }
+
+  const descMultiplier = isDesc ? -1: 1;
+
   if (a1 === b1) {
-    return 0;
-  } if (a1 < b1) {
-    return -1;
+    return  0;
   }
-  return 1;
+  return (a1 < b1 ? -1 : 1) * descMultiplier as -1 | 0 | 1;
 };
 
 window.filterUnsupported = function filterUnsupported(string) {

--- a/frontend/src/utils/repo-sorter.ts
+++ b/frontend/src/utils/repo-sorter.ts
@@ -54,8 +54,8 @@ function groupByRepos(
   sortingControl: {
     sortingOption: string,
     sortingWithinOption: string,
-    isSortingDsc: string,
-    isSortingWithinDsc: string, },
+    isSortingDsc: boolean,
+    isSortingWithinDsc: boolean, },
 ): User[][] {
   const sortedRepos: User[][] = [];
   const {
@@ -65,20 +65,13 @@ function groupByRepos(
   const sortOption = sortingOption === 'groupTitle' ? 'searchPath' : sortingOption;
   repos.forEach((users) => {
     if (sortWithinOption === 'totalCommits') {
-      users.sort(window.comparator((ele) => ele.checkedFileTypeContribution ?? 0));
+      users.sort(window.comparator((ele) => ele.checkedFileTypeContribution ?? 0, isSortingWithinDsc));
     } else {
-      users.sort(window.comparator((ele) => getComparablePrimitive(ele, sortWithinOption)));
-    }
-
-    if (isSortingWithinDsc) {
-      users.reverse();
+      users.sort(window.comparator((ele) => getComparablePrimitive(ele, sortWithinOption), isSortingWithinDsc));
     }
     sortedRepos.push(users);
   });
-  sortedRepos.sort(window.comparator(sortingHelper, sortOption));
-  if (isSortingDsc) {
-    sortedRepos.reverse();
-  }
+  sortedRepos.sort(window.comparator(sortingHelper, isSortingDsc, sortOption));
   return sortedRepos;
 }
 
@@ -86,7 +79,7 @@ function groupByNone(
   repos: User[][],
   sortingControl: {
     sortingOption: string,
-    isSortingDsc: string, },
+    isSortingDsc: boolean, },
 ): User[] {
   const sortedRepos: User[] = [];
   const { sortingOption, isSortingDsc } = sortingControl;
@@ -104,10 +97,7 @@ function groupByNone(
       return repo.checkedFileTypeContribution ?? 0;
     }
     return getComparablePrimitive(repo, sortingOption);
-  }));
-  if (isSortingDsc) {
-    sortedRepos.reverse();
-  }
+  }, isSortingDsc));
 
   return sortedRepos;
 }
@@ -117,8 +107,8 @@ function groupByAuthors(
   sortingControl: {
     sortingOption: string,
     sortingWithinOption: string,
-    isSortingDsc: string,
-    isSortingWithinDsc: string, },
+    isSortingDsc: boolean,
+    isSortingWithinDsc: boolean, },
 ): User[][] {
   const authorMap: { [userName: string]: User[] } = {};
   const filtered: User[][] = [];
@@ -138,20 +128,16 @@ function groupByAuthors(
   });
   Object.keys(authorMap).forEach((author) => {
     if (sortWithinOption === 'totalCommits') {
-      authorMap[author].sort(window.comparator((repo) => repo.checkedFileTypeContribution ?? 0));
+      authorMap[author].sort(window.comparator((repo) => repo.checkedFileTypeContribution ?? 0, isSortingWithinDsc));
     } else {
-      authorMap[author].sort(window.comparator((repo) => getComparablePrimitive(repo, sortingWithinOption)));
-    }
-    if (isSortingWithinDsc) {
-      authorMap[author].reverse();
+      authorMap[author].sort(
+        window.comparator((repo) => getComparablePrimitive(repo, sortWithinOption), isSortingWithinDsc)
+      );
     }
     filtered.push(authorMap[author]);
   });
 
-  filtered.sort(window.comparator(sortingHelper, sortOption));
-  if (isSortingDsc) {
-    filtered.reverse();
-  }
+  filtered.sort(window.comparator(sortingHelper, isSortingDsc, sortOption));
   return filtered;
 }
 
@@ -161,8 +147,8 @@ function sortFiltered(
     filterGroupSelection: FilterGroupSelection,
     sortingOption: string,
     sortingWithinOption: string,
-    isSortingDsc: string,
-    isSortingWithinDsc: string, },
+    isSortingDsc: boolean,
+    isSortingWithinDsc: boolean, },
 ): User[][] {
   const { filterGroupSelection } = filterControl;
   let full = [];

--- a/frontend/src/views/c-summary.vue
+++ b/frontend/src/views/c-summary.vue
@@ -203,9 +203,9 @@ export default defineComponent({
     sortGroupSelection: SortGroupSelection,
     sortWithinGroupSelection: SortWithinGroupSelection,
     sortingOption: string,
-    isSortingDsc: string,
+    isSortingDsc: boolean,
     sortingWithinOption: string,
-    isSortingWithinDsc: string,
+    isSortingWithinDsc: boolean,
     filterTimeFrame: FilterTimeFrame,
     filterBreakdown: boolean,
     tmpFilterSinceDate: string,
@@ -234,9 +234,9 @@ export default defineComponent({
       sortGroupSelection: SortGroupSelection.GroupTitleDsc, // UI for sorting groups
       sortWithinGroupSelection: SortWithinGroupSelection.Title, // UI for sorting within groups
       sortingOption: '',
-      isSortingDsc: '',
+      isSortingDsc: false,
       sortingWithinOption: '',
-      isSortingWithinDsc: '',
+      isSortingWithinDsc: false,
       filterTimeFrame: FilterTimeFrame.Commit,
       filterBreakdown: false,
       tmpFilterSinceDate: '',
@@ -897,11 +897,16 @@ export default defineComponent({
     },
 
     getOptionWithOrder(): void {
-      [this.sortingOption, this.isSortingDsc] = this.sortGroupSelection.split(' ');
-      [this.sortingWithinOption, this.isSortingWithinDsc] = this.sortWithinGroupSelection.split(' ');
+      const [sortingOption, isSortingDsc] = this.sortGroupSelection.split(' ');
+      this.sortingOption = sortingOption;
+      this.isSortingDsc = isSortingDsc === 'dsc';
+
+      const [sortingWithinOption, isSortingWithinDsc] = this.sortWithinGroupSelection.split(' ');
+      this.sortingWithinOption = sortingWithinOption;
+      this.isSortingWithinDsc = isSortingWithinDsc === 'dsc';
     },
 
-    // updating filters programically //
+    // updating filters programmatically //
     resetDateRange(): void {
       this.hasModifiedSinceDate = false;
       this.hasModifiedUntilDate = false;


### PR DESCRIPTION
Fixes #2332, #2362


```
Frontend Sort Function Enhancement

Improve frontend sort function efficiency for descending order by
refactoring to use boolean, and modify the sort comparator to take in 1
additional argument `isDesc` instead of calling `.reverse()` after
doing an ascending sort.


Important: A Cypress test case was modified to account for corrected
behavior because previous code for 'groupByAuthors' contains a bug
where we use `sortingWithinOption` instead of `sortWithinOption`, thus
causing the sort order within a group to be arbitrary if we sort by
'title' 
since the property doesn't exist and we are sorting an array of blank
strings.
```