### PR TITLE
[#2427] --since flag in the CLI description is outdated

### DIFF
--- a/docs/ug/cli.md
+++ b/docs/ug/cli.md
@@ -264,16 +264,21 @@ Cannot be used with `--last-modified-date`. This may result in an incorrect last
   3. DD/MM/YYYY'T'HH:mm:ss
   ```
   Default:
-  - If `START_DATE` is not specified, it defaults to one month before the current date at `00:00:00`.
-  - If hours/ minutes/ seconds are not provided, each will default to `00`.
+  - If `START_DATE` is not specified, the program will check for the `sinceDate` field in the configuration file (`repo-config.csv` or `report-config.yaml`) and use it if available.
+  - If no `sinceDate` is provided in either the CLI or configuration file, it defaults to **one month before the current date** at `00:00:00`.
+  - If hours/minutes/seconds are not provided, they will default to `00:00:00`.
+
 * Alias: `-s`
-* Example:`--since 21/10/2017T03:09` or `-s 21/10/2017T03:09`
+* Example: `--since 21/10/2017T03:09` or `-s 21/10/2017T03:09`
 
 <box type="info" seamless>
 
-* If the start date is not specified, only commits made one month before the end date (if specified) or the date of generating the report, will be captured and analyzed.
-* If `d1` is specified as the start date (`--since d1` or `-s d1`), then the program will search for the earliest commit date of all repositories and use that as the start date.
-* If `d1` is specified together with `--period`, then the program will warn that the date range being analyzed may be incorrect.
+* If `d1` is specified as the start date (`--since d1` or `-s d1`), RepoSense will search for the **earliest commit date** across all repositories and use that as the start date. However: 
+  - If the `sinceDate` field is defined in the configuration file (`repo-config.csv` or `report-config.yaml`), it will **override** the behavior of `d1`.
+* If used together with `--period`, the program will warn that the analyzed date range may be incorrect.
+* Precedence: 
+  - CLI-provided `--since` overrides the value in the configuration file (`sinceDate`).
+
 </box>
 </div>
 
@@ -308,21 +313,27 @@ Cannot be used with `--last-modified-date`. This may result in an incorrect last
 <div id="section-until-date">
 
 **`--until END_DATE`**: Specifies the end date of the analysis period.
-* Parameter: `END_DATE` The last date of the period to be analyzed (with optional time specification), in one of the following formats:<br>
+* Parameter: `END_DATE` The last day of the period to be analyzed (with optional time specification), in one of the following formats:<br>
   ```
   1. DD/MM/YYYY
   2. DD/MM/YYYY'T'HH:mm
   3. DD/MM/YYYY'T'HH:mm:ss
   ```
-Default:
-- If `END_DATE` is not specified, it defaults to the current date at `23:59:59`.
-- If hours/ minutes/ seconds are not provided, they will default to `23`, `59`, and `59`, respectively.
+  Default:
+  - If `END_DATE` is not specified, the program will check for the `untilDate` field in the configuration file (`repo-config.csv` or `report-config.yaml`) and use it if available.
+  - If no `untilDate` is provided in either the CLI or configuration file, it defaults to the **current date** at `23:59:59`.
+  - If hours/minutes/seconds are not provided, they will default to `23:59:59`.
+
 * Alias: `-u`
-* Example:`--until 21/10/2017T01:02:00` or `-u 21/10/2017T01:02:00`
+* Example: `--until 21/10/2017T01:02:00` or `-u 21/10/2017T01:02:00`
 
 <box type="info" seamless>
 
-Note: If the end date is not specified, the date of generating the report will be taken as the end date.
+* If the end date is not specified, RepoSense will attempt to use the `untilDate` from the configuration file or default to the date of generating the report.
+
+* Precedence:
+  - CLI-provided `--until` overrides the value in the configuration file (`untilDate`).
+  
 </box>
 </div>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "RepoSense",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}


### PR DESCRIPTION
<!--
    If this pull request fully addresses an issue, use:
    Fixes #xxxx

    If this pull request partially addresses an issue, use:
    Part of #xxxx

    If this pull request addresses multiple issues, put them in multiple lines:
    Fixes #xxxx
    Fixes #yyyy

    Format the title of the pull request with most relevant issue number as follows:
    [#xxxx] Title
-->
Fixes #2427 

### Proposed commit message
<!--
    Propose a detailed commit message for this pull request within the triple backticks below.
    Wrap lines at 72 characters.

    Guide on how to write a good commit message:
    https://oss-generic.github.io/process/docs/FormatsAndConventions.html#commit-message
-->
```

This pull request updates the documentation for CLI parameters in `docs/ug/cli.md` to clarify the behavior of date-related options (`--since` and `--until`) and their precedence when used alongside configuration files. The changes enhance user understanding by detailing how default values are determined and how CLI inputs interact with configuration file settings.

### Updates to `--since` parameter behavior:

* Clarified that if `START_DATE` is not provided, the program checks for the `sinceDate` field in configuration files (`repo-config.csv` or `report-config.yaml`) before defaulting to one month before the current date at `00:00:00`.
* Added precedence rules: CLI-provided `--since` takes priority over the `sinceDate` value in configuration files.

### Updates to `--until` parameter behavior:

* Specified that if `END_DATE` is not provided, the program checks for the `untilDate` field in configuration files (`repo-config.csv` or `report-config.yaml`) before defaulting to the current date at `23:59:59`.
* Added precedence rules: CLI-provided `--until` takes priority over the `untilDate` value in configuration files.
```

### Other information
<!--
    Are there other relevant information, such as special testing instructions,
    which will help the reviewer better understand the code?

    You may also include a brief description of why the problem occurred.
-->
