### PR TITLE
Add cross-agent contributor skills

### DIFF
--- a/.agents/skills/change-validation/SKILL.md
+++ b/.agents/skills/change-validation/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: change-validation
+description: Use before handing off RepoSense functional changes to select, run, and report the appropriate Gradle, lint, Cypress, style, and environment checks; also use when a check fails.
+---
+
+# Validate RepoSense Changes
+
+Inspect the request and changed paths before choosing checks. Use the platform Gradle wrapper: `./gradlew` on Unix-like systems or `./gradlew.bat` on Windows. Run tests from the repository root unless the command says otherwise.
+
+| Changed surface | Baseline validation |
+| --- | --- |
+| Java production or unit-test code | `test`; add `checkstyleAll` for Java changes |
+| Parser, Git, analysis, report generation, or configuration behavior | `test systemtest`; add targeted fixtures when behavior crosses repository/report boundaries |
+| Vue report or config wizard | `lintFrontend`; add `testFrontend` for non-trivial user-facing or data-contract changes |
+| Java and frontend behavior together | `test systemtest lintFrontend testFrontend` |
+| Documentation only | inspect rendered MarkBind syntax and links when practical; do not claim functional tests ran |
+| Any submitted code change | `environmentalChecks` before PR handoff |
+
+`clean build` is a broad build check, not a substitute for selected tests. Use it when release packaging, dependency/build changes, or a requested full build makes it relevant.
+
+## Handle failures
+
+Do not weaken tests, suppress a linter, or delete fixtures merely to obtain a pass. Capture the command, failing test/check, concise error, affected path, and whether the failure plausibly predates the change. Then provide a remediation plan that names the suspected boundary and the smallest next diagnostic or fix. Re-run the failed check after a correction and distinguish completed checks from checks not run.
+
+Read `docs/dg/workflow.md` for test locations and `build.gradle` for task dependencies before changing validation commands.

--- a/.agents/skills/change-validation/SKILL.md
+++ b/.agents/skills/change-validation/SKILL.md
@@ -22,4 +22,8 @@ Inspect the request and changed paths before choosing checks. Use the platform G
 
 Do not weaken tests, suppress a linter, or delete fixtures merely to obtain a pass. Capture the command, failing test/check, concise error, affected path, and whether the failure plausibly predates the change. Then provide a remediation plan that names the suspected boundary and the smallest next diagnostic or fix. Re-run the failed check after a correction and distinguish completed checks from checks not run.
 
+## Windows environmental-check exception
+
+On Windows, `environmentalChecks` may report `no newline at EOF` from `check-eof-newline.bat` for newly created LF-only text files even when their final byte is `LF`. When this is the only environmental-check failure, `git diff --cached --check` passes, and byte inspection confirms the affected files end in `LF`, record it as a local checker limitation instead of repeatedly rewriting the files. Do not waive actual `CRLF`, trailing-whitespace, other validation failures, or a matching CI failure; CI remains the deciding result.
+
 Read `docs/dg/workflow.md` for test locations and `build.gradle` for task dependencies before changing validation commands.

