### PR TITLE
[#2622] Hide bucket time in ramp tooltips

### DIFF
--- a/frontend/cypress/tests/chartView/chartView_mergeCommits.cy.js
+++ b/frontend/cypress/tests/chartView/chartView_mergeCommits.cy.js
@@ -1,7 +1,7 @@
 describe('include merge commits in chart view', () => {
   it('show merge commits in summary chart', () => {
     // ramp chart should have merge commit slices
-    cy.get('[title="[2023-03-03T00:00:00] Merge branch \'new-branch\' into cypress: +0 -0 lines "]')
+    cy.get('[title="[2023-03-03] Merge branch \'new-branch\' into cypress: +0 -0 lines "]')
       .should('have.class', 'ramp__slice')
       .should('exist');
   });
@@ -19,7 +19,7 @@ describe('include merge commits in chart view', () => {
       .should('not.be.checked');
 
     // ramp chart should not have merge commit slices
-    cy.get('[title="[2023-03-03T00:00:00] Merge branch \'new-branch\' into cypress: +0 -0 lines "]')
+    cy.get('[title="[2023-03-03] Merge branch \'new-branch\' into cypress: +0 -0 lines "]')
       .should('not.exist');
   });
 });

--- a/frontend/cypress/tests/chartView/chartView_optimiseTimeline.cy.js
+++ b/frontend/cypress/tests/chartView/chartView_optimiseTimeline.cy.js
@@ -147,7 +147,7 @@ describe('optimise timeline', () => {
     cy.get('#tab-zoom .ramp .ramp__slice')
       .invoke('attr', 'title')
       .then((title) => {
-        cy.wrap(title).should('eq', '[2019-08-18T00:00:00] AboutUs: update team members (#867): +94 -12 lines ');
+        cy.wrap(title).should('eq', '[2019-08-18] AboutUs: update team members (#867): +94 -12 lines ');
       });
   });
 });

--- a/frontend/cypress/tests/chartView/chartView_zoomFeature.cy.js
+++ b/frontend/cypress/tests/chartView/chartView_zoomFeature.cy.js
@@ -266,11 +266,11 @@ describe('range changes in chartview should reflect in zoom', () => {
     cy.get('#tab-zoom .ramp .ramp__slice')
       .first()
       .invoke('attr', 'title')
-      .should('eq', '[2021-01-04T00:00:00] Update `About us` page (#1393): +55 -30 lines ');
+      .should('eq', '[2021-01-04] Update `About us` page (#1393): +55 -30 lines ');
     cy.get('#tab-zoom .ramp .ramp__slice')
       .last()
       .invoke('attr', 'title')
-      .should('eq', '[2019-12-20T00:00:00] [#46] Show total time after batch processing (#758): +43 -0 lines ');
+      .should('eq', '[2019-12-20] [#46] Show total time after batch processing (#758): +43 -0 lines ');
   });
 
   // Assumptions: Contributer 'jamessspanggg' is the first result,
@@ -295,11 +295,11 @@ describe('range changes in chartview should reflect in zoom', () => {
     cy.get('#tab-zoom .ramp .ramp__slice')
       .first()
       .invoke('attr', 'title')
-      .should('eq', '[2020-05-23T00:00:00] [#1241] Restore checked file types (#1256): +14 -1 lines ');
+      .should('eq', '[2020-05-23] [#1241] Restore checked file types (#1256): +14 -1 lines ');
     cy.get('#tab-zoom .ramp .ramp__slice')
       .last()
       .invoke('attr', 'title')
-      .should('eq', '[2019-12-20T00:00:00] [#46] Show total time after batch processing (#758): +43 -0 lines ');
+      .should('eq', '[2019-12-20] [#46] Show total time after batch processing (#758): +43 -0 lines ');
   });
 
   // Assumptions: Contributer 'jamessspanggg' is the first result,
@@ -324,11 +324,11 @@ describe('range changes in chartview should reflect in zoom', () => {
     cy.get('#tab-zoom .ramp .ramp__slice')
       .first()
       .invoke('attr', 'title')
-      .should('eq', '[2021-01-04T00:00:00] Update `About us` page (#1393): +55 -30 lines ');
+      .should('eq', '[2021-01-04] Update `About us` page (#1393): +55 -30 lines ');
     cy.get('#tab-zoom .ramp .ramp__slice')
       .last()
       .invoke('attr', 'title')
-      .should('eq', '[2020-09-27T00:00:00] Add optional check for quotes in diff file regex (#1330): +1 -1 lines ');
+      .should('eq', '[2020-09-27] Add optional check for quotes in diff file regex (#1330): +1 -1 lines ');
   });
 
   // Assumptions: Contributer 'jamessspanggg' is the first result,
