### PR TITLE
[#2572] Update About page

### DIFF
--- a/docs/about.md
+++ b/docs/about.md
@@ -17,33 +17,15 @@ RepoSense is a project based in the [National University of Singapore, School of
 
 <!-- ------------------------------------------------------------------------------------------------------ -->
 
-### [Charisma Kausar](https://www.github.com/ckcherry23)
-**Role**: Project Lead [2024 May - ]<br/>
-Senior Developer [2024 January - 2024 April]<br/>
-Developer [2022 December - 2023 December]<br/>
+### [Chen Yixun](https://www.github.com/CYX22222003)
+**Role**: Senior Developer [2026 January - ]<br/>
+Developer [2025 January - 2025 December]<br/>
 
 <!-- ------------------------------------------------------------------------------------------------------ -->
 
-### [Gokul Rajiv](https://github.com/gok99)
-**Role**: Project Lead [2024 May - ]<br/>
-Senior Developer [2024 January - 2024 April]<br/>
-Developer [2022 January - 2023 December]<br/>
-
-<!-- ------------------------------------------------------------------------------------------------------ -->
-
-### [Chang Si Kai](https://github.com/sikai00)
-**Role**: Senior Developer [2025 January - ]<br/>
-Developer [2023 January - 2024 December]<br/>
-
-<!-- ------------------------------------------------------------------------------------------------------ -->
-
-### [Alvis Ng](https://www.github.com/supermii2)
-**Role**: Developer [2024 January - ]<br/>
-
-<!-- ------------------------------------------------------------------------------------------------------ -->
-
-### [George Tay Quan Yao](https://www.github.com/jonasongg)
-**Role**: Developer [2024 January - ]<br/>
+### [Wong Li Yuan](https://www.github.com/lyuanww)
+**Role**: Senior Developer [2026 January - ]<br/>
+Developer [2025 January - 2025 December]<br/>
 
 <!-- ------------------------------------------------------------------------------------------------------ -->
 
@@ -53,38 +35,73 @@ Developer [2024 January - 2024 December]<br/>
 
 <!-- ------------------------------------------------------------------------------------------------------ -->
 
-### [Poon Yip Hang, Ryan](https://www.github.com/sopa301)
-**Role**: Senior Developer [2025 January - ]<br/>
-Developer [2024 January - 2024 December]<br/>
+### [Yu Letian](https://www.github.com/FisherSkyi)
+**Role**: Developer [2026 January - ]<br/>
 
 <!-- ------------------------------------------------------------------------------------------------------ -->
 
-### [Alexander Liswandy](https://www.github.com/Airiinnn)
-**Role**: Developer [2025 January - ]<br/>
+### [Chen Yizhong](https://www.github.com/yizhong187)
+**Role**: Developer [2026 January - ]<br/>
 
 <!-- ------------------------------------------------------------------------------------------------------ -->
 
-### [Chen Yixun](https://www.github.com/CYX22222003)
-**Role**: Developer [2025 January - ]<br/>
-
-<!-- ------------------------------------------------------------------------------------------------------ -->
-
-### [Hing Yen Xing](https://www.github.com/JoanneHing)
-**Role**: Developer [2025 January - ]<br/>
-
-<!-- ------------------------------------------------------------------------------------------------------ -->
-
-### [Ng Yin Joe](https://www.github.com/joeng03)
-**Role**: Developer [2025 January - ]<br/>
-
-<!-- ------------------------------------------------------------------------------------------------------ -->
-
-### [Wong Li Yuan](https://www.github.com/lyuanww)
-**Role**: Developer [2025 January - ]<br/>
+### [Ashmita Haldar](https://www.github.com/ashmitahaldar)
+**Role**: Developer [2026 January - ]<br/>
 
 <!-- ------------------------------------------------------------------------------------------------------ -->
 
 ## Past Members
+
+### [Poon Yip Hang, Ryan](https://www.github.com/sopa301)
+**Role**: Senior Developer [2025 January - 2025 December]<br/>
+Developer [2024 January - 2024 December]<br/>
+
+<!-- ------------------------------------------------------------------------------------------------------ -->
+
+### [Chang Si Kai](https://github.com/sikai00)
+**Role**: Senior Developer [2025 January - 2025 December]<br/>
+Developer [2023 January - 2024 December]<br/>
+
+<!-- ------------------------------------------------------------------------------------------------------ -->
+
+### [Alexander Liswandy](https://www.github.com/Airiinnn)
+**Role**: Developer [2025 January - 2025 December]<br/>
+
+<!-- ------------------------------------------------------------------------------------------------------ -->
+
+### [Hing Yen Xing](https://www.github.com/JoanneHing)
+**Role**: Developer [2025 January - 2025 December]<br/>
+
+<!-- ------------------------------------------------------------------------------------------------------ -->
+
+### [Ng Yin Joe](https://www.github.com/joeng03)
+**Role**: Developer [2025 January - 2025 December]<br/>
+
+<!-- ------------------------------------------------------------------------------------------------------ -->
+
+### [Charisma Kausar](https://www.github.com/ckcherry23)
+**Role**: Project Lead [2024 May - 2024 December]<br/>
+Senior Developer [2024 January - 2024 April]<br/>
+Developer [2022 December - 2023 December]<br/>
+
+<!-- ------------------------------------------------------------------------------------------------------ -->
+
+### [Gokul Rajiv](https://github.com/gok99)
+**Role**: Project Lead [2024 May - 2024 December]<br/>
+Senior Developer [2024 January - 2024 April]<br/>
+Developer [2022 January - 2023 December]<br/>
+
+<!-- ------------------------------------------------------------------------------------------------------ -->
+
+### [Alvis Ng](https://www.github.com/supermii2)
+**Role**: Developer [2024 January - 2024 December]<br/>
+
+<!-- ------------------------------------------------------------------------------------------------------ -->
+
+### [George Tay Quan Yao](https://www.github.com/jonasongg)
+**Role**: Developer [2024 January - 2024 December]<br/>
+
+<!-- ------------------------------------------------------------------------------------------------------ -->
 
 ### [David Gareth Ong](https://www.github.com/vvidday)
 **Role**: Senior Developer [2024 January - 2024 April]<br/>


### PR DESCRIPTION
Fixes #2572 

### Proposed commit message
```
The about page lists outdated team member roles, with members who
have since moved on still listed as active, and new members not
yet added.

Update the about page to reflect the current team for AY2526 S2:
add new developers, promote returning members to their updated
roles, close end dates for past members, and move past members
to the Past Members section.
```

### Other information
N/A