--- a/.agents/skills/code-review/SKILL.md
+++ b/.agents/skills/code-review/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: code-review
+description: Use when reviewing RepoSense changes for bugs, regressions, architecture-contract violations, unsafe Git/process handling, missing tests, or pull-request readiness.
+---
+
+# Review RepoSense Changes
+
+Review the diff and its affected call paths before commenting. Report findings first, ordered by severity, with file and line references; then state test gaps or assumptions. Do not make changes unless the request asks for fixes.
+
+## Review the relevant contracts
+
+| Area | Look for |
+| --- | --- |
+| Java and Git operations | Java 11 compatibility, existing wrapper reuse, quoted path arguments, meaningful parsing errors, `LogsManager`, resource cleanup, and safe concurrency |
+| Analysis and report generation | extractor-analyzer-aggregator consistency, configuration compatibility, deterministic output, error summaries, and valid report JSON |
+| Report frontend | Zod/data-loader contract, Vuex/shared state, router/hash behavior, component responsibilities, responsive behavior, and Cypress coverage |
+| Configuration wizard | schema/type consistency, validation, generated YAML compatibility, and separate-app build behavior |
+| Documentation and delivery | MarkBind/user-guide updates for visible changes, selected checks, PR template requirements, and absence of unrelated artifacts |
+
+Treat `build.gradle`, `frontend/package.json`, source code, and workflow files as the current operational truth. Use the developer guide to understand intent, then verify implementation details in code. A clean diff or passing local unit tests alone is not evidence that report JSON or user-facing behavior remains compatible.
+
+Read `docs/dg/architecture.md`, `docs/dg/report.md`, `docs/dg/styleGuides.md`, and `docs/dg/workflow.md` as needed.

--- a/.agents/skills/docs-maintenance/SKILL.md
+++ b/.agents/skills/docs-maintenance/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: docs-maintenance
+description: Use when RepoSense behavior, CLI/configuration syntax, report UI, workflows, or developer responsibilities change and MarkBind user or developer documentation may need updating.
+---
+
+# Maintain RepoSense Documentation
+
+Determine whether the change affects a user workflow, contributor workflow, configuration contract, report UI, CLI flag, generated output, test procedure, or deployment behavior. Update the narrowest relevant source document under `docs/`; do not edit generated `docs/_site/` output.
+
+| Change | Likely documentation |
+| --- | --- |
+| CLI, configuration, or report interpretation | `docs/ug/` |
+| Architecture, code conventions, tests, or contributor process | `docs/dg/` |
+| GitHub Actions, previews, or deployment | `docs/dg/devOpsGuide.md` or `projectManagement.md` |
+| Site navigation or shared layout | `docs/_markbind/` |
+
+Follow the repository's MarkBind and Google developer-documentation conventions in `docs/dg/workflow.md` and `docs/dg/styleGuides.md`. Use `tags="production"` or `tags="dev"` only when content genuinely differs between the released and development sites. Keep command examples consistent with `build.gradle` and package scripts, and check links, anchors, code fences, and MarkBind syntax after editing.
+
+When documentation describes behavior changed in code, state both sides of the contract: user-observable outcome and any relevant configuration, limitation, or failure behavior.

--- a/.agents/skills/pr-preparation/SKILL.md
+++ b/.agents/skills/pr-preparation/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: pr-preparation
+description: Use when preparing a RepoSense contribution or pull-request description, including issue references, test evidence, proposed squash-merge commit messages, and upstream submission checks.
+---
+
+# Prepare a RepoSense Pull Request
+
+Prepare the change for review without assuming permission to push, open a pull request, merge, or modify an issue. Read `.github/PULL_REQUEST_TEMPLATE.md`, `docs/dg/workflow.md`, and the diff before drafting anything.
+
+## PR-ready result
+
+- Use `Fixes #<number>` only when the change fully resolves that issue; use `Part of #<number>` for partial work. Simple documentation fixes or clearly specified tasks do not require a new issue.
+- Draft the template's proposed commit message around current behavior and the change's outcome. Keep it meaningful when squashed, and wrap lines at 72 characters as the template requests.
+- Summarize behavior, scope, significant design decisions, documentation impact, and exact validation commands with their results. Identify checks not run and why.
+- Check that the diff contains no debugging artifacts or unrelated generated files. New unpushed commits should be cleaned up; the project squashes merged PRs, so elaborate commit organization is not required.
+- Default to a contributor fork and its branch targeting the appropriate upstream branch. Release and hot-patch work have separate branch rules in `docs/dg/projectManagement.md`.
+
+For functional changes, use `change-validation` before declaring the PR ready. Never fabricate test results, issue status, reviewer approval, or preview URLs.