@@ -355,12 +355,12 @@ describe('range changes in chartview should reflect in zoom', () => {
       .invoke('attr', 'title')
       .should(
         'eq',
-        '[2021-01-04T00:00:00] Update `About us` page (#1393): +55 -30 lines ',
+        '[2021-01-04] Update `About us` page (#1393): +55 -30 lines ',
       );
 
     cy.get('#tab-zoom .ramp .ramp__slice')
       .last()
       .invoke('attr', 'title')
-      .should('eq', '[2020-09-27T00:00:00] Add optional check for quotes in diff file regex (#1330): +1 -1 lines ');
+      .should('eq', '[2020-09-27] Add optional check for quotes in diff file regex (#1330): +1 -1 lines ');
   });
 });

--- a/frontend/cypress/tests/zoomView/zoomView_rampChart.cy.js
+++ b/frontend/cypress/tests/zoomView/zoomView_rampChart.cy.js
@@ -98,7 +98,7 @@ describe('show ramp chart for period', () => {
     cy.get('#tab-zoom .ramp .ramp__slice')
       .last()
       .invoke('attr', 'title')
-      .should('eq', '[2018-06-12T00:00:00] Setup AppVeyor CI (#142): +19 -0 lines ');
+      .should('eq', '[2018-06-12] Setup AppVeyor CI (#142): +19 -0 lines ');
 
     // last ramp should be for commit before end date
     cy.get('#tab-zoom .ramp .ramp__slice')
@@ -106,7 +106,7 @@ describe('show ramp chart for period', () => {
       .invoke('attr', 'title')
       .should(
         'eq',
-        '[2019-03-25T00:00:00] [#622] CsvParser#parse: fix error handling of `processLine` (#623): +30 -10 lines '
+        '[2019-03-25] [#622] CsvParser#parse: fix error handling of `processLine` (#623): +30 -10 lines '
       );
   });
 
@@ -152,7 +152,7 @@ describe('show ramp chart for period', () => {
       .click();
 
     // deletes commit ramp should have expected color
-    cy.get('[title="[2019-07-24T00:00:00] [#828] Revert \\"v_summary.js: remove redundant calls '
+    cy.get('[title="[2019-07-24] [#828] Revert \\"v_summary.js: remove redundant calls '
      + 'to getFiltered() (#800)\\" (#832): +0 -9 lines "]')
       .eq(1)
       .should('have.class', 'ramp__slice')

--- a/frontend/src/components/c-ramp.vue
+++ b/frontend/src/components/c-ramp.vue
@@ -153,14 +153,19 @@ export default defineComponent({
       return Math.max(newSize * this.rampSize, 0.5);
     },
     getContributionMessageByCommit(slice: Commit, commit: CommitResult): string {
-      return `[${slice.date}] ${commit.messageTitle}: +${commit.insertions} -${commit.deletions} lines `;
+      const date = this.getDateOnly(slice.date);
+      return `[${date}] ${commit.messageTitle}: +${commit.insertions} -${commit.deletions} lines `;
     },
     getContributionMessage(slice: Commit): string {
+      const startDate = this.getDateOnly(slice.date);
       let title = this.tframe === 'day'
-          ? `[${slice.date}] Daily `
-          : `[${slice.date} till ${slice.endDate}] Weekly `;
+          ? `[${startDate}] Daily `
+          : `[${startDate} till ${this.getDateOnly(slice.endDate)}] Weekly `;
       title += `contribution: +${slice.insertions} -${slice.deletions} lines`;
       return title;
+    },
+    getDateOnly(date?: string): string {
+      return date?.split('T')[0] ?? '';
     },
     openTabZoom(user: User, slice: Commit, evt: MouseEvent): void {
       // prevent opening of zoom tab when cmd/ctrl click


### PR DESCRIPTION
Fixes #2622

### Proposed commit message
```
Hide bucket time from ramp tooltips.

Format ramp tooltip dates as date-only values, because the timestamp
shown there represents the daily bucket start rather than an actual
commit timestamp.
```

### Other information
This is a display-only frontend change. The underlying date values used
for filtering, ramp positioning, report generation, and JSON output are
left unchanged.

Tested with:
- `.\gradlew.bat testFrontend -Pci`
- `.\gradlew.bat test --tests "reposense.commits.*" --tests "reposense.parser.LocalDateTimeParserTest"`
