### PR TITLE
[#2384] Testing publish-Reposense on every push/PR on the main repo.

### DIFF
--- a/.github/workflows/trigger-regression-test.yml
+++ b/.github/workflows/trigger-regression-test.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - name: Trigger publish-RepoSense Test Workflow
         run: |
-          repo_owner="feliciahmq"
+          repo_owner="reposense"
           repo_name="publish-RepoSense"
           event_type="trigger-regression-test"
           pr="${{ github.event.number }}"

--- a/.github/workflows/trigger-regression-test.yml
+++ b/.github/workflows/trigger-regression-test.yml
@@ -14,8 +14,10 @@ jobs:
           repo_owner="feliciahmq"
           repo_name="publish-RepoSense"
           event_type="trigger-regression-test"
-          pr="${{ github.event.inputs.pr_number }}"
-          sha="${{ github.event.inputs.commit_sha }}"
+          pr="${{ github.event.number }}"
+          sha="${{ github.event.pull_request.head.sha }}"
+          
+          echo "Triggering with PR: $pr, SHA: $sha"
 
           curl -L \
             -X POST \

--- a/.github/workflows/trigger-regression-test.yml
+++ b/.github/workflows/trigger-regression-test.yml
@@ -1,14 +1,8 @@
 name: Auto-trigger publish-RepoSense Test Workflow
 
 on:
-  workflow_dispatch:
-    inputs:
-      pr_number:
-        description: "Pull request number"
-        required: true
-      commit_sha:
-        description: "Commit SHA"
-        required: true
+  pull_request:
+    types: [opened, synchronize]
 
 jobs:
   trigger:

--- a/.github/workflows/trigger-regression-test.yml
+++ b/.github/workflows/trigger-regression-test.yml
@@ -16,7 +16,7 @@ jobs:
           event_type="trigger-regression-test"
           pr="${{ github.event.number }}"
           sha="${{ github.event.pull_request.head.sha }}"
-          
+
           echo "Triggering with PR: $pr, SHA: $sha"
 
           curl -L \

--- a/.github/workflows/trigger-regression-test.yml
+++ b/.github/workflows/trigger-regression-test.yml
@@ -26,7 +26,7 @@ jobs:
           curl -L \
             -X POST \
             -H "Accept: application/vnd.github.v3+json" \
-            -H "Authorization: Bearer ${{ secrets.REPO_DISPATCH_TOKEN }}" \
+            -H "Authorization: token ${{ secrets.REPO_DISPATCH_TOKEN }}" \
             https://api.github.com/repos/$repo_owner/$repo_name/dispatches \
             -d "{\"event_type\": \"$event_type\", \"client_payload\": {\"sha\": \"$sha\", \"pr\": \"$pr\", \"run_lighthouse\": true}}"
 


### PR DESCRIPTION
<!--
    If this pull request fully addresses an issue, use:
    Fixes #xxxx

    If this pull request partially addresses an issue, use:
    Part of #xxxx

    If this pull request addresses multiple issues, put them in multiple lines:
    Fixes #xxxx
    Fixes #yyyy

    Format the title of the pull request with most relevant issue number as follows:
    [#xxxx] Title
-->
Fixes #2384 

### Proposed commit message
<!--
    Propose a detailed commit message for this pull request within the triple backticks below.
    Wrap lines at 72 characters.

    Guide on how to write a good commit message:
    https://oss-generic.github.io/process/docs/FormatsAndConventions.html#commit-message
-->
```

```

### Other information
<!--
    Are there other relevant information, such as special testing instructions,
    which will help the reviewer better understand the code?

    You may also include a brief description of why the problem occurred.
-->
ive added a `trigger-regression-test.yml` workflow in `RepoSense` that automatically triggers a workflow in `publish-RepoSense` on every pull request. this trigger sends over the PR number and commit SHA to the downstream repo.

in `publish-reposense`, it clones the `RepoSense` repository at the specified SHA, builds the project with Gradle, runs the website on a GitHub Actions runner and uses Lighthouse CLI to audit the generated site.

a `REPO_DISPATCH_TOKEN` needs to be created as it is required when using `curl` to call `repository_dispatch` GitHub API in a different repo (`publish-reposense`). 