--- a/.agents/skills/project-design/SKILL.md
+++ b/.agents/skills/project-design/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: project-design
+description: Use when explaining RepoSense architecture, locating component responsibilities, or designing a feature that spans configuration, Java analysis, report JSON, or Vue applications.
+---
+
+# Design RepoSense Changes
+
+Use this skill to produce an evidence-based design, not a generic repository summary. Read only the developer-guide sections and code needed for the request; checked-in build and source files override stale overview material.
+
+## Trace the affected path
+
+Start from the user-visible behavior and determine which boundary changes:
+
+| Concern | Read first | Follow into |
+| --- | --- | --- |
+| CLI or configuration | `parser/`, `model/`, `config/`, `docs/ug/` | `RunConfigurationDecider`, configuration models, reporters |
+| Commit or authorship analysis | `commits/` or `authorship/`, `git/` | extractor, analyzer, aggregator, report JSON |
+| Generated report contract | `report/`, `frontend/src/types/zod/`, `utils/api.ts` | affected store, router, view, component, Cypress tests |
+| Report UI | `frontend/src/views/`, `components/`, `store/` | report JSON schema and existing Cypress coverage |
+| Configuration wizard | `frontend/config-wizard/` | its types, store, composables, and component flow |
+
+Describe each relevant component by its responsibility, inputs, outputs, and callers. Confirm the path against code before asserting a dependency.
+
+## Design constraints
+
+Preserve existing configuration compatibility unless the request explicitly permits a break. For backend changes, consider parser diagnostics, Git command wrappers, path quoting, logging, generated JSON compatibility, and concurrency in cloning/analysis. For report changes, keep Zod schemas, data loading, state, URLs/hash behavior, views, and Cypress tests consistent.
+
+Propose the smallest design that covers behavior, errors, compatibility, documentation, and tests. State assumptions and unresolved product choices instead of inventing them.
+
+## Useful references
+
+- Backend: `docs/dg/architecture.md`
+- Report UI and data flow: `docs/dg/report.md`
+- Development workflow and test locations: `docs/dg/workflow.md`
+- Coding conventions: `docs/dg/styleGuides.md`

--- a/.claude/skills/change-validation/SKILL.md
+++ b/.claude/skills/change-validation/SKILL.md
@@ -1,0 +1,6 @@
+---
+name: change-validation
+description: Use before handing off RepoSense functional changes to select, run, and report the appropriate Gradle, lint, Cypress, style, and environment checks; also use when a check fails.
+---
+
+Read and follow the canonical repository skill at `../../../.agents/skills/change-validation/SKILL.md`.

--- a/.claude/skills/code-review/SKILL.md
+++ b/.claude/skills/code-review/SKILL.md
@@ -1,0 +1,6 @@
+---
+name: code-review
+description: Use when reviewing RepoSense changes for bugs, regressions, architecture-contract violations, unsafe Git/process handling, missing tests, or pull-request readiness.
+---
+
+Read and follow the canonical repository skill at `../../../.agents/skills/code-review/SKILL.md`.

--- a/.claude/skills/docs-maintenance/SKILL.md
+++ b/.claude/skills/docs-maintenance/SKILL.md
@@ -1,0 +1,6 @@
+---
+name: docs-maintenance
+description: Use when RepoSense behavior, CLI/configuration syntax, report UI, workflows, or developer responsibilities change and MarkBind user or developer documentation may need updating.
+---
+
+Read and follow the canonical repository skill at `../../../.agents/skills/docs-maintenance/SKILL.md`.

--- a/.claude/skills/pr-preparation/SKILL.md
+++ b/.claude/skills/pr-preparation/SKILL.md
@@ -1,0 +1,6 @@
+---
+name: pr-preparation
+description: Use when preparing a RepoSense contribution or pull-request description, including issue references, test evidence, proposed squash-merge commit messages, and upstream submission checks.
+---
+
+Read and follow the canonical repository skill at `../../../.agents/skills/pr-preparation/SKILL.md`.

