### PR TITLE
[#2523] Delete deprecated test

### DIFF
--- a/src/test/java/reposense/report/ReportGeneratorTest.java
+++ b/src/test/java/reposense/report/ReportGeneratorTest.java
@@ -16,7 +16,6 @@ import java.time.format.DateTimeFormatter;
 import java.util.List;
 
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import reposense.model.AuthorBlurbMap;


### PR DESCRIPTION
Fixes #2523 

### Proposed commit message
```
Remove faulty IOException test for missing summary.json

The test fails when frontend/public contains report data, which gets
included in templateZip.zip during the build process.

Let's remove
generateReposReport_isOnlyTextRefreshedTrueButInvalidPath_throwsIoException

Since the validation logic is straightforward, setting up additional
test setup is not worth the complexity.
```

### Other information
The root of failure in removed test case: 
- hotReloadFrontend copies report data into frontend/public
- Gradle build packages it into templateZip.zip
- Tests extract a contaminated template and no longer trigger IOException
