### PR TITLE
[#2575] Attempt to fix renovate config to not include linters

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,7 +8,15 @@
       "groupName": "all non-major dependencies except typescript",
       "groupSlug": "all-minor-patch",
       "matchPackageNames": [
-        "!typescript"
+        "!typescript",
+        "!eslint",
+        "!eslint-*",
+        "!@eslint/*",
+        "!@stylistic/*",
+        "!stylelint",
+        "!stylelint-*",
+        "!@stylelint/*",
+        "!puglint"
       ],
       "matchDepTypes": [
         "dependencies",
@@ -20,6 +28,30 @@
       ],
       "enabled": true,
       "automerge": true
+    },
+    {
+      "groupName": "linting dependencies",
+      "groupSlug": "linting",
+      "matchPackageNames": [
+        "eslint",
+        "eslint-*",
+        "@eslint/*",
+        "@stylistic/*",
+        "stylelint",
+        "stylelint-*",
+        "@stylelint/*",
+        "puglint"
+      ],
+      "matchDepTypes": [
+        "dependencies",
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "minor",
+        "patch"
+      ],
+      "enabled": true,
+      "automerge": false
     },
     {
       "matchPackageNames": [

--- a/renovate.json
+++ b/renovate.json
@@ -64,5 +64,6 @@
       "automerge": true
     }
   ],
-  "dependencyDashboard": true
+  "dependencyDashboard": true,
+  "baseBranches": ["master", "update-renovate-config"]
 }


### PR DESCRIPTION
<!--
    If this pull request fully addresses an issue, use:
    Fixes #xxxx

    If this pull request partially addresses an issue, use:
    Part of #xxxx

    If this pull request addresses multiple issues, put them in multiple lines:
    Fixes #xxxx
    Fixes #yyyy

    Format the title of the pull request with most relevant issue number as follows:
    [#xxxx] Title
-->
Fixes #2575 

### Proposed commit message
<!--
    Propose a detailed commit message for this pull request within the triple backticks below.
    Wrap lines at 72 characters.

    Guide on how to write a good commit message:
    https://oss-generic.github.io/process/docs/FormatsAndConventions.html#commit-message
-->
```
Update Renovate config to not include linters
```

### Probelm
<!--
    Are there other relevant information, such as special testing instructions,
    which will help the reviewer better understand the code?

    You may also include a brief description of why the problem occurred.
-->
Renovate was bundling linting dependencies (e.g. stylelint, eslint, @stylistic/*) into the "all non-major dependencies" grouped PR, which has automerge: true. Linting tool updates can introduce new or stricter lint rules that break the lintFrontend CI check — as seen in #2437, where a stylelint update caused declaration-property-value-no-unknown errors across multiple Vue components.

Since these failures require manual code fixes (not just dependency bumps), auto-merging linting updates is unsafe.

### Changes
Excluded eslint, stylelint, @stylistic/*, puglint, and their scoped/prefixed variants from the auto-merged group
Added a separate "linting dependencies" Renovate group for these packages with automerge: false, so they are still updated but require manual review before merging