### PR TITLE
[#2522] Remove backward compatibility support for title.md

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -343,7 +343,6 @@ def syncFrontendPublic = tasks.register('syncFrontendPublic', Sync) {
         include 'index.html'
         include 'favicon.ico'
         include 'intro.md'
-        include 'title.md'
         include 'logo.png'
     }
 }

--- a/docs/ug/cli.md
+++ b/docs/ug/cli.md
@@ -282,12 +282,12 @@ Cannot be used with `--last-modified-date`. This may result in an incorrect last
 
 ### `--text`, `-T`
 
-**`--text`**: Refreshes text content (intro.md/title.md, repo-blurbs.md and author-blurbs.md) without reanalyzing repository data.
+**`--text`**: Refreshes text content (intro.md, repo-blurbs.md and author-blurbs.md) without reanalyzing repository data.
 * Alias: `-T` (uppercase T)
 
 <box type="info" seamless>
 
-* This flag is used to update only the text content (intro.md/title.md, repo-blurbs.md and author-blurbs.md) of the report. The new report will be generated with the existing data from the previous report.
+* This flag is used to update only the text content (intro.md, repo-blurbs.md and author-blurbs.md) of the report. The new report will be generated with the existing data from the previous report.
 * Ensure that there is an existing valid report generated before using this flag.
 * Cannot be used with any other flags except from `--view`, `--assets` and `--config`.
 </box>

--- a/docs/ug/customizingReports.md
+++ b/docs/ug/customizingReports.md
@@ -89,9 +89,9 @@ To ensure that their PRs are correct, you can use [Netlify _deploy previews_](ht
 There is a default `favicon.ico` file provided in the template zip folder. If you want to self-configure the `favicon.ico`, please ensure that the file is valid and has the file name of `favicon.ico`. This icon will appear in the browser tab when your report is viewed. Copy or move your `favicon.ico file` into the `assets` folder of the config directory.
 
 ##### Add an intro
-Add the introductory section of the dashboard by creating an `intro.md` file in the config directory. Existing `title.md` files still work for now, but will be deprecated in favour of `intro.md`.
+Add the introductory section of the dashboard by creating an `intro.md` file in the config directory.
 
-The intro can render a combination of Markdown/HTML and plaintext ([example](https://github.com/reposense/RepoSense/blob/master/docs/ug/title.md)), and will appear on the top of the left panel as shown below:
+The intro can render a combination of Markdown/HTML and plaintext, and will appear on the top of the left panel as shown below:
 ![Intro Component Example](../images/title-example.png)
 
 Do note that the width of the intro is bound by the width of the left panel.

--- a/frontend/src/components/c-intro.vue
+++ b/frontend/src/components/c-intro.vue
@@ -8,7 +8,6 @@ import { defineComponent } from "vue";
 import CMarkdownChunk from "./c-markdown-chunk.vue";
 
 const INTRO_FILE_PATH = "intro.md";
-const LEGACY_TITLE_FILE_PATH = "title.md";
 
 export default defineComponent({
   name: "c-intro",
@@ -20,19 +19,7 @@ export default defineComponent({
   },
   async beforeMount() {
     try {
-      const introText = await this.fetchMarkdown(INTRO_FILE_PATH);
-      if (introText) {
-        this.markdownText = introText;
-        return;
-      }
-
-      const legacyText = await this.fetchMarkdown(LEGACY_TITLE_FILE_PATH);
-      if (legacyText) {
-        console.warn(
-          "Detected deprecated title.md. Please rename it to intro.md.",
-        );
-      }
-      this.markdownText = legacyText;
+      this.markdownText = await this.fetchMarkdown(INTRO_FILE_PATH);
     } catch (error) {
       this.markdownText = (error as Error).toString();
     }


### PR DESCRIPTION
Fixes #2522 

### Proposed commit message
```
The dashboard's introductory section was previously renamed from
title.md to intro.md (PR #2516) to resolve naming conflicts with
the browser tab title field. Backward compatibility was maintained
to allow users time to migrate, with a fallback that loads title.md
and emits a deprecation warning when intro.md is not found.

Remove deprecated title.md support by deleting the legacy fallback
logic and console warning in c-intro.vue, removing title.md from
the build sync task, and updating documentation in
customizingReports.md and cli.md to no longer reference title.md.
```

### Other information
This PR is the planned follow-up to #2516 and #2538, completing the migration from title.md to intro.md. 
Users who have not yet renamed their title.md file will no longer see it rendered in the dashboard, the introductory section will simply be empty.