### PR TITLE
[#2447] Add support for multiple git author names

### DIFF
--- a/docs/ug/reportConfig.md
+++ b/docs/ug/reportConfig.md
@@ -36,7 +36,8 @@ repos:
         authors:
           - author-git-host-id: Your username on GitHub, GitLab or Bitbucket
             author-display-name: Your display name
-            author-git-author-name: Author Name Of Your Git Configuration
+            author-git-author-name: 
+              - Author Name Of Your Git Configuration
             author-emails:
               - emails-of-your-commits@email.com
               - emails-of-your-git-configuration@email.com

--- a/src/main/java/reposense/model/OneStopConfigRunConfiguration.java
+++ b/src/main/java/reposense/model/OneStopConfigRunConfiguration.java
@@ -59,7 +59,7 @@ public class OneStopConfigRunConfiguration implements RunConfiguration {
                     Author author = new Author(rad.getAuthorGitHostId());
                     author.setEmails(rad.getAuthorEmails());
                     author.setDisplayName(rad.getAuthorDisplayName());
-                    author.setAuthorAliases(List.of(rad.getAuthorGitAuthorName()));
+                    author.setAuthorAliases(rad.getAuthorGitAuthorNames());
 
                     authorConfiguration.addAuthor(author);
                 }

--- a/src/main/java/reposense/model/reportconfig/ReportAuthorDetails.java
+++ b/src/main/java/reposense/model/reportconfig/ReportAuthorDetails.java
@@ -13,21 +13,21 @@ public class ReportAuthorDetails {
     private final List<String> authorEmails;
     private final String authorGitHostId;
     private final String authorDisplayName;
-    private final String authorGitAuthorName;
+    private final List<String> authorGitAuthorNames;
 
     @JsonCreator
     public ReportAuthorDetails(
             @JsonProperty("author-emails") List<String> authorEmails,
             @JsonProperty("author-git-host-id") String authorGitHostId,
             @JsonProperty("author-display-name") String authorDisplayName,
-            @JsonProperty("author-git-author-name") String authorGitAuthorName) {
+            @JsonProperty("author-git-author-name") List<String> authorGitAuthorNames) {
         if (authorGitHostId == null) {
             throw new IllegalArgumentException("Author Git Host ID cannot be empty.");
         }
         this.authorGitHostId = authorGitHostId;
         this.authorEmails = authorEmails == null ? new ArrayList<>() : authorEmails;
         this.authorDisplayName = authorDisplayName == null ? "" : authorDisplayName;
-        this.authorGitAuthorName = authorGitAuthorName == null ? "" : authorGitAuthorName;
+        this.authorGitAuthorNames = authorGitAuthorNames == null ? new ArrayList<>() : authorGitAuthorNames;
     }
 
     public List<String> getAuthorEmails() {
@@ -42,8 +42,8 @@ public class ReportAuthorDetails {
         return authorDisplayName;
     }
 
-    public String getAuthorGitAuthorName() {
-        return authorGitAuthorName;
+    public List<String> getAuthorGitAuthorNames() {
+        return authorGitAuthorNames;
     }
 
     @Override
@@ -57,7 +57,7 @@ public class ReportAuthorDetails {
             return rad.getAuthorEmails().equals(this.getAuthorEmails())
                     && rad.getAuthorGitHostId().equals(this.getAuthorGitHostId())
                     && rad.getAuthorDisplayName().equals(this.getAuthorDisplayName())
-                    && rad.getAuthorGitAuthorName().equals(this.getAuthorGitAuthorName());
+                    && rad.getAuthorGitAuthorNames().equals(this.getAuthorGitAuthorNames());
         }
 
         return false;

--- a/src/systemtest/resources/ReportConfigSystemTest/report-config.yaml
+++ b/src/systemtest/resources/ReportConfigSystemTest/report-config.yaml
@@ -19,7 +19,8 @@ repos:
         authors:
           - author-git-host-id: jedkohjk
             author-display-name: jedkohjk
-            author-git-author-name: jedkohjk
+            author-git-author-name:
+              - jedkohjk
             author-emails:
         ignore-authors-list:
         ignore-glob-list:

--- a/src/test/java/reposense/model/OneStopConfigRunConfigurationTest.java
+++ b/src/test/java/reposense/model/OneStopConfigRunConfigurationTest.java
@@ -26,7 +26,7 @@ class OneStopConfigRunConfigurationTest {
 
         List<String> emailList = List.of("fh@gmail.com");
         ReportAuthorDetails author = new ReportAuthorDetails(emailList, "FH-30",
-                "Francis Hodianto", "Francis Hodianto");
+                "Francis Hodianto", List.of("Francis Hodianto"));
 
         List<ReportAuthorDetails> authorList = List.of(author);
         List<String> ignoreGlobList = List.of("**.md");

--- a/src/test/java/reposense/model/reportconfig/ReportAuthorDetailsTest.java
+++ b/src/test/java/reposense/model/reportconfig/ReportAuthorDetailsTest.java
@@ -10,7 +10,7 @@ public class ReportAuthorDetailsTest {
             List.of("test@example.com"),
             "gitHostId",
             "Display Name",
-            "Git Author"
+            List.of("Git Author")
     );
 
     @Test
@@ -20,13 +20,13 @@ public class ReportAuthorDetailsTest {
                 emails,
                 "Git Host Id",
                 "Display Name",
-                "Git Author"
+                List.of("Git Author")
         );
 
         Assertions.assertEquals(emails, details.getAuthorEmails());
         Assertions.assertEquals("Git Host Id", details.getAuthorGitHostId());
         Assertions.assertEquals("Display Name", details.getAuthorDisplayName());
-        Assertions.assertEquals("Git Author", details.getAuthorGitAuthorName());
+        Assertions.assertEquals("Git Author", details.getAuthorGitAuthorNames().get(0));
     }
 
     @Test
@@ -36,7 +36,7 @@ public class ReportAuthorDetailsTest {
                     List.of("test@example.com"),
                     null,
                     "Display Name",
-                    "Git Author"
+                    List.of("Git Author")
             );
         });
     }