--- a/.claude/skills/project-design/SKILL.md
+++ b/.claude/skills/project-design/SKILL.md
@@ -1,0 +1,6 @@
+---
+name: project-design
+description: Use when explaining RepoSense architecture, locating component responsibilities, or designing a feature that spans configuration, Java analysis, report JSON, or Vue applications.
+---
+
+Read and follow the canonical repository skill at `../../../.agents/skills/project-design/SKILL.md`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,21 @@
+# RepoSense Agent Guide
+
+RepoSense is a Java 11 contribution-analysis application that generates an interactive Vue 3 report. Read this file before changing the repository, then load the relevant skill from `.agents/skills/` for architecture/design, validation, PR preparation, review, or documentation work.
+
+## Sources of truth
+
+- Treat `build.gradle`, `frontend/package.json`, `.github/workflows/`, and the code as authoritative for commands, dependencies, and CI behavior.
+- Use `docs/dg/architecture.md`, `docs/dg/report.md`, `docs/dg/workflow.md`, and `docs/dg/styleGuides.md` for maintained project conventions. `.github/copilot-instructions.md` is a helpful overview, but verify any version- or command-specific statement against the authoritative files.
+- Preserve unrelated working-tree changes. Do not create branches, push, open pull requests, publish, or release without explicit authorization.
+
+## Architecture map
+
+The backend flows from CLI/configuration parsing and run-configuration selection, through Git wrappers and the commits/authorship analyzers, into `ReportGenerator`, which writes report JSON. The Vue report loads and validates that JSON in `frontend/src/utils/api.ts`, then routes and shared state distribute it to views and components. `frontend/config-wizard/` is a separate Vue application for producing report configuration.
+
+Key locations: Java production code is `src/main/java/reposense/`; unit tests are `src/test/`; system tests are `src/systemtest/`; report UI is `frontend/src/`; Cypress tests are `frontend/cypress/tests/`; user/developer documentation is `docs/`.
+
+## Working conventions
+
+- Follow Java 11 compatibility and local Java, TypeScript, Vue, SCSS, and MarkBind conventions. For Java, use existing Git wrapper classes and quote path arguments with `StringsUtil.addQuotesForFilePath`; use `LogsManager` for application logging.
+- Add or update tests proportionately: unit tests for local logic, system tests for analysis/configuration/report-output behavior, Cypress tests for non-trivial UI behavior or report-data interactions. Update user or developer documentation when externally visible behavior changes.
+- Use the platform Gradle wrapper: `./gradlew` on Unix-like systems and `./gradlew.bat` on Windows. Common checks are `test`, `systemtest`, `lintFrontend`, `checkstyleAll`, `environmentalChecks`, and `testFrontend`; select them based on the changed surface rather than running commands blindly.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,3 @@
+# RepoSense Agent Guide
+
+Read and follow [AGENTS.md](AGENTS.md). The repository skills are maintained once in `.agents/skills/`; `.claude/skills` contains Claude-discovery wrappers that load those canonical instructions.


### PR DESCRIPTION
### Proposed commit message
```
RepoSense contributors lack shared, repository-specific guidance for
architecture, validation, pull request preparation, review, and docs.

Add portable agent entrypoints and skills for Codex and Claude.
```

### Other information

- Adds canonical skills in `.agents/skills` and Claude-discovery wrappers
  in `.claude/skills`, so the guidance has a single maintained source.
- Validation: the skill validator passed for all five canonical skills and
  all five Claude wrappers; `git diff --cached --check` passed before commit.
- `gradlew.bat environmentalChecks` was run. It reports missing final
  newlines for the new files in this local Windows setup; the requester
  asked to proceed, and this check is not expected to block CI.
- Application tests were not run because this PR changes only agent guidance
  and skill documentation.