### PR TITLE
[#2430] Fix 404 optional title md

### DIFF
--- a/src/main/java/reposense/system/GracefulFileHandler.java
+++ b/src/main/java/reposense/system/GracefulFileHandler.java
@@ -1,0 +1,43 @@
+package reposense.system;
+
+import net.freeutils.httpserver.HTTPServer;
+import net.freeutils.httpserver.HTTPServer.Request;
+import net.freeutils.httpserver.HTTPServer.Response;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Set;
+
+/**
+ * Serves static files from disk like FileContextHandler,
+ * but handles optional files gracefully by suppressing 404 errors.
+ * For listed optional paths, responds with 204 No Content if file is missing.
+ */
+public class GracefulFileHandler implements HTTPServer.ContextHandler {
+
+    private final File rootDirectory;
+    private final Set<String> optionalPaths;
+
+    public GracefulFileHandler(File rootDirectory, Set<String> optionalPaths) {
+        this.rootDirectory = rootDirectory;
+        this.optionalPaths = optionalPaths;
+    }
+
+    @Override
+    public int serve(Request request, Response response) throws IOException {
+        String reqPath = request.getPath();
+
+        // If file is optional and doesn't exist, return 204 No Content
+        File targetFile = new File(rootDirectory, reqPath);
+        if (optionalPaths.contains(reqPath) && !targetFile.exists()) {
+            System.out.println("Optional file missing: " + reqPath + " — returning 204");
+            response.getHeaders().add("Content-Type", "text/plain");
+            response.send(204, "");
+            return 0;
+        }
+
+        // Fall back to normal file serving
+        HTTPServer.ContextHandler fileHandler = new HTTPServer.FileContextHandler(rootDirectory);
+        return fileHandler.serve(request, response);
+    }
+}

--- a/src/main/java/reposense/system/GracefulFileHandler.java
+++ b/src/main/java/reposense/system/GracefulFileHandler.java
@@ -1,12 +1,12 @@
 package reposense.system;
 
-import net.freeutils.httpserver.HTTPServer;
-import net.freeutils.httpserver.HTTPServer.Request;
-import net.freeutils.httpserver.HTTPServer.Response;
-
 import java.io.File;
 import java.io.IOException;
 import java.util.Set;
+
+import net.freeutils.httpserver.HTTPServer;
+import net.freeutils.httpserver.HTTPServer.Request;
+import net.freeutils.httpserver.HTTPServer.Response;
 
 /**
  * Serves static files from disk like FileContextHandler,
@@ -29,6 +29,7 @@ public class GracefulFileHandler implements HTTPServer.ContextHandler {
 
         // If file is optional and doesn't exist, return 204 No Content
         File targetFile = new File(rootDirectory, reqPath);
+
         if (optionalPaths.contains(reqPath) && !targetFile.exists()) {
             System.out.println("Optional file missing: " + reqPath + " — returning 204");
             response.getHeaders().add("Content-Type", "text/plain");

--- a/src/main/java/reposense/system/ReportServer.java
+++ b/src/main/java/reposense/system/ReportServer.java
@@ -1,10 +1,13 @@
 package reposense.system;
 
+import reposense.system.GracefulFileHandler;
+
 import java.awt.Desktop;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.file.Path;
+import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -30,8 +33,9 @@ public class ReportServer {
         HTTPServer.VirtualHost host = server.getVirtualHost(null);
 
         try {
+            Set<String> optionalPaths = Set.of("/title.md"); // add more if needed
             // a handler to process the request and give the corresponding response
-            host.addContext("/", new HTTPServer.FileContextHandler(requestPath.toFile()));
+            host.addContext("/", new GracefulFileHandler(requestPath.toFile(), optionalPaths));
             server.start();
             launchBrowser(String.format(LOCAL_HOST_URL, port));
             logger.info("Press Ctrl + C or equivalent to stop the server");

--- a/src/main/java/reposense/system/ReportServer.java
+++ b/src/main/java/reposense/system/ReportServer.java
@@ -1,7 +1,5 @@
 package reposense.system;
 
-import reposense.system.GracefulFileHandler;
-
 import java.awt.Desktop;
 import java.io.IOException;
 import java.net.URI;


### PR DESCRIPTION
Fixes #2430

### Proposed commit message

```
ReportServer: suppress 404 for optional files like title.md

Previously, missing optional files like title.md resulted in 404 errors,
cluttering the console output and affecting user experience. Let’s handle
these gracefully by returning 204 No Content instead and logging a message.
```

### Other information

This PR adds GracefulFileHandler to intercept requests for optional paths like /title.md and return 204 when not found, instead of defaulting to 404.

Changes:
- GracefulFileHandler.java: new class for serving optional files with 204 handling
- ReportServer.java: updated to use this handler for /title.md

Note: 
The test `generateReposReport_isOnlyTextRefreshedTrueButInvalidPath_throwsIoException`
is currently failing, but unrelated to the files touched in this PR.
Would appreciate guidance on whether it should be updated.