@@ -52,7 +52,7 @@ public class ReportAuthorDetailsTest {
                 List.of("test@example.com"),
                 "gitHostId",
                 "Display Name",
-                "Git Author"
+                List.of("Git Author")
         );
 
         Assertions.assertEquals(details1, details2);
@@ -64,7 +64,7 @@ public class ReportAuthorDetailsTest {
                 List.of("test1@example.com"),
                 "gitHostId",
                 "Display Name",
-                "Git Author"
+                List.of("Git Author")
         );
 
         Assertions.assertNotEquals(details1, details2);

--- a/src/test/java/reposense/model/reportconfig/ReportConfigurationTest.java
+++ b/src/test/java/reposense/model/reportconfig/ReportConfigurationTest.java
@@ -21,7 +21,7 @@ public class ReportConfigurationTest {
 
         List<String> emailList = List.of("fh@gmail.com");
         ReportAuthorDetails author = new ReportAuthorDetails(emailList, "FH-30",
-                "Francis Hodianto", "Francis Hodianto");
+                "Francis Hodianto", List.of("Francis Hodianto"));
 
         List<ReportAuthorDetails> authorList = List.of(author);
         List<String> ignoreGlobList = List.of("**.md");

--- a/src/test/java/reposense/parser/ReportConfigYamlParserTest.java
+++ b/src/test/java/reposense/parser/ReportConfigYamlParserTest.java
@@ -37,7 +37,7 @@ public class ReportConfigYamlParserTest {
         List<String> emailList = new ArrayList<>();
         emailList.add("fh@gmail.com");
         ReportAuthorDetails author = new ReportAuthorDetails(emailList, "FH-30",
-                "Francis Hodianto", "Francis Hodianto");
+                "Francis Hodianto", List.of("Francis Hodianto"));
 
         List<ReportAuthorDetails> authorList = new ArrayList<>();
         authorList.add(author);

--- a/src/test/resources/ReportConfigYamlParserTest/report-config-valid.yaml
+++ b/src/test/resources/ReportConfigYamlParserTest/report-config-valid.yaml
@@ -11,7 +11,8 @@ repos:
         authors:
           - author-git-host-id: FH-30
             author-display-name: Francis Hodianto
-            author-git-author-name: Francis Hodianto
+            author-git-author-name:
+              - Francis Hodianto
             author-emails:
               - fh@gmail.com
         ignore-authors-list:

--- a/src/test/resources/RunConfigurationDeciderTest/both-configs/report-config.yaml
+++ b/src/test/resources/RunConfigurationDeciderTest/both-configs/report-config.yaml
@@ -19,7 +19,8 @@ repos:
         authors:
           - author-git-host-id: jedkohjk
             author-display-name: jedkohjk
-            author-git-author-name: jedkohjk
+            author-git-author-name:
+              - jedkohjk
             author-emails:
         ignore-authors-list:
           - bot


### PR DESCRIPTION
<!--
    If this pull request fully addresses an issue, use:
    Fixes #xxxx

    If this pull request partially addresses an issue, use:
    Part of #xxxx

    If this pull request addresses multiple issues, put them in multiple lines:
    Fixes #xxxx
    Fixes #yyyy

    Format the title of the pull request with most relevant issue number as follows:
    [#xxxx] Title
-->
Fixes #2447

### Proposed commit message
<!--
    Propose a detailed commit message for this pull request within the triple backticks below.
    Wrap lines at 72 characters.

    Guide on how to write a good commit message:
    https://oss-generic.github.io/process/docs/FormatsAndConventions.html#commit-message
-->
```
Add support for multiple author names.

This is similar to how the parser handles
authors emails.
```

### Other information
Users can specify multiple author-name in the following way:
```yaml
author-git-author-name:
  - name1
  - name2
  - name3
